### PR TITLE
Update user list sorting to be case-insensitive

### DIFF
--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -146,13 +146,13 @@ impl<'a> From<&'a str> for Nick {
 
 impl PartialOrd for Nick {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        other.0.partial_cmp(&self.0)
+        other.0.to_lowercase().partial_cmp(&self.0.to_lowercase())
     }
 }
 
 impl Ord for Nick {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        other.0.cmp(&self.0)
+        other.0.to_lowercase().cmp(&self.0.to_lowercase())
     }
 }
 


### PR DESCRIPTION
I'm not entirely sure if there is a better way to do this, or if it can be done with less allocations than `to_lowercase()` may produce, but this changes the user list sorting to be case-insensitive.

Without this, the ordering would look like `[Alice, Bob, Chris, anna, barbara]` rather than the more-useful `[Alice, anna, barbara, Bob, Chris]`.

I did originally try to do this with a character-by-character iterator, but it turns out that is unsafe if the nicknames have the potential to be unicode. `to_lowercase()` over the entire string seemingly is unicode-aware so it is safe.