### PR TITLE
user count in title bar text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changed:
 
 - Default channel in `config.yaml` has been changed to `#halloy` (from `##rust`)
 - Sorting channel nicknames
+- Title headers has been changed to also display user count for channels
 
 # 2023.1-alpha1 (2023-06-30)
 

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use data::server::Server;
 use data::{buffer, client, history};
 use iced::widget::{column, container, row, vertical_space};
@@ -171,14 +169,6 @@ impl Channel {
 
     pub fn focus(&self) -> Command<Message> {
         self.input_view.focus().map(Message::InputView)
-    }
-}
-
-impl fmt::Display for Channel {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let channel = self.channel.to_string();
-
-        write!(f, "{} ({})", channel, self.server)
     }
 }
 

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -1,5 +1,3 @@
-use core::fmt;
-
 use data::user::Nick;
 use data::{buffer, client, history, message, Server};
 use iced::widget::{column, container, row, vertical_space};
@@ -149,11 +147,5 @@ impl Query {
 
     pub fn focus(&self) -> Command<Message> {
         self.input_view.focus().map(Message::InputView)
-    }
-}
-
-impl fmt::Display for Query {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.nick)
     }
 }

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use data::{buffer, client, history};
 use iced::widget::{column, container, row, vertical_space};
 use iced::{Command, Length};
@@ -105,11 +103,5 @@ impl Server {
 
     pub fn focus(&self) -> Command<Message> {
         self.input_view.focus().map(Message::InputView)
-    }
-}
-
-impl fmt::Display for Server {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.server)
     }
 }

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -50,9 +50,22 @@ impl Pane {
     ) -> widget::Content<'a, Message> {
         let title_bar_text = match &self.buffer {
             Buffer::Empty => "".to_string(),
-            Buffer::Channel(state) => state.to_string(),
-            Buffer::Server(state) => state.to_string(),
-            Buffer::Query(state) => state.to_string(),
+            Buffer::Channel(state) => {
+                let channel = &state.channel;
+                let server = &state.server;
+                let users = clients
+                    .get_channel_users(&state.server, &state.channel)
+                    .len();
+
+                format!("{channel} @ {server} - {users} users")
+            }
+            Buffer::Server(state) => state.server.to_string(),
+            Buffer::Query(state) => {
+                let nick = &state.nick;
+                let server = &state.server;
+
+                format!("{nick} @ {server}")
+            }
         };
 
         let title_bar = self.title_bar.view(


### PR DESCRIPTION
Fixes #84.

I have added user count to title headers for channels. Also, I didn't like our `Buffer` conformed to `std::fmt::Display`. I feel it was a little confusing that their display value was the title header.

The new title header for a channel looks like:

<img width="263" alt="Screenshot 2023-07-02 at 23 20 52" src="https://github.com/squidowl/halloy/assets/2248455/d571eab2-f1db-46fa-b997-0b39e4661560">