### PR TITLE
Add Leave context entry & PART completion

### DIFF
--- a/data/src/server.rs
+++ b/data/src/server.rs
@@ -55,6 +55,10 @@ impl<'a> From<(&'a Server, &'a Config)> for Entry {
 pub struct Map(BTreeMap<Server, Config>);
 
 impl Map {
+    pub fn remove(&mut self, server: &Server) {
+        self.0.remove(server);
+    }
+
     pub fn entries(&self) -> impl Iterator<Item = Entry> + '_ {
         self.0.iter().map(Entry::from)
     }

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -6,7 +6,8 @@ use iced::widget::{column, container, horizontal_rule, scrollable};
 use iced::{Command, Length};
 
 use super::user_context;
-use crate::widget::{Column, Element};
+use crate::theme;
+use crate::widget::Element;
 
 #[derive(Debug, Clone)]
 pub enum Message {

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -6,8 +6,7 @@ use iced::widget::{column, container, horizontal_rule, scrollable};
 use iced::{Command, Length};
 
 use super::user_context;
-use crate::theme;
-use crate::widget::Element;
+use crate::widget::{Column, Element};
 
 #[derive(Debug, Clone)]
 pub enum Message {

--- a/src/widget/input/completion.rs
+++ b/src/widget/input/completion.rs
@@ -96,6 +96,19 @@ impl Default for Completion {
                         },
                     ],
                 },
+                Entry {
+                    title: "PART",
+                    args: vec![
+                        Arg {
+                            text: "channels",
+                            optional: false,
+                        },
+                        Arg {
+                            text: "reason",
+                            optional: true,
+                        },
+                    ],
+                },
             ],
             filtered_entries: vec![],
         }


### PR DESCRIPTION
Adds a new context entry to leave a server / channel / query.

If leaving a server, it sends QUIT and drops the connection. I've confirmed via `lsof` the underlying connection is killed.

If leaving a channel, it sends a PART.

If leaving a query, nothing is sent but the buffer is closed.

In all cases the associated history is cleanly flushed and removed. Side menu properly doesn't show entries anymore.