### PR TITLE
Allow configuring sidebar default pane action (new pane vs replace)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Unreleased
 
+Added:
+
+- New configuration option `dashboard.sidebar_default_action` allows controlling the pane behaviour when selecting channels in the sidebar
+
 Changed:
+
 - Default channel in `config.yaml` has been changed to `#halloy` (from `##rust`)
 
 # 2023.1-alpha1 (2023-06-30)

--- a/config.yaml
+++ b/config.yaml
@@ -83,3 +83,10 @@ new_buffer:
       # - Left: Left side of pane
       # - Right: Right side of pane [default]
       position: Right  
+
+# Dashboard settings
+dashboard:
+  # Default action when selecting channels in the sidebar:
+  # - NewPane: Open a new pane for each unique channel [default]
+  # - ReplacePane: Replace the currently selected pane
+  sidebar_default_action: NewPane

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use thiserror::Error;
 
 use crate::palette::Palette;
-use crate::{buffer, environment, server};
+use crate::{buffer, dashboard, environment, server};
 
 const CONFIG_TEMPLATE: &[u8] = include_bytes!("../../config.yaml");
 
@@ -20,6 +20,8 @@ pub struct Config {
     /// Default settings when creating a new buffer
     #[serde(default)]
     pub new_buffer: buffer::Settings,
+    #[serde(default)]
+    pub dashboard: dashboard::Config,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]

--- a/data/src/dashboard.rs
+++ b/data/src/dashboard.rs
@@ -11,6 +11,19 @@ pub struct Dashboard {
     pub pane: Pane,
 }
 
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
+pub enum DefaultAction {
+    #[default]
+    NewPane,
+    ReplacePane,
+}
+
+#[derive(Debug, Copy, Default, Clone, Deserialize, Serialize)]
+pub struct Config {
+    #[serde(default)]
+    pub sidebar_default_action: DefaultAction,
+}
+
 impl Dashboard {
     pub fn load() -> Result<Self, Error> {
         let path = path()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -315,7 +315,9 @@ impl Application for Halloy {
 
     fn view(&self) -> Element<Message> {
         let content = match &self.screen {
-            Screen::Dashboard(dashboard) => dashboard.view(&self.clients).map(Message::Dashboard),
+            Screen::Dashboard(dashboard) => dashboard
+                .view(&self.clients, self.config.dashboard)
+                .map(Message::Dashboard),
             Screen::Help(help) => help.view().map(Message::Help),
             Screen::Welcome(welcome) => welcome.view().map(Message::Welcome),
         };

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -4,7 +4,7 @@ pub mod side_menu;
 use std::time::{Duration, Instant};
 
 use data::history::manager::Broadcast;
-use data::{history, Config, Server};
+use data::{dashboard, history, Config, Server};
 use iced::widget::pane_grid::{self, PaneGrid};
 use iced::widget::{container, row};
 use iced::{clipboard, window, Command, Length, Subscription};
@@ -330,7 +330,11 @@ impl Dashboard {
         Command::none()
     }
 
-    pub fn view<'a>(&'a self, clients: &'a data::client::Map) -> Element<'a, Message> {
+    pub fn view<'a>(
+        &'a self,
+        clients: &'a data::client::Map,
+        config: dashboard::Config,
+    ) -> Element<'a, Message> {
         let focus = self.focus;
 
         let pane_grid: Element<_> = PaneGrid::new(&self.panes, |id, pane, maximized| {
@@ -351,7 +355,13 @@ impl Dashboard {
 
         let side_menu = self
             .side_menu
-            .view(clients, &self.history, &self.panes, self.focus)
+            .view(
+                clients,
+                &self.history,
+                &self.panes,
+                self.focus,
+                config.sidebar_default_action,
+            )
             .map(Message::SideMenu);
 
         // The height margin varies across different operating systems due to design differences.


### PR DESCRIPTION
This is somewhat of an attempt to modify the default click behaviour of channels in the sidebar. Today, each channel clicked opens a new pane, which quickly clutters up when dealing with lots of channels. Ideally I'd like to be able to just replace the focused pane instead, allowing me to right-click to open new panes as needed, but to not clutter up the window otherwise.

I figured just changing the default behaviour without configurability is probably a bad thing, so in lieu of that, I've tried to add a new configuration option that lets you choose either `NewPane` (today's behaviour) or `ReplacePane` (my proposed behaviour):
```
dashboard:
  sidebar_default_action: ReplacePane
```

The fundamental new-vs-replace pane part works but I am struggling with the config side of things. I am not really a native Rustacean (please go easy on me) and I am not *really* sure of the best place to put this config item or how to pass it down the hierarchy.

It appears that the `Dashboard` state gets written out to a file, so that means that any config there also gets written into the state file and therefore later changes to the option in `config.yaml` are ignored. I'd appreciate any pointers on what the best approach here should be or if it should go somewhere else.