### PR TITLE
Added username completion in channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Added:
 - Messages from other users containing your nickname are now highlighted using the `info` colour
 - Previously sent messages can be accessed per buffer in the text input with up / down arrows
 - Themes directory where users can add their own theme files
-- Nickname completions in text input with TAB
+- Nickname completions in text input with <kbd>Tab</kbd>
 
 Changed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Added:
 - Messages from other users containing your nickname are now highlighted using the `info` colour
 - Previously sent messages can be accessed per buffer in the text input with up / down arrows
 - Themes directory where users can add their own theme files
+- Nickname completions in text input with TAB
 
 Changed:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,6 +1078,7 @@ dependencies = [
  "iced",
  "image",
  "log",
+ "once_cell",
  "open",
  "palette",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ chrono = { version = "0.4", features = ['serde'] }
 fern = "0.6.1"
 iced = { version = "0.9", features = ["tokio", "lazy", "advanced", "image"] }
 log = "0.4.16"
+once_cell = "1.18"
 palette = "=0.7.2"
 thiserror = "1.0.30"
 tokio = { version = "1.0", features = ["rt", "fs", "process"] }

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -83,7 +83,7 @@ pub fn view<'a>(
 
     let spacing = is_focused.then_some(vertical_space(4));
     let users = clients.get_channel_users(&state.server, &state.channel);
-    let nick_list = nick_list::view(users.clone()).map(Message::UserContext);
+    let nick_list = nick_list::view(users).map(Message::UserContext);
     let text_input = (is_focused && status.connected()).then(|| {
         input_view::view(
             &state.input_view,

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -82,16 +82,16 @@ pub fn view<'a>(
     .height(Length::Fill);
 
     let spacing = is_focused.then_some(vertical_space(4));
+    let users = clients.get_channel_users(&state.server, &state.channel);
+    let nick_list = nick_list::view(users.clone()).map(Message::UserContext);
     let text_input = (is_focused && status.connected()).then(|| {
         input_view::view(
             &state.input_view,
             data::Buffer::Channel(state.server.clone(), state.channel.clone()),
+            users,
         )
         .map(Message::InputView)
     });
-
-    let users = clients.get_channel_users(&state.server, &state.channel);
-    let nick_list = nick_list::view(users).map(Message::UserContext);
 
     let content = match (
         settings.channel.users.visible,

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -14,7 +14,7 @@ pub enum Message {
     CompletionSelected,
 }
 
-pub fn view<'a>(state: &State, buffer: Buffer, users: Vec<User>) -> Element<'a, Message> {
+pub fn view<'a>(state: &State, buffer: Buffer, users: &'a [User]) -> Element<'a, Message> {
     input(
         state.input_id.clone(),
         buffer,

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -1,3 +1,4 @@
+use data::user::User;
 use data::{client, history, Buffer, Input, Server};
 use iced::Command;
 
@@ -13,10 +14,11 @@ pub enum Message {
     CompletionSelected,
 }
 
-pub fn view<'a>(state: &State, buffer: Buffer) -> Element<'a, Message> {
+pub fn view<'a>(state: &State, buffer: Buffer, users: Vec<User>) -> Element<'a, Message> {
     input(
         state.input_id.clone(),
         buffer,
+        users,
         Message::Send,
         Message::CompletionSelected,
     )

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -74,6 +74,7 @@ pub fn view<'a>(
         input_view::view(
             &state.input_view,
             data::Buffer::Query(state.server.clone(), state.nick.clone()),
+            vec![],
         )
         .map(Message::InputView)
     });

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -74,7 +74,7 @@ pub fn view<'a>(
         input_view::view(
             &state.input_view,
             data::Buffer::Query(state.server.clone(), state.nick.clone()),
-            vec![],
+            &[],
         )
         .map(Message::InputView)
     });

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -41,7 +41,7 @@ pub fn view<'a>(
         input_view::view(
             &state.input_view,
             data::Buffer::Server(state.server.clone()),
-            vec![],
+            &[],
         )
         .map(Message::InputView)
     });

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -41,6 +41,7 @@ pub fn view<'a>(
         input_view::view(
             &state.input_view,
             data::Buffer::Server(state.server.clone()),
+            vec![],
         )
         .map(Message::InputView)
     });

--- a/src/widget/input.rs
+++ b/src/widget/input.rs
@@ -19,7 +19,7 @@ pub type Id = text_input::Id;
 pub fn input<'a, Message>(
     id: Id,
     buffer: Buffer,
-    users: Vec<User>,
+    users: &'a [User],
     on_submit: impl Fn(data::Input) -> Message + 'a,
     on_completion: Message,
 ) -> Element<'a, Message>
@@ -54,7 +54,7 @@ pub enum Event {
 pub struct Input<'a, Message> {
     id: Id,
     buffer: Buffer,
-    users: Vec<User>,
+    users: &'a [User],
     on_submit: Box<dyn Fn(data::Input) -> Message + 'a>,
     on_completion: Message,
 }
@@ -85,7 +85,7 @@ where
 
                 state.input = input;
 
-                state.completion.process(&state.input, &self.users);
+                state.completion.process(&state.input, self.users);
 
                 None
             }
@@ -142,7 +142,7 @@ where
                         .get(state.selected_history.unwrap())
                         .unwrap()
                         .clone();
-                    state.completion.process(&state.input, &self.users);
+                    state.completion.process(&state.input, self.users);
 
                     return Some(self.on_completion.clone());
                 }
@@ -159,7 +159,7 @@ where
                     } else {
                         *index -= 1;
                         state.input = state.history.get(*index).unwrap().clone();
-                        state.completion.process(&state.input, &self.users);
+                        state.completion.process(&state.input, self.users);
                     }
 
                     return Some(self.on_completion.clone());

--- a/src/widget/input.rs
+++ b/src/widget/input.rs
@@ -119,7 +119,16 @@ where
             }
             Event::Tab => {
                 state.completion.tab();
-                None
+                if let Some(entry) = state.completion.select() {
+                    if entry.is_user() {
+                        state.input = entry.complete_input(&state.input);
+                        Some(self.on_completion.clone())
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
             }
             Event::Up => {
                 state.completion.reset();

--- a/src/widget/input.rs
+++ b/src/widget/input.rs
@@ -1,8 +1,8 @@
-use std::collections::VecDeque;
-use data::{user::User, input, Buffer, Command};
+use data::{input, user::User, Buffer, Command};
 use iced::advanced::widget::{self, Operation};
 pub use iced::widget::text_input::{focus, move_cursor_to_end};
 use iced::widget::{component, container, row, text, text_input, Component};
+use std::collections::VecDeque;
 
 use self::completion::Completion;
 use super::{anchored_overlay, key_press, Element, Renderer};
@@ -93,10 +93,8 @@ where
                 // Reset selected history
                 state.selected_history = None;
 
-                if let Some(command) = state.completion.select() {
-                    state.input = Completion::complete_selected_word(&state.input, &command);
-                    // We've completed a word and replace out input, reset our completion options
-                    state.completion.reset();
+                if let Some(entry) = state.completion.select() {
+                    state.input = entry.complete_input(&state.input);
                     Some(self.on_completion.clone())
                 } else if !state.input.is_empty() {
                     state.completion.reset();

--- a/src/widget/input.rs
+++ b/src/widget/input.rs
@@ -1,8 +1,10 @@
-use data::{input, user::User, Buffer, Command};
+use std::collections::VecDeque;
+
+use data::user::User;
+use data::{input, Buffer, Command};
 use iced::advanced::widget::{self, Operation};
 pub use iced::widget::text_input::{focus, move_cursor_to_end};
 use iced::widget::{component, container, row, text, text_input, Component};
-use std::collections::VecDeque;
 
 use self::completion::Completion;
 use super::{anchored_overlay, key_press, Element, Renderer};
@@ -118,14 +120,9 @@ where
                 }
             }
             Event::Tab => {
-                state.completion.tab();
-                if let Some(entry) = state.completion.select() {
-                    if entry.is_user() {
-                        state.input = entry.complete_input(&state.input);
-                        Some(self.on_completion.clone())
-                    } else {
-                        None
-                    }
+                if let Some(entry) = state.completion.tab() {
+                    state.input = entry.complete_input(&state.input);
+                    Some(self.on_completion.clone())
                 } else {
                     None
                 }
@@ -185,20 +182,15 @@ where
             .on_submit(Event::Send)
             .id(self.id.clone())
             .padding(8)
-            .style(style)
-            .into();
+            .style(style);
 
-        // Add tab support if selecting a completion
-        let input = if state.completion.is_selecting() {
-            key_press(
-                text_input,
-                key_press::KeyCode::Tab,
-                key_press::Modifiers::default(),
-                Event::Tab,
-            )
-        } else {
-            text_input
-        };
+        // Add tab support
+        let input = key_press(
+            text_input,
+            key_press::KeyCode::Tab,
+            key_press::Modifiers::default(),
+            Event::Tab,
+        );
 
         // Add up / down support for history cycling
         let input = key_press(

--- a/src/widget/input.rs
+++ b/src/widget/input.rs
@@ -74,7 +74,6 @@ where
     type Event = Event;
 
     fn update(&mut self, state: &mut Self::State, event: Self::Event) -> Option<Message> {
-        let users = &self.users;
         match event {
             Event::Input(input) => {
                 // Reset error state
@@ -84,7 +83,7 @@ where
 
                 state.input = input;
 
-                state.completion.process(&state.input, users.clone());
+                state.completion.process(&state.input, &self.users);
 
                 None
             }
@@ -139,7 +138,7 @@ where
                         .get(state.selected_history.unwrap())
                         .unwrap()
                         .clone();
-                    state.completion.process(&state.input);
+                    state.completion.process(&state.input, &self.users);
 
                     return Some(self.on_completion.clone());
                 }
@@ -156,7 +155,7 @@ where
                     } else {
                         *index -= 1;
                         state.input = state.history.get(*index).unwrap().clone();
-                        state.completion.process(&state.input);
+                        state.completion.process(&state.input, &self.users);
                     }
 
                     return Some(self.on_completion.clone());

--- a/src/widget/input/completion.rs
+++ b/src/widget/input/completion.rs
@@ -239,8 +239,11 @@ impl Completion {
                 self.filtered_entries = users
                     .iter()
                     .filter_map(|user| {
-                        let nickname = user.nickname().as_ref().to_string();
-                        nickname.starts_with(nick).then_some(nickname)
+                        let nickname = user.nickname();
+                        nickname
+                            .as_ref()
+                            .starts_with(nick)
+                            .then(|| nickname.to_string())
                     })
                     .map(Entry::User)
                     .collect();

--- a/src/widget/input/completion.rs
+++ b/src/widget/input/completion.rs
@@ -167,8 +167,8 @@ impl Completion {
         self.selection = Selection::None;
     }
 
-    /// If the entered text begins with a command char ('/'), then we want to look at the available
-    /// command completions
+    /// If the entered text begins with a command char ('/') then we want to populate
+    /// applicable command completions
     fn process_command(&mut self, input: &str) {
         let Some((head, rest)) = input.split_once('/') else {
             self.reset();
@@ -223,8 +223,7 @@ impl Completion {
         }
     }
 
-    /// For any given word, we want to check if the user is attempting to autocomplete a name in a
-    /// channel
+    /// If the trailing word starts with an @ we want to populate applicable user completions
     fn process_users(&mut self, input: &str, users: &[User]) {
         let (_, rest) = input.rsplit_once(' ').unwrap_or(("", input));
 
@@ -250,7 +249,7 @@ impl Completion {
         }
     }
 
-    /// Process input and
+    /// Process input and update the completion state
     pub fn process(&mut self, input: &str, users: &[User]) {
         if input.starts_with('/') {
             self.process_command(input);
@@ -395,8 +394,6 @@ pub struct Command {
     args: Vec<Arg>,
 }
 
-/// Dictates how we render a command completion. A command may or may not have args,
-/// so we want to include those as autocomplete hints when the completion is selected
 impl Command {
     pub fn view<'a, Message: 'a>(&self, input: &str) -> Element<'a, Message> {
         let active_arg = [input, "_"]

--- a/src/widget/input/completion.rs
+++ b/src/widget/input/completion.rs
@@ -298,16 +298,17 @@ impl Users {
             return;
         }
 
+        let nick = rest.to_lowercase();
+
         self.selected = None;
         self.prompt = rest.to_string();
         self.filtered = users
             .iter()
             .filter_map(|user| {
-                let nickname = user.nickname();
-                nickname
-                    .as_ref()
-                    .starts_with(rest)
-                    .then(|| nickname.to_string())
+                let lower_nick = user.nickname().as_ref().to_lowercase();
+                lower_nick
+                    .starts_with(&nick)
+                    .then(|| user.nickname().to_string())
             })
             .collect();
     }

--- a/src/widget/input/completion.rs
+++ b/src/widget/input/completion.rs
@@ -226,8 +226,14 @@ impl Completion {
     fn process_users(&mut self, input: &str, users: &[User]) {
         let (_, rest) = input.rsplit_once(' ').unwrap_or(("", input));
 
+        // Only show user completions if using @
+        let Some((_, nick)) = rest.split_once('@') else {
+            self.reset();
+            return;
+        };
+
         // Empty input to operate on, ignore completions
-        if rest.is_empty() {
+        if nick.is_empty() {
             self.reset();
             return;
         }
@@ -239,7 +245,7 @@ impl Completion {
                     .iter()
                     .filter_map(|user| {
                         let nickname = user.nickname().as_ref().to_string();
-                        nickname.starts_with(rest).then_some(nickname)
+                        nickname.starts_with(nick).then_some(nickname)
                     })
                     .map(Entry::User)
                     .collect();


### PR DESCRIPTION
This adds nickname auto-completion for channels.

When we instantiate the text_input from the Channel's view with a list of users in that channel. 

From there, we need to differentiate between a /command and a user completion, so we add a CompletionType to each Completion Entry. /commands only auto-complete from the start of the input text, whereas name completion can occur from any word.

Finally, we replace the current word being completed without sending, so the user can continue to type.