### PR TITLE
Sync channels & users to connection state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Added:
 - Messages from other users containing your nickname are now highlighted using the `info` colour
 - Previously sent messages can be accessed per buffer in the text input with up / down arrows
 - Themes directory where users can add their own theme files
+- Nickname completions in text input with <kbd>Tab</kbd>
 
 Changed:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,6 +1078,7 @@ dependencies = [
  "iced",
  "image",
  "log",
+ "once_cell",
  "open",
  "palette",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ chrono = { version = "0.4", features = ['serde'] }
 fern = "0.6.1"
 iced = { version = "0.9", features = ["tokio", "lazy", "advanced", "image"] }
 log = "0.4.16"
+once_cell = "1.18"
 palette = "=0.7.2"
 thiserror = "1.0.30"
 tokio = { version = "1.0", features = ["rt", "fs", "process"] }

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -82,16 +82,16 @@ pub fn view<'a>(
     .height(Length::Fill);
 
     let spacing = is_focused.then_some(vertical_space(4));
+    let users = clients.get_channel_users(&state.server, &state.channel);
+    let nick_list = nick_list::view(users).map(Message::UserContext);
     let text_input = (is_focused && status.connected()).then(|| {
         input_view::view(
             &state.input_view,
             data::Buffer::Channel(state.server.clone(), state.channel.clone()),
+            users,
         )
         .map(Message::InputView)
     });
-
-    let users = clients.get_channel_users(&state.server, &state.channel);
-    let nick_list = nick_list::view(users).map(Message::UserContext);
 
     let content = match (
         settings.channel.users.visible,

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -198,7 +198,7 @@ mod nick_list {
     use crate::theme;
     use crate::widget::Element;
 
-    pub fn view<'a>(users: Vec<User>) -> Element<'a, Message> {
+    pub fn view(users: &[User]) -> Element<Message> {
         let column = column(
             users
                 .iter()

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -1,3 +1,4 @@
+use data::user::User;
 use data::{client, history, Buffer, Input, Server};
 use iced::Command;
 
@@ -13,10 +14,11 @@ pub enum Message {
     CompletionSelected,
 }
 
-pub fn view<'a>(state: &State, buffer: Buffer) -> Element<'a, Message> {
+pub fn view<'a>(state: &State, buffer: Buffer, users: &'a [User]) -> Element<'a, Message> {
     input(
         state.input_id.clone(),
         buffer,
+        users,
         Message::Send,
         Message::CompletionSelected,
     )

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -74,6 +74,7 @@ pub fn view<'a>(
         input_view::view(
             &state.input_view,
             data::Buffer::Query(state.server.clone(), state.nick.clone()),
+            &[],
         )
         .map(Message::InputView)
     });

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -41,6 +41,7 @@ pub fn view<'a>(
         input_view::view(
             &state.input_view,
             data::Buffer::Server(state.server.clone()),
+            &[],
         )
         .map(Message::InputView)
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -325,6 +325,10 @@ impl Application for Halloy {
                         }
                     });
 
+                    // Must be called after receiving message batches to ensure
+                    // user & channel lists are in sync
+                    self.clients.sync();
+
                     Command::none()
                 }
             },


### PR DESCRIPTION
Resolves #102. 

Will also resolve an issue we're having w/ broadcasting QUIT / PART messages to buffers because the underlying lists from `irc` crate are already updated to exclude those users. Now we can reference the lists from our state before we "sync" them so the users will still be there.