### PR TITLE
Extension support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ cargo build --release
 cargo run --release
 ```
 
+## Capabilities
+
+Halloy supports the following IRCv3.2 capabilities
+
+- `batch`
+- `server-time`
+- `labeled-response`
+- `echo-message` (server must also support `labeled-response`)
+
 ## Why?
 <div align="center">
   <a href="https://xkcd.com/1782/">

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 
 use crate::time::Posix;
 use crate::user::{Nick, NickRef};
-use crate::{message, Buffer, Message, Server, User};
+use crate::{message, Buffer, Server, User};
 
 #[derive(Debug, Clone, Copy)]
 pub enum Status {
@@ -42,20 +42,10 @@ pub enum Brodcast {
 }
 
 #[derive(Debug)]
-pub enum Event<T = Message> {
-    Single(T),
+pub enum Event {
+    Single(message::Encoded, Nick),
     Brodcast(Brodcast),
-    Whois(T, Option<Buffer>),
-}
-
-impl<T> Event<T> {
-    fn and_then<U>(self, f: impl FnOnce(T) -> Option<U>) -> Option<Event<U>> {
-        match self {
-            Event::Single(t) => f(t).map(Event::Single),
-            Event::Brodcast(broadcast) => Some(Event::Brodcast(broadcast)),
-            Event::Whois(t, buffer) => f(t).map(|u| Event::Whois(u, buffer)),
-        }
-    }
+    Whois(message::Encoded, Nick, Option<Buffer>),
 }
 
 #[derive(Debug)]
@@ -112,18 +102,14 @@ impl Connection {
     fn receive(&mut self, message: message::Encoded) -> Vec<Event> {
         log::trace!("Message received => {:?}", *message);
 
-        self.handle(message, None)
-            .unwrap_or_default()
-            .into_iter()
-            .flat_map(|event| event.and_then(|encoded| Message::received(encoded, self.nickname())))
-            .collect()
+        self.handle(message, None).unwrap_or_default()
     }
 
     fn handle(
         &mut self,
         mut message: message::Encoded,
         parent_context: Option<Context>,
-    ) -> Option<Vec<Event<message::Encoded>>> {
+    ) -> Option<Vec<Event>> {
         use irc::proto::Command;
         use irc::proto::Response::*;
 
@@ -215,13 +201,23 @@ impl Connection {
             }
             // WHOIS
             _ if context.as_ref().map(Context::is_whois).unwrap_or_default() => {
-                return Some(vec![Event::Whois(message, context.map(Context::buffer))]);
+                return Some(vec![Event::Whois(
+                    message,
+                    self.nickname().to_owned(),
+                    context.map(Context::buffer),
+                )]);
             }
             Command::Response(
                 RPL_WHOISCERTFP | RPL_WHOISCHANNELS | RPL_WHOISIDLE | RPL_WHOISKEYVALUE
                 | RPL_WHOISOPERATOR | RPL_WHOISSERVER | RPL_WHOISUSER | RPL_ENDOFWHOIS,
                 _,
-            ) => return Some(vec![Event::Whois(message, context.map(Context::buffer))]),
+            ) => {
+                return Some(vec![Event::Whois(
+                    message,
+                    self.nickname().to_owned(),
+                    context.map(Context::buffer),
+                )])
+            }
             // QUIT
             Command::QUIT(comment) => {
                 let user = message.user()?;
@@ -237,7 +233,7 @@ impl Connection {
             _ => {}
         }
 
-        Some(vec![Event::Single(message)])
+        Some(vec![Event::Single(message, self.nickname().to_owned())])
     }
 
     fn sync(&mut self) {
@@ -419,7 +415,7 @@ impl Context {
 #[derive(Debug)]
 pub struct Batch {
     context: Option<Context>,
-    events: Vec<Event<message::Encoded>>,
+    events: Vec<Event>,
 }
 
 impl Batch {

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -161,10 +161,12 @@ impl Connection {
                     return Some(events);
                 }
             }
-            Command::PRIVMSG(target, _) => {
-                // If we sent (buffer exists) & we're target (echo), ignore
-                if target == self.nickname().as_ref() && buffer.is_some() {
-                    return None;
+            Command::PRIVMSG(_, _) | Command::NOTICE(_, _) => {
+                if let Some(user) = message.user() {
+                    // If we sent (echo) & buffer exists (we sent from this client), ignore
+                    if user.nickname() == self.nickname() && buffer.is_some() {
+                        return None;
+                    }
                 }
             }
             Command::NICK(nick) => {

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -38,6 +38,12 @@ impl std::ops::Deref for Encoded {
     }
 }
 
+impl std::ops::DerefMut for Encoded {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 impl From<proto::Message> for Encoded {
     fn from(proto: proto::Message) -> Self {
         Self(proto)

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -138,10 +138,10 @@ impl Message {
             && matches!(self.source.sender(), Some(Sender::User(_) | Sender::Action))
     }
 
-    pub fn received(encoded: Encoded, our_nick: NickRef) -> Option<Message> {
+    pub fn received(encoded: Encoded, our_nick: Nick) -> Option<Message> {
         let server_time = server_time(&encoded);
-        let text = text(&encoded, our_nick)?;
-        let source = source(encoded, our_nick)?;
+        let text = text(&encoded, &our_nick)?;
+        let source = source(encoded, &our_nick)?;
 
         Some(Message {
             received_at: Posix::now(),
@@ -153,7 +153,7 @@ impl Message {
     }
 }
 
-fn source(message: Encoded, our_nick: NickRef) -> Option<Source> {
+fn source(message: Encoded, our_nick: &Nick) -> Option<Source> {
     let user = message.user();
 
     match message.0.command {
@@ -186,7 +186,7 @@ fn source(message: Encoded, our_nick: NickRef) -> Option<Source> {
                 (false, Some(user)) => {
                     let target = User::try_from(target.as_str()).ok()?;
 
-                    (target.nickname() == our_nick)
+                    (target.nickname() == *our_nick)
                         .then(|| Source::Query(user.nickname().to_owned(), sender(user)))
                 }
                 _ => None,
@@ -207,7 +207,7 @@ fn source(message: Encoded, our_nick: NickRef) -> Option<Source> {
                 (false, Some(user)) => {
                     let target = User::try_from(target.as_str()).ok()?;
 
-                    (target.nickname() == our_nick)
+                    (target.nickname() == *our_nick)
                         .then(|| Source::Query(user.nickname().to_owned(), sender(user)))
                 }
                 _ => Some(Source::Server),
@@ -287,7 +287,7 @@ fn server_time(message: &Encoded) -> DateTime<Utc> {
         .unwrap_or_else(Utc::now)
 }
 
-fn text(message: &Encoded, our_nick: NickRef) -> Option<String> {
+fn text(message: &Encoded, our_nick: &Nick) -> Option<String> {
     let user = message.user();
     match &message.command {
         proto::Command::TOPIC(_, topic) => {
@@ -308,7 +308,7 @@ fn text(message: &Encoded, our_nick: NickRef) -> Option<String> {
         proto::Command::JOIN(_, _, _) | proto::Command::SAJOIN(_, _) => {
             let user = user?;
 
-            (user.nickname() != our_nick)
+            (user.nickname() != *our_nick)
                 .then(|| format!("⟶ {} has joined the channel", user.formatted()))
         }
         proto::Command::ChannelMODE(_, modes) => {

--- a/data/src/stream.rs
+++ b/data/src/stream.rs
@@ -188,11 +188,13 @@ async fn connect(
         if server_caps.contains(&"batch") {
             caps.push(Capability::Batch);
         }
-        // We require both so we can properly tag
-        // echo-messages
-        if server_caps.contains(&"echo-message") && server_caps.contains(&"labeled-response") {
-            caps.push(Capability::EchoMessage);
+        if server_caps.contains(&"labeled-response") {
             caps.push(Capability::Custom("labeled-response"));
+
+            // We require labeled-response so we can properly tag echo-messages
+            if server_caps.contains(&"echo-message") {
+                caps.push(Capability::EchoMessage);
+            }
         }
 
         let _ = client.send_cap_req(&caps);

--- a/data/src/stream.rs
+++ b/data/src/stream.rs
@@ -161,6 +161,8 @@ async fn connect(
         let mut caps = vec![];
 
         while let Some(Ok(message)) = stream.next().await {
+            log::trace!("Message received => {:?}", message);
+
             if let Command::CAP(_, CapSubCommand::LS, a, b) = message.command {
                 let (cap_str, asterisk) = match (a, b) {
                     (Some(cap_str), None) => (cap_str, None),

--- a/data/src/time.rs
+++ b/data/src/time.rs
@@ -20,6 +20,10 @@ impl Posix {
         Self(seconds * 1_000_000_000)
     }
 
+    pub fn as_nanos(&self) -> u64 {
+        self.0
+    }
+
     pub fn datetime(&self) -> Option<DateTime<Utc>> {
         let seconds = (self.0 / 1_000_000_000) as i64;
         let nanos = (self.0 % 1_000_000_000) as u32;

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -63,7 +63,7 @@ impl State {
                 self.input.clear();
 
                 if let Some(encoded) = input.encoded() {
-                    clients.send(input.server(), encoded);
+                    clients.send(input.buffer(), encoded);
                 }
 
                 if let Some(nick) = clients.nickname(input.server()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -336,42 +336,36 @@ impl Application for Halloy {
                     };
 
                     messages.into_iter().for_each(|encoded| {
-                        if let Some(event) = self.clients.receive(&server, encoded) {
+                        for event in self.clients.receive(&server, encoded) {
                             match event {
                                 data::client::Event::Single(message) => {
                                     dashboard.record_message(&server, message);
                                 }
-                                data::client::Event::Whois(message) => {
-                                    dashboard.record_whois(&server, message);
+                                data::client::Event::Whois(message, buffer) => {
+                                    dashboard.record_whois(&server, message, buffer);
                                 }
                                 data::client::Event::Brodcast(brodcast) => match brodcast {
-                                    data::client::Brodcast::Quit { user, comment } => {
-                                        let user_channels = self
-                                            .clients
-                                            .get_user_channels(&server, user.nickname());
-
-                                        dashboard.broadcast_quit(
-                                            &server,
-                                            user,
-                                            comment,
-                                            user_channels,
-                                        );
+                                    data::client::Brodcast::Quit {
+                                        user,
+                                        comment,
+                                        channels,
+                                    } => {
+                                        dashboard.broadcast_quit(&server, user, comment, channels);
                                     }
                                     data::client::Brodcast::Nickname {
                                         old_user,
                                         new_nick,
                                         ourself,
+                                        channels,
                                     } => {
                                         let old_nick = old_user.nickname();
-                                        let user_channels =
-                                            self.clients.get_user_channels(&server, old_nick);
 
                                         dashboard.broadcast_nickname(
                                             &server,
                                             old_nick.to_owned(),
                                             new_nick,
                                             ourself,
-                                            user_channels,
+                                            channels,
                                         );
                                     }
                                 },

--- a/src/main.rs
+++ b/src/main.rs
@@ -335,14 +335,22 @@ impl Application for Halloy {
                         return Command::none()
                     };
 
-                    messages.into_iter().for_each(|encoded| {
-                        for event in self.clients.receive(&server, encoded) {
+                    messages.into_iter().for_each(|message| {
+                        for event in self.clients.receive(&server, message) {
                             match event {
-                                data::client::Event::Single(message) => {
-                                    dashboard.record_message(&server, message);
+                                data::client::Event::Single(encoded, our_nick) => {
+                                    if let Some(message) =
+                                        data::Message::received(encoded, our_nick)
+                                    {
+                                        dashboard.record_message(&server, message);
+                                    }
                                 }
-                                data::client::Event::Whois(message, buffer) => {
-                                    dashboard.record_whois(&server, message, buffer);
+                                data::client::Event::Whois(encoded, our_nick, buffer) => {
+                                    if let Some(message) =
+                                        data::Message::received(encoded, our_nick)
+                                    {
+                                        dashboard.record_whois(&server, message, buffer);
+                                    }
                                 }
                                 data::client::Event::Brodcast(brodcast) => match brodcast {
                                     data::client::Brodcast::Quit {

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -123,7 +123,7 @@ impl Dashboard {
                                         let input = data::Input::command(buffer, command);
 
                                         if let Some(encoded) = input.encoded() {
-                                            clients.send(input.server(), encoded);
+                                            clients.send(input.buffer(), encoded);
                                         }
 
                                         if let Some(message) = clients
@@ -245,10 +245,10 @@ impl Dashboard {
                             data::Buffer::Channel(server, channel) => {
                                 // Send part & close history file
                                 let command = data::Command::Part(channel.clone(), None);
-                                let input = data::Input::command(buffer, command);
+                                let input = data::Input::command(buffer.clone(), command);
 
                                 if let Some(encoded) = input.encoded() {
-                                    clients.send(&server, encoded);
+                                    clients.send(&buffer, encoded);
                                 }
 
                                 return self
@@ -494,15 +494,24 @@ impl Dashboard {
         self.history.record_message(server, message);
     }
 
-    pub fn record_whois(&mut self, server: &Server, mut message: data::Message) {
-        // If a buffer for the server is focused, put the whois message there
-        message.source = self
-            .get_focused()
-            .and_then(|pane| {
-                pane.buffer.data().and_then(|buffer| {
-                    (buffer.server() == server).then(|| buffer.server_message_source())
-                })
+    pub fn record_whois(
+        &mut self,
+        server: &Server,
+        mut message: data::Message,
+        buffer: Option<data::Buffer>,
+    ) {
+        // If server supports labels, we should receive the buffer sent from. Otherwise
+        // fallback to the focused buffer for the server.
+        let buffer = buffer.or_else(|| {
+            self.get_focused().and_then(|pane| {
+                pane.buffer
+                    .data()
+                    .and_then(|buffer| (buffer.server() == server).then_some(buffer))
             })
+        });
+
+        message.source = buffer
+            .map(|buffer| buffer.server_message_source())
             .unwrap_or(message::Source::Server);
 
         self.history.record_message(server, message);


### PR DESCRIPTION
This PR adds initial support for the following extensions:

- `batch` 
- `echo-message`
- `labeled-response`

It appears `echo-message` is required by some bouncers (soju) for seeing sent messages across multiple connected clients. `labeled-response` has been added so we can properly track our sent messages to know if we need to apply the echo or not. These capabilities are only sent if the server supports BOTH, as `echo-message` without `labeled-response` will cause duplicate messages in halloy.

`batch` is added since `labeled-response` has a hard requirement on it per the docs.

I've not been able to fully test this yet since `ZNC` doesn't use `labeled-response`. I'll need to setup a soju instance to further test.