### PR TITLE
Ensure input is focused when replacing buffer

### DIFF
--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -178,6 +178,7 @@ impl Dashboard {
                         if let Some(state) = self.panes.get_mut(&pane) {
                             state.buffer = Buffer::from(kind);
                             self.last_changed = Some(Instant::now());
+                            self.focus = None;
                             return Command::batch(vec![
                                 self.reset_pane(pane),
                                 self.focus_pane(pane),


### PR DESCRIPTION
Fixes a small bug where the buffer text input wouldn't get focused (if not already focused) when replacing w/ a new buffer because we already had the pane marked as focus.