### PR TITLE
A few different UI tweaks

### DIFF
--- a/data/src/channel.rs
+++ b/data/src/channel.rs
@@ -7,8 +7,8 @@ pub struct Config {
 
 #[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
 pub enum Position {
-    #[default]
     Left,
+    #[default]
     Right,
 }
 
@@ -23,7 +23,7 @@ impl Default for Users {
     fn default() -> Self {
         Self {
             visible: true,
-            position: Position::Left,
+            position: Position::default(),
         }
     }
 }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -177,15 +177,19 @@ impl Map {
     }
 
     pub fn get_channels(&self) -> BTreeMap<Server, Vec<String>> {
+        let mut servers = Vec::from_iter(self.0.iter());
+        servers.sort_by(|(s1, _), (s2, _)| s2.name.cmp(&s1.name));
+
         let mut map = BTreeMap::new();
 
-        for (server, _) in self.0.iter() {
-            map.insert(
-                server.clone(),
-                self.connection(server)
-                    .map(|connection| connection.channels())
-                    .unwrap_or_default(),
-            );
+        for (server, _) in servers.into_iter() {
+            let mut channels = self
+                .connection(server)
+                .map(|connection| connection.channels())
+                .unwrap_or_default();
+            channels.sort();
+
+            map.insert(server.clone(), channels);
         }
 
         map

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use data::server::Server;
-use iced::widget::{column, container, row, scrollable, text, vertical_space, Rule};
+use iced::widget::{column, container, row, scrollable, text, vertical_space};
 use iced::{Command, Length};
 
 use crate::theme;
@@ -51,6 +51,7 @@ pub fn view<'a>(
         )
         .id(state.scrollable.clone()),
     )
+    .width(Length::FillPortion(2))
     .height(Length::Fill);
 
     let spacing = is_focused.then_some(vertical_space(4));
@@ -62,46 +63,53 @@ pub fn view<'a>(
         )
     });
 
-    // TODO: Maybe we should show it to the right instead of left.
-    let users = if config.users.visible {
+    let user_column = {
         let users = clients.get_channel_users(&state.server, &state.channel);
-        let mut column = column![].padding(4).width(Length::Shrink).spacing(1);
-
-        for user in users {
-            // TODO: Enable button pushes (interactions) on users.
-            column = column.push(
-                row![]
-                    .padding([0, 4])
-                    .push(text(user.highest_access_level().to_string()))
-                    .push(text(user.nickname())),
-            );
-        }
-
-        let users = container(
-            row![
-                scrollable(column)
-                    .vertical_scroll(
-                        iced::widget::scrollable::Properties::new()
-                            .width(1)
-                            .scroller_width(1)
+        let column = Column::with_children(
+            users
+                .iter()
+                .map(|user| {
+                    container(
+                        row![]
+                            .padding([0, 4])
+                            .push(text(user.highest_access_level().to_string()))
+                            .push(text(user.nickname())),
                     )
-                    .style(theme::Scrollable::Hidden),
-                Rule::vertical(1)
-            ]
-            .spacing(4)
-            .height(Length::Fill),
-        );
+                    .into()
+                })
+                .collect(),
+        )
+        .padding(4)
+        .spacing(1);
 
-        Some(container(users))
-    } else {
-        None
+        container(
+            scrollable(column)
+                .vertical_scroll(
+                    iced::widget::scrollable::Properties::new()
+                        .width(1)
+                        .scroller_width(1),
+                )
+                .style(theme::Scrollable::Hidden),
+        )
+        .width(Length::Shrink)
+        .max_width(120)
+        .height(Length::Fill)
     };
 
-    let scrollable =
-        column![container(row![].push_maybe(users).push(messages)).height(Length::Fill)]
-            .push_maybe(spacing)
-            .push_maybe(text_input)
-            .height(Length::Fill);
+    let content = match (config.users.visible, config.users.position) {
+        (true, data::channel::Position::Left) => {
+            row![user_column, messages]
+        }
+        (true, data::channel::Position::Right) => {
+            row![messages, user_column]
+        }
+        (false, _) => { row![messages] }.height(Length::Fill),
+    };
+
+    let scrollable = column![container(content).height(Length::Fill)]
+        .push_maybe(spacing)
+        .push_maybe(text_input)
+        .height(Length::Fill);
 
     container(scrollable)
         .width(Length::Fill)

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -9,7 +9,7 @@ pub fn globe<'a>() -> Text<'a> {
     to_text('\u{f3ef}')
 }
 
-pub fn chat<'a>() -> Text<'a> {
+pub fn _chat<'a>() -> Text<'a> {
     to_text('\u{f267}')
 }
 

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -1,4 +1,5 @@
 use iced::widget::text;
+use iced::widget::text::LineHeight;
 
 use crate::widget::Text;
 use crate::{font, theme};
@@ -35,7 +36,7 @@ pub fn people<'a>() -> Text<'a> {
 
 fn to_text<'a>(unicode: char) -> Text<'a> {
     text(unicode.to_string())
-        .line_height(1.1)
+        .line_height(LineHeight::Relative(1.0))
         .size(theme::ICON_SIZE)
         .font(font::ICON)
 }

--- a/src/screen/dashboard/side_menu.rs
+++ b/src/screen/dashboard/side_menu.rs
@@ -1,12 +1,10 @@
 use data::server::Server;
-use iced::widget::{
-    button, column, container, horizontal_space, pane_grid, row, text, vertical_space,
-};
+use iced::widget::{button, column, container, horizontal_space, pane_grid, row, text};
 use iced::Length;
 
 use super::pane::Pane;
 use crate::widget::Element;
-use crate::{buffer, font, icon, theme};
+use crate::{buffer, icon, theme};
 
 #[derive(Debug, Clone)]
 pub enum Message {

--- a/src/screen/dashboard/side_menu.rs
+++ b/src/screen/dashboard/side_menu.rs
@@ -1,10 +1,12 @@
 use data::server::Server;
-use iced::widget::{button, column, container, pane_grid, row, text};
+use iced::widget::{
+    button, column, container, horizontal_space, pane_grid, row, text, vertical_space,
+};
 use iced::Length;
 
 use super::pane::Pane;
 use crate::widget::Element;
-use crate::{buffer, icon, theme};
+use crate::{buffer, font, icon, theme};
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -75,7 +77,7 @@ impl SideMenu {
             for channel in channels {
                 column = column.push(
                     button(
-                        row![icon::chat(), text(channel)]
+                        row![horizontal_space(10), text(channel)]
                             .spacing(8)
                             .align_items(iced::Alignment::Center),
                     )

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -186,6 +186,7 @@ impl rule::StyleSheet for Theme {
 pub enum Text {
     #[default]
     Default,
+    Action,
     Accent,
     Error,
     Nickname(Option<String>),
@@ -198,6 +199,9 @@ impl text::StyleSheet for Theme {
         match style {
             Text::Default => text::Appearance {
                 color: Some(self.colors.text.base),
+            },
+            Text::Action => text::Appearance {
+                color: Some(self.colors.action.base),
             },
             Text::Accent => text::Appearance {
                 color: Some(self.colors.accent.base),
@@ -226,6 +230,10 @@ pub enum Container {
         selected: bool,
     },
     PaneHeader,
+    Commands,
+    Command {
+        selected: bool,
+    },
 }
 
 impl container::StyleSheet for Theme {
@@ -257,6 +265,21 @@ impl container::StyleSheet for Theme {
                 border_radius: [4.0, 4.0, 0.0, 0.0].into(),
                 border_width: 1.0,
                 border_color: Color::TRANSPARENT,
+                ..Default::default()
+            },
+            Container::Commands => container::Appearance {
+                background: Some(Background::Color(self.colors.background.base)),
+                text_color: Some(self.colors.text.base),
+                border_radius: 4.0.into(),
+                ..Default::default()
+            },
+            Container::Command { selected } if *selected => container::Appearance {
+                background: Some(Background::Color(self.colors.background.mute_06)),
+                border_radius: 3.0.into(),
+                ..Default::default()
+            },
+            Container::Command { .. } => container::Appearance {
+                background: None,
                 ..Default::default()
             },
         }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -3,7 +3,7 @@ use iced::widget::{button, container, pane_grid, rule, scrollable, text, text_in
 use iced::{application, Background, Color};
 
 pub const TEXT_SIZE: f32 = 13.0;
-pub const ICON_SIZE: f32 = 11.0;
+pub const ICON_SIZE: f32 = 12.0;
 
 #[derive(Clone)]
 pub struct Theme {

--- a/src/widget/anchored_overlay.rs
+++ b/src/widget/anchored_overlay.rs
@@ -184,7 +184,7 @@ impl<'a, 'b, Message> overlay::Overlay<Message, Renderer> for Overlay<'a, 'b, Me
         .height(Length::Fill);
 
         let mut node = self.content.as_widget().layout(renderer, &limits);
-        node.move_to(position - Vector::new(0.0, node.size().height));
+        node.move_to(position - Vector::new(0.0, node.size().height + 4.0));
 
         node
     }

--- a/src/widget/input/completion.rs
+++ b/src/widget/input/completion.rs
@@ -2,8 +2,8 @@ use std::fmt;
 
 use iced::widget::{column, container, row, text};
 
-use crate::theme;
 use crate::widget::Element;
+use crate::{font, theme};
 
 #[derive(Debug, Clone)]
 pub struct Completion {
@@ -153,23 +153,24 @@ impl Completion {
                         .iter()
                         .enumerate()
                         .map(|(index, entry)| {
-                            // TODO: New styles
-                            let style = if Some(index) == self.selection.highlighted() {
-                                theme::Container::PaneBody { selected: true }
-                            } else {
-                                theme::Container::Primary
-                            };
+                            let selected = Some(index) == self.selection.highlighted();
+                            let content = text(format!("/{}", entry.title));
 
                             Element::from(
-                                container(text(format!("/{}", entry.title)))
-                                    .padding(8)
-                                    .style(style)
+                                container(content)
+                                    .style(theme::Container::Command { selected })
+                                    .padding(6)
                                     .center_y(),
                             )
                         })
                         .collect();
 
-                    Some(column(entries).into())
+                    Some(
+                        container(column(entries))
+                            .padding(4)
+                            .style(theme::Container::Commands)
+                            .into(),
+                    )
                 }
                 Selection::Selected(entry) => Some(entry.view(input)),
             }
@@ -223,7 +224,7 @@ impl Entry {
         });
 
         container(row(title.into_iter().chain(args).collect()))
-            .style(theme::Container::Primary)
+            .style(theme::Container::Commands)
             .padding(8)
             .center_y()
             .into()


### PR DESCRIPTION
1. Updated UI on side menu to make it a little easier to distinguish servers from channels.
    1. Sorted channels and servers alphabetical 
2. Added ability to change side on channel users. Also changed default to right to give the UI a better weight ([menu, channel, user]). Changing side is done through config, don't want to add clutter for that right now.
3. Updated styling on commands. Hardcoded a small y-offset which could turn into a config later. 

<img width="935" alt="Screenshot 2023-06-11 at 23 36 15" src="https://github.com/squidowl/halloy/assets/2248455/aa969c45-d6d8-41d8-8f82-7b6202a8cca0">
