### PR TITLE
single ci script for macos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         target:
           - target: macos
             os: macos-latest
-            make: bash scripts/build-macos.sh dmg
+            make: bash scripts/build-macos.sh
             binary_path: target/release/macos/halloy.dmg
 
     runs-on: ${{ matrix.target.os }}
@@ -27,18 +27,6 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-
-      - name: Assign version to .app
-        if: ${{ matrix.target.os == 'macos-latest' }}
-        run: |
-          VERSION=$(cat VERSION)
-          sed -i '' -e "s/{{ VERSION }}/$VERSION/g" "assets/macos/Halloy.app/Contents/Info.plist"
-
-      - name: Assign build to .app
-        if: ${{ matrix.target.os == 'macos-latest' }}
-        run: |
-          BUILD=${GITHUB_SHA::7}
-          sed -i '' -e "s/{{ BUILD }}/$BUILD/g" "assets/macos/Halloy.app/Contents/Info.plist"
 
       - name: Build
         run: ${{ matrix.target.make }}

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -5,62 +5,39 @@ ASSETS_DIR="assets"
 RELEASE_DIR="target/release"
 APP_NAME="Halloy.app"
 APP_TEMPLATE="$ASSETS_DIR/macos/$APP_NAME"
+APP_TEMPLATE_PLIST="$APP_TEMPLATE/Contents/Info.plist"
 APP_DIR="$RELEASE_DIR/macos"
 APP_BINARY="$RELEASE_DIR/$TARGET"
 APP_BINARY_DIR="$APP_DIR/$APP_NAME/Contents/MacOS"
 APP_EXTRAS_DIR="$APP_DIR/$APP_NAME/Contents/Resources"
-APP_COMPLETIONS_DIR="$APP_EXTRAS_DIR/completions"
 
 DMG_NAME="halloy.dmg"
 DMG_DIR="$RELEASE_DIR/macos"
 
-binary() {
-    export MACOSX_DEPLOYMENT_TARGET="11.0"
-    cargo build --release --target=x86_64-apple-darwin
-    cargo build --release --target=aarch64-apple-darwin
-    lipo "target/x86_64-apple-darwin/release/$TARGET" "target/aarch64-apple-darwin/release/$TARGET" -create -output "$APP_BINARY"
-}
+VERSION=$(cat VERSION)
+BUILD=$(git rev-parse HEAD | cut -c 1-7)
 
-app() {
-    mkdir -p "$APP_BINARY_DIR"
-    mkdir -p "$APP_EXTRAS_DIR"
-    mkdir -p "$APP_COMPLETIONS_DIR"
-    cp -fRp "$APP_TEMPLATE" "$APP_DIR"
-    cp -fp "$APP_BINARY" "$APP_BINARY_DIR"
-    touch -r "$APP_BINARY" "$APP_DIR/$APP_NAME"
-    echo "Created '$APP_NAME' in '$APP_DIR'"
-}
+# update version and build
+sed -i '' -e "s/{{ VERSION }}/$VERSION/g" "$APP_TEMPLATE_PLIST"
+sed -i '' -e "s/{{ BUILD }}/$BUILD/g" "$APP_TEMPLATE_PLIST"
 
-dmg() {
-    echo "Packing disk image..."
-    ln -sf /Applications "$DMG_DIR/Applications"
-    hdiutil create "$DMG_DIR/$DMG_NAME" -volname "Halloy" -fs HFS+ -srcfolder "$APP_DIR" -ov -format UDZO
-    echo "Packed '$APP_NAME' in '$APP_DIR'"
-}
+# build binary
+export MACOSX_DEPLOYMENT_TARGET="11.0"
+cargo build --release --target=x86_64-apple-darwin
+cargo build --release --target=aarch64-apple-darwin
+lipo "target/x86_64-apple-darwin/release/$TARGET" "target/aarch64-apple-darwin/release/$TARGET" -create -output "$APP_BINARY"
 
+# build app
+mkdir -p "$APP_BINARY_DIR"
+mkdir -p "$APP_EXTRAS_DIR"
+cp -fRp "$APP_TEMPLATE" "$APP_DIR"
+cp -fp "$APP_BINARY" "$APP_BINARY_DIR"
+touch -r "$APP_BINARY" "$APP_DIR/$APP_NAME"
+echo "Created '$APP_NAME' in '$APP_DIR'"
 
-clean() {
-    cargo clean
-}
+# package dmg
+echo "Packing disk image..."
+ln -sf /Applications "$DMG_DIR/Applications"
+hdiutil create "$DMG_DIR/$DMG_NAME" -volname "Halloy" -fs HFS+ -srcfolder "$APP_DIR" -ov -format UDZO
+echo "Packed '$APP_NAME' in '$APP_DIR'"
 
-case "$1" in
-    binary)
-        binary
-        ;;
-    app)
-        app
-        ;;
-    dmg)
-        app
-        dmg
-        ;;
-    clean)
-        clean
-        ;;
-    *)
-        echo "  binary      Build the $TARGET binary"
-        echo "  app         Create the $APP_NAME application bundle"
-        echo "  dmg         Create the $DMG_NAME disk image"
-        echo "  clean       Clean the project"
-        ;;
-esac

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -15,7 +15,7 @@ DMG_NAME="halloy.dmg"
 DMG_DIR="$RELEASE_DIR/macos"
 
 VERSION=$(cat VERSION)
-BUILD=$(git rev-parse HEAD | cut -c 1-7)
+BUILD=$(git describe --always --dirty --exclude='*')
 
 # update version and build
 sed -i '' -e "s/{{ VERSION }}/$VERSION/g" "$APP_TEMPLATE_PLIST"


### PR DESCRIPTION
This PR simplifies the build script to do only one thing; build a .dmg file.
In the process it also updates both version and build, something that happened in the github action before.

Now it all happens through `build-macos.sh`