### PR TITLE
Allow overlay menus to layout as shrink

### DIFF
--- a/src/buffer/user_context.rs
+++ b/src/buffer/user_context.rs
@@ -56,15 +56,14 @@ pub fn update(message: Message) -> Event {
 pub fn view<'a>(content: impl Into<Element<'a, Message>>, user: User) -> Element<'a, Message> {
     let entries = Entry::list();
 
-    context_menu(content, entries, move |entry| {
+    context_menu(content, entries, move |entry, length| {
         let (content, message) = match entry {
             Entry::Whois => ("Whois", Message::Whois(user.clone())),
             Entry::Query => ("Message", Message::Query(user.clone())),
         };
 
         button(text(content).style(theme::Text::Primary))
-            // Based off longest entry text
-            .width(110)
+            .width(length)
             .style(theme::Button::Context)
             .on_press(message)
             .into()

--- a/src/buffer/user_context.rs
+++ b/src/buffer/user_context.rs
@@ -30,25 +30,7 @@ pub enum Event {
 
 pub fn update(message: Message) -> Event {
     match message {
-        Message::Whois(user) => {
-            Event::SendWhois(user)
-            // let command = data::Command::Whois(None, user.nickname().to_string());
-
-            // let input = data::Input::command(buffer, command);
-
-            // if let Some(encoded) = input.encoded() {
-            //     clients.send(input.server(), encoded);
-            // }
-
-            // if let Some(message) = clients
-            //     .nickname(input.server())
-            //     .and_then(|nick| input.message(&nick))
-            // {
-            //     history.record_message(input.server(), message);
-            // }
-
-            // None
-        }
+        Message::Whois(user) => Event::SendWhois(user),
         Message::Query(user) => Event::OpenQuery(user),
     }
 }

--- a/src/screen/dashboard/side_menu.rs
+++ b/src/screen/dashboard/side_menu.rs
@@ -207,7 +207,7 @@ fn buffer_button<'a>(
     if entries.is_empty() || !connected {
         base.into()
     } else {
-        context_menu(base, entries, move |entry| {
+        context_menu(base, entries, move |entry, length| {
             let (content, message) = match entry {
                 Entry::NewPane => ("Open in new pane", Message::Open(buffer.clone())),
                 Entry::Replace(pane) => (
@@ -227,8 +227,7 @@ fn buffer_button<'a>(
             };
 
             button(text(content).style(theme::Text::Primary))
-                // Based off longest entry text
-                .width(175)
+                .width(length)
                 .style(theme::Button::Context)
                 .on_press(message)
                 .into()

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -2,6 +2,7 @@
 pub use self::anchored_overlay::anchored_overlay;
 pub use self::collection::Collection;
 pub use self::context_menu::context_menu;
+pub use self::double_pass::double_pass;
 pub use self::hover::hover;
 pub use self::input::input;
 pub use self::key_press::key_press;
@@ -11,6 +12,7 @@ use crate::Theme;
 pub mod anchored_overlay;
 pub mod collection;
 pub mod context_menu;
+mod double_pass;
 pub mod hover;
 pub mod input;
 pub mod key_press;

--- a/src/widget/double_pass.rs
+++ b/src/widget/double_pass.rs
@@ -1,0 +1,140 @@
+//! A widget that uses a two pass layout.
+//!
+//! Layout from first pass is used as the limits for the second pass
+
+use iced::advanced::widget::tree;
+use iced::advanced::{layout, overlay, renderer, widget, Clipboard, Layout, Shell, Widget};
+pub use iced::keyboard::{KeyCode, Modifiers};
+use iced::{event, mouse, Event, Length, Rectangle};
+
+use super::{Element, Renderer};
+use crate::Theme;
+
+/// Layout from first pass is used as the limits for the second pass
+pub fn double_pass<'a, Message>(
+    first_pass: impl Into<Element<'a, Message>>,
+    second_pass: impl Into<Element<'a, Message>>,
+) -> Element<'a, Message>
+where
+    Message: 'a,
+{
+    DoublePass {
+        first_pass: first_pass.into(),
+        second_pass: second_pass.into(),
+    }
+    .into()
+}
+
+struct DoublePass<'a, Message> {
+    first_pass: Element<'a, Message>,
+    second_pass: Element<'a, Message>,
+}
+
+impl<'a, Message> Widget<Message, Renderer> for DoublePass<'a, Message> {
+    fn width(&self) -> Length {
+        self.second_pass.as_widget().width()
+    }
+
+    fn height(&self) -> Length {
+        self.second_pass.as_widget().height()
+    }
+
+    fn layout(&self, renderer: &Renderer, limits: &layout::Limits) -> layout::Node {
+        let layout = self.first_pass.as_widget().layout(renderer, limits);
+
+        let new_limits = layout::Limits::new(layout.size(), layout.size());
+
+        self.second_pass.as_widget().layout(renderer, &new_limits)
+    }
+
+    fn draw(
+        &self,
+        tree: &widget::Tree,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        self.second_pass
+            .as_widget()
+            .draw(tree, renderer, theme, style, layout, cursor, viewport)
+    }
+
+    fn tag(&self) -> tree::Tag {
+        self.second_pass.as_widget().tag()
+    }
+
+    fn state(&self) -> tree::State {
+        self.second_pass.as_widget().state()
+    }
+
+    fn children(&self) -> Vec<widget::Tree> {
+        self.second_pass.as_widget().children()
+    }
+
+    fn diff(&self, tree: &mut widget::Tree) {
+        self.second_pass.as_widget().diff(tree);
+    }
+
+    fn operate(
+        &self,
+        tree: &mut iced::advanced::widget::Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn widget::Operation<Message>,
+    ) {
+        self.second_pass
+            .as_widget()
+            .operate(tree, layout, renderer, operation);
+    }
+
+    fn on_event(
+        &mut self,
+        tree: &mut widget::Tree,
+        event: Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+    ) -> event::Status {
+        self.second_pass
+            .as_widget_mut()
+            .on_event(tree, event, layout, cursor, renderer, clipboard, shell)
+    }
+
+    fn mouse_interaction(
+        &self,
+        tree: &widget::Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        self.second_pass
+            .as_widget()
+            .mouse_interaction(tree, layout, cursor, viewport, renderer)
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        tree: &'b mut widget::Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+    ) -> Option<overlay::Element<'b, Message, Renderer>> {
+        self.second_pass
+            .as_widget_mut()
+            .overlay(tree, layout, renderer)
+    }
+}
+
+impl<'a, Message> From<DoublePass<'a, Message>> for Element<'a, Message>
+where
+    Message: 'a,
+{
+    fn from(double_pass: DoublePass<'a, Message>) -> Self {
+        Element::new(double_pass)
+    }
+}


### PR DESCRIPTION
This adds a new `double_pass` widget which enables us to use the layout size from the first widget for the second widget. By doing this, we can set the first widget to `Shrink` and then safely set the second widget to `Fill` and it'll only fill within the bounds produced by the `Shrink` layout.

This is needed for our completion popup & context menu widgets because they are overlay's and using "fill" causes it to fill the entire viewport. Now we don't need to hardcode widths for these and they'll always shrink around the largest item.
