### PR TITLE
Add early support for showing highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Added:
 
 - New configuration option `dashboard.sidebar_default_action` allows controlling the pane behaviour when selecting channels in the sidebar
 - Support for RAW command
+- Messages from other users containing your nickname are now highlighted using the `info` colour
 
 Changed:
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -40,6 +40,7 @@ impl Connection {
 
     pub async fn quit(self) {
         use std::time::Duration;
+
         use tokio::time;
 
         let _ = self.client.send_quit("");
@@ -100,7 +101,7 @@ impl Connection {
             .collect()
     }
 
-    fn nickname(&self) -> Nick {
+    pub fn nickname(&self) -> Nick {
         Nick::from(
             self.resolved_nick
                 .as_deref()

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use irc::client::Client;
 
-use crate::user::Nick;
+use crate::user::NickRef;
 use crate::{message, Message, Server, User};
 
 #[derive(Debug, Clone, Copy)]
@@ -60,7 +60,7 @@ impl Connection {
 
         self.handle(&message);
 
-        Message::received(message, &self.nickname())
+        Message::received(message, self.nickname())
     }
 
     fn handle(&mut self, message: &message::Encoded) {
@@ -101,8 +101,8 @@ impl Connection {
             .collect()
     }
 
-    pub fn nickname(&self) -> Nick {
-        Nick::from(
+    pub fn nickname(&self) -> NickRef {
+        NickRef::from(
             self.resolved_nick
                 .as_deref()
                 .unwrap_or_else(|| self.client.current_nickname()),
@@ -149,7 +149,7 @@ impl Map {
         }
     }
 
-    pub fn nickname(&self, server: &Server) -> Option<Nick> {
+    pub fn nickname(&self, server: &Server) -> Option<NickRef> {
         self.connection(server).map(Connection::nickname)
     }
 

--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -2,7 +2,7 @@ use chrono::Utc;
 use irc::proto::ChannelExt;
 
 use crate::time::Posix;
-use crate::user::Nick;
+use crate::user::NickRef;
 use crate::{command, message, Buffer, Command, Message, Server, User};
 
 pub fn parse(buffer: Buffer, input: &str) -> Result<Input, command::Error> {
@@ -33,14 +33,14 @@ impl Input {
         self.buffer.server()
     }
 
-    pub fn message(&self, our_nick: &Nick) -> Option<Message> {
+    pub fn message(&self, our_nick: NickRef) -> Option<Message> {
         let command = self.content.command(&self.buffer)?;
 
         let source = |target: String, sender| {
             if target.is_channel_name() {
                 Some(message::Source::Channel(target, sender))
             } else if let Ok(user) = User::try_from(target) {
-                Some(message::Source::Query(user.nickname(), sender))
+                Some(message::Source::Query(user.nickname().to_owned(), sender))
             } else {
                 None
             }
@@ -53,7 +53,7 @@ impl Input {
                 direction: message::Direction::Sent,
                 source: source(
                     target,
-                    message::Sender::User(User::new(our_nick.clone(), None, None)),
+                    message::Sender::User(User::new(our_nick.to_owned(), None, None)),
                 )?,
                 text,
             }),

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -27,12 +27,14 @@ pub fn view<'a>(
     settings: &'a buffer::Settings,
     is_focused: bool,
 ) -> Element<'a, Message> {
+    let our_nick = clients.nickname(&state.server);
+
     let messages = container(
         scroll_view::view(
             &state.scroll_view,
             scroll_view::Kind::Channel(&state.server, &state.channel),
             history,
-            |message| match &message.source {
+            move |message| match &message.source {
                 data::message::Source::Channel(_, kind) => match kind {
                     data::message::Sender::User(user) => {
                         let timestamp =
@@ -48,10 +50,10 @@ pub fn view<'a>(
                             user.clone(),
                         )
                         .map(scroll_view::Message::UserContext);
-                        let row_style = match clients.connection(&state.server) {
-                            Some(conn)
-                                if user.nickname() != conn.nickname()
-                                    && message.text.contains(&conn.nickname().to_string()) =>
+                        let row_style = match our_nick {
+                            Some(nick)
+                                if user.nickname() != nick
+                                    && message.text.contains(nick.as_ref()) =>
                             {
                                 theme::Container::Highlight
                             }

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -48,10 +48,20 @@ pub fn view<'a>(
                             user.clone(),
                         )
                         .map(scroll_view::Message::UserContext);
+                        let row_style = match clients.connection(&state.server) {
+                            Some(conn)
+                                if user.nickname() != conn.nickname()
+                                    && message.text.contains(&conn.nickname().to_string()) =>
+                            {
+                                theme::Container::Highlight
+                            }
+                            _ => theme::Container::Default,
+                        };
                         let message = selectable_text(&message.text);
-
                         Some(
-                            container(row![].push_maybe(timestamp).push(nick).push(message)).into(),
+                            container(row![].push_maybe(timestamp).push(nick).push(message))
+                                .style(row_style)
+                                .into(),
                         )
                     }
                     data::message::Sender::Server => Some(

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -48,7 +48,7 @@ impl State {
                 }
                 if let Some(message) = clients
                     .nickname(server)
-                    .and_then(|nick| input.message(&nick))
+                    .and_then(|nick| input.message(nick))
                 {
                     history.record_message(server, message);
                 }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -131,7 +131,7 @@ impl Dashboard {
 
                                         if let Some(message) = clients
                                             .nickname(input.server())
-                                            .and_then(|nick| input.message(&nick))
+                                            .and_then(|nick| input.message(nick))
                                         {
                                             self.history.record_message(input.server(), message);
                                         }
@@ -141,7 +141,7 @@ impl Dashboard {
                                     if let Some(data) = pane.buffer.data() {
                                         let buffer = data::Buffer::Query(
                                             data.server().clone(),
-                                            user.nickname(),
+                                            user.nickname().to_owned(),
                                         );
                                         return self.open_buffer(buffer, config);
                                     }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -86,6 +86,7 @@ impl Colors {
 pub struct Subpalette {
     pub base: Color,
     pub weak: Color,
+    pub alpha_005: Color,
     pub alpha_02: Color,
     pub alpha_04: Color,
     pub alpha_06: Color,
@@ -108,6 +109,7 @@ impl Subpalette {
         Subpalette {
             base: color,
             weak: palette::mix(palette.background, color, 0.8),
+            alpha_005: palette::alpha(color, 0.05),
             alpha_02: palette::alpha(color, 0.2),
             alpha_04: palette::alpha(color, 0.4),
             alpha_06: palette::alpha(color, 0.6),
@@ -221,6 +223,7 @@ pub enum Container {
         selected: bool,
     },
     Context,
+    Highlight,
 }
 
 impl container::StyleSheet for Theme {
@@ -269,6 +272,11 @@ impl container::StyleSheet for Theme {
                 border_radius: 4.0.into(),
                 border_width: 1.0,
                 border_color: self.colors.accent.base,
+                ..Default::default()
+            },
+            Container::Highlight => container::Appearance {
+                background: Some(Background::Color(self.colors.info.alpha_005)),
+                border_radius: 3.0.into(),
                 ..Default::default()
             },
         }


### PR DESCRIPTION
This adds very early support for highlights. Any messages from other users containing your current nickname will be rendered in the `info` colour.

Some future work might include making highlights more obvious in the sidebar and/or allowing additional words to match in the config file.