### PR TITLE
Fix/scroll view

### DIFF
--- a/data/src/environment.rs
+++ b/data/src/environment.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 pub const VERSION: &str = env!("VERSION");
 pub const GIT_HASH: Option<&str> = option_env!("GIT_HASH");
@@ -47,7 +47,7 @@ pub(crate) fn data_dir() -> Option<PathBuf> {
     }
 }
 
-#[allow(dead_code)]
-fn is_absolute(path: &Path) -> bool {
+#[cfg(target_os = "linux")]
+fn is_absolute(path: &std::path::Path) -> bool {
     path.is_absolute()
 }

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -246,7 +246,7 @@ fn with_limit<'a>(
             collected[length.saturating_sub(n)..length].to_vec()
         }
         Some(Limit::Since(timestamp)) => messages
-            .skip_while(|message| Posix::from(message.datetime) < timestamp)
+            .skip_while(|message| Posix::from(message.received_at) < timestamp)
             .collect(),
         None => messages.collect(),
     }

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -7,7 +7,6 @@ use tokio::time::Instant;
 
 use crate::history::{self, History};
 use crate::message::{self, Limit};
-use crate::time::Posix;
 use crate::user::Nick;
 use crate::{server, Server};
 
@@ -246,7 +245,7 @@ fn with_limit<'a>(
             collected[length.saturating_sub(n)..length].to_vec()
         }
         Some(Limit::Since(timestamp)) => messages
-            .skip_while(|message| Posix::from(message.received_at) < timestamp)
+            .skip_while(|message| message.received_at < timestamp)
             .collect(),
         None => messages.collect(),
     }

--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use irc::proto::ChannelExt;
 
+use crate::time::Posix;
 use crate::user::Nick;
 use crate::{command, message, Buffer, Command, Message, Server, User};
 
@@ -40,7 +41,8 @@ impl Input {
 
         match command {
             Command::Msg(target, text) => Some(Message {
-                datetime: Utc::now(),
+                received_at: Posix::now(),
+                server_time: Utc::now(),
                 direction: message::Direction::Sent,
                 source: source(
                     target,
@@ -49,7 +51,8 @@ impl Input {
                 text,
             }),
             Command::Me(target, action) => Some(Message {
-                datetime: Utc::now(),
+                received_at: Posix::now(),
+                server_time: Utc::now(),
                 direction: message::Direction::Sent,
                 source: source(target, message::Sender::Action)?,
                 text: message::action_text(our_nick, &action),

--- a/data/src/time.rs
+++ b/data/src/time.rs
@@ -28,11 +28,3 @@ impl Posix {
             .map(|datetime| DateTime::from_utc(datetime, Utc))
     }
 }
-
-impl From<DateTime<Utc>> for Posix {
-    fn from(datetime: DateTime<Utc>) -> Self {
-        let seconds = datetime.timestamp();
-
-        Self::from_seconds(seconds as u64)
-    }
-}

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -36,7 +36,7 @@ pub fn view<'a>(
                     data::message::Sender::User(user) => {
                         let timestamp =
                             settings
-                                .format_timestamp(&message.datetime)
+                                .format_timestamp(&message.server_time)
                                 .map(|timestamp| {
                                     selectable_text(timestamp).style(theme::Text::Alpha04)
                                 });

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -39,7 +39,7 @@ pub fn view<'a>(
                     message::Sender::User(user) => {
                         let timestamp =
                             settings
-                                .format_timestamp(&message.datetime)
+                                .format_timestamp(&message.server_time)
                                 .map(|timestamp| {
                                     selectable_text(timestamp).style(theme::Text::Alpha04)
                                 });

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -13,6 +13,7 @@ pub enum Message {
         count: usize,
         remaining: bool,
         oldest: time::Posix,
+        status: Status,
         viewport: scrollable::Viewport,
     },
 }
@@ -44,6 +45,7 @@ pub fn view<'a>(
         .first()
         .map(|message| message.received_at)
         .unwrap_or_else(time::Posix::now);
+    let status = state.status;
 
     scrollable(
         Column::with_children(messages.into_iter().filter_map(format).collect())
@@ -52,7 +54,7 @@ pub fn view<'a>(
     )
     .vertical_scroll(
         scrollable::Properties::default()
-            .alignment(state.status.alignment())
+            .alignment(status.alignment())
             .width(5)
             .scroller_width(5),
     )
@@ -60,6 +62,7 @@ pub fn view<'a>(
         count,
         remaining,
         oldest,
+        status,
         viewport,
     })
     .id(state.scrollable.clone())
@@ -94,13 +97,31 @@ impl State {
                 count,
                 remaining,
                 oldest,
+                status: old_status,
                 viewport,
             } => {
-                let old_status = self.status;
                 let relative_offset = viewport.relative_offset().y;
 
                 match old_status {
-                    _ if old_status.is_loading_zone(relative_offset) && remaining => {
+                    Status::Loading(anchor) => {
+                        self.status = Status::Unlocked(anchor);
+
+                        if matches!(anchor, Anchor::Bottom) {
+                            self.limit = Limit::Since(oldest);
+                        }
+                        // Top anchor can get stuck in loading state at
+                        // end of scrollable.
+                        else if old_status.is_end(relative_offset) {
+                            if remaining {
+                                self.status = Status::Loading(Anchor::Top);
+                                self.limit = Limit::Top(count + Limit::DEFAULT_STEP);
+                            } else {
+                                self.status = Status::Idle(Anchor::Bottom);
+                                self.limit = Limit::bottom();
+                            }
+                        }
+                    }
+                    _ if old_status.is_end(relative_offset) && remaining => {
                         match old_status.anchor() {
                             Anchor::Top => {
                                 self.status = Status::Loading(Anchor::Top);
@@ -112,22 +133,15 @@ impl State {
                             }
                         }
                     }
-                    _ if old_status.is_bottom_of_scrollable(relative_offset) => {
+                    _ if old_status.is_bottom(relative_offset) => {
                         self.status = Status::Idle(Anchor::Bottom);
                         self.limit = Limit::bottom();
                     }
-                    _ if old_status.is_top_of_scrollable(relative_offset) => {
+                    _ if old_status.is_top(relative_offset) => {
                         self.status = Status::Idle(Anchor::Top);
                         self.limit = Limit::top();
                     }
-                    Status::Idle(anchor) if !old_status.is_idle_zone(relative_offset) => {
-                        self.status = Status::Unlocked(anchor);
-
-                        if matches!(anchor, Anchor::Bottom) {
-                            self.limit = Limit::Since(oldest);
-                        }
-                    }
-                    Status::Loading(anchor) => {
+                    Status::Idle(anchor) if !old_status.is_start(relative_offset) => {
                         self.status = Status::Unlocked(anchor);
 
                         if matches!(anchor, Anchor::Bottom) {
@@ -166,14 +180,14 @@ impl State {
 }
 
 #[derive(Debug, Clone, Copy)]
-enum Status {
+pub enum Status {
     Idle(Anchor),
     Unlocked(Anchor),
     Loading(Anchor),
 }
 
 #[derive(Debug, Clone, Copy)]
-enum Anchor {
+pub enum Anchor {
     Top,
     Bottom,
 }
@@ -201,28 +215,28 @@ impl Status {
         }
     }
 
-    fn is_loading_zone(self, relative_offset: f32) -> bool {
+    fn is_end(self, relative_offset: f32) -> bool {
         match self.anchor() {
-            Anchor::Top => self.is_bottom_of_scrollable(relative_offset),
-            Anchor::Bottom => self.is_top_of_scrollable(relative_offset),
+            Anchor::Top => self.is_bottom(relative_offset),
+            Anchor::Bottom => self.is_top(relative_offset),
         }
     }
 
-    fn is_idle_zone(self, relative_offset: f32) -> bool {
+    fn is_start(self, relative_offset: f32) -> bool {
         match self.anchor() {
-            Anchor::Top => self.is_top_of_scrollable(relative_offset),
-            Anchor::Bottom => self.is_bottom_of_scrollable(relative_offset),
+            Anchor::Top => self.is_top(relative_offset),
+            Anchor::Bottom => self.is_bottom(relative_offset),
         }
     }
 
-    fn is_top_of_scrollable(self, relative_offset: f32) -> bool {
+    fn is_top(self, relative_offset: f32) -> bool {
         match self.alignment() {
             scrollable::Alignment::Start => relative_offset == 0.0,
             scrollable::Alignment::End => relative_offset == 1.0,
         }
     }
 
-    fn is_bottom_of_scrollable(self, relative_offset: f32) -> bool {
+    fn is_bottom(self, relative_offset: f32) -> bool {
         match self.alignment() {
             scrollable::Alignment::Start => relative_offset == 1.0,
             scrollable::Alignment::End => relative_offset == 0.0,

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -42,7 +42,7 @@ pub fn view<'a>(
     let remaining = count < total;
     let oldest = messages
         .first()
-        .map(|message| message.datetime.into())
+        .map(|message| message.received_at)
         .unwrap_or_else(time::Posix::now);
 
     scrollable(

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -31,7 +31,7 @@ pub fn view<'a>(
             history,
             |message| {
                 let timestamp = settings
-                    .format_timestamp(&message.datetime)
+                    .format_timestamp(&message.server_time)
                     .map(|timestamp| selectable_text(timestamp).style(theme::Text::Alpha04));
                 let message = selectable_text(&message.text).style(theme::Text::Alpha04);
 

--- a/src/font.rs
+++ b/src/font.rs
@@ -1,7 +1,6 @@
 use std::sync::OnceLock;
 
 use data::Config;
-
 use iced::font::{self, Error};
 use iced::Command;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,11 +15,11 @@ use std::env;
 use data::config::{self, Config};
 use iced::widget::container;
 use iced::{executor, Application, Command, Length, Subscription};
+use screen::{dashboard, help, welcome};
 
 use self::event::{events, Event};
 pub use self::theme::Theme;
 use self::widget::Element;
-use screen::{dashboard, help, welcome};
 
 pub fn main() -> iced::Result {
     let mut args = env::args();


### PR DESCRIPTION
Fixes a few issues related to scrollview:

- Changing message time to DateTime removed nanosecond precision which makes using `Limit::Since` not reliable for filtering since a specific message.
- Macos trackpad w/ multiple on_scroll events between views caused some issues.

Scrolling extremely fast on trackpad either from top of scrollable down or bottom up should be very reliable now.

@casperstorm can you confirm you can't break scrollable from either top or bottom (home / end) then scroll? I usually issue a `/list` in server to ensure scrollable is huge and scroll like crazy.