### PR TITLE
leave text is now dependent on buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Changed:
 - `palette` field has been deprecated and replaced by `theme` in `config.yaml`
 - Sorting channel nicknames
 - Title headers has been changed to also display user count for channels
+- Copy change: "Leave" has been changed to "Close query" for queries
 
 Fixed:
 

--- a/src/screen/dashboard/side_menu.rs
+++ b/src/screen/dashboard/side_menu.rs
@@ -216,7 +216,14 @@ fn buffer_button<'a>(
                 ),
                 Entry::Close(pane) => ("Close pane", Message::Close(pane)),
                 Entry::Swap(from, to) => ("Swap with current pane", Message::Swap(from, to)),
-                Entry::Leave => ("Leave", Message::Leave(buffer.clone())),
+                Entry::Leave => (
+                    match &buffer {
+                        Buffer::Server(_) => "Leave server",
+                        Buffer::Channel(_, _) => "Leave channel",
+                        Buffer::Query(_, _) => "Close query",
+                    },
+                    Message::Leave(buffer.clone()),
+                ),
             };
 
             button(text(content).style(theme::Text::Primary))


### PR DESCRIPTION
Closes #117 

"Leave" text has been changed to be more in line with buffer context:
```
query   -> "Close query"
channel -> "Leave channel"
server  -> "Leave server"
```

Leaving a server, when you only have 1 server will leave you in a quite broken state. I'll look into that in a separate PR.