### PR TITLE
Only allow input history if buffer is focused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Fixed:
 - Changes done in the config file are now properly applied to the old buffers
 - Text and colors on light themes will no longer appear washed out
 - All WHOIS responses are now properly routed to the buffer where the request was made (text input or via context menu)
+- Accessing text input history will only populate the current buffer, not all of them
 
 # 2023.2 (2023-07-07)
 

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -108,7 +108,7 @@ pub fn view<'a>(
     let text_input = show_text_input.then(|| {
         column![
             vertical_space(4),
-            input_view::view(&state.input_view, buffer, users, input_history)
+            input_view::view(&state.input_view, buffer, users, input_history, is_focused)
                 .map(Message::InputView)
         ]
     });

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -20,6 +20,7 @@ pub fn view<'a>(
     buffer: Buffer,
     users: &'a [User],
     history: &'a [String],
+    buffer_focused: bool,
 ) -> Element<'a, Message> {
     input(
         state.input_id.clone(),
@@ -27,6 +28,7 @@ pub fn view<'a>(
         &state.input,
         users,
         history,
+        buffer_focused,
         Message::Input,
         Message::Send,
         Message::Completion,

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -92,7 +92,8 @@ pub fn view<'a>(
     let text_input = show_text_input.then(|| {
         column![
             vertical_space(4),
-            input_view::view(&state.input_view, buffer, &[], input_history).map(Message::InputView)
+            input_view::view(&state.input_view, buffer, &[], input_history, is_focused)
+                .map(Message::InputView)
         ]
     });
 

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -61,7 +61,8 @@ pub fn view<'a>(
     let text_input = show_text_input.then(|| {
         column![
             vertical_space(4),
-            input_view::view(&state.input_view, buffer, &[], input_history).map(Message::InputView)
+            input_view::view(&state.input_view, buffer, &[], input_history, is_focused)
+                .map(Message::InputView)
         ]
     });
 

--- a/src/widget/input.rs
+++ b/src/widget/input.rs
@@ -18,6 +18,7 @@ pub fn input<'a, Message>(
     input: &'a str,
     users: &'a [User],
     history: &'a [String],
+    buffer_focused: bool,
     on_input: impl Fn(String) -> Message + 'a,
     on_submit: impl Fn(data::Input) -> Message + 'a,
     on_completion: impl Fn(String) -> Message + 'a,
@@ -31,6 +32,7 @@ where
         input,
         users,
         history,
+        buffer_focused,
         on_input: Box::new(on_input),
         on_submit: Box::new(on_submit),
         on_completion: Box::new(on_completion),
@@ -59,6 +61,7 @@ pub struct Input<'a, Message> {
     input: &'a str,
     users: &'a [User],
     history: &'a [String],
+    buffer_focused: bool,
     on_input: Box<dyn Fn(String) -> Message + 'a>,
     on_submit: Box<dyn Fn(data::Input) -> Message + 'a>,
     on_completion: Box<dyn Fn(String) -> Message + 'a>,
@@ -183,7 +186,7 @@ where
             .style(style);
 
         // Add tab support
-        let input = key_press(
+        let mut input = key_press(
             text_input,
             key_press::KeyCode::Tab,
             key_press::Modifiers::default(),
@@ -191,17 +194,19 @@ where
         );
 
         // Add up / down support for history cycling
-        let input = key_press(
-            key_press(
-                input,
-                key_press::KeyCode::Up,
+        if self.buffer_focused {
+            input = key_press(
+                key_press(
+                    input,
+                    key_press::KeyCode::Up,
+                    key_press::Modifiers::default(),
+                    Event::Up,
+                ),
+                key_press::KeyCode::Down,
                 key_press::Modifiers::default(),
-                Event::Up,
-            ),
-            key_press::KeyCode::Down,
-            key_press::Modifiers::default(),
-            Event::Down,
-        );
+                Event::Down,
+            );
+        }
 
         let overlay = state
             .error


### PR DESCRIPTION
Fixed bug where if multiple buffers are open and messages have been sent in each, using `up / down` arrows to cycle input history affects all buffers. Now only the current focused buffer is cycled.