### PR TITLE
Rename config key to buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 Added:
 
-- Configuration option `new_buffer.input_visibility` to control input field visibility: always shown or following the focused buffer.
+- Configuration option `buffer.input_visibility` to control input field visibility: always shown or following the focused buffer.
+
+Changed:
+
+- Configuration option `new_buffer` has been renamed to `buffer`. `new_buffer` key will still work for backwards compatibility.
 
 Fixed:
 

--- a/config.yaml
+++ b/config.yaml
@@ -43,8 +43,8 @@ font:
   # - Default is 13
   size: 13
       
-# Settings applied by default to new buffers
-new_buffer:
+# Buffer settings
+buffer:
   # Nickname settings
   nickname:
     # User color settings:

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -68,9 +68,8 @@ impl Config {
             pub servers: server::Map,
             #[serde(default)]
             pub font: Font,
-            /// Default settings when creating a new buffer
-            #[serde(default)]
-            pub new_buffer: Buffer,
+            #[serde(default, alias = "new_buffer")]
+            pub buffer: Buffer,
             #[serde(default)]
             pub dashboard: Dashboard,
         }
@@ -82,7 +81,7 @@ impl Config {
             theme,
             servers,
             font,
-            new_buffer,
+            buffer,
             dashboard,
         } = serde_yaml::from_reader(BufReader::new(file))
             .map_err(|e| Error::Parse(e.to_string()))?;
@@ -94,7 +93,7 @@ impl Config {
             palette,
             servers,
             font,
-            buffer: new_buffer,
+            buffer,
             dashboard,
         })
     }


### PR DESCRIPTION
Small fix now that #127 is merged. Renames `new_buffer` in config to `buffer`. I've kept the alias in on `new_buffer` so old config formats don't break