### PR TITLE
update default irc channel

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -33,7 +33,7 @@ servers:
     
     # Channels to join upon connecting to the server
     channels:
-      - "##rust"
+      - "#halloy"
 
 # Font settings
 font: 


### PR DESCRIPTION
This updates the ##rust channel to #halloy.
Sorry ##rust community.

Fixes #70 