### PR TITLE
let users know if query taget is away with `RPL_AWAY`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Added:
 
 - Configuration option `buffer.input_visibility` to control input field visibility: always shown or following the focused buffer.
 - Upon joining a channel, display the channel mode in the buffer
+- When querying an away user, you will see an away message
 
 Changed:
 


### PR DESCRIPTION
Simply prints away message, if the target is away.   
This only has to printed to query, since we will tackle the visual of away users in channels with `away-notify` later.