### PR TITLE
extended user info on `PART`, `JOIN` and `QUIT`

### DIFF
--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -291,7 +291,7 @@ fn text(message: &Encoded, our_nick: NickRef) -> Option<String> {
             Some(format!(" ∙ {user} changed topic to {topic}"))
         }
         proto::Command::PART(_, text) => {
-            let user = user?;
+            let user = user?.formatted();
             let text = text
                 .as_ref()
                 .map(|text| format!(" ({text})"))
@@ -302,7 +302,8 @@ fn text(message: &Encoded, our_nick: NickRef) -> Option<String> {
         proto::Command::JOIN(_, _, _) | proto::Command::SAJOIN(_, _) => {
             let user = user?;
 
-            (user.nickname() != our_nick).then(|| format!("⟶ {user} has joined the channel"))
+            (user.nickname() != our_nick)
+                .then(|| format!("⟶ {} has joined the channel", user.formatted()))
         }
         proto::Command::ChannelMODE(_, modes) => {
             let user = user?;
@@ -485,7 +486,7 @@ pub(crate) mod broadcast {
             .as_ref()
             .map(|comment| format!(" ({comment})"))
             .unwrap_or_default();
-        let text = format!("⟵ {user} has quit{comment}");
+        let text = format!("⟵ {} has quit{comment}", user.formatted());
 
         expand(channels, queries, false, Cause::Server, text)
     }

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -36,52 +36,59 @@ pub fn view<'a>(
             &state.scroll_view,
             scroll_view::Kind::Channel(&state.server, &state.channel),
             history,
-            move |message| match &message.source {
-                data::message::Source::Channel(_, kind) => match kind {
-                    data::message::Sender::User(user) => {
-                        let timestamp =
-                            settings
-                                .format_timestamp(&message.server_time)
-                                .map(|timestamp| {
-                                    selectable_text(timestamp).style(theme::Text::Alpha04)
-                                });
-                        let nick = user_context::view(
-                            selectable_text(settings.nickname.brackets.format(user)).style(
-                                theme::Text::Nickname(user.color_seed(&settings.nickname.color)),
-                            ),
-                            user.clone(),
-                        )
-                        .map(scroll_view::Message::UserContext);
-                        let row_style = match our_nick {
-                            Some(nick)
-                                if user.nickname() != nick
-                                    && message.text.contains(nick.as_ref()) =>
-                            {
-                                theme::Container::Highlight
-                            }
-                            _ => theme::Container::Default,
-                        };
-                        let message = selectable_text(&message.text);
-                        Some(
-                            container(row![].push_maybe(timestamp).push(nick).push(message))
-                                .style(row_style)
-                                .into(),
-                        )
-                    }
-                    data::message::Sender::Server => Some(
-                        container(selectable_text(&message.text).style(theme::Text::Server)).into(),
-                    ),
-                    data::message::Sender::Action => Some(
-                        container(selectable_text(&message.text).style(theme::Text::Accent)).into(),
-                    ),
-                    data::message::Sender::Status(status) => Some(
-                        container(
-                            selectable_text(&message.text).style(theme::Text::Status(*status)),
-                        )
-                        .into(),
-                    ),
-                },
-                _ => None,
+            move |message| {
+                let timestamp = settings
+                    .format_timestamp(&message.server_time)
+                    .map(|timestamp| selectable_text(timestamp).style(theme::Text::Alpha04));
+
+                match &message.source {
+                    data::message::Source::Channel(_, kind) => match kind {
+                        data::message::Sender::User(user) => {
+                            let nick = user_context::view(
+                                selectable_text(settings.nickname.brackets.format(user)).style(
+                                    theme::Text::Nickname(
+                                        user.color_seed(&settings.nickname.color),
+                                    ),
+                                ),
+                                user.clone(),
+                            )
+                            .map(scroll_view::Message::UserContext);
+                            let row_style = match our_nick {
+                                Some(nick)
+                                    if user.nickname() != nick
+                                        && message.text.contains(nick.as_ref()) =>
+                                {
+                                    theme::Container::Highlight
+                                }
+                                _ => theme::Container::Default,
+                            };
+                            let message = selectable_text(&message.text);
+
+                            Some(
+                                container(row![].push_maybe(timestamp).push(nick).push(message))
+                                    .style(row_style)
+                                    .into(),
+                            )
+                        }
+                        data::message::Sender::Server => {
+                            let message = selectable_text(&message.text).style(theme::Text::Server);
+
+                            Some(container(row![].push_maybe(timestamp).push(message)).into())
+                        }
+                        data::message::Sender::Action => {
+                            let message = selectable_text(&message.text).style(theme::Text::Accent);
+
+                            Some(container(row![].push_maybe(timestamp).push(message)).into())
+                        }
+                        data::message::Sender::Status(status) => {
+                            let message =
+                                selectable_text(&message.text).style(theme::Text::Status(*status));
+
+                            Some(container(row![].push_maybe(timestamp).push(message)).into())
+                        }
+                    },
+                    _ => None,
+                }
             },
         )
         .map(Message::ScrollView),

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -34,18 +34,16 @@ pub fn view<'a>(
             scroll_view::Kind::Query(&state.server, &state.nick),
             history,
             |message| {
+                let timestamp = settings
+                    .format_timestamp(&message.server_time)
+                    .map(|timestamp| selectable_text(timestamp).style(theme::Text::Alpha04));
+
                 let message::Source::Query(_, sender) = &message.source else {
                     return None;
                 };
 
                 match sender {
                     message::Sender::User(user) => {
-                        let timestamp =
-                            settings
-                                .format_timestamp(&message.server_time)
-                                .map(|timestamp| {
-                                    selectable_text(timestamp).style(theme::Text::Alpha04)
-                                });
                         let nick = user_context::view(
                             selectable_text(settings.nickname.brackets.format(user)).style(
                                 theme::Text::Nickname(user.color_seed(&settings.nickname.color)),
@@ -60,18 +58,22 @@ pub fn view<'a>(
                             container(row![].push_maybe(timestamp).push(nick).push(message)).into(),
                         )
                     }
-                    message::Sender::Server => Some(
-                        container(selectable_text(&message.text).style(theme::Text::Server)).into(),
-                    ),
-                    message::Sender::Action => Some(
-                        container(selectable_text(&message.text).style(theme::Text::Accent)).into(),
-                    ),
-                    message::Sender::Status(status) => Some(
-                        container(
-                            selectable_text(&message.text).style(theme::Text::Status(*status)),
-                        )
-                        .into(),
-                    ),
+                    message::Sender::Server => {
+                        let message = selectable_text(&message.text).style(theme::Text::Server);
+
+                        Some(container(row![].push_maybe(timestamp).push(message)).into())
+                    }
+                    message::Sender::Action => {
+                        let message = selectable_text(&message.text).style(theme::Text::Accent);
+
+                        Some(container(row![].push_maybe(timestamp).push(message)).into())
+                    }
+                    message::Sender::Status(status) => {
+                        let message =
+                            selectable_text(&message.text).style(theme::Text::Status(*status));
+
+                        Some(container(row![].push_maybe(timestamp).push(message)).into())
+                    }
                 }
             },
         )

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -27,20 +27,25 @@ pub fn view<'a>(
             &state.scroll_view,
             scroll_view::Kind::Server(&state.server),
             history,
-            |message| match message.source {
-                data::message::Source::Server => {
-                    let timestamp = settings
-                        .format_timestamp(&message.server_time)
-                        .map(|timestamp| selectable_text(timestamp).style(theme::Text::Alpha04));
-                    let message = selectable_text(&message.text).style(theme::Text::Alpha04);
+            |message| {
+                let timestamp = settings
+                    .format_timestamp(&message.server_time)
+                    .map(|timestamp| selectable_text(timestamp).style(theme::Text::Alpha04));
 
-                    Some(container(row![].push_maybe(timestamp).push(message)).into())
+                match message.source {
+                    data::message::Source::Server => {
+                        let message = selectable_text(&message.text).style(theme::Text::Alpha04);
+
+                        Some(container(row![].push_maybe(timestamp).push(message)).into())
+                    }
+                    data::message::Source::Status(status) => {
+                        let message =
+                            selectable_text(&message.text).style(theme::Text::Status(status));
+
+                        Some(container(row![].push_maybe(timestamp).push(message)).into())
+                    }
+                    _ => None,
                 }
-                data::message::Source::Status(status) => Some(
-                    container(selectable_text(&message.text).style(theme::Text::Status(status)))
-                        .into(),
-                ),
-                _ => None,
             },
         )
         .map(Message::ScrollView),


### PR DESCRIPTION
Fixes #130.

This PR adds extra information about the user when `PART`, `JOIN` and `QUIT`.
Also added timestamps to `Sender::Action`, `Sender::Server`, `Sender::Status` for all buffers.