### PR TITLE
Feat/optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,7 +1017,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.9.0"
-source = "git+https://github.com/tarkah/iced?rev=a10ef7908db941452c662616b492f0a52c853e5f#a10ef7908db941452c662616b492f0a52c853e5f"
+source = "git+https://github.com/tarkah/iced?rev=bcd8fda9a6e9c5fb1e1c6d1fa38d807c931bfebc#bcd8fda9a6e9c5fb1e1c6d1fa38d807c931bfebc"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1030,7 +1030,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.9.0"
-source = "git+https://github.com/tarkah/iced?rev=a10ef7908db941452c662616b492f0a52c853e5f#a10ef7908db941452c662616b492f0a52c853e5f"
+source = "git+https://github.com/tarkah/iced?rev=bcd8fda9a6e9c5fb1e1c6d1fa38d807c931bfebc#bcd8fda9a6e9c5fb1e1c6d1fa38d807c931bfebc"
 dependencies = [
  "bitflags 1.3.2",
  "instant",
@@ -1043,7 +1043,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.6.0"
-source = "git+https://github.com/tarkah/iced?rev=a10ef7908db941452c662616b492f0a52c853e5f#a10ef7908db941452c662616b492f0a52c853e5f"
+source = "git+https://github.com/tarkah/iced?rev=bcd8fda9a6e9c5fb1e1c6d1fa38d807c931bfebc#bcd8fda9a6e9c5fb1e1c6d1fa38d807c931bfebc"
 dependencies = [
  "futures",
  "iced_core",
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.8.0"
-source = "git+https://github.com/tarkah/iced?rev=a10ef7908db941452c662616b492f0a52c853e5f#a10ef7908db941452c662616b492f0a52c853e5f"
+source = "git+https://github.com/tarkah/iced?rev=bcd8fda9a6e9c5fb1e1c6d1fa38d807c931bfebc#bcd8fda9a6e9c5fb1e1c6d1fa38d807c931bfebc"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -1071,7 +1071,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.1.0"
-source = "git+https://github.com/tarkah/iced?rev=a10ef7908db941452c662616b492f0a52c853e5f#a10ef7908db941452c662616b492f0a52c853e5f"
+source = "git+https://github.com/tarkah/iced?rev=bcd8fda9a6e9c5fb1e1c6d1fa38d807c931bfebc#bcd8fda9a6e9c5fb1e1c6d1fa38d807c931bfebc"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -1083,7 +1083,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.1.0"
-source = "git+https://github.com/tarkah/iced?rev=a10ef7908db941452c662616b492f0a52c853e5f#a10ef7908db941452c662616b492f0a52c853e5f"
+source = "git+https://github.com/tarkah/iced?rev=bcd8fda9a6e9c5fb1e1c6d1fa38d807c931bfebc#bcd8fda9a6e9c5fb1e1c6d1fa38d807c931bfebc"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1093,7 +1093,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.8.0"
-source = "git+https://github.com/tarkah/iced?rev=a10ef7908db941452c662616b492f0a52c853e5f#a10ef7908db941452c662616b492f0a52c853e5f"
+source = "git+https://github.com/tarkah/iced?rev=bcd8fda9a6e9c5fb1e1c6d1fa38d807c931bfebc#bcd8fda9a6e9c5fb1e1c6d1fa38d807c931bfebc"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -1103,7 +1103,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.1.0"
-source = "git+https://github.com/tarkah/iced?rev=a10ef7908db941452c662616b492f0a52c853e5f#a10ef7908db941452c662616b492f0a52c853e5f"
+source = "git+https://github.com/tarkah/iced?rev=bcd8fda9a6e9c5fb1e1c6d1fa38d807c931bfebc#bcd8fda9a6e9c5fb1e1c6d1fa38d807c931bfebc"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -1120,7 +1120,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.10.0"
-source = "git+https://github.com/tarkah/iced?rev=a10ef7908db941452c662616b492f0a52c853e5f#a10ef7908db941452c662616b492f0a52c853e5f"
+source = "git+https://github.com/tarkah/iced?rev=bcd8fda9a6e9c5fb1e1c6d1fa38d807c931bfebc#bcd8fda9a6e9c5fb1e1c6d1fa38d807c931bfebc"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -1140,7 +1140,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.1.0"
-source = "git+https://github.com/tarkah/iced?rev=a10ef7908db941452c662616b492f0a52c853e5f#a10ef7908db941452c662616b492f0a52c853e5f"
+source = "git+https://github.com/tarkah/iced?rev=bcd8fda9a6e9c5fb1e1c6d1fa38d807c931bfebc#bcd8fda9a6e9c5fb1e1c6d1fa38d807c931bfebc"
 dependencies = [
  "iced_renderer",
  "iced_runtime",
@@ -1154,7 +1154,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.9.1"
-source = "git+https://github.com/tarkah/iced?rev=a10ef7908db941452c662616b492f0a52c853e5f#a10ef7908db941452c662616b492f0a52c853e5f"
+source = "git+https://github.com/tarkah/iced?rev=bcd8fda9a6e9c5fb1e1c6d1fa38d807c931bfebc#bcd8fda9a6e9c5fb1e1c6d1fa38d807c931bfebc"
 dependencies = [
  "iced_graphics",
  "iced_runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,7 +1017,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.9.0"
-source = "git+https://github.com/tarkah/iced?rev=38da9535831d4371cac0bf21282d4c1a6a82c209#38da9535831d4371cac0bf21282d4c1a6a82c209"
+source = "git+https://github.com/tarkah/iced?rev=a10ef7908db941452c662616b492f0a52c853e5f#a10ef7908db941452c662616b492f0a52c853e5f"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1030,7 +1030,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.9.0"
-source = "git+https://github.com/tarkah/iced?rev=38da9535831d4371cac0bf21282d4c1a6a82c209#38da9535831d4371cac0bf21282d4c1a6a82c209"
+source = "git+https://github.com/tarkah/iced?rev=a10ef7908db941452c662616b492f0a52c853e5f#a10ef7908db941452c662616b492f0a52c853e5f"
 dependencies = [
  "bitflags 1.3.2",
  "instant",
@@ -1043,7 +1043,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.6.0"
-source = "git+https://github.com/tarkah/iced?rev=38da9535831d4371cac0bf21282d4c1a6a82c209#38da9535831d4371cac0bf21282d4c1a6a82c209"
+source = "git+https://github.com/tarkah/iced?rev=a10ef7908db941452c662616b492f0a52c853e5f#a10ef7908db941452c662616b492f0a52c853e5f"
 dependencies = [
  "futures",
  "iced_core",
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.8.0"
-source = "git+https://github.com/tarkah/iced?rev=38da9535831d4371cac0bf21282d4c1a6a82c209#38da9535831d4371cac0bf21282d4c1a6a82c209"
+source = "git+https://github.com/tarkah/iced?rev=a10ef7908db941452c662616b492f0a52c853e5f#a10ef7908db941452c662616b492f0a52c853e5f"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -1071,7 +1071,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.1.0"
-source = "git+https://github.com/tarkah/iced?rev=38da9535831d4371cac0bf21282d4c1a6a82c209#38da9535831d4371cac0bf21282d4c1a6a82c209"
+source = "git+https://github.com/tarkah/iced?rev=a10ef7908db941452c662616b492f0a52c853e5f#a10ef7908db941452c662616b492f0a52c853e5f"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -1083,7 +1083,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.1.0"
-source = "git+https://github.com/tarkah/iced?rev=38da9535831d4371cac0bf21282d4c1a6a82c209#38da9535831d4371cac0bf21282d4c1a6a82c209"
+source = "git+https://github.com/tarkah/iced?rev=a10ef7908db941452c662616b492f0a52c853e5f#a10ef7908db941452c662616b492f0a52c853e5f"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1093,7 +1093,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.8.0"
-source = "git+https://github.com/tarkah/iced?rev=38da9535831d4371cac0bf21282d4c1a6a82c209#38da9535831d4371cac0bf21282d4c1a6a82c209"
+source = "git+https://github.com/tarkah/iced?rev=a10ef7908db941452c662616b492f0a52c853e5f#a10ef7908db941452c662616b492f0a52c853e5f"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -1103,7 +1103,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.1.0"
-source = "git+https://github.com/tarkah/iced?rev=38da9535831d4371cac0bf21282d4c1a6a82c209#38da9535831d4371cac0bf21282d4c1a6a82c209"
+source = "git+https://github.com/tarkah/iced?rev=a10ef7908db941452c662616b492f0a52c853e5f#a10ef7908db941452c662616b492f0a52c853e5f"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -1120,7 +1120,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.10.0"
-source = "git+https://github.com/tarkah/iced?rev=38da9535831d4371cac0bf21282d4c1a6a82c209#38da9535831d4371cac0bf21282d4c1a6a82c209"
+source = "git+https://github.com/tarkah/iced?rev=a10ef7908db941452c662616b492f0a52c853e5f#a10ef7908db941452c662616b492f0a52c853e5f"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -1140,7 +1140,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.1.0"
-source = "git+https://github.com/tarkah/iced?rev=38da9535831d4371cac0bf21282d4c1a6a82c209#38da9535831d4371cac0bf21282d4c1a6a82c209"
+source = "git+https://github.com/tarkah/iced?rev=a10ef7908db941452c662616b492f0a52c853e5f#a10ef7908db941452c662616b492f0a52c853e5f"
 dependencies = [
  "iced_renderer",
  "iced_runtime",
@@ -1154,7 +1154,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.9.1"
-source = "git+https://github.com/tarkah/iced?rev=38da9535831d4371cac0bf21282d4c1a6a82c209#38da9535831d4371cac0bf21282d4c1a6a82c209"
+source = "git+https://github.com/tarkah/iced?rev=a10ef7908db941452c662616b492f0a52c853e5f#a10ef7908db941452c662616b492f0a52c853e5f"
 dependencies = [
  "iced_graphics",
  "iced_runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ features = ["v4"]
 members = ["data"]
 
 [patch.crates-io]
-iced = { git = "https://github.com/tarkah/iced", rev = "a10ef7908db941452c662616b492f0a52c853e5f" }
+iced = { git = "https://github.com/tarkah/iced", rev = "bcd8fda9a6e9c5fb1e1c6d1fa38d807c931bfebc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ features = ["v4"]
 members = ["data"]
 
 [patch.crates-io]
-iced = { git = "https://github.com/tarkah/iced", rev = "38da9535831d4371cac0bf21282d4c1a6a82c209" }
+iced = { git = "https://github.com/tarkah/iced", rev = "a10ef7908db941452c662616b492f0a52c853e5f" }

--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -15,4 +15,5 @@ pub mod message;
 pub mod palette;
 pub mod server;
 pub mod stream;
+pub mod time;
 pub mod user;

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -93,3 +93,37 @@ fn text(message: &irc::proto::Message) -> Option<String> {
         _ => None,
     }
 }
+
+#[derive(Debug, Clone, Copy)]
+pub enum Limit {
+    Top(usize),
+    Bottom(usize),
+}
+
+impl Default for Limit {
+    fn default() -> Self {
+        Self::Bottom(500)
+    }
+}
+
+impl Limit {
+    pub const DEFAULT_STEP: usize = 50;
+
+    pub fn value(self) -> usize {
+        match self {
+            Limit::Top(i) => i,
+            Limit::Bottom(i) => i,
+        }
+    }
+
+    fn value_mut(&mut self) -> &mut usize {
+        match self {
+            Limit::Top(i) => i,
+            Limit::Bottom(i) => i,
+        }
+    }
+
+    pub fn increase(&mut self, n: usize) {
+        *self.value_mut() += n;
+    }
+}

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -3,7 +3,7 @@ use irc::proto::ChannelExt;
 
 use crate::User;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Source {
     Server,
     Channel(String, User),

--- a/data/src/time.rs
+++ b/data/src/time.rs
@@ -1,0 +1,15 @@
+use std::time::SystemTime;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Posix(u64);
+
+impl Posix {
+    pub fn now() -> Self {
+        let nanos_since_epoch = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("valid unix timestamp")
+            .as_nanos() as u64;
+
+        Self(nanos_since_epoch)
+    }
+}

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -1,9 +1,21 @@
+use std::hash::Hash;
+
 use irc::client::data;
 
 use crate::config;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct User(data::User);
+
+impl Eq for User {}
+
+impl Hash for User {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.get_nickname().hash(state);
+        self.0.get_username().hash(state);
+        self.0.get_hostname().hash(state);
+    }
+}
 
 impl User {
     pub fn new(nick: &str, user: Option<&str>, host: Option<&str>) -> Self {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -74,6 +74,8 @@ impl Buffer {
         }
     }
 
+    // TODO: Placeholder in case we need
+    #[allow(unused)]
     pub fn get_server(&self, server: &data::Server) -> Option<&Server> {
         if let Buffer::Server(state) = self {
             (&state.server == server).then_some(state)
@@ -82,6 +84,8 @@ impl Buffer {
         }
     }
 
+    // TODO: Placeholder in case we need
+    #[allow(unused)]
     pub fn get_channel(&self, server: &data::Server, channel: &str) -> Option<&Channel> {
         if let Buffer::Channel(state) = self {
             (&state.server == server && state.channel.as_str() == channel).then_some(state)

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -7,6 +7,7 @@ use crate::widget::Element;
 
 pub mod channel;
 pub mod empty;
+mod scroll_view;
 pub mod server;
 
 #[derive(Clone)]
@@ -56,17 +57,17 @@ impl Buffer {
 
     pub fn view<'a>(
         &'a self,
-        clients: &data::client::Map,
-        config: &data::config::Config,
+        clients: &'a data::client::Map,
+        config: &'a data::config::Config,
         is_focused: bool,
     ) -> Element<'a, Message> {
         match self {
             Buffer::Empty(state) => empty::view(state, clients).map(Message::Empty),
             Buffer::Channel(state) => {
-                let user_colors = config.user_colors.clone();
+                let user_colors = &config.user_colors;
                 let config = config.channel_config(&state.server.name, &state.channel);
 
-                channel::view(state, clients, &config, &user_colors, is_focused)
+                channel::view(state, clients, &config, user_colors, is_focused)
                     .map(Message::Channel)
             }
             Buffer::Server(state) => server::view(state, clients, is_focused).map(Message::Server),

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -147,13 +147,7 @@ impl Channel {
                         clients.send_command(&self.server, command);
                     }
                 }
-                return (
-                    scrollable::snap_to(
-                        self.messages.scrollable.clone(),
-                        scrollable::RelativeOffset::END,
-                    ),
-                    None,
-                );
+                return (Command::none(), None);
             }
             Message::CompletionSelected => {
                 return (input::move_cursor_to_end(self.input_id.clone()), None);

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -27,7 +27,7 @@ pub fn view<'a>(
 ) -> Element<'a, Message> {
     let messages = container(
         scroll_view::view(
-            &state.messages,
+            &state.scroll_view,
             scroll_view::Kind::Channel(&state.server, &state.channel),
             clients,
             |message| {
@@ -117,7 +117,7 @@ pub struct Channel {
     pub server: Server,
     pub channel: String,
     pub topic: Option<String>,
-    pub messages: scroll_view::State,
+    pub scroll_view: scroll_view::State,
     input_id: input::Id,
 }
 
@@ -127,7 +127,7 @@ impl Channel {
             server,
             channel,
             topic: None,
-            messages: scroll_view::State::new(),
+            scroll_view: scroll_view::State::new(),
             input_id: input::Id::unique(),
         }
     }
@@ -147,13 +147,16 @@ impl Channel {
                         clients.send_command(&self.server, command);
                     }
                 }
-                return (Command::none(), None);
+                return (
+                    self.scroll_view.scroll_to_end().map(Message::ScrollView),
+                    None,
+                );
             }
             Message::CompletionSelected => {
                 return (input::move_cursor_to_end(self.input_id.clone()), None);
             }
             Message::ScrollView(message) => {
-                let command = self.messages.update(message);
+                let command = self.scroll_view.update(message);
                 (command.map(Message::ScrollView), None)
             }
         }

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -4,6 +4,7 @@ use data::server::Server;
 use iced::widget::{column, container, row, scrollable, text, vertical_space};
 use iced::{Command, Length};
 
+use super::scroll_view;
 use crate::theme;
 use crate::widget::{input, selectable_text, Collection, Column, Element};
 
@@ -11,42 +12,38 @@ use crate::widget::{input, selectable_text, Collection, Column, Element};
 pub enum Message {
     Send(input::Content),
     CompletionSelected,
+    ScrollView(scroll_view::Message),
 }
 
 #[derive(Debug, Clone)]
 pub enum Event {}
 
 pub fn view<'a>(
-    state: &Channel,
-    clients: &data::client::Map,
+    state: &'a Channel,
+    clients: &'a data::client::Map,
     config: &data::channel::Config,
-    user_colors: &data::config::UserColor,
+    user_colors: &'a data::config::UserColor,
     is_focused: bool,
 ) -> Element<'a, Message> {
-    let messages: Vec<Element<'a, Message>> = clients
-        .get_channel_messages(&state.server, &state.channel)
-        .into_iter()
-        .filter_map(|message| {
-            let user = message.user()?;
-
-            Some(
-                container(row![
-                    selectable_text(format!("<{}> ", user.nickname()))
-                        .style(theme::Text::Nickname(user.color_seed(user_colors))),
-                    selectable_text(&message.text)
-                ])
-                .into(),
-            )
-        })
-        .collect();
-
     let messages = container(
-        scrollable(
-            Column::with_children(messages)
-                .width(Length::Fill)
-                .padding([0, 8]),
+        scroll_view::view(
+            &state.messages,
+            scroll_view::Kind::Channel(&state.server, &state.channel),
+            clients,
+            |message| {
+                let user = message.user()?;
+
+                Some(
+                    container(row![
+                        selectable_text(format!("<{}> ", user.nickname()))
+                            .style(theme::Text::Nickname(user.color_seed(user_colors))),
+                        selectable_text(&message.text)
+                    ])
+                    .into(),
+                )
+            },
         )
-        .id(state.scrollable.clone()),
+        .map(Message::ScrollView),
     )
     .width(Length::FillPortion(2))
     .height(Length::Fill);
@@ -120,7 +117,7 @@ pub struct Channel {
     pub server: Server,
     pub channel: String,
     pub topic: Option<String>,
-    pub scrollable: scrollable::Id,
+    pub messages: scroll_view::State,
     input_id: input::Id,
 }
 
@@ -130,7 +127,7 @@ impl Channel {
             server,
             channel,
             topic: None,
-            scrollable: scrollable::Id::unique(),
+            messages: scroll_view::State::new(),
             input_id: input::Id::unique(),
         }
     }
@@ -151,12 +148,19 @@ impl Channel {
                     }
                 }
                 return (
-                    scrollable::snap_to(self.scrollable.clone(), scrollable::RelativeOffset::END),
+                    scrollable::snap_to(
+                        self.messages.scrollable.clone(),
+                        scrollable::RelativeOffset::END,
+                    ),
                     None,
                 );
             }
             Message::CompletionSelected => {
                 return (input::move_cursor_to_end(self.input_id.clone()), None);
+            }
+            Message::ScrollView(message) => {
+                let command = self.messages.update(message);
+                (command.map(Message::ScrollView), None)
             }
         }
     }

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -1,0 +1,77 @@
+use data::client;
+use data::message::Limit;
+use data::server::Server;
+use iced::widget::scrollable;
+use iced::{Command, Length};
+
+use crate::widget::{Column, Element};
+
+#[derive(Debug, Clone)]
+pub enum Message {
+    Scrolled(scrollable::Viewport),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Kind<'a> {
+    Server(&'a Server),
+    Channel(&'a Server, &'a str),
+}
+
+pub fn view<'a>(
+    state: &State,
+    kind: Kind,
+    clients: &'a client::Map,
+    format: impl Fn(&'a data::Message) -> Option<Element<'a, Message>> + 'a,
+) -> Element<'a, Message> {
+    let messages = match kind {
+        Kind::Server(server) => clients.get_server_messages(server, Some(state.limit)),
+        Kind::Channel(server, channel) => {
+            clients.get_channel_messages(server, channel, Some(state.limit))
+        }
+    };
+    let at_limit = messages.len() == state.limit.value();
+
+    let messages: Vec<_> = messages.into_iter().filter_map(format).collect();
+
+    let mut scrollable = scrollable(
+        Column::with_children(messages)
+            .width(Length::Fill)
+            .padding([0, 8]),
+    )
+    .id(state.scrollable.clone());
+
+    if at_limit {
+        scrollable = scrollable.on_scroll(Message::Scrolled)
+    }
+
+    scrollable.into()
+}
+
+#[derive(Debug, Clone)]
+pub struct State {
+    pub scrollable: scrollable::Id,
+    limit: Limit,
+}
+
+impl State {
+    pub fn new() -> Self {
+        Self {
+            scrollable: scrollable::Id::unique(),
+            limit: Limit::default(),
+        }
+    }
+
+    pub fn update(&mut self, message: Message) -> Command<Message> {
+        match message {
+            Message::Scrolled(_viewport) => {
+                // TODO: Need a proper reversed scrollable to get this
+                // behavior working
+                // if viewport.absolute_offset().y == 0.0 {
+                //     self.limit.increase(Limit::DEFAULT_STEP)
+                // }
+
+                Command::none()
+            }
+        }
+    }
+}

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -38,6 +38,7 @@ pub fn view<'a>(
             .width(Length::Fill)
             .padding([0, 8]),
     )
+    .vertical_scroll(scrollable::Properties::default().alignment(scrollable::Alignment::End))
     .id(state.scrollable.clone());
 
     if at_limit {

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -1,6 +1,6 @@
-use data::client;
 use data::message::Limit;
 use data::server::Server;
+use data::{client, time};
 use iced::widget::scrollable;
 use iced::{Command, Length};
 
@@ -8,7 +8,12 @@ use crate::widget::{Column, Element};
 
 #[derive(Debug, Clone)]
 pub enum Message {
-    Scrolled(scrollable::Viewport),
+    Scrolled {
+        count: usize,
+        remaining: bool,
+        oldest: time::Posix,
+        viewport: scrollable::Viewport,
+    },
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -23,35 +28,41 @@ pub fn view<'a>(
     clients: &'a client::Map,
     format: impl Fn(&'a data::Message) -> Option<Element<'a, Message>> + 'a,
 ) -> Element<'a, Message> {
-    let messages = match kind {
+    let (total, messages) = match kind {
         Kind::Server(server) => clients.get_server_messages(server, Some(state.limit)),
         Kind::Channel(server, channel) => {
             clients.get_channel_messages(server, channel, Some(state.limit))
         }
     };
-    let at_limit = messages.len() == state.limit.value();
 
-    let messages: Vec<_> = messages.into_iter().filter_map(format).collect();
+    let count = messages.len();
+    let remaining = count < total;
+    let oldest = messages
+        .first()
+        .map(|message| message.timestamp)
+        .unwrap_or_else(|| time::Posix::now());
 
-    let mut scrollable = scrollable(
-        Column::with_children(messages)
+    scrollable(
+        Column::with_children(messages.into_iter().filter_map(format).collect())
             .width(Length::Fill)
             .padding([0, 8]),
     )
-    .vertical_scroll(scrollable::Properties::default().alignment(scrollable::Alignment::End))
-    .id(state.scrollable.clone());
-
-    if at_limit {
-        scrollable = scrollable.on_scroll(Message::Scrolled)
-    }
-
-    scrollable.into()
+    .vertical_scroll(scrollable::Properties::default().alignment(state.anchor.alignment()))
+    .on_scroll(move |viewport| Message::Scrolled {
+        count,
+        remaining,
+        oldest,
+        viewport,
+    })
+    .id(state.scrollable.clone())
+    .into()
 }
 
 #[derive(Debug, Clone)]
 pub struct State {
     pub scrollable: scrollable::Id,
     limit: Limit,
+    anchor: Anchor,
 }
 
 impl State {
@@ -59,20 +70,118 @@ impl State {
         Self {
             scrollable: scrollable::Id::unique(),
             limit: Limit::default(),
+            anchor: Anchor::default(),
         }
     }
 
     pub fn update(&mut self, message: Message) -> Command<Message> {
         match message {
-            Message::Scrolled(_viewport) => {
-                // TODO: Need a proper reversed scrollable to get this
-                // behavior working
-                // if viewport.absolute_offset().y == 0.0 {
-                //     self.limit.increase(Limit::DEFAULT_STEP)
-                // }
+            Message::Scrolled {
+                count,
+                remaining,
+                oldest,
+                viewport,
+            } => {
+                let old_anchor = self.anchor;
+                let relative_offset = viewport.relative_offset().y;
 
-                Command::none()
+                match old_anchor {
+                    _ if old_anchor.is_top(relative_offset) && remaining => {
+                        self.anchor = Anchor::Loading;
+                        self.limit = Limit::Bottom(count + Limit::DEFAULT_STEP);
+                    }
+                    _ if old_anchor.is_bottom(relative_offset) => {
+                        self.anchor = Anchor::Bottom;
+                        self.limit = Limit::default();
+                    }
+                    Anchor::Bottom if !old_anchor.is_bottom(relative_offset) => {
+                        self.anchor = Anchor::Unlocked;
+                        self.limit = Limit::Since(oldest);
+                    }
+                    Anchor::Loading => {
+                        self.anchor = Anchor::Unlocked;
+                        self.limit = Limit::Since(oldest);
+                    }
+                    Anchor::Unlocked | Anchor::Bottom => {}
+                }
+
+                if let Some(new_offset) = self.anchor.new_offset(old_anchor, viewport) {
+                    return scrollable::scroll_to(self.scrollable.clone(), new_offset);
+                }
             }
         }
+
+        Command::none()
+    }
+
+    pub fn scroll_to_end(&mut self) -> Command<Message> {
+        self.anchor = Anchor::Bottom;
+        self.limit = Limit::default();
+        scrollable::scroll_to(
+            self.scrollable.clone(),
+            scrollable::AbsoluteOffset { x: 0.0, y: 0.0 },
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Anchor {
+    // TODO: Add top anchor (cmd + home behavior)
+    Bottom,
+    Unlocked,
+    Loading,
+}
+
+impl Anchor {
+    fn alignment(self) -> scrollable::Alignment {
+        match self {
+            Anchor::Bottom => scrollable::Alignment::End,
+            Anchor::Unlocked => scrollable::Alignment::Start,
+            Anchor::Loading => scrollable::Alignment::End,
+        }
+    }
+
+    fn is_top(self, relative_offset: f32) -> bool {
+        match self.alignment() {
+            scrollable::Alignment::Start => relative_offset == 0.0,
+            scrollable::Alignment::End => relative_offset == 1.0,
+        }
+    }
+
+    fn is_bottom(self, relative_offset: f32) -> bool {
+        match self.alignment() {
+            scrollable::Alignment::Start => relative_offset == 1.0,
+            scrollable::Alignment::End => relative_offset == 0.0,
+        }
+    }
+
+    fn new_offset(
+        self,
+        other: Self,
+        viewport: scrollable::Viewport,
+    ) -> Option<scrollable::AbsoluteOffset> {
+        let old = self.alignment();
+        let new = other.alignment();
+
+        let absolute_offset = viewport.absolute_offset();
+
+        if old != new {
+            let scrollable::AbsoluteOffset { x, y } = absolute_offset;
+
+            let scroll_height = (viewport.content_bounds.height - viewport.bounds.height).max(0.0);
+
+            Some(scrollable::AbsoluteOffset {
+                x,
+                y: (scroll_height - y).max(0.0),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl Default for Anchor {
+    fn default() -> Self {
+        Self::Bottom
     }
 }

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -77,13 +77,7 @@ impl Server {
             Message::Send(content) => {
                 if let input::Content::Command(command) = content {
                     clients.send_command(&self.server, command);
-                    (
-                        scrollable::snap_to(
-                            self.messages.scrollable.clone(),
-                            scrollable::RelativeOffset::END,
-                        ),
-                        None,
-                    )
+                    (Command::none(), None)
                 } else {
                     (Command::none(), None)
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,16 +155,18 @@ impl Application for Halloy {
 
                     Command::none()
                 }
-                stream::Event::MessageReceived(server, message) => {
-                    let Some(source) = self.clients.add_message(&server, message) else {
-                        return Command::none();
-                    };
-                    let Screen::Dashboard(dashboard) = &self.screen;
-
-                    dashboard
-                        .message_received(&server, source)
-                        .map(Message::Dashboard)
-                }
+                stream::Event::MessagesReceived(messages) => Command::batch(
+                    self.clients
+                        .add_messages(messages)
+                        .into_iter()
+                        .map(|(server, source)| {
+                            let Screen::Dashboard(dashboard) = &self.screen;
+                            dashboard
+                                .message_received(&server, source)
+                                .map(Message::Dashboard)
+                        })
+                        .collect::<Vec<_>>(),
+                ),
             },
             Message::Stream(Err(error)) => {
                 log::error!("{:?}", error);

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -278,8 +278,8 @@ impl Dashboard {
 
     pub fn view<'a>(
         &'a self,
-        clients: &data::client::Map,
-        config: &data::config::Config,
+        clients: &'a data::client::Map,
+        config: &'a data::config::Config,
     ) -> Element<'a, Message> {
         let focus = self.focus;
 
@@ -358,7 +358,7 @@ impl Dashboard {
                     .find_map(|(_, pane)| pane.buffer.get_server(server))
                 {
                     return scrollable::snap_to(
-                        server.scrollable.clone(),
+                        server.messages.scrollable.clone(),
                         scrollable::RelativeOffset::END,
                     );
                 }
@@ -370,7 +370,7 @@ impl Dashboard {
                     .find_map(|(_, pane)| pane.buffer.get_channel(server, channel))
                 {
                     return scrollable::snap_to(
-                        channel.scrollable.clone(),
+                        channel.messages.scrollable.clone(),
                         scrollable::RelativeOffset::END,
                     );
                 }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -350,35 +350,6 @@ impl Dashboard {
         server: &data::Server,
         source: message::Source,
     ) -> Command<Message> {
-        match &source {
-            message::Source::Server => {
-                if let Some(server) = self
-                    .panes
-                    .iter()
-                    .find_map(|(_, pane)| pane.buffer.get_server(server))
-                {
-                    return scrollable::snap_to(
-                        server.messages.scrollable.clone(),
-                        scrollable::RelativeOffset::END,
-                    );
-                }
-            }
-            message::Source::Channel(channel, _) => {
-                if let Some(channel) = self
-                    .panes
-                    .iter()
-                    .find_map(|(_, pane)| pane.buffer.get_channel(server, channel))
-                {
-                    return scrollable::snap_to(
-                        channel.messages.scrollable.clone(),
-                        scrollable::RelativeOffset::END,
-                    );
-                }
-            }
-            // TODO:
-            message::Source::Private(_) => {}
-        }
-
         Command::none()
     }
 

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -4,7 +4,7 @@ pub mod side_menu;
 use data::config::Config;
 use data::message;
 use iced::widget::pane_grid::{self, PaneGrid};
-use iced::widget::{container, row, scrollable};
+use iced::widget::{container, row};
 use iced::{clipboard, keyboard, Command, Length};
 use pane::Pane;
 use side_menu::SideMenu;
@@ -347,9 +347,10 @@ impl Dashboard {
 
     pub fn message_received(
         &self,
-        server: &data::Server,
-        source: message::Source,
+        _server: &data::Server,
+        _source: message::Source,
     ) -> Command<Message> {
+        // TODO: Placeholder for message related hooks
         Command::none()
     }
 

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -49,8 +49,8 @@ impl Pane {
         panes: usize,
         is_focused: bool,
         maximized: bool,
-        clients: &data::client::Map,
-        config: &data::config::Config,
+        clients: &'a data::client::Map,
+        config: &'a data::config::Config,
     ) -> widget::Content<'a, M> {
         let title_bar_text = match &self.buffer {
             Buffer::Empty(state) => state.to_string(),


### PR DESCRIPTION
Optimizes two different things

Adds message batching to reduce number of Messages app has to `update`

Refactors the buffer scrollable to a new `scroll_view` module which now handles the following:

- A new Limit to limit how many messages we render
- Scrollable alignment settings to align to bottom by default, but then handle switching alignment for desired scrolling behavior when "lazy loading" older messages
- Bumping limit / displaying more messages when top of scrollable is hit
- If user scrolls away from bottom, the viewport will stay where it's at when new messages come in so the user isn't pulled away from the messages they were looking at
- Scroll to bottom when user submits a new message.

You can test this scroll_view behavior by issuing a `/list` command and scrolling up while looking at scrollabar, you'll notice the new messages "loading" and displaying seamlessly 

