### PR TITLE
Add support for /me

### DIFF
--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -7,3 +7,13 @@ pub enum Buffer {
     Channel(Server, String),
     Query(Server, Nick),
 }
+
+impl Buffer {
+    pub fn target(&self) -> Option<String> {
+        match self {
+            Buffer::Server(_) => None,
+            Buffer::Channel(_, channel) => Some(channel.clone()),
+            Buffer::Query(_, nick) => Some(nick.to_string()),
+        }
+    }
+}

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -41,7 +41,7 @@ impl Connection {
         let our_user = User::new(self.nickname(), None, None);
 
         let (text, sender) = if let Some(action) = message::action_text(&self.nickname(), &text) {
-            (action, message::Sender::Server)
+            (action, message::Sender::Action)
         } else {
             (text, message::Sender::User(our_user))
         };

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -21,6 +21,7 @@ pub enum Source {
 pub enum Sender {
     User(User),
     Server,
+    Action,
 }
 
 impl Sender {
@@ -28,6 +29,7 @@ impl Sender {
         match self {
             Sender::User(user) => Some(user),
             Sender::Server => None,
+            Sender::Action => None,
         }
     }
 }
@@ -123,7 +125,7 @@ fn source(message: irc::proto::Message, our_nick: &Nick) -> Option<Source> {
             let is_action = is_action(&text);
             let sender = |user| {
                 if is_action {
-                    Sender::Server
+                    Sender::Action
                 } else {
                     Sender::User(user)
                 }
@@ -322,10 +324,10 @@ impl Limit {
 }
 
 fn is_action(text: &str) -> bool {
-    text.starts_with("\u{1}ACTION ") && text.ends_with("\u{1}")
+    text.starts_with("\u{1}ACTION ") && text.ends_with('\u{1}')
 }
 
 pub fn action_text(nick: &Nick, text: &str) -> Option<String> {
-    let action = text.strip_prefix("\u{1}ACTION ")?.strip_suffix("\u{1}")?;
+    let action = text.strip_prefix("\u{1}ACTION ")?.strip_suffix('\u{1}')?;
     Some(format!(" ∙ {nick} {action}"))
 }

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -13,23 +13,21 @@ pub type Channel = String;
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Source {
     Server,
-    Channel(Channel, ChannelSender),
-    Query(Nick, User),
+    Channel(Channel, Sender),
+    Query(Nick, Sender),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum ChannelSender {
-    /// `ChannelSender::User(_)` is coming from another client.
+pub enum Sender {
     User(User),
-    /// `ChannelSender::Server()` is from the server, targeting a channel.
     Server,
 }
 
-impl ChannelSender {
+impl Sender {
     pub fn user(&self) -> Option<&User> {
         match self {
-            ChannelSender::User(user) => Some(user),
-            ChannelSender::Server => None,
+            Sender::User(user) => Some(user),
+            Sender::Server => None,
         }
     }
 }
@@ -69,7 +67,7 @@ impl Message {
         match &self.source {
             Source::Server => None,
             Source::Channel(_, kind) => kind.user(),
-            Source::Query(_, user) => Some(user),
+            Source::Query(_, kind) => kind.user(),
         }
     }
 
@@ -113,23 +111,30 @@ fn source(message: irc::proto::Message, our_nick: &Nick) -> Option<Source> {
         | proto::Command::ChannelMODE(channel, _)
         | proto::Command::KICK(channel, _, _)
         | proto::Command::SAJOIN(_, channel)
-        | proto::Command::JOIN(channel, _, _) => {
-            Some(Source::Channel(channel, ChannelSender::Server))
-        }
+        | proto::Command::JOIN(channel, _, _) => Some(Source::Channel(channel, Sender::Server)),
         proto::Command::Response(
             proto::Response::RPL_TOPIC | proto::Response::RPL_TOPICWHOTIME,
             params,
         ) => {
             let channel = params.get(1)?.clone();
-            Some(Source::Channel(channel, ChannelSender::Server))
+            Some(Source::Channel(channel, Sender::Server))
         }
-        proto::Command::PRIVMSG(target, _) | proto::Command::NOTICE(target, _) => {
+        proto::Command::PRIVMSG(target, text) | proto::Command::NOTICE(target, text) => {
+            let is_action = is_action(&text);
+            let sender = |user| {
+                if is_action {
+                    Sender::Server
+                } else {
+                    Sender::User(user)
+                }
+            };
+
             match (target.is_channel_name(), user) {
-                (true, Some(user)) => Some(Source::Channel(target, ChannelSender::User(user))),
+                (true, Some(user)) => Some(Source::Channel(target, sender(user))),
                 (false, Some(user)) => {
                     let target = User::try_from(target.as_str()).ok()?.nickname();
 
-                    (&target == our_nick).then(|| Source::Query(user.nickname(), user))
+                    (&target == our_nick).then(|| Source::Query(user.nickname(), sender(user)))
                 }
                 _ => None,
             }
@@ -241,7 +246,17 @@ fn text(message: &irc::proto::Message, our_nick: &Nick) -> Option<String> {
 
             Some(format!(" ∙ {user} sets mode {modes}"))
         }
-        proto::Command::PRIVMSG(_, text) | proto::Command::NOTICE(_, text) => Some(text.clone()),
+        proto::Command::PRIVMSG(_, text) => {
+            // Check if a synthetic action message
+            if let Some(nick) = user.as_ref().map(User::nickname) {
+                if let Some(action) = action_text(&nick, text) {
+                    return Some(action);
+                }
+            }
+
+            Some(text.clone())
+        }
+        proto::Command::NOTICE(_, text) => Some(text.clone()),
         proto::Command::Response(proto::Response::RPL_TOPIC, params) => {
             let topic = params.get(2)?;
 
@@ -304,4 +319,13 @@ impl Limit {
             *value += n;
         }
     }
+}
+
+fn is_action(text: &str) -> bool {
+    text.starts_with("\u{1}ACTION ") && text.ends_with("\u{1}")
+}
+
+pub fn action_text(nick: &Nick, text: &str) -> Option<String> {
+    let action = text.strip_prefix("\u{1}ACTION ")?.strip_suffix("\u{1}")?;
+    Some(format!(" ∙ {nick} {action}"))
 }

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -56,6 +56,9 @@ pub fn view<'a>(
                     data::message::Sender::Server => Some(
                         container(selectable_text(&message.text).style(theme::Text::Server)).into(),
                     ),
+                    data::message::Sender::Action => Some(
+                        container(selectable_text(&message.text).style(theme::Text::Accent)).into(),
+                    ),
                 },
                 _ => None,
             },

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -34,7 +34,7 @@ pub fn view<'a>(
             history,
             |message| match &message.source {
                 data::message::Source::Channel(_, kind) => match kind {
-                    data::message::ChannelSender::User(user) => {
+                    data::message::Sender::User(user) => {
                         let timestamp = buffer_config.timestamp.clone().map(|timestamp| {
                             let content = &message.formatted_datetime(timestamp.format.as_str());
                             selectable_text(content_with_brackets(content, &timestamp.brackets))
@@ -53,7 +53,7 @@ pub fn view<'a>(
                             container(row![].push_maybe(timestamp).push(nick).push(message)).into(),
                         )
                     }
-                    data::message::ChannelSender::Server => Some(
+                    data::message::Sender::Server => Some(
                         container(selectable_text(&message.text).style(theme::Text::Server)).into(),
                     ),
                 },
@@ -69,6 +69,7 @@ pub fn view<'a>(
     let text_input = is_focused.then(|| {
         input(
             state.input_id.clone(),
+            data::Buffer::Channel(state.server.clone(), state.channel.clone()),
             Message::Send,
             Message::CompletionSelected,
         )

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -59,6 +59,9 @@ pub fn view<'a>(
                     message::Sender::Server => Some(
                         container(selectable_text(&message.text).style(theme::Text::Server)).into(),
                     ),
+                    message::Sender::Action => Some(
+                        container(selectable_text(&message.text).style(theme::Text::Accent)).into(),
+                    ),
                 }
             },
         )

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
 use data::user::Nick;
-use data::{history, Server};
+use data::{history, message, Server};
 use iced::widget::{column, container, row, vertical_space};
 use iced::{Command, Length};
 
@@ -31,23 +31,35 @@ pub fn view<'a>(
             scroll_view::Kind::Query(&state.server, &state.nick),
             history,
             |message| {
-                let user = message.sent_by()?;
-                let timestamp = buffer_config.timestamp.clone().map(|timestamp| {
-                    let content = &message.formatted_datetime(timestamp.format.as_str());
-                    selectable_text(content_with_brackets(content, &timestamp.brackets))
-                        .style(theme::Text::Alpha04)
-                });
-                let nick = selectable_text(content_with_brackets(
-                    user,
-                    &buffer_config.nickname.brackets,
-                ))
-                .style(theme::Text::Nickname(
-                    user.color_seed(&buffer_config.nickname.color),
-                ));
+                let message::Source::Query(_, sender) = &message.source else {
+                    return None;
+                };
 
-                let message = selectable_text(&message.text);
+                match sender {
+                    message::Sender::User(user) => {
+                        let timestamp = buffer_config.timestamp.clone().map(|timestamp| {
+                            let content = &message.formatted_datetime(timestamp.format.as_str());
+                            selectable_text(content_with_brackets(content, &timestamp.brackets))
+                                .style(theme::Text::Alpha04)
+                        });
+                        let nick = selectable_text(content_with_brackets(
+                            user,
+                            &buffer_config.nickname.brackets,
+                        ))
+                        .style(theme::Text::Nickname(
+                            user.color_seed(&buffer_config.nickname.color),
+                        ));
 
-                Some(container(row![].push_maybe(timestamp).push(nick).push(message)).into())
+                        let message = selectable_text(&message.text);
+
+                        Some(
+                            container(row![].push_maybe(timestamp).push(nick).push(message)).into(),
+                        )
+                    }
+                    message::Sender::Server => Some(
+                        container(selectable_text(&message.text).style(theme::Text::Server)).into(),
+                    ),
+                }
             },
         )
         .map(Message::ScrollView),
@@ -57,6 +69,7 @@ pub fn view<'a>(
     let text_input = is_focused.then(|| {
         input(
             state.input_id.clone(),
+            data::Buffer::Query(state.server.clone(), state.nick.clone()),
             Message::Send,
             Message::CompletionSelected,
         )

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -47,6 +47,7 @@ pub fn view<'a>(
     let text_input = is_focused.then(|| {
         input(
             state.input_id.clone(),
+            data::Buffer::Server(state.server.clone()),
             Message::Send,
             Message::CompletionSelected,
         )

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -397,7 +397,7 @@ impl scrollable::StyleSheet for Theme {
                 border_width: 1.0,
                 border_color: Color::TRANSPARENT,
                 scroller: scrollable::Scroller {
-                    color: self.colors.action.alpha_06,
+                    color: self.colors.accent.alpha_06,
                     border_radius: 8.0.into(),
                     border_width: 0.0,
                     border_color: Color::TRANSPARENT,

--- a/src/widget/input.rs
+++ b/src/widget/input.rs
@@ -1,4 +1,4 @@
-use data::{command, Command};
+use data::{command, Buffer, Command};
 pub use iced::widget::text_input::{focus, move_cursor_to_end};
 use iced::widget::{component, container, row, text, text_input, Component};
 
@@ -12,6 +12,7 @@ pub type Id = text_input::Id;
 
 pub fn input<'a, Message>(
     id: Id,
+    buffer: Buffer,
     on_submit: impl Fn(Content) -> Message + 'a,
     on_completion: Message,
 ) -> Element<'a, Message>
@@ -20,6 +21,7 @@ where
 {
     Input {
         id,
+        buffer,
         on_submit: Box::new(on_submit),
         on_completion,
     }
@@ -41,6 +43,7 @@ pub enum Event {
 
 pub struct Input<'a, Message> {
     id: Id,
+    buffer: Buffer,
     on_submit: Box<dyn Fn(Content) -> Message + 'a>,
     on_completion: Message,
 }
@@ -80,7 +83,7 @@ where
                     state.completion.reset();
 
                     // Parse message
-                    let content = match state.input.parse::<Command>() {
+                    let content = match command::parse(&state.input, &self.buffer) {
                         Ok(command) => Content::Command(command),
                         Err(command::Error::MissingSlash) => Content::Text(state.input.clone()),
                         Err(error) => {

--- a/src/widget/input/completion.rs
+++ b/src/widget/input/completion.rs
@@ -65,6 +65,13 @@ impl Default for Completion {
                         },
                     ],
                 },
+                Entry {
+                    title: "ME",
+                    args: vec![Arg {
+                        text: "action",
+                        optional: false,
+                    }],
+                },
             ],
             filtered_entries: vec![],
         }

--- a/src/widget/input/completion.rs
+++ b/src/widget/input/completion.rs
@@ -239,7 +239,7 @@ impl Entry {
             .saturating_sub(2)
             .min(self.args.len().saturating_sub(1));
 
-        let title = Some(Element::from(text(&self.title)));
+        let title = Some(Element::from(text(self.title)));
 
         let args = self.args.iter().enumerate().map(|(index, arg)| {
             let style = if index == active_arg {


### PR DESCRIPTION
Adds support for issuing `/me <action>` commands and receiving them as well.

This is a "synthetic" type command where it just encode the action into PRIVMSG and we need to decode from that.

<img width="217" alt="image" src="https://github.com/squidowl/halloy/assets/10239377/b1a02693-41f3-4908-bf59-81500eed72b8">

@casperstorm do we maybe want to use a different color for this from normal server message? If so, I'd add a variant to `Sender::Action` and you can use that for theming different