### PR TITLE
Fix query messages

### DIFF
--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -1,8 +1,9 @@
-use crate::{Server, User};
+use crate::user::Nick;
+use crate::Server;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Buffer {
     Server(Server),
     Channel(Server, String),
-    Query(Server, User),
+    Query(Server, Nick),
 }

--- a/data/src/command.rs
+++ b/data/src/command.rs
@@ -8,6 +8,7 @@ pub enum Kind {
     Motd,
     Nick,
     Quit,
+    PrivMsg,
 }
 
 impl FromStr for Kind {
@@ -19,6 +20,7 @@ impl FromStr for Kind {
             "motd" => Ok(Kind::Motd),
             "nick" => Ok(Kind::Nick),
             "quit" => Ok(Kind::Quit),
+            "privmsg" => Ok(Kind::PrivMsg),
             _ => Err(()),
         }
     }
@@ -30,6 +32,7 @@ pub enum Command {
     Motd(Option<String>),
     Nick(String),
     Quit(Option<String>),
+    PrivMsg(String, String),
     Unknown(String, Vec<String>),
 }
 
@@ -56,6 +59,9 @@ impl FromStr for Command {
                 Kind::Motd => validated::<0, 1>(args, |_, [target]| Command::Motd(target)),
                 Kind::Nick => validated::<1, 0>(args, |[nick], _| Command::Nick(nick)),
                 Kind::Quit => validated::<0, 1>(args, |_, [comment]| Command::Quit(comment)),
+                Kind::PrivMsg => {
+                    validated::<2, 0>(args, |[target, msg], []| Command::PrivMsg(target, msg))
+                }
             },
             Err(_) => Ok(Command::Unknown(
                 cmd.to_string(),
@@ -107,6 +113,7 @@ impl TryFrom<Command> for proto::Command {
             Command::Motd(target) => proto::Command::MOTD(target),
             Command::Nick(nick) => proto::Command::NICK(nick),
             Command::Quit(comment) => proto::Command::QUIT(comment),
+            Command::PrivMsg(target, msg) => proto::Command::PRIVMSG(target, msg),
             Command::Unknown(command, args) => {
                 let args = args.iter().map(|arg| arg.as_str()).collect();
 

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -8,7 +8,8 @@ use tokio::fs;
 use tokio::time::Instant;
 
 pub use self::manager::{Manager, Resource};
-use crate::{compression, message, server, Message, User};
+use crate::user::Nick;
+use crate::{compression, message, server, Message};
 
 pub mod manager;
 
@@ -20,7 +21,7 @@ const FLUSH_AFTER_LAST_RECEIVED: Duration = Duration::from_secs(5);
 pub enum Kind {
     Server,
     Channel(String),
-    Query(User),
+    Query(Nick),
 }
 
 impl fmt::Display for Kind {
@@ -28,7 +29,7 @@ impl fmt::Display for Kind {
         match self {
             Kind::Server => write!(f, "server"),
             Kind::Channel(channel) => write!(f, "channel {channel}"),
-            Kind::Query(user) => write!(f, "user {}", user.nickname()),
+            Kind::Query(nick) => write!(f, "user {}", nick),
         }
     }
 }
@@ -38,7 +39,7 @@ impl From<message::Source> for Kind {
         match source {
             message::Source::Server => Kind::Server,
             message::Source::Channel(channel, _) => Kind::Channel(channel),
-            message::Source::Query(user) => Kind::Query(user),
+            message::Source::Query(user, _) => Kind::Query(user),
         }
     }
 }
@@ -95,7 +96,7 @@ async fn path(server: &server::Name, kind: &Kind) -> Result<PathBuf, Error> {
     let name = match kind {
         Kind::Server => format!("{server}"),
         Kind::Channel(channel) => format!("{server}channel{channel}"),
-        Kind::Query(user) => format!("{server}nickname{}", user.nickname()),
+        Kind::Query(nick) => format!("{server}nickname{}", nick),
     };
     let hashed_name = seahash::hash(name.as_bytes());
 

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -139,7 +139,7 @@ impl Manager {
         messages
             .into_iter()
             .filter_map(|(server, message)| {
-                log::debug!("Message received => {message:?}");
+                // log::debug!("Message received => {message:?}");
 
                 let connection = clients.connection_mut(&server)?;
                 connection.handle_message(&message);

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -48,7 +48,7 @@ impl Buffer {
             Buffer::Server(state) => Some(data::Buffer::Server(state.server.clone())),
             Buffer::Query(state) => Some(data::Buffer::Query(
                 state.server.clone(),
-                state.user.clone(),
+                state.nick.clone(),
             )),
         }
     }
@@ -69,12 +69,12 @@ impl Buffer {
                 (command.map(Message::Channel), event.map(Event::Channel))
             }
             (Buffer::Server(state), Message::Server(message)) => {
-                let (command, event) = state.update(message, clients);
+                let (command, event) = state.update(message, clients, history);
 
                 (command.map(Message::Server), event.map(Event::Server))
             }
             (Buffer::Query(state), Message::Query(message)) => {
-                let (command, event) = state.update(message, clients);
+                let (command, event) = state.update(message, clients, history);
 
                 (command.map(Message::Query), event.map(Event::Query))
             }

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -148,13 +148,15 @@ impl Channel {
                 match content {
                     input::Content::Text(message) => {
                         if let Some(message) =
-                            clients.send_privmsg(&self.server, &self.channel, &message)
+                            clients.send_channel_message(&self.server, &self.channel, &message)
                         {
                             history.add_message(&self.server, message);
                         }
                     }
                     input::Content::Command(command) => {
-                        clients.send_command(&self.server, command);
+                        if let Some(message) = clients.send_command(&self.server, command) {
+                            history.add_message(&self.server, message);
+                        }
                     }
                 }
 

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -1,6 +1,7 @@
 use data::message::Limit;
 use data::server::Server;
-use data::{history, time, User};
+use data::user::Nick;
+use data::{history, time};
 use iced::widget::scrollable;
 use iced::{Command, Length};
 
@@ -20,7 +21,7 @@ pub enum Message {
 pub enum Kind<'a> {
     Server(&'a Server),
     Channel(&'a Server, &'a str),
-    Query(&'a Server, &'a User),
+    Query(&'a Server, &'a Nick),
 }
 
 pub fn view<'a>(

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -73,11 +73,15 @@ impl Server {
         &mut self,
         message: Message,
         clients: &mut data::client::Map,
+        history: &mut history::Manager,
     ) -> (Command<Message>, Option<Event>) {
         match message {
             Message::Send(content) => {
                 if let input::Content::Command(command) = content {
-                    clients.send_command(&self.server, command);
+                    if let Some(message) = clients.send_command(&self.server, command) {
+                        history.add_message(&self.server, message);
+                    }
+
                     (
                         self.scroll_view.scroll_to_end().map(Message::ScrollView),
                         None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,7 +190,7 @@ impl Application for Halloy {
                 stream::Event::MessagesReceived(messages) => {
                     let Screen::Dashboard(dashboard) = &mut self.screen;
                     dashboard
-                        .messages_received(messages)
+                        .messages_received(messages, &mut self.clients)
                         .map(Message::Dashboard)
                 }
             },

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -331,8 +331,12 @@ impl Dashboard {
         }
     }
 
-    pub fn messages_received(&mut self, messages: Vec<(Server, message::Raw)>) -> Command<Message> {
-        let _ = self.history.add_raw_messages(messages);
+    pub fn messages_received(
+        &mut self,
+        messages: Vec<(Server, message::Raw)>,
+        clients: &mut data::client::Map,
+    ) -> Command<Message> {
+        let _ = self.history.add_raw_messages(messages, clients);
         Command::none()
     }
 

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -90,7 +90,7 @@ impl Pane {
             }),
             Buffer::Query(query) => Some(history::Resource {
                 server: query.server.name.clone(),
-                kind: history::Kind::Query(query.user.clone()),
+                kind: history::Kind::Query(query.nick.clone()),
             }),
         }
     }

--- a/src/screen/dashboard/side_menu.rs
+++ b/src/screen/dashboard/side_menu.rs
@@ -123,7 +123,7 @@ fn buffer_button<'a>(
         Buffer::Channel(_, channel) => row![horizontal_space(4), icon::chat(), text(channel)]
             .spacing(8)
             .align_items(iced::Alignment::Center),
-        Buffer::Query(_, user) => row![horizontal_space(4), icon::person(), text(user.nickname())]
+        Buffer::Query(_, nick) => row![horizontal_space(4), icon::person(), text(nick)]
             .spacing(8)
             .align_items(iced::Alignment::Center),
     };


### PR DESCRIPTION
Fixes query messages in the following ways:

- Only ties nick to the query source 
- Adds a user field so we know who sent the message in the query buffer (us vs them)
- Ensures the privmsg target matches our nick
- Update our nickname when REPL_WELCOME or NICK messages come over the wire

I've also hooked into `send_command` to dispatch the `send_user_message` when `/privmsg` is used and return a message we can record to history. This will ensure the buffer is viewable from the sidebar when initially sending a query message to someone.