### PR TITLE
Route whois messages to focused buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Added:
 - Better error descriptions on connection failures
 - Support RAW command
 - Drag & drop buffers to the edges for better customization of the grid
+- Whois messages are printed in the currently focused buffer
 
 Changed:
 

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Local, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::user::Nick;
-use crate::{channel, Server};
+use crate::{channel, message, Server};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Buffer {
@@ -27,6 +27,14 @@ impl Buffer {
             Buffer::Server(_) => None,
             Buffer::Channel(_, channel) => Some(channel.clone()),
             Buffer::Query(_, nick) => Some(nick.to_string()),
+        }
+    }
+
+    pub fn message_source(self) -> message::Source {
+        match self {
+            Self::Server(_) => message::Source::Server,
+            Self::Channel(_, channel) => message::Source::Channel(channel, message::Sender::Server),
+            Self::Query(_, nick) => message::Source::Query(nick, message::Sender::Server),
         }
     }
 }

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -30,7 +30,7 @@ impl Buffer {
         }
     }
 
-    pub fn message_source(self) -> message::Source {
+    pub fn server_message_source(self) -> message::Source {
         match self {
             Self::Server(_) => message::Source::Server,
             Self::Channel(_, channel) => message::Source::Channel(channel, message::Sender::Server),

--- a/src/main.rs
+++ b/src/main.rs
@@ -341,6 +341,9 @@ impl Application for Halloy {
                                 data::client::Event::Single(message) => {
                                     dashboard.record_message(&server, message);
                                 }
+                                data::client::Event::Whois(message) => {
+                                    dashboard.record_whois(&server, message);
+                                }
                                 data::client::Event::Brodcast(brodcast) => match brodcast {
                                     data::client::Brodcast::Quit { user, comment } => {
                                         let user_channels = self

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 
 use data::history::manager::Broadcast;
 use data::user::Nick;
-use data::{dashboard, history, Config, Server, User};
+use data::{dashboard, history, message, Config, Server, User};
 use iced::widget::pane_grid::{self, PaneGrid};
 use iced::widget::{container, row};
 use iced::{clipboard, window, Command, Length, Subscription};
@@ -494,6 +494,16 @@ impl Dashboard {
         self.history.record_message(server, message);
     }
 
+    pub fn record_whois(&mut self, server: &Server, mut message: data::Message) {
+        // If a buffer is focused, put the whois message there
+        message.source = self
+            .get_focused()
+            .and_then(|pane| pane.buffer.data().map(data::Buffer::message_source))
+            .unwrap_or(message::Source::Server);
+
+        self.history.record_message(server, message);
+    }
+
     pub fn broadcast_quit(
         &mut self,
         server: &Server,
@@ -550,6 +560,11 @@ impl Dashboard {
     pub fn broadcast_connection_failed(&mut self, server: &Server, error: String) {
         self.history
             .broadcast(server, Broadcast::ConnectionFailed { error });
+    }
+
+    fn get_focused(&mut self) -> Option<&Pane> {
+        let pane = self.focus?;
+        self.panes.get(&pane)
     }
 
     fn get_focused_mut(&mut self) -> Option<(pane_grid::Pane, &mut Pane)> {

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -495,10 +495,14 @@ impl Dashboard {
     }
 
     pub fn record_whois(&mut self, server: &Server, mut message: data::Message) {
-        // If a buffer is focused, put the whois message there
+        // If a buffer for the server is focused, put the whois message there
         message.source = self
             .get_focused()
-            .and_then(|pane| pane.buffer.data().map(data::Buffer::message_source))
+            .and_then(|pane| {
+                pane.buffer.data().and_then(|buffer| {
+                    (buffer.server() == server).then(|| buffer.server_message_source())
+                })
+            })
             .unwrap_or(message::Source::Server);
 
         self.history.record_message(server, message);


### PR DESCRIPTION
This routes whois replies to the currently focused buffer for the server. This makes the WHOIS from user context menu a lot more usable as it'll print it into the buffer you triggered it from.