### PR TITLE
Rework config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -72,7 +72,7 @@ new_pane:
         # Visible by default
         # - Default is true
         visible: true
-        # Position of the list in the buffer
-        # - Left
-        # - Right (default)
+        # List position
+        # - Left: Left side of pane
+        # - Right: Right side of pane [default]
         position: Right  

--- a/config.yaml
+++ b/config.yaml
@@ -35,30 +35,44 @@ servers:
     channels:
       - "##rust"
       
-# Buffer settings
-buffer:
-  # Nickname settings
-  nickname:
-    # User color settings:
-    # - Unique: Unique user colors [default]
-    # - Solid: Solid user colors
-    color: Unique
-    
-    # Nickname brackets:
-    # - Default is empty ""
-    brackets:
-      left: "<"
-      right: ">"
+# Settings applied by default to new panes
+new_pane:
+  # Buffer settings
+  buffer:
+    # Nickname settings
+    nickname:
+      # User color settings:
+      # - Unique: Unique user colors [default]
+      # - Solid: Solid user colors
+      color: Unique
       
-  # Timestamp settings
-  timestamp: 
-    # Timestamp format:
-    # - Use `strftime` format (see documentation for details):
-    #   https://pubs.opengroup.org/onlinepubs/007908799/xsh/strftime.html
-    format: "%T"
-    
-    # Timestamp brackets:
-    # - Default is empty ""
-    brackets:
-      left: "["
-      right: "]"
+      # Nickname brackets:
+      # - Default is empty ""
+      brackets:
+        left: "<"
+        right: ">"
+        
+    # Timestamp settings
+    timestamp: 
+      # Timestamp format:
+      # - Use `strftime` format (see documentation for details):
+      #   https://pubs.opengroup.org/onlinepubs/007908799/xsh/strftime.html
+      format: "%T"
+      
+      # Timestamp brackets:
+      # - Default is empty ""
+      brackets:
+        left: "["
+        right: "]"
+
+    # Channel buffer settings
+    channel:
+      # User list settings
+      users:
+        # Visible by default
+        # - Default is true
+        visible: true
+        # Position of the list in the buffer
+        # - Left
+        # - Right (default)
+        position: Right  

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -1,0 +1,64 @@
+use serde::{Deserialize, Serialize};
+
+use crate::Message;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Buffer {
+    #[serde(default)]
+    pub timestamp: Option<Timestamp>,
+    #[serde(default)]
+    pub nickname: Nickname,
+}
+
+impl Default for Buffer {
+    fn default() -> Self {
+        Buffer {
+            timestamp: Some(Timestamp {
+                format: "%T".into(),
+                brackets: Default::default(),
+            }),
+            nickname: Nickname {
+                color: Color::Unique,
+                brackets: Default::default(),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Timestamp {
+    pub format: String,
+    #[serde(default)]
+    pub brackets: Brackets,
+}
+
+impl Timestamp {
+    pub fn format_message_with_timestamp(&self, message: &Message) -> String {
+        format!(
+            "{}{}{} ",
+            self.brackets.left,
+            &message.formatted_datetime(self.format.as_str()),
+            self.brackets.right,
+        )
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct Nickname {
+    pub color: Color,
+    #[serde(default)]
+    pub brackets: Brackets,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct Brackets {
+    pub left: String,
+    pub right: String,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub enum Color {
+    Solid,
+    #[default]
+    Unique,
+}

--- a/data/src/config/channel.rs
+++ b/data/src/config/channel.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
-pub struct Settings {
+pub struct Channel {
     pub users: Users,
 }
 

--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -20,6 +20,7 @@ pub mod input;
 pub mod log;
 pub mod message;
 pub mod palette;
+pub mod pane;
 pub mod server;
 pub mod stream;
 pub mod time;

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Local, Utc};
+use chrono::{DateTime, Utc};
 use irc::proto;
 use irc::proto::ChannelExt;
 use serde::{Deserialize, Serialize};
@@ -73,10 +73,6 @@ pub struct Message {
 impl Message {
     pub fn is_server(&self) -> bool {
         matches!(self.source, Source::Server)
-    }
-
-    pub fn formatted_datetime(&self, fmt: &str) -> String {
-        self.datetime.with_timezone(&Local).format(fmt).to_string()
     }
 
     pub fn channel(&self) -> Option<&str> {

--- a/data/src/pane.rs
+++ b/data/src/pane.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+
+use crate::buffer;
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct Settings {
+    #[serde(default)]
+    pub buffer: buffer::Settings,
+}

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -4,7 +4,7 @@ use std::hash::Hash;
 use irc::client::data;
 use serde::{Deserialize, Serialize};
 
-use crate::config;
+use crate::buffer;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(into = "String")]
@@ -78,10 +78,10 @@ impl User {
         Self(data::User::new(&formatted))
     }
 
-    pub fn color_seed(&self, color: &config::Color) -> Option<String> {
+    pub fn color_seed(&self, color: &buffer::Color) -> Option<String> {
         match color {
-            config::Color::Solid => None,
-            config::Color::Unique => Some(
+            buffer::Color::Solid => None,
+            buffer::Color::Unique => Some(
                 self.hostname()
                     .map(ToString::to_string)
                     .unwrap_or_else(|| self.nickname().to_string()),

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,4 +1,4 @@
-use data::history;
+use data::{buffer, config, history};
 use iced::Command;
 
 use self::channel::Channel;
@@ -87,31 +87,22 @@ impl Buffer {
         &'a self,
         clients: &'a data::client::Map,
         history: &'a history::Manager,
-        config: &'a data::config::Config,
+        settings: &'a buffer::Settings,
         is_focused: bool,
+        load_config_error: &'a Option<config::Error>,
     ) -> Element<'a, Message> {
-        let buffer_config = &config.buffer;
-
         match self {
-            Buffer::Empty(state) => empty::view(state, clients, config).map(Message::Empty),
+            Buffer::Empty(state) => {
+                empty::view(state, clients, load_config_error).map(Message::Empty)
+            }
             Buffer::Channel(state) => {
-                let channel_config = config.channel_config(&state.server.name, &state.channel);
-
-                channel::view(
-                    state,
-                    clients,
-                    history,
-                    &channel_config,
-                    buffer_config,
-                    is_focused,
-                )
-                .map(Message::Channel)
+                channel::view(state, clients, history, settings, is_focused).map(Message::Channel)
             }
             Buffer::Server(state) => {
-                server::view(state, history, buffer_config, is_focused).map(Message::Server)
+                server::view(state, history, settings, is_focused).map(Message::Server)
             }
             Buffer::Query(state) => {
-                query::view(state, history, buffer_config, is_focused).map(Message::Query)
+                query::view(state, history, settings, is_focused).map(Message::Query)
             }
         }
     }

--- a/src/buffer/empty.rs
+++ b/src/buffer/empty.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use data::Config;
+use data::{config, Config};
 use iced::widget::{button, column, container, text, vertical_space};
 use iced::{alignment, Length};
 
@@ -18,7 +18,9 @@ pub enum Event {}
 pub fn view<'a>(
     _state: &Empty,
     clients: &data::client::Map,
-    config: &'a data::config::Config,
+    // TODO: Make error a separate screen so we don't
+    // have to pass this all the way down
+    load_config_error: &'a Option<config::Error>,
 ) -> Element<'a, Message> {
     let is_empty = clients.get_channels().is_empty();
     let config_dir = is_empty
@@ -29,8 +31,7 @@ pub fn view<'a>(
         })
         .flatten();
 
-    let error = config
-        .error
+    let error = load_config_error
         .as_ref()
         .map(|error| text(error.to_string()).style(theme::Text::Error));
     let title = if is_empty {

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use data::history;
+use data::{buffer, history};
 use iced::widget::{column, container, row, vertical_space};
 use iced::{Command, Length};
 
@@ -20,7 +20,7 @@ pub enum Event {}
 pub fn view<'a>(
     state: &'a Server,
     history: &'a history::Manager,
-    buffer_config: &'a data::config::Buffer,
+    settings: &'a buffer::Settings,
     is_focused: bool,
 ) -> Element<'a, Message> {
     let messages = container(
@@ -29,11 +29,9 @@ pub fn view<'a>(
             scroll_view::Kind::Server(&state.server),
             history,
             |message| {
-                let timestamp = buffer_config.timestamp.clone().map(|timestamp| {
-                    let content = &message.formatted_datetime(timestamp.format.as_str());
-                    selectable_text(content_with_brackets(content, &timestamp.brackets))
-                        .style(theme::Text::Alpha04)
-                });
+                let timestamp = settings
+                    .format_timestamp(&message.datetime)
+                    .map(|timestamp| selectable_text(timestamp).style(theme::Text::Alpha04));
                 let message = selectable_text(&message.text).style(theme::Text::Alpha04);
 
                 Some(container(row![].push_maybe(timestamp).push(message)).into())
@@ -114,13 +112,6 @@ impl Server {
     pub fn focus(&self) -> Command<Message> {
         self.input_view.focus().map(Message::InputView)
     }
-}
-
-fn content_with_brackets(
-    content: impl std::fmt::Display,
-    brackets: &data::config::Brackets,
-) -> String {
-    format!("{}{}{} ", brackets.left, content, brackets.right)
 }
 
 impl fmt::Display for Server {


### PR DESCRIPTION
This improves the config by making it read only and refactors all the options into `Settings` related structures.

The config now defines a `new_pane` option which are the pane settings that will be applied to new panes by default. Toggling the user list will update the settings for that single pane for the duration of the program.

When we eventually add layout persistence, these pane settings will get persisted.