### PR TITLE
added raw command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Added:
 
 - New configuration option `dashboard.sidebar_default_action` allows controlling the pane behaviour when selecting channels in the sidebar
+- Support for RAW command
 
 Changed:
 

--- a/data/src/command.rs
+++ b/data/src/command.rs
@@ -107,12 +107,14 @@ pub fn parse(s: &str, buffer: &Buffer) -> Result<Command, Error> {
             Kind::Kick => validated::<2, 1, true>(args, |[channel, user], [comment]| {
                 Command::Kick(channel, user, comment)
             }),
-            Kind::Raw => validated::<1, 1, true>(args, |[cmd], [args]| {
-                let args = args
-                    .map(|args| args.split_whitespace().map(|s| s.to_string()).collect())
-                    .unwrap_or_default();
-                Command::Raw(cmd, args)
-            }),
+            Kind::Raw => {
+                let (cmd, args) = args.split_first().ok_or(Error::MissingCommand)?;
+
+                Ok(Command::Raw(
+                    cmd.to_string(),
+                    args.iter().map(|s| s.to_string()).collect(),
+                ))
+            }
         },
         Err(_) => Ok(unknown()),
     }

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -312,7 +312,7 @@ fn text(message: &Encoded, our_nick: &Nick) -> Option<String> {
 
             Some(format!(" ∙ topic set by {nick} at {datetime}"))
         }
-        proto::Command::Response(_, responses) => Some(
+        proto::Command::Response(_, responses) | proto::Command::Raw(_, responses) => Some(
             responses
                 .iter()
                 .map(|s| s.as_str())

--- a/src/widget/input/completion.rs
+++ b/src/widget/input/completion.rs
@@ -139,6 +139,19 @@ impl Default for Completion {
                         },
                     ],
                 },
+                Entry {
+                    title: "RAW",
+                    args: vec![
+                        Arg {
+                            text: "command",
+                            optional: false,
+                        },
+                        Arg {
+                            text: "args",
+                            optional: true,
+                        },
+                    ],
+                },
             ],
             filtered_entries: vec![],
         }


### PR DESCRIPTION
Fixes #86.

We now correctly handle, and show a RAW command.

<img width="358" alt="Screenshot 2023-07-03 at 00 01 58" src="https://github.com/squidowl/halloy/assets/2248455/f3adb286-35fd-447a-b440-41ae74fe83c9">
