### PR TITLE
create `config.template.yaml` on Welcome screen creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 Halloy is an open-source IRC client written in Rust, with the Iced GUI library. It aims to provide a simple and fast client for Mac, Windows, and Linux platforms.
 
+Join **#halloy** on libera.chat if you have questions or looking for help.
+
 <a href="https://github.com/iced-rs/iced">
   <img src="https://gist.githubusercontent.com/hecrj/ad7ecd38f6e47ff3688a38c79fd108f0/raw/74384875ecbad02ae2a926425e9bcafd0695bade/color.svg" width="130px">
 </a>

--- a/src/screen/welcome.rs
+++ b/src/screen/welcome.rs
@@ -21,6 +21,9 @@ pub struct Welcome;
 
 impl Welcome {
     pub fn new() -> Self {
+        // Create template config file.
+        Config::create_template_config();
+
         Welcome::default()
     }
 
@@ -28,9 +31,6 @@ impl Welcome {
         match message {
             Message::RefreshConfiguration => Some(Event::RefreshConfiguration),
             Message::OpenConfigurationDirectory => {
-                // Create template config file.
-                Config::create_template_config();
-
                 // Open config directory.
                 let _ = open::that(Config::config_dir());
 
@@ -96,8 +96,9 @@ impl Welcome {
                     ])
                     .push(row![
                         text("4. ").style(theme::Text::Accent),
-                        text("For help and assistance, please visit "),
-                        text("github.com/squidowl/halloy").style(theme::Text::Info),
+                        text("Join "),
+                        text("#halloy").style(theme::Text::Info),
+                        text(" on libera.chat if you have questions or looking for help"),
                     ])
                     .spacing(2)
                     .align_items(iced::Alignment::Start),

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -317,13 +317,13 @@ impl button::StyleSheet for Theme {
     fn active(&self, style: &Self::Style) -> button::Appearance {
         match style {
             Button::Default => button::Appearance {
-                background: Some(Background::Color(self.colors.action.med_alpha)),
+                background: Some(Background::Color(self.colors.action.high_alpha)),
                 text_color: self.colors.action.base,
                 border_radius: 3.0.into(),
                 ..Default::default()
             },
             Button::Secondary => button::Appearance {
-                background: Some(Background::Color(self.colors.text.med_alpha)),
+                background: Some(Background::Color(self.colors.text.high_alpha)),
                 text_color: self.colors.text.base,
                 border_radius: 3.0.into(),
                 ..Default::default()


### PR DESCRIPTION
This PR fixes a few smaller things:

1. Create config template file when welcome screen is created, rather than when user open the directory with the button. This is also better for users navigating there with the terminal. Fixes #136.
2. Copy change so we direct users to join our IRC channel instead of just pointing them back to Github.
3. Updated README with a mention of our IRC channel
4. Small error on colors