### PR TITLE
Added sorting channel nicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Added:
 
 - New configuration option `dashboard.sidebar_default_action` allows controlling the pane behaviour when selecting channels in the sidebar
+- Sorting channel nicknames
 
 Changed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 Added:
 
 - New configuration option `dashboard.sidebar_default_action` allows controlling the pane behaviour when selecting channels in the sidebar
-- Sorting channel nicknames
 
 Changed:
 
 - Default channel in `config.yaml` has been changed to `#halloy` (from `##rust`)
+- Sorting channel nicknames
 
 # 2023.1-alpha1 (2023-06-30)
 

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -23,17 +23,27 @@ impl Hash for User {
 
 impl Ord for User {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        other
-            .highest_access_level()
-            .cmp(&self.highest_access_level())
+        let access_level_comparison = other.highest_access_level()
+            .cmp(&self.highest_access_level());
+
+        if access_level_comparison != std::cmp::Ordering::Equal {
+            return access_level_comparison;
+        }
+
+        other.nickname().cmp(&self.nickname())
     }
 }
 
 impl PartialOrd for User {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        other
-            .highest_access_level()
-            .partial_cmp(&self.highest_access_level())
+        let access_level_comparison = other.highest_access_level()
+            .partial_cmp(&self.highest_access_level());
+
+        if access_level_comparison != Some(std::cmp::Ordering::Equal) {
+            return access_level_comparison;
+        }
+
+        other.nickname().partial_cmp(&self.nickname())
     }
 }
 
@@ -143,6 +153,18 @@ impl fmt::Display for Nick {
 impl<'a> From<&'a str> for Nick {
     fn from(nick: &'a str) -> Self {
         Nick(nick.to_string())
+    }
+}
+
+impl PartialOrd for Nick {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        other.0.partial_cmp(&self.0)
+    }
+}
+
+impl Ord for Nick {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        other.0.cmp(&self.0)
     }
 }
 

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -31,7 +31,7 @@ impl Ord for User {
 
 impl PartialOrd for User {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(&other))
+        Some(self.cmp(other))
     }
 }
 

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -23,14 +23,9 @@ impl Hash for User {
 
 impl Ord for User {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        let access_level_comparison = other.highest_access_level()
-            .cmp(&self.highest_access_level());
-
-        if access_level_comparison != std::cmp::Ordering::Equal {
-            return access_level_comparison;
-        }
-
-        other.nickname().cmp(&self.nickname())
+        other.highest_access_level()
+            .cmp(&self.highest_access_level())
+            .then(other.nickname().cmp(&self.nickname()))
     }
 }
 

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -31,14 +31,7 @@ impl Ord for User {
 
 impl PartialOrd for User {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        let access_level_comparison = other.highest_access_level()
-            .partial_cmp(&self.highest_access_level());
-
-        if access_level_comparison != Some(std::cmp::Ordering::Equal) {
-            return access_level_comparison;
-        }
-
-        other.nickname().partial_cmp(&self.nickname())
+        Some(self.cmp(&other))
     }
 }
 


### PR DESCRIPTION
This PR sorts the nicknames in the channel and keeps the highest level access nicknames sorted at the top. This addresses #68 

This is my first time working in Rust. Please let me know if I'm doing anything non Rustic(?) or if you'd like any changes to the code.