### PR TITLE
brodcast quit and nick changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Added:
 - Previously sent messages can be accessed per buffer in the text input with up / down arrows
 - Themes directory where users can add their own theme files
 - Nickname completions in text input with <kbd>Tab</kbd>
+- Broadcast nickname changes to relevant channels and queries.
+- Broadcast quit messages to relevant channels and queries.
 
 Changed:
 

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -9,7 +9,7 @@ use crate::history::{self, History};
 use crate::message::{self, Limit};
 use crate::time::Posix;
 use crate::user::{Nick, NickRef};
-use crate::{server, Buffer, Input, Server};
+use crate::{server, Buffer, Input, Server, User};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Resource {
@@ -260,7 +260,7 @@ impl Manager {
                 }
             })
             .cloned();
-        let queries = map
+        let mut queries = map
             .keys()
             .filter_map(|kind| {
                 if let history::Kind::Query(nick) = kind {
@@ -272,11 +272,35 @@ impl Manager {
             .cloned();
 
         let messages = match broadcast {
-            Broadcast::Disconnected => {
-                message::broadcast::disconnected(channels, queries).collect::<Vec<_>>()
+            Broadcast::Disconnected => message::broadcast::disconnected(channels, queries),
+            Broadcast::Reconnected => message::broadcast::reconnected(channels, queries),
+            Broadcast::Quit {
+                user,
+                comment,
+                user_channels,
+            } => {
+                let user_query = queries.find(|nick| user.nickname() == *nick);
+
+                message::broadcast::quit(user_channels, user_query, &user, &comment)
             }
-            Broadcast::Reconnected => {
-                message::broadcast::reconnected(channels, queries).collect::<Vec<_>>()
+            Broadcast::Nickname {
+                new_nick,
+                old_nick,
+                changed_own_nickname,
+                user_channels,
+            } => {
+                let user_query = queries.find(|nick| {
+                    let old_nick = NickRef::from(old_nick.as_str());
+                    old_nick == *nick
+                });
+
+                message::broadcast::nickname(
+                    user_channels,
+                    user_query,
+                    &new_nick,
+                    &old_nick,
+                    changed_own_nickname,
+                )
             }
         };
 
@@ -438,8 +462,19 @@ impl Data {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum Broadcast {
     Disconnected,
     Reconnected,
+    Quit {
+        user: User,
+        comment: Option<String>,
+        user_channels: Vec<String>,
+    },
+    Nickname {
+        new_nick: String,
+        old_nick: String,
+        changed_own_nickname: bool,
+        user_channels: Vec<String>,
+    },
 }

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -12,6 +12,24 @@ pub type Channel = String;
 #[derive(Debug, Clone)]
 pub struct Encoded(proto::Message);
 
+impl Encoded {
+    pub fn user(&self) -> Option<User> {
+        fn not_empty(s: &str) -> Option<&str> {
+            (!s.is_empty()).then_some(s)
+        }
+
+        let prefix = self.prefix.as_ref()?;
+        match prefix {
+            proto::Prefix::Nickname(nickname, username, hostname) => Some(User::new(
+                Nick::from(nickname.as_str()),
+                not_empty(username),
+                not_empty(hostname),
+            )),
+            _ => None,
+        }
+    }
+}
+
 impl std::ops::Deref for Encoded {
     type Target = proto::Message;
 
@@ -122,24 +140,8 @@ impl Message {
     }
 }
 
-fn user(message: &Encoded) -> Option<User> {
-    fn not_empty(s: &str) -> Option<&str> {
-        (!s.is_empty()).then_some(s)
-    }
-
-    let prefix = message.prefix.as_ref()?;
-    match prefix {
-        proto::Prefix::Nickname(nickname, username, hostname) => Some(User::new(
-            Nick::from(nickname.as_str()),
-            not_empty(username),
-            not_empty(hostname),
-        )),
-        _ => None,
-    }
-}
-
 fn source(message: Encoded, our_nick: NickRef) -> Option<Source> {
-    let user = user(&message);
+    let user = message.user();
 
     match message.0.command {
         // Channel
@@ -252,7 +254,7 @@ fn server_time(message: &Encoded) -> DateTime<Utc> {
 }
 
 fn text(message: &Encoded, our_nick: NickRef) -> Option<String> {
-    let user = user(message);
+    let user = message.user();
     match &message.command {
         proto::Command::TOPIC(_, topic) => {
             let user = user?;
@@ -267,7 +269,7 @@ fn text(message: &Encoded, our_nick: NickRef) -> Option<String> {
                 .map(|text| format!(" ({text})"))
                 .unwrap_or_default();
 
-            Some(format!("⟵ {user}{text} has left the channel"))
+            Some(format!("⟵ {user} has left the channel{text}"))
         }
         proto::Command::JOIN(_, _, _) | proto::Command::SAJOIN(_, _) => {
             let user = user?;
@@ -365,54 +367,80 @@ pub(crate) mod broadcast {
     use super::{Direction, Message, Sender, Source};
     use crate::time::Posix;
     use crate::user::Nick;
+    use crate::User;
 
     fn expand(
         channels: impl IntoIterator<Item = String>,
         queries: impl IntoIterator<Item = Nick>,
-        f: fn(source: Source) -> Message,
-    ) -> impl Iterator<Item = Message> {
+        include_server: bool,
+        text: String,
+    ) -> Vec<Message> {
+        let message = |source, text| -> Message {
+            Message {
+                received_at: Posix::now(),
+                server_time: Utc::now(),
+                direction: Direction::Received,
+                source,
+                text,
+            }
+        };
+
         channels
             .into_iter()
-            .map(move |channel| f(Source::Channel(channel, Sender::Server)))
+            .map(|channel| message(Source::Channel(channel, Sender::Server), text.clone()))
             .chain(
                 queries
                     .into_iter()
-                    .map(move |nick| f(Source::Query(nick, Sender::Server))),
+                    .map(|nick| message(Source::Query(nick, Sender::Server), text.clone())),
             )
-            .chain(Some(f(Source::Server)))
+            .chain(include_server.then(|| message(Source::Server, text.clone())))
+            .collect()
     }
 
     pub fn disconnected(
         channels: impl IntoIterator<Item = String>,
         queries: impl IntoIterator<Item = Nick>,
-    ) -> impl Iterator<Item = Message> {
-        fn message(source: Source) -> Message {
-            Message {
-                received_at: Posix::now(),
-                server_time: Utc::now(),
-                direction: Direction::Received,
-                source,
-                text: " ∙ connection to server lost".into(),
-            }
-        }
-
-        expand(channels, queries, message)
+    ) -> Vec<Message> {
+        let text = " ∙ connection to server lost".into();
+        expand(channels, queries, true, text)
     }
 
     pub fn reconnected(
         channels: impl IntoIterator<Item = String>,
         queries: impl IntoIterator<Item = Nick>,
-    ) -> impl Iterator<Item = Message> {
-        fn message(source: Source) -> Message {
-            Message {
-                received_at: Posix::now(),
-                server_time: Utc::now(),
-                direction: Direction::Received,
-                source,
-                text: " ∙ connection to server restored".into(),
-            }
-        }
+    ) -> Vec<Message> {
+        let text = " ∙ connection to server restored".into();
+        expand(channels, queries, true, text)
+    }
 
-        expand(channels, queries, message)
+    pub fn quit(
+        channels: impl IntoIterator<Item = String>,
+        queries: impl IntoIterator<Item = Nick>,
+        user: &User,
+        comment: &Option<String>,
+    ) -> Vec<Message> {
+        let comment = comment
+            .as_ref()
+            .map(|comment| format!(" ({comment})"))
+            .unwrap_or_default();
+        let text = format!("⟵ {user} has quit{comment}");
+
+        expand(channels, queries, false, text)
+    }
+
+    pub fn nickname(
+        channels: impl IntoIterator<Item = String>,
+        queries: impl IntoIterator<Item = Nick>,
+        new_nick: &str,
+        old_nick: &str,
+        changed_own_nickname: bool,
+    ) -> Vec<Message> {
+        let text = if changed_own_nickname {
+            format!(" ∙ You're now known as {new_nick}")
+        } else {
+            format!(" ∙ {old_nick} is now known as {new_nick}")
+        };
+
+        expand(channels, queries, false, text)
     }
 }

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -431,11 +431,11 @@ pub(crate) mod broadcast {
     pub fn nickname(
         channels: impl IntoIterator<Item = String>,
         queries: impl IntoIterator<Item = Nick>,
-        new_nick: &str,
-        old_nick: &str,
-        changed_own_nickname: bool,
+        old_nick: &Nick,
+        new_nick: &Nick,
+        ourself: bool,
     ) -> Vec<Message> {
-        let text = if changed_own_nickname {
+        let text = if ourself {
             format!(" ∙ You're now known as {new_nick}")
         } else {
             format!(" ∙ {old_nick} is now known as {new_nick}")

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -184,6 +184,12 @@ impl<'a> Ord for NickRef<'a> {
     }
 }
 
+impl<'a> PartialEq<Nick> for NickRef<'a> {
+    fn eq(&self, other: &Nick) -> bool {
+        self.0.eq(other.0.as_str())
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct AccessLevel(data::AccessLevel);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -324,7 +324,7 @@ impl Application for Halloy {
                                     dashboard.record_message(&server, message);
                                 }
                                 data::client::Event::Brodcast(brodcast) => match brodcast {
-                                    data::client::Brodcast::Quit(user, comment) => {
+                                    data::client::Brodcast::Quit { user, comment } => {
                                         let user_channels = self
                                             .clients
                                             .get_user_channels(&server, user.nickname());
@@ -336,20 +336,20 @@ impl Application for Halloy {
                                             user_channels,
                                         );
                                     }
-                                    data::client::Brodcast::Nickname(
+                                    data::client::Brodcast::Nickname {
+                                        old_user,
                                         new_nick,
-                                        old_nick,
-                                        changed_own_nickname,
-                                    ) => {
-                                        let user_channels = self
-                                            .clients
-                                            .get_user_channels(&server, old_nick.as_str().into());
+                                        ourself,
+                                    } => {
+                                        let old_nick = old_user.nickname();
+                                        let user_channels =
+                                            self.clients.get_user_channels(&server, old_nick);
 
                                         dashboard.broadcast_nickname(
                                             &server,
+                                            old_nick.to_owned(),
                                             new_nick,
-                                            old_nick,
-                                            changed_own_nickname,
+                                            ourself,
                                             user_channels,
                                         );
                                     }
@@ -360,7 +360,7 @@ impl Application for Halloy {
 
                     // Must be called after receiving message batches to ensure
                     // user & channel lists are in sync
-                    self.clients.sync();
+                    self.clients.sync(&server);
 
                     Command::none()
                 }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -4,6 +4,7 @@ pub mod side_menu;
 use std::time::{Duration, Instant};
 
 use data::history::manager::Broadcast;
+use data::user::Nick;
 use data::{dashboard, history, Config, Server, User};
 use iced::widget::pane_grid::{self, PaneGrid};
 use iced::widget::{container, row};
@@ -516,9 +517,9 @@ impl Dashboard {
     pub fn broadcast_nickname(
         &mut self,
         server: &Server,
-        new_nick: String,
-        old_nick: String,
-        changed_own_nickname: bool,
+        old_nick: Nick,
+        new_nick: Nick,
+        ourself: bool,
         user_channels: Vec<String>,
     ) {
         self.history.broadcast(
@@ -526,7 +527,7 @@ impl Dashboard {
             Broadcast::Nickname {
                 new_nick,
                 old_nick,
-                changed_own_nickname,
+                ourself,
                 user_channels,
             },
         );

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -4,7 +4,7 @@ pub mod side_menu;
 use std::time::{Duration, Instant};
 
 use data::history::manager::Broadcast;
-use data::{dashboard, history, Config, Server};
+use data::{dashboard, history, Config, Server, User};
 use iced::widget::pane_grid::{self, PaneGrid};
 use iced::widget::{container, row};
 use iced::{clipboard, window, Command, Length, Subscription};
@@ -496,11 +496,47 @@ impl Dashboard {
         self.history.record_message(server, message);
     }
 
-    pub fn disconnected(&mut self, server: &Server) {
+    pub fn broadcast_quit(
+        &mut self,
+        server: &Server,
+        user: User,
+        comment: Option<String>,
+        user_channels: Vec<String>,
+    ) {
+        self.history.broadcast(
+            server,
+            Broadcast::Quit {
+                user,
+                comment,
+                user_channels,
+            },
+        );
+    }
+
+    pub fn broadcast_nickname(
+        &mut self,
+        server: &Server,
+        new_nick: String,
+        old_nick: String,
+        changed_own_nickname: bool,
+        user_channels: Vec<String>,
+    ) {
+        self.history.broadcast(
+            server,
+            Broadcast::Nickname {
+                new_nick,
+                old_nick,
+                changed_own_nickname,
+                user_channels,
+            },
+        );
+    }
+
+    pub fn broadcast_disconnected(&mut self, server: &Server) {
         self.history.broadcast(server, Broadcast::Disconnected);
     }
 
-    pub fn reconnected(&mut self, server: &Server) {
+    pub fn broadcast_reconnected(&mut self, server: &Server) {
         self.history.broadcast(server, Broadcast::Reconnected);
     }
 


### PR DESCRIPTION
This PR adds a the ability to broadcast two types of Messages:
* Quit (when a user quit, it will broadcast it to all channels, and queries user was on)
* Nick (when a user change nickname, it will broadcast it to all channels, and queries user is on)


Fixes #83, #73