### PR TITLE
simplify colors

### DIFF
--- a/data/src/palette.rs
+++ b/data/src/palette.rs
@@ -96,14 +96,6 @@ pub fn alpha(color: Color, alpha: f32) -> Color {
     Color { a: alpha, ..color }
 }
 
-pub fn lightness(color: Color, amount: f32) -> Color {
-    let mut hsl = to_hsl(color);
-
-    hsl.lightness = amount;
-
-    from_hsl(hsl)
-}
-
 pub fn mix(a: Color, b: Color, factor: f32) -> Color {
     let a_hsl = to_hsl(a);
     let b_hsl = to_hsl(b);
@@ -124,30 +116,6 @@ pub fn darken(color: Color, amount: f32) -> Color {
     let mut hsl = to_hsl(color);
 
     hsl.darken_fixed_assign(amount);
-
-    from_hsl(hsl)
-}
-
-pub fn mute(color: Color, amount: f32) -> Color {
-    let mut hsl = to_hsl(color);
-
-    if is_dark(color) {
-        hsl.lighten_fixed_assign(amount)
-    } else {
-        hsl.darken_fixed_assign(amount)
-    };
-
-    from_hsl(hsl)
-}
-
-pub fn intensify(color: Color, amount: f32) -> Color {
-    let mut hsl = to_hsl(color);
-
-    if is_dark(color) {
-        hsl.darken_fixed_assign(amount)
-    } else {
-        hsl.lighten_fixed_assign(amount)
-    };
 
     from_hsl(hsl)
 }

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -41,7 +41,7 @@ pub fn view<'a>(
                 let timestamp = config
                     .buffer
                     .format_timestamp(&message.server_time)
-                    .map(|timestamp| selectable_text(timestamp).style(theme::Text::Alpha04));
+                    .map(|timestamp| selectable_text(timestamp).style(theme::Text::Transparent));
 
                 match &message.source {
                     data::message::Source::Channel(_, kind) => match kind {

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -37,7 +37,7 @@ pub fn view<'a>(
                 let timestamp = config
                     .buffer
                     .format_timestamp(&message.server_time)
-                    .map(|timestamp| selectable_text(timestamp).style(theme::Text::Alpha04));
+                    .map(|timestamp| selectable_text(timestamp).style(theme::Text::Transparent));
 
                 let message::Source::Query(_, sender) = &message.source else {
                     return None;

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -31,11 +31,11 @@ pub fn view<'a>(
                 let timestamp = config
                     .buffer
                     .format_timestamp(&message.server_time)
-                    .map(|timestamp| selectable_text(timestamp).style(theme::Text::Alpha04));
+                    .map(|timestamp| selectable_text(timestamp).style(theme::Text::Transparent));
 
                 match message.source {
                     data::message::Source::Server => {
-                        let message = selectable_text(&message.text).style(theme::Text::Alpha04);
+                        let message = selectable_text(&message.text).style(theme::Text::Server);
 
                         Some(container(row![].push_maybe(timestamp).push(message)).into())
                     }

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -187,7 +187,7 @@ impl TitleBar {
             controls = controls.push(delete);
         }
 
-        let title = container(text(value).style(theme::Text::Alpha04))
+        let title = container(text(value).style(theme::Text::Transparent))
             .height(22)
             .padding([0, 4])
             .align_y(iced::alignment::Vertical::Center);


### PR DESCRIPTION
This PR simplifies the our `Subpalette` - with the goal of making it simpler to manage colors.
We are moving from a long and detailed set of variants, to a more simple list of just a few variants.

Now
```rust
    pub base: Color,
    pub light: Color,
    pub lighter: Color,
    pub lightest: Color,
    pub dark: Color,
    pub darker: Color,
    pub darkest: Color,
    pub low_alpha: Color,
    pub med_alpha: Color,
    pub high_alpha: Color,
```

One Issue previously to this PR was that light themes looked washed out, and hard to read in a few places. This is now fixed by handling transparency on a theme color level. If the theme is dark, we use different values than if its light.

This is probably not perfect just yet, we could adjust value even further, but main idea here is that's its easier to adjust going forward than before.

To test, try both dark and light themes and make sure they are readable as expected.

