### PR TITLE
Add server name

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,7 +18,8 @@ palette:
 # For fields under server, please refer to: https://docs.rs/irc/0.15.0/irc/client/data/config/struct.Config.html#fields
 
 servers:
-  - nickname: halloy
+  liberachat:
+    nickname: halloy
     server: irc.libera.chat
     port: 6697
     use_tls: true

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
@@ -12,7 +13,7 @@ use crate::server;
 pub struct Config {
     #[serde(default)]
     pub palette: Palette,
-    pub servers: Vec<server::Config>,
+    pub servers: BTreeMap<String, server::Config>,
 }
 
 impl Config {

--- a/data/src/server.rs
+++ b/data/src/server.rs
@@ -4,17 +4,23 @@ use std::ops::Deref;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Server(String);
+pub struct Server {
+    name: String,
+    hostname: String,
+}
 
-impl From<String> for Server {
-    fn from(server: String) -> Self {
-        Self(server)
+impl Server {
+    pub fn new(name: impl ToString, hostname: impl ToString) -> Self {
+        Self {
+            name: name.to_string(),
+            hostname: hostname.to_string(),
+        }
     }
 }
 
 impl fmt::Display for Server {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
+        self.name.fmt(f)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,8 +76,12 @@ impl Application for Halloy {
 
         let mut clients = data::client::Map::default();
 
-        for server in &config.servers {
-            clients.disconnected(server.server.clone().expect("config server").into());
+        for (server, server_config) in &config.servers {
+            let server = data::Server::new(
+                server,
+                server_config.server.as_ref().expect("server hostname"),
+            );
+            clients.disconnected(server);
         }
 
         (
@@ -113,8 +117,8 @@ impl Application for Halloy {
                 stream::Event::Ready(sender) => {
                     log::debug!("Client ready to receive connections");
 
-                    for server in self.config.servers.clone() {
-                        let _ = sender.blocking_send(stream::Message::Connect(server));
+                    for (name, config) in self.config.servers.clone() {
+                        let _ = sender.blocking_send(stream::Message::Connect(name, config));
                     }
 
                     Command::none()


### PR DESCRIPTION
This allows us to have multiple connections to the same `hostname` (like multiple connections to the same ZNC server). Use now defines a map of human readable server name to server config. We use the human readable name instead of hostname for server `Display` purposes