### PR TITLE
Feat/input refactor

### DIFF
--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -9,6 +9,14 @@ pub enum Buffer {
 }
 
 impl Buffer {
+    pub fn server(&self) -> &Server {
+        match self {
+            Buffer::Server(server) | Buffer::Channel(server, _) | Buffer::Query(server, _) => {
+                server
+            }
+        }
+    }
+
     pub fn target(&self) -> Option<String> {
         match self {
             Buffer::Server(_) => None,

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -125,7 +125,7 @@ impl Connection {
         )
     }
 
-    pub fn handle_message(&mut self, message: &irc::proto::Message) {
+    pub fn handle_message(&mut self, message: &message::Encoded) {
         use irc::proto::{Command, Response};
 
         match &message.command {

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1,12 +1,9 @@
 use std::collections::BTreeMap;
 
-use chrono::Utc;
 use irc::client::Client;
-use irc::proto;
-use irc::proto::ChannelExt;
 
 use crate::user::Nick;
-use crate::{message, Command, Message, Server, User};
+use crate::{message, Message, Server, User};
 
 #[derive(Debug)]
 pub enum State {
@@ -28,80 +25,35 @@ impl Connection {
         }
     }
 
-    fn send_channel_message(&mut self, channel: String, text: impl ToString) -> Message {
-        let text = text.to_string();
-
-        let command = proto::Command::PRIVMSG(channel.clone(), text.clone());
-        let proto_message = irc::proto::Message::from(command);
-
-        if let Err(e) = self.client.send(proto_message) {
-            dbg!(&e);
-        }
-
-        let our_user = User::new(self.nickname(), None, None);
-
-        let (text, sender) = if let Some(action) = message::action_text(&self.nickname(), &text) {
-            (action, message::Sender::Action)
-        } else {
-            (text, message::Sender::User(our_user))
-        };
-
-        Message {
-            datetime: Utc::now(),
-            direction: message::Direction::Sent,
-            source: message::Source::Channel(channel, sender),
-            text,
+    fn send(&mut self, message: message::Encoded) {
+        if let Err(e) = self.client.send(message) {
+            log::warn!("Error sending message: {e}");
         }
     }
 
-    fn send_user_message(&mut self, nick: &Nick, text: impl ToString) -> Message {
-        let text = text.to_string();
-        let target = nick.to_string();
+    fn receive(&mut self, message: message::Encoded) -> Option<Message> {
+        log::trace!("Message received => {:?}", *message);
 
-        let command = proto::Command::PRIVMSG(target, text.clone());
-        let proto_message = irc::proto::Message::from(command);
+        self.handle(&message);
 
-        if let Err(e) = self.client.send(proto_message) {
-            dbg!(&e);
-        }
-
-        let our_user = User::new(self.nickname(), None, None);
-
-        let (text, sender) = if let Some(action) = message::action_text(&self.nickname(), &text) {
-            (action, message::Sender::Server)
-        } else {
-            (text, message::Sender::User(our_user))
-        };
-
-        Message {
-            datetime: Utc::now(),
-            direction: message::Direction::Sent,
-            source: message::Source::Query(nick.clone(), sender),
-            text,
-        }
+        Message::received(message, &self.nickname())
     }
 
-    fn send_command(&mut self, command: Command) -> Option<Message> {
-        let Ok(command) = proto::Command::try_from(command) else {
-            return None;
-        };
+    fn handle(&mut self, message: &message::Encoded) {
+        use irc::proto::{Command, Response};
 
-        if let proto::Command::PRIVMSG(target, message) = &command {
-            if target.is_channel_name() {
-                return Some(self.send_channel_message(target.clone(), message));
-            } else if let Ok(user) = User::try_from(target.clone()) {
-                return Some(self.send_user_message(&user.nickname(), message));
-            }
+        match &message.command {
+            Command::NICK(nick) => self.resolved_nick = Some(nick.to_string()),
+            Command::Response(response, args) => match response {
+                Response::RPL_WELCOME => {
+                    if let Some(nick) = args.first() {
+                        self.resolved_nick = Some(nick.to_string());
+                    }
+                }
+                _ => {}
+            },
+            _ => {}
         }
-
-        let proto_message = irc::proto::Message::from(command);
-
-        // TODO: Handle error
-        if let Err(e) = self.client.send(proto_message) {
-            dbg!(&e);
-        }
-
-        None
     }
 
     fn channels(&self) -> Vec<String> {
@@ -117,29 +69,12 @@ impl Connection {
             .collect()
     }
 
-    pub fn nickname(&self) -> Nick {
+    fn nickname(&self) -> Nick {
         Nick::from(
             self.resolved_nick
                 .as_deref()
                 .unwrap_or_else(|| self.client.current_nickname()),
         )
-    }
-
-    pub fn handle_message(&mut self, message: &message::Encoded) {
-        use irc::proto::{Command, Response};
-
-        match &message.command {
-            Command::NICK(nick) => self.resolved_nick = Some(nick.to_string()),
-            Command::Response(response, args) => match response {
-                Response::RPL_WELCOME => {
-                    if let Some(nick) = args.first() {
-                        self.resolved_nick = Some(nick.to_string());
-                    }
-                }
-                _ => {}
-            },
-            _ => {}
-        }
     }
 }
 
@@ -175,31 +110,18 @@ impl Map {
         }
     }
 
-    pub fn send_channel_message(
-        &mut self,
-        server: &Server,
-        channel: &str,
-        text: impl ToString,
-    ) -> Option<Message> {
-        self.connection_mut(server)
-            .map(|connection| connection.send_channel_message(channel.to_string(), text))
+    pub fn nickname(&self, server: &Server) -> Option<Nick> {
+        self.connection(server).map(Connection::nickname)
     }
 
-    pub fn send_user_message(
-        &mut self,
-        server: &Server,
-        nick: &Nick,
-        text: impl ToString,
-    ) -> Option<Message> {
+    pub fn receive(&mut self, server: &Server, message: message::Encoded) -> Option<Message> {
         self.connection_mut(server)
-            .map(|connection| connection.send_user_message(nick, text))
+            .and_then(|connection| connection.receive(message))
     }
 
-    pub fn send_command(&mut self, server: &Server, command: Command) -> Option<Message> {
+    pub fn send(&mut self, server: &Server, message: message::Encoded) {
         if let Some(connection) = self.connection_mut(server) {
-            connection.send_command(command)
-        } else {
-            None
+            connection.send(message);
         }
     }
 

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -132,9 +132,9 @@ impl Manager {
         );
     }
 
-    pub fn add_raw_messages(
+    pub fn add_encoded_messages(
         &mut self,
-        messages: Vec<(Server, irc::proto::Message)>,
+        messages: Vec<(Server, message::Encoded)>,
         clients: &mut client::Map,
     ) -> HashSet<(Server, message::Source)> {
         messages

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -7,10 +7,10 @@ use itertools::Itertools;
 use tokio::time::Instant;
 
 use crate::history::{self, History};
-use crate::message::{self, Limit};
+use crate::message::Limit;
 use crate::time::Posix;
 use crate::user::Nick;
-use crate::{client, server, Server};
+use crate::{server, Server};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Resource {
@@ -124,38 +124,12 @@ impl Manager {
         }
     }
 
-    pub fn add_message(&mut self, server: &Server, message: crate::Message) {
+    pub fn record_message(&mut self, server: &Server, message: crate::Message) {
         self.data.add_message(
             server.name.clone(),
             history::Kind::from(message.source.clone()),
             message,
         );
-    }
-
-    pub fn add_encoded_messages(
-        &mut self,
-        messages: Vec<(Server, message::Encoded)>,
-        clients: &mut client::Map,
-    ) -> HashSet<(Server, message::Source)> {
-        messages
-            .into_iter()
-            .filter_map(|(server, message)| {
-                log::trace!("Message received => {message:?}");
-
-                let connection = clients.connection_mut(&server)?;
-                connection.handle_message(&message);
-
-                let nick = connection.nickname();
-
-                let message = crate::Message::received(message, &nick)?;
-                let source = message.source.clone();
-                let kind = history::Kind::from(source.clone());
-
-                self.data.add_message(server.name.clone(), kind, message);
-
-                Some((server, source))
-            })
-            .collect()
     }
 
     pub fn get_channel_messages(

--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -1,0 +1,89 @@
+use chrono::Utc;
+use irc::proto::ChannelExt;
+
+use crate::user::Nick;
+use crate::{command, message, Buffer, Command, Message, Server, User};
+
+pub fn parse(buffer: Buffer, input: &str) -> Result<Input, command::Error> {
+    let content = match command::parse(input, &buffer) {
+        Ok(command) => Content::Command(command),
+        Err(command::Error::MissingSlash) => Content::Text(input.to_string()),
+        Err(error) => return Err(error),
+    };
+
+    Ok(Input { buffer, content })
+}
+
+#[derive(Debug, Clone)]
+pub struct Input {
+    buffer: Buffer,
+    content: Content,
+}
+
+impl Input {
+    pub fn server(&self) -> &Server {
+        self.buffer.server()
+    }
+
+    pub fn message(&self, our_nick: &Nick) -> Option<Message> {
+        let command = self.content.command(&self.buffer)?;
+
+        let source = |target: String, sender| {
+            if target.is_channel_name() {
+                Some(message::Source::Channel(target, sender))
+            } else if let Ok(user) = User::try_from(target) {
+                Some(message::Source::Query(user.nickname(), sender))
+            } else {
+                None
+            }
+        };
+
+        match command {
+            Command::Msg(target, text) => Some(Message {
+                datetime: Utc::now(),
+                direction: message::Direction::Sent,
+                source: source(
+                    target,
+                    message::Sender::User(User::new(our_nick.clone(), None, None)),
+                )?,
+                text: text.clone(),
+            }),
+            Command::Me(target, action) => Some(Message {
+                datetime: Utc::now(),
+                direction: message::Direction::Sent,
+                source: source(target, message::Sender::Action)?,
+                text: message::action_text(our_nick, &action),
+            }),
+            _ => None,
+        }
+    }
+
+    pub fn encoded(&self) -> Option<message::Encoded> {
+        use irc::proto;
+
+        let command = self
+            .content
+            .command(&self.buffer)
+            .and_then(|command| proto::Command::try_from(command).ok())?;
+
+        Some(message::Encoded::from(proto::Message::from(command)))
+    }
+}
+
+#[derive(Debug, Clone)]
+enum Content {
+    Text(String),
+    Command(Command),
+}
+
+impl Content {
+    fn command(&self, buffer: &Buffer) -> Option<Command> {
+        match self {
+            Self::Text(text) => {
+                let target = buffer.target()?;
+                Some(Command::Msg(target, text.clone()))
+            }
+            Self::Command(command) => Some(command.clone()),
+        }
+    }
+}

--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -46,7 +46,7 @@ impl Input {
                     target,
                     message::Sender::User(User::new(our_nick.clone(), None, None)),
                 )?,
-                text: text.clone(),
+                text,
             }),
             Command::Me(target, action) => Some(Message {
                 datetime: Utc::now(),

--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -3,6 +3,7 @@
 pub use self::buffer::Buffer;
 pub use self::command::Command;
 pub use self::config::Config;
+pub use self::input::Input;
 pub use self::message::Message;
 pub use self::palette::Palette;
 pub use self::server::Server;
@@ -15,6 +16,7 @@ pub mod command;
 mod compression;
 pub mod config;
 pub mod history;
+pub mod input;
 pub mod log;
 pub mod message;
 pub mod palette;

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -7,8 +7,24 @@ use crate::time::{self, Posix};
 use crate::user::Nick;
 use crate::User;
 
-pub type Raw = irc::proto::Message;
 pub type Channel = String;
+
+#[derive(Debug, Clone)]
+pub struct Encoded(proto::Message);
+
+impl std::ops::Deref for Encoded {
+    type Target = proto::Message;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<proto::Message> for Encoded {
+    fn from(proto: proto::Message) -> Self {
+        Self(proto)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Source {
@@ -73,10 +89,10 @@ impl Message {
         }
     }
 
-    pub fn received(proto: proto::Message, our_nick: &Nick) -> Option<Message> {
-        let datetime = datetime(&proto);
-        let text = text(&proto, our_nick)?;
-        let source = source(proto, our_nick)?;
+    pub fn received(encoded: Encoded, our_nick: &Nick) -> Option<Message> {
+        let datetime = datetime(&encoded);
+        let text = text(&encoded, our_nick)?;
+        let source = source(encoded, our_nick)?;
 
         Some(Message {
             datetime,
@@ -87,26 +103,26 @@ impl Message {
     }
 }
 
-fn user(proto: &proto::Message) -> Option<User> {
+fn user(message: &Encoded) -> Option<User> {
     fn not_empty(s: &str) -> Option<&str> {
         (!s.is_empty()).then_some(s)
     }
 
-    let prefix = proto.clone().prefix?;
+    let prefix = message.prefix.as_ref()?;
     match prefix {
         proto::Prefix::Nickname(nickname, username, hostname) => Some(User::new(
             Nick::from(nickname.as_str()),
-            not_empty(&username),
-            not_empty(&hostname),
+            not_empty(username),
+            not_empty(hostname),
         )),
         _ => None,
     }
 }
 
-fn source(message: irc::proto::Message, our_nick: &Nick) -> Option<Source> {
+fn source(message: Encoded, our_nick: &Nick) -> Option<Source> {
     let user = user(&message);
 
-    match message.command {
+    match message.0.command {
         // Channel
         proto::Command::TOPIC(channel, _)
         | proto::Command::PART(channel, _)
@@ -204,7 +220,7 @@ fn source(message: irc::proto::Message, our_nick: &Nick) -> Option<Source> {
     }
 }
 
-fn datetime(message: &irc::proto::Message) -> DateTime<Utc> {
+fn datetime(message: &Encoded) -> DateTime<Utc> {
     message
         .tags
         .as_ref()
@@ -215,7 +231,7 @@ fn datetime(message: &irc::proto::Message) -> DateTime<Utc> {
         .unwrap_or_else(Utc::now)
 }
 
-fn text(message: &irc::proto::Message, our_nick: &Nick) -> Option<String> {
+fn text(message: &Encoded, our_nick: &Nick) -> Option<String> {
     let user = user(message);
     match &message.command {
         proto::Command::TOPIC(_, topic) => {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -9,6 +9,7 @@ use crate::widget::Element;
 
 pub mod channel;
 pub mod empty;
+mod input_view;
 pub mod query;
 mod scroll_view;
 pub mod server;

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -1,0 +1,65 @@
+use data::{client, history, Buffer, Input, Server};
+use iced::Command;
+
+use crate::widget::{input, Element};
+
+pub enum Event {
+    InputSent,
+}
+
+#[derive(Debug, Clone)]
+pub enum Message {
+    Send(Input),
+    CompletionSelected,
+}
+
+pub fn view<'a>(state: &State, buffer: Buffer) -> Element<'a, Message> {
+    input(
+        state.input_id.clone(),
+        buffer,
+        Message::Send,
+        Message::CompletionSelected,
+    )
+}
+
+#[derive(Debug, Clone)]
+pub struct State {
+    input_id: input::Id,
+}
+
+impl State {
+    pub fn new() -> Self {
+        Self {
+            input_id: input::Id::unique(),
+        }
+    }
+
+    pub fn update(
+        &mut self,
+        message: Message,
+        server: &Server,
+        clients: &mut client::Map,
+        history: &mut history::Manager,
+    ) -> (Command<Message>, Option<Event>) {
+        match message {
+            Message::Send(input) => {
+                if let Some(encoded) = input.encoded() {
+                    clients.send(server, encoded);
+                }
+                if let Some(message) = clients
+                    .nickname(server)
+                    .and_then(|nick| input.message(&nick))
+                {
+                    history.record_message(server, message);
+                }
+
+                (Command::none(), Some(Event::InputSent))
+            }
+            Message::CompletionSelected => (input::move_cursor_to_end(self.input_id.clone()), None),
+        }
+    }
+
+    pub fn focus(&self) -> Command<Message> {
+        input::focus(self.input_id.clone())
+    }
+}

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -5,15 +5,14 @@ use data::{history, message, Server};
 use iced::widget::{column, container, row, vertical_space};
 use iced::{Command, Length};
 
-use super::scroll_view;
+use super::{input_view, scroll_view};
 use crate::theme;
-use crate::widget::{input, selectable_text, Collection, Element};
+use crate::widget::{selectable_text, Collection, Element};
 
 #[derive(Debug, Clone)]
 pub enum Message {
-    Send(input::Content),
-    CompletionSelected,
     ScrollView(scroll_view::Message),
+    InputView(input_view::Message),
 }
 
 #[derive(Debug, Clone)]
@@ -70,12 +69,11 @@ pub fn view<'a>(
     .height(Length::Fill);
     let spacing = is_focused.then_some(vertical_space(4));
     let text_input = is_focused.then(|| {
-        input(
-            state.input_id.clone(),
+        input_view::view(
+            &state.input_view,
             data::Buffer::Query(state.server.clone(), state.nick.clone()),
-            Message::Send,
-            Message::CompletionSelected,
         )
+        .map(Message::InputView)
     });
 
     let scrollable = column![messages]
@@ -95,7 +93,7 @@ pub struct Query {
     pub server: Server,
     pub nick: Nick,
     pub scroll_view: scroll_view::State,
-    input_id: input::Id,
+    input_view: input_view::State,
 }
 
 impl Query {
@@ -104,7 +102,7 @@ impl Query {
             server,
             nick,
             scroll_view: scroll_view::State::new(),
-            input_id: input::Id::unique(),
+            input_view: input_view::State::new(),
         }
     }
 
@@ -115,37 +113,33 @@ impl Query {
         history: &mut history::Manager,
     ) -> (Command<Message>, Option<Event>) {
         match message {
-            Message::Send(content) => {
-                match content {
-                    input::Content::Text(message) => {
-                        if let Some(message) =
-                            clients.send_user_message(&self.server, &self.nick, &message)
-                        {
-                            history.add_message(&self.server, message);
-                        }
-                    }
-                    input::Content::Command(command) => {
-                        if let Some(message) = clients.send_command(&self.server, command) {
-                            history.add_message(&self.server, message);
-                        }
-                    }
-                }
-
-                (
-                    self.scroll_view.scroll_to_end().map(Message::ScrollView),
-                    None,
-                )
-            }
-            Message::CompletionSelected => (input::move_cursor_to_end(self.input_id.clone()), None),
             Message::ScrollView(message) => {
                 let command = self.scroll_view.update(message);
                 (command.map(Message::ScrollView), None)
+            }
+            Message::InputView(message) => {
+                let (command, event) =
+                    self.input_view
+                        .update(message, &self.server, clients, history);
+                let command = command.map(Message::InputView);
+
+                match event {
+                    Some(input_view::Event::InputSent) => {
+                        let command = Command::batch(vec![
+                            command,
+                            self.scroll_view.scroll_to_end().map(Message::ScrollView),
+                        ]);
+
+                        (command, None)
+                    }
+                    None => (command, None),
+                }
             }
         }
     }
 
     pub fn focus(&self) -> Command<Message> {
-        input::focus(self.input_id.clone())
+        self.input_view.focus().map(Message::InputView)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,9 +189,14 @@ impl Application for Halloy {
                 }
                 stream::Event::MessagesReceived(messages) => {
                     let Screen::Dashboard(dashboard) = &mut self.screen;
-                    dashboard
-                        .messages_received(messages, &mut self.clients)
-                        .map(Message::Dashboard)
+
+                    messages.into_iter().for_each(|(server, encoded)| {
+                        if let Some(message) = self.clients.receive(&server, encoded) {
+                            dashboard.record_message(&server, message);
+                        }
+                    });
+
+                    Command::none()
                 }
             },
             Message::Stream(Err(error)) => {

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1,7 +1,7 @@
 pub mod pane;
 pub mod side_menu;
 
-use data::{history, message, Server};
+use data::{history, Server};
 use iced::widget::pane_grid::{self, PaneGrid};
 use iced::widget::{container, row};
 use iced::{clipboard, subscription, window, Command, Length, Subscription};
@@ -331,13 +331,8 @@ impl Dashboard {
         }
     }
 
-    pub fn messages_received(
-        &mut self,
-        messages: Vec<(Server, message::Encoded)>,
-        clients: &mut data::client::Map,
-    ) -> Command<Message> {
-        let _ = self.history.add_encoded_messages(messages, clients);
-        Command::none()
+    pub fn record_message(&mut self, server: &Server, message: data::Message) {
+        self.history.record_message(server, message);
     }
 
     fn get_focused_mut(&mut self) -> Option<(pane_grid::Pane, &mut Pane)> {

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -333,10 +333,10 @@ impl Dashboard {
 
     pub fn messages_received(
         &mut self,
-        messages: Vec<(Server, message::Raw)>,
+        messages: Vec<(Server, message::Encoded)>,
         clients: &mut data::client::Map,
     ) -> Command<Message> {
-        let _ = self.history.add_raw_messages(messages, clients);
+        let _ = self.history.add_encoded_messages(messages, clients);
         Command::none()
     }
 

--- a/src/widget/input.rs
+++ b/src/widget/input.rs
@@ -1,4 +1,4 @@
-use data::{command, Buffer, Command};
+use data::{input, Buffer, Command};
 pub use iced::widget::text_input::{focus, move_cursor_to_end};
 use iced::widget::{component, container, row, text, text_input, Component};
 
@@ -13,7 +13,7 @@ pub type Id = text_input::Id;
 pub fn input<'a, Message>(
     id: Id,
     buffer: Buffer,
-    on_submit: impl Fn(Content) -> Message + 'a,
+    on_submit: impl Fn(data::Input) -> Message + 'a,
     on_completion: Message,
 ) -> Element<'a, Message>
 where
@@ -44,7 +44,7 @@ pub enum Event {
 pub struct Input<'a, Message> {
     id: Id,
     buffer: Buffer,
-    on_submit: Box<dyn Fn(Content) -> Message + 'a>,
+    on_submit: Box<dyn Fn(data::Input) -> Message + 'a>,
     on_completion: Message,
 }
 
@@ -82,10 +82,9 @@ where
                 } else if !state.input.is_empty() {
                     state.completion.reset();
 
-                    // Parse message
-                    let content = match command::parse(&state.input, &self.buffer) {
-                        Ok(command) => Content::Command(command),
-                        Err(command::Error::MissingSlash) => Content::Text(state.input.clone()),
+                    // Parse input
+                    let input = match input::parse(self.buffer.clone(), &state.input) {
+                        Ok(input) => input,
                         Err(error) => {
                             state.error = Some(error.to_string());
                             return None;
@@ -95,7 +94,7 @@ where
                     // Clear message, we parsed it succesfully
                     state.input = String::new();
 
-                    Some((self.on_submit)(content))
+                    Some((self.on_submit)(input))
                 } else {
                     None
                 }


### PR DESCRIPTION
This refactors how we handle receiving encoding messages, recording parsed messags into history, parsing user input into both encoded messages and parsed messages that get recorded into history.

There is now a much better separation between everything. `client / connection` isn't aware of history. `history` isn't aware of `client / connection`. `client / connection` is responsible over sending encoded messages. `history` is responsible over storing / recording parsed messages.

`input` now parses into the new `Input` on send. This struct defines how we go from input to both encoded messages to send via `client / connection` and parsed messages that get recorded in `history`.

A new `input_view` module is added to de-duplicate the input flow of send -> input -> send encoded + record parsed message from each buffer.