### PR TITLE
Fix/clipboard overwrite empty text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Fixed:
 - Text and colors on light themes will no longer appear washed out
 - All WHOIS responses are now properly routed to the buffer where the request was made (text input or via context menu)
 - Accessing text input history will only populate the current buffer, not all of them
+- Text from input box can be copied to clipboard
 
 # 2023.2 (2023-07-07)
 

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -284,7 +284,9 @@ impl Dashboard {
                         }
                     });
 
-                return clipboard::write(contents);
+                if !contents.is_empty() {
+                    return clipboard::write(contents);
+                }
             }
             Message::History(message) => {
                 self.history.update(message);


### PR DESCRIPTION
We were overwriting the clipboard on every cmd+c via our selectable text implementation even when no text was selected. This caused any copied text via the text input widget to get overwritten.

Now text in text input widget can be copied when selected.

Resolves #156