### PR TITLE
Print more information for TLS errors

### DIFF
--- a/data/src/stream.rs
+++ b/data/src/stream.rs
@@ -98,12 +98,17 @@ pub async fn run(server: server::Entry, mut sender: mpsc::Sender<Update>) -> Nev
                         };
                     }
                     Err(e) => {
+                        let e = match e {
+                            // unwrap Tls-specific error enums to access more error info
+                            irc::error::Error::Tls(e) => format!("a TLS error occured: {e}"),
+                            _ => e.to_string(),
+                        };
                         log::warn!("[{server}] connection failed: {e}");
 
                         let _ = sender
                             .send(Update::ConnectionFailed {
                                 server: server.clone(),
-                                error: e.to_string(),
+                                error: e,
                             })
                             .await;
 

--- a/data/src/stream.rs
+++ b/data/src/stream.rs
@@ -98,17 +98,18 @@ pub async fn run(server: server::Entry, mut sender: mpsc::Sender<Update>) -> Nev
                         };
                     }
                     Err(e) => {
-                        let e = match e {
+                        let error = match e {
                             // unwrap Tls-specific error enums to access more error info
                             irc::error::Error::Tls(e) => format!("a TLS error occured: {e}"),
                             _ => e.to_string(),
                         };
-                        log::warn!("[{server}] connection failed: {e}");
+
+                        log::warn!("[{server}] connection failed: {error}");
 
                         let _ = sender
                             .send(Update::ConnectionFailed {
                                 server: server.clone(),
-                                error: e,
+                                error,
                             })
                             .await;
 


### PR DESCRIPTION
The aatxe/irc crate defines a crate-wide Error enum in irc/src/error.rs, wrapping different errors from various kinds of sources, such as TLS errors by tls-native.  When `.to_string()` is invoked on such an enum, the error message using `#[error("...")]` is displayed.  However, they wrap the actual Tls error enum inside with its own `.to_string()` function.  In case of such errors, also include this information in our error message which is much more helpful for debugging.

![image](https://github.com/squidowl/halloy/assets/7831843/4a8bd260-228f-4a35-93e7-cb270575e828)

Note that perhaps it'd be better to fix this upstream, it seems that the macro can at least also access fields from the enum, as seen here: https://github.com/aatxe/irc/blob/develop/src/error.rs#L76. Maybe something like

```
#[error("a TLS error occured: {}", tlserror)
```

with a corresponding field in the enum upstream would work, but my Rust foo is quite limited.