### PR TITLE
Better separation between config & settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+Fixed:
+
+- Changes done in the config file are now properly applied to the old buffers
+
 # 2023.2 (2023-07-07)
 
 Added:

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -1,10 +1,9 @@
 use core::fmt;
 
-use chrono::{DateTime, Local, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::user::Nick;
-use crate::{channel, message, Server};
+use crate::{channel, config, message, Server};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Buffer {
@@ -39,57 +38,34 @@ impl Buffer {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct Settings {
-    #[serde(default)]
-    pub timestamp: Option<Timestamp>,
-    #[serde(default)]
-    pub nickname: Nickname,
-    #[serde(default)]
     pub channel: channel::Settings,
 }
 
-impl Default for Settings {
-    fn default() -> Self {
-        Settings {
-            timestamp: Some(Timestamp {
-                format: "%T".into(),
-                brackets: Default::default(),
-            }),
-            nickname: Nickname {
-                color: Color::Unique,
-                brackets: Default::default(),
-            },
-            channel: channel::Settings::default(),
+impl From<config::Buffer> for Settings {
+    fn from(config: config::Buffer) -> Self {
+        Self {
+            channel: channel::Settings::from(config.channel),
         }
     }
 }
 
-impl Settings {
-    pub fn format_timestamp(&self, date_time: &DateTime<Utc>) -> Option<String> {
-        self.timestamp.as_ref().map(|timestamp| {
-            timestamp
-                .brackets
-                .format(date_time.with_timezone(&Local).format(&timestamp.format))
-        })
-    }
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Timestamp {
     pub format: String,
     #[serde(default)]
     pub brackets: Brackets,
 }
 
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct Nickname {
     pub color: Color,
     #[serde(default)]
     pub brackets: Brackets,
 }
 
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct Brackets {
     pub left: String,
     pub right: String,
@@ -101,7 +77,7 @@ impl Brackets {
     }
 }
 
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub enum Color {
     Solid,
     #[default]

--- a/data/src/channel.rs
+++ b/data/src/channel.rs
@@ -1,11 +1,21 @@
 use serde::{Deserialize, Serialize};
 
+use crate::config;
+
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct Settings {
     pub users: Users,
 }
 
-#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
+impl From<config::Channel> for Settings {
+    fn from(config: config::Channel) -> Self {
+        Self {
+            users: Users::from(config.users),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
 pub enum Position {
     Left,
     #[default]
@@ -15,16 +25,19 @@ pub enum Position {
 #[derive(Debug, Clone, Copy, Deserialize, Serialize)]
 pub struct Users {
     pub visible: bool,
-    #[serde(default)]
-    pub position: Position,
+}
+
+impl From<config::channel::Users> for Users {
+    fn from(config: config::channel::Users) -> Self {
+        Users {
+            visible: config.visible,
+        }
+    }
 }
 
 impl Default for Users {
     fn default() -> Self {
-        Self {
-            visible: true,
-            position: Position::default(),
-        }
+        Self { visible: true }
     }
 }
 

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -5,8 +5,15 @@ use std::path::PathBuf;
 use serde::Deserialize;
 use thiserror::Error;
 
+pub use self::buffer::Buffer;
+pub use self::channel::Channel;
+pub use self::dashboard::Dashboard;
 use crate::palette::Palette;
-use crate::{buffer, dashboard, environment, server};
+use crate::{environment, server};
+
+mod buffer;
+pub mod channel;
+mod dashboard;
 
 const CONFIG_TEMPLATE: &[u8] = include_bytes!("../../config.yaml");
 const DEFAULT_THEME: (&str, &[u8]) = ("ferra", include_bytes!("../../assets/themes/ferra.yaml"));
@@ -16,9 +23,8 @@ pub struct Config {
     pub palette: Palette,
     pub servers: server::Map,
     pub font: Font,
-    /// Default settings when creating a new buffer
-    pub new_buffer: buffer::Settings,
-    pub dashboard: dashboard::Config,
+    pub buffer: Buffer,
+    pub dashboard: Dashboard,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -64,9 +70,9 @@ impl Config {
             pub font: Font,
             /// Default settings when creating a new buffer
             #[serde(default)]
-            pub new_buffer: buffer::Settings,
+            pub new_buffer: Buffer,
             #[serde(default)]
-            pub dashboard: dashboard::Config,
+            pub dashboard: Dashboard,
         }
 
         let path = Self::path();
@@ -88,7 +94,7 @@ impl Config {
             palette,
             servers,
             font,
-            new_buffer,
+            buffer: new_buffer,
             dashboard,
         })
     }

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -1,13 +1,17 @@
-use serde::{Deserialize, Serialize};
+use chrono::{DateTime, Local, Utc};
+use serde::Deserialize;
 
-use crate::Message;
+use super::Channel;
+use crate::buffer::{Color, Nickname, Timestamp};
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Buffer {
     #[serde(default)]
     pub timestamp: Option<Timestamp>,
     #[serde(default)]
     pub nickname: Nickname,
+    #[serde(default)]
+    pub channel: Channel,
 }
 
 impl Default for Buffer {
@@ -21,44 +25,17 @@ impl Default for Buffer {
                 color: Color::Unique,
                 brackets: Default::default(),
             },
+            channel: Channel::default(),
         }
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct Timestamp {
-    pub format: String,
-    #[serde(default)]
-    pub brackets: Brackets,
-}
-
-impl Timestamp {
-    pub fn format_message_with_timestamp(&self, message: &Message) -> String {
-        format!(
-            "{}{}{} ",
-            self.brackets.left,
-            &message.formatted_datetime(self.format.as_str()),
-            self.brackets.right,
-        )
+impl Buffer {
+    pub fn format_timestamp(&self, date_time: &DateTime<Utc>) -> Option<String> {
+        self.timestamp.as_ref().map(|timestamp| {
+            timestamp
+                .brackets
+                .format(date_time.with_timezone(&Local).format(&timestamp.format))
+        })
     }
-}
-
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
-pub struct Nickname {
-    pub color: Color,
-    #[serde(default)]
-    pub brackets: Brackets,
-}
-
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
-pub struct Brackets {
-    pub left: String,
-    pub right: String,
-}
-
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
-pub enum Color {
-    Solid,
-    #[default]
-    Unique,
 }

--- a/data/src/config/channel.rs
+++ b/data/src/config/channel.rs
@@ -1,20 +1,14 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+use crate::channel::Position;
+
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct Channel {
     pub users: Users,
 }
-
-#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
-pub enum Position {
-    Left,
-    #[default]
-    Right,
-}
-
-#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Deserialize)]
 pub struct Users {
-    pub visible: bool,
+    pub(crate) visible: bool,
     #[serde(default)]
     pub position: Position,
 }
@@ -25,11 +19,5 @@ impl Default for Users {
             visible: true,
             position: Position::default(),
         }
-    }
-}
-
-impl Users {
-    pub fn toggle_visibility(&mut self) {
-        self.visible = !self.visible
     }
 }

--- a/data/src/config/dashboard.rs
+++ b/data/src/config/dashboard.rs
@@ -1,0 +1,9 @@
+use serde::Deserialize;
+
+use crate::dashboard::DefaultAction;
+
+#[derive(Debug, Copy, Default, Clone, Deserialize)]
+pub struct Dashboard {
+    #[serde(default)]
+    pub sidebar_default_action: DefaultAction,
+}

--- a/data/src/dashboard.rs
+++ b/data/src/dashboard.rs
@@ -18,12 +18,6 @@ pub enum DefaultAction {
     ReplacePane,
 }
 
-#[derive(Debug, Copy, Default, Clone, Deserialize, Serialize)]
-pub struct Config {
-    #[serde(default)]
-    pub sidebar_default_action: DefaultAction,
-}
-
 impl Dashboard {
     pub fn load() -> Result<Self, Error> {
         let path = path()?;

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,5 +1,5 @@
 pub use data::buffer::Settings;
-use data::{buffer, history};
+use data::{buffer, history, Config};
 use iced::Command;
 
 use self::channel::Channel;
@@ -88,6 +88,7 @@ impl Buffer {
         clients: &'a data::client::Map,
         history: &'a history::Manager,
         settings: &'a buffer::Settings,
+        config: &'a Config,
         is_focused: bool,
     ) -> Element<'a, Message> {
         match self {
@@ -95,18 +96,26 @@ impl Buffer {
             Buffer::Channel(state) => {
                 let status = clients.status(&state.server);
 
-                channel::view(state, status, clients, history, settings, is_focused)
-                    .map(Message::Channel)
+                channel::view(
+                    state,
+                    status,
+                    clients,
+                    history,
+                    &settings.channel,
+                    config,
+                    is_focused,
+                )
+                .map(Message::Channel)
             }
             Buffer::Server(state) => {
                 let status = clients.status(&state.server);
 
-                server::view(state, status, history, settings, is_focused).map(Message::Server)
+                server::view(state, status, history, config, is_focused).map(Message::Server)
             }
             Buffer::Query(state) => {
                 let status = clients.status(&state.server);
 
-                query::view(state, status, history, settings, is_focused).map(Message::Query)
+                query::view(state, status, history, config, is_focused).map(Message::Query)
             }
         }
     }

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -1,5 +1,5 @@
 use data::server::Server;
-use data::{buffer, client, history};
+use data::{channel, client, history, Config};
 use iced::widget::{column, container, row, vertical_space};
 use iced::{Command, Length};
 
@@ -24,7 +24,8 @@ pub fn view<'a>(
     status: client::Status,
     clients: &'a data::client::Map,
     history: &'a history::Manager,
-    settings: &'a buffer::Settings,
+    settings: &'a channel::Settings,
+    config: &'a Config,
     is_focused: bool,
 ) -> Element<'a, Message> {
     let buffer = state.buffer();
@@ -103,10 +104,7 @@ pub fn view<'a>(
         input_view::view(&state.input_view, buffer, users, input_history).map(Message::InputView)
     });
 
-    let content = match (
-        settings.channel.users.visible,
-        settings.channel.users.position,
-    ) {
+    let content = match (settings.users.visible, config.buffer.channel.users.position) {
         (true, data::channel::Position::Left) => {
             row![nick_list, messages]
         }

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -38,7 +38,8 @@ pub fn view<'a>(
             scroll_view::Kind::Channel(&state.server, &state.channel),
             history,
             move |message| {
-                let timestamp = settings
+                let timestamp = config
+                    .buffer
                     .format_timestamp(&message.server_time)
                     .map(|timestamp| selectable_text(timestamp).style(theme::Text::Alpha04));
 
@@ -46,11 +47,10 @@ pub fn view<'a>(
                     data::message::Source::Channel(_, kind) => match kind {
                         data::message::Sender::User(user) => {
                             let nick = user_context::view(
-                                selectable_text(settings.nickname.brackets.format(user)).style(
-                                    theme::Text::Nickname(
-                                        user.color_seed(&settings.nickname.color),
-                                    ),
-                                ),
+                                selectable_text(config.buffer.nickname.brackets.format(user))
+                                    .style(theme::Text::Nickname(
+                                        user.color_seed(&config.buffer.nickname.color),
+                                    )),
                                 user.clone(),
                             )
                             .map(scroll_view::Message::UserContext);

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -34,7 +34,8 @@ pub fn view<'a>(
             scroll_view::Kind::Query(&state.server, &state.nick),
             history,
             |message| {
-                let timestamp = settings
+                let timestamp = config
+                    .buffer
                     .format_timestamp(&message.server_time)
                     .map(|timestamp| selectable_text(timestamp).style(theme::Text::Alpha04));
 

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -1,5 +1,5 @@
 use data::user::Nick;
-use data::{buffer, client, history, message, Server};
+use data::{client, history, message, Config, Server};
 use iced::widget::{column, container, row, vertical_space};
 use iced::{Command, Length};
 
@@ -22,7 +22,7 @@ pub fn view<'a>(
     state: &'a Query,
     status: client::Status,
     history: &'a history::Manager,
-    settings: &'a buffer::Settings,
+    config: &'a Config,
     is_focused: bool,
 ) -> Element<'a, Message> {
     let buffer = state.buffer();
@@ -45,8 +45,10 @@ pub fn view<'a>(
                 match sender {
                     message::Sender::User(user) => {
                         let nick = user_context::view(
-                            selectable_text(settings.nickname.brackets.format(user)).style(
-                                theme::Text::Nickname(user.color_seed(&settings.nickname.color)),
+                            selectable_text(config.buffer.nickname.brackets.format(user)).style(
+                                theme::Text::Nickname(
+                                    user.color_seed(&config.buffer.nickname.color),
+                                ),
                             ),
                             user.clone(),
                         )

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -1,4 +1,4 @@
-use data::{buffer, client, history};
+use data::{client, history, Config};
 use iced::widget::{column, container, row, vertical_space};
 use iced::{Command, Length};
 
@@ -16,7 +16,7 @@ pub fn view<'a>(
     state: &'a Server,
     status: client::Status,
     history: &'a history::Manager,
-    settings: &'a buffer::Settings,
+    config: &'a Config,
     is_focused: bool,
 ) -> Element<'a, Message> {
     let buffer = state.buffer();

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -28,7 +28,8 @@ pub fn view<'a>(
             scroll_view::Kind::Server(&state.server),
             history,
             |message| {
-                let timestamp = settings
+                let timestamp = config
+                    .buffer
                     .format_timestamp(&message.server_time)
                     .map(|timestamp| selectable_text(timestamp).style(theme::Text::Alpha04));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -406,7 +406,7 @@ impl Application for Halloy {
     fn view(&self) -> Element<Message> {
         let content = match &self.screen {
             Screen::Dashboard(dashboard) => dashboard
-                .view(&self.clients, self.config.dashboard)
+                .view(&self.clients, &self.config)
                 .map(Message::Dashboard),
             Screen::Help(help) => help.view().map(Message::Help),
             Screen::Welcome(welcome) => welcome.view().map(Message::Welcome),

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -1,4 +1,4 @@
-use data::history;
+use data::{history, Config};
 use iced::widget::{button, container, pane_grid, row, text};
 use iced::Length;
 use uuid::Uuid;
@@ -30,7 +30,11 @@ pub struct Pane {
 pub struct TitleBar {}
 
 impl Pane {
-    pub fn new(buffer: Buffer, settings: buffer::Settings) -> Self {
+    pub fn new(buffer: Buffer, config: &Config) -> Self {
+        Self::with_settings(buffer, buffer::Settings::from(config.buffer.clone()))
+    }
+
+    pub fn with_settings(buffer: Buffer, settings: buffer::Settings) -> Self {
         Self {
             id: Uuid::new_v4(),
             buffer,
@@ -47,6 +51,7 @@ impl Pane {
         maximized: bool,
         clients: &'a data::client::Map,
         history: &'a history::Manager,
+        config: &'a Config,
     ) -> widget::Content<'a, Message> {
         let title_bar_text = match &self.buffer {
             Buffer::Empty => "".to_string(),
@@ -80,7 +85,7 @@ impl Pane {
 
         let content = self
             .buffer
-            .view(clients, history, &self.settings, is_focused)
+            .view(clients, history, &self.settings, config, is_focused)
             .map(move |msg| Message::Buffer(id, msg));
 
         widget::Content::new(content)


### PR DESCRIPTION
This refactors our settings structs to move most of the fields over to config structs. Currently when we persist Dashboard, all the settings are saved. However, most of these aren't runtime settings and things that should only be controlled via config. Since we used the same structs for both, this caused "config" to get persisted in a buffer and not updated when users updated their config.

- `config` module now contains all top-level config data structures
- `Settings` structs have been updated to only include the runtime configured settings
- We can convert from Config -> Settings where the config determines the default settings values
- For the above, the fields in config that derive a settings field are marked `pub(crate)` so they can't accidentally be referenced from the config and MUST be referenced from the settings. This ensure the application is always pulling from the right location.

@neilalexander This is the refactor I mentioned last week. Hopefully this makes more sense and provides a better separation of concerns