### PR TITLE
Route whois on last sent buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Fixed:
 
 - Changes done in the config file are now properly applied to the old buffers
 - Text and colors on light themes will no longer appear washed out
+- All WHOIS responses are now properly routed to the buffer where the request was made (text input or via context menu)
 
 # 2023.2 (2023-07-07)
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -97,9 +97,7 @@ impl Connection {
             message.tags = Some(vec![Tag("label".to_string(), Some(label))]);
         }
 
-        if start_reroute(&message.command) {
-            self.reroute_responses_to = Some(buffer.clone());
-        }
+        self.reroute_responses_to = start_reroute(&message.command).then(|| buffer.clone());
 
         if let Err(e) = self.client.send(message) {
             log::warn!("Error sending message: {e}");

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -151,6 +151,10 @@ impl Message {
             text,
         })
     }
+
+    pub fn with_source(self, source: Source) -> Self {
+        Self { source, ..self }
+    }
 }
 
 fn source(message: Encoded, our_nick: &Nick) -> Option<Source> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -345,11 +345,12 @@ impl Application for Halloy {
                                         dashboard.record_message(&server, message);
                                     }
                                 }
-                                data::client::Event::Whois(encoded, our_nick, buffer) => {
+                                data::client::Event::WithSource(encoded, our_nick, source) => {
                                     if let Some(message) =
                                         data::Message::received(encoded, our_nick)
                                     {
-                                        dashboard.record_whois(&server, message, buffer);
+                                        dashboard
+                                            .record_message(&server, message.with_source(source));
                                     }
                                 }
                                 data::client::Event::Brodcast(brodcast) => match brodcast {

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 
 use data::history::manager::Broadcast;
 use data::user::Nick;
-use data::{history, message, Config, Server, User};
+use data::{history, Config, Server, User};
 use iced::widget::pane_grid::{self, PaneGrid};
 use iced::widget::{container, row};
 use iced::{clipboard, window, Command, Length, Subscription};
@@ -499,29 +499,6 @@ impl Dashboard {
         self.history.record_message(server, message);
     }
 
-    pub fn record_whois(
-        &mut self,
-        server: &Server,
-        mut message: data::Message,
-        buffer: Option<data::Buffer>,
-    ) {
-        // If server supports labels, we should receive the buffer sent from. Otherwise
-        // fallback to the focused buffer for the server.
-        let buffer = buffer.or_else(|| {
-            self.get_focused().and_then(|pane| {
-                pane.buffer
-                    .data()
-                    .and_then(|buffer| (buffer.server() == server).then_some(buffer))
-            })
-        });
-
-        message.source = buffer
-            .map(|buffer| buffer.server_message_source())
-            .unwrap_or(message::Source::Server);
-
-        self.history.record_message(server, message);
-    }
-
     pub fn broadcast_quit(
         &mut self,
         server: &Server,
@@ -578,11 +555,6 @@ impl Dashboard {
     pub fn broadcast_connection_failed(&mut self, server: &Server, error: String) {
         self.history
             .broadcast(server, Broadcast::ConnectionFailed { error });
-    }
-
-    fn get_focused(&mut self) -> Option<&Pane> {
-        let pane = self.focus?;
-        self.panes.get(&pane)
     }
 
     fn get_focused_mut(&mut self) -> Option<(pane_grid::Pane, &mut Pane)> {


### PR DESCRIPTION
Resolves #132 

Instead of routing whois based on focused buffer, we add some state to track the last buffer to send WHOIS command and use that. This solution works for both context menu WHOIS when focused / unfocused and using text input command. 