### PR TITLE
Make image windows only dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,16 @@ thiserror = "1.0.30"
 tokio = { version = "1.0", features = ["rt", "fs", "process"] }
 unicode-segmentation = "1.6"
 open = "4.1.0"
-image = "0.24.6"
-
-[build-dependencies]
-embed-resource = "2.1.1"
 
 [dependencies.uuid]
 version = "1.0"
 features = ["v4"]
+
+[target.'cfg(windows)'.dependencies]
+image = "0.24.6"
+
+[build-dependencies]
+embed-resource = "2.1.1"
 
 [workspace]
 members = ["data"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,6 @@ use iced::widget::container;
 use iced::{executor, window, Application, Command, Length, Subscription};
 use screen::{dashboard, help, welcome};
 
-extern crate image;
-
 use self::event::{events, Event};
 pub use self::theme::Theme;
 use self::widget::Element;


### PR DESCRIPTION
@casperstorm can you test this, it should still work. We don't need image as a non-windows dep for now. Also removed `extern crate` as that's not idiomatic