### PR TITLE
added text_input visibility option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Unreleased
 
+Added:
+
+- Configuration option `new_buffer.input_visibility` to control input field visibility: always shown or following the focused buffer.
+
 Fixed:
 
 - Changes done in the config file are now properly applied to the old buffers
+
 
 # 2023.2 (2023-07-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ Fixed:
 
 - Changes done in the config file are now properly applied to the old buffers
 
-
 # 2023.2 (2023-07-07)
 
 Added:

--- a/config.yaml
+++ b/config.yaml
@@ -71,6 +71,11 @@ new_buffer:
       left: "["
       right: "]"
 
+  # Input visibility behaviour
+  # - Always: Show input at all times [default]
+  # - Focused: Only show input when the buffer is focused
+  input_visibility: Always
+      
   # Channel buffer settings
   channel:
     # User list settings

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -51,6 +51,13 @@ impl From<config::Buffer> for Settings {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+pub enum InputVisibility {
+    Focused,
+    #[default]
+    Always,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct Timestamp {
     pub format: String,

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Local, Utc};
 use serde::Deserialize;
 
 use super::Channel;
-use crate::buffer::{Color, Nickname, Timestamp};
+use crate::buffer::{Color, InputVisibility, Nickname, Timestamp};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Buffer {
@@ -10,6 +10,8 @@ pub struct Buffer {
     pub timestamp: Option<Timestamp>,
     #[serde(default)]
     pub nickname: Nickname,
+    #[serde(default)]
+    pub input_visibility: InputVisibility,
     #[serde(default)]
     pub channel: Channel,
 }
@@ -25,6 +27,7 @@ impl Default for Buffer {
                 color: Color::Unique,
                 brackets: Default::default(),
             },
+            input_visibility: InputVisibility::default(),
             channel: Channel::default(),
         }
     }

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -83,13 +83,20 @@ pub fn view<'a>(
         .map(Message::ScrollView),
     )
     .height(Length::Fill);
-    let spacing = is_focused.then_some(vertical_space(4));
-    let text_input = (is_focused && status.connected()).then(|| {
-        input_view::view(&state.input_view, buffer, &[], input_history).map(Message::InputView)
+
+    let show_text_input = match config.buffer.input_visibility {
+        data::buffer::InputVisibility::Focused => is_focused && status.connected(),
+        data::buffer::InputVisibility::Always => status.connected(),
+    };
+
+    let text_input = show_text_input.then(|| {
+        column![
+            vertical_space(4),
+            input_view::view(&state.input_view, buffer, &[], input_history).map(Message::InputView)
+        ]
     });
 
     let scrollable = column![messages]
-        .push_maybe(spacing)
         .push_maybe(text_input)
         .height(Length::Fill);
 

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -52,13 +52,20 @@ pub fn view<'a>(
         .map(Message::ScrollView),
     )
     .height(Length::Fill);
-    let spacing = is_focused.then_some(vertical_space(4));
-    let text_input = (is_focused && status.connected()).then(|| {
-        input_view::view(&state.input_view, buffer, &[], input_history).map(Message::InputView)
+
+    let show_text_input = match config.buffer.input_visibility {
+        data::buffer::InputVisibility::Focused => is_focused && status.connected(),
+        data::buffer::InputVisibility::Always => status.connected(),
+    };
+
+    let text_input = show_text_input.then(|| {
+        column![
+            vertical_space(4),
+            input_view::view(&state.input_view, buffer, &[], input_history).map(Message::InputView)
+        ]
     });
 
     let scrollable = column![messages]
-        .push_maybe(spacing)
         .push_maybe(text_input)
         .height(Length::Fill);
 


### PR DESCRIPTION
This adds `new_buffer.input_visibility` to control input visibility.
If you have multiple buffers it can be annoying that the text jumps within the buffer when input appears, and disappears.