### PR TITLE
Feat/message filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Unreleased
 
+**Message history and dashboard state will be reset due to a breaking change. We've switched to a more flexible storage format 
+to ensure future breakages won't occur.**
+
 Added:
 
+- Configuration option `buffer.hidden_server_messages` to hide server messages from the provided array of sources: ["join", "part", "quit"]
 - Configuration option `buffer.input_visibility` to control input field visibility: always shown or following the focused buffer.
 - Upon joining a channel, display the channel mode in the buffer
 - When querying an away user, you will see an away message

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,7 @@ dependencies = [
  "rand_chacha",
  "seahash",
  "serde",
+ "serde_json",
  "serde_yaml",
  "thiserror",
  "tokio",
@@ -1442,6 +1443,12 @@ checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jni-sys"
@@ -2603,6 +2610,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.18",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/config.yaml
+++ b/config.yaml
@@ -75,6 +75,11 @@ buffer:
   # - Always: Show input at all times [default]
   # - Focused: Only show input when the buffer is focused
   input_visibility: Always
+
+  # An array of server message types that will be hidden
+  # - Default: []
+  # - Supported values: ["join", "part", "quit"]
+  hidden_server_messages: []
       
   # Channel buffer settings
   channel:

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -16,6 +16,7 @@ palette = "=0.7.2"
 rand = "0.8.4"
 rand_chacha = "0.3.0"
 seahash = "4.1.0"
+serde_json = "1.0"
 serde_yaml = "0.8.23"
 thiserror = "1.0.30"
 tokio = { version = "1.0", features = ["io-util"] }

--- a/data/build.rs
+++ b/data/build.rs
@@ -28,7 +28,9 @@ fn main() {
         .ok()
         .filter(|output| output.status.success())
         .and_then(|x| String::from_utf8(x.stdout).ok())
-    else{ return; };
+    else {
+        return;
+    };
     // If heads starts pointing at something else (different branch)
     // we need to return
     let head = Path::new(&git_dir).join("HEAD");
@@ -43,7 +45,9 @@ fn main() {
         .ok()
         .filter(|output| output.status.success())
         .and_then(|x| String::from_utf8(x.stdout).ok())
-    else{ return; };
+    else {
+        return;
+    };
     let head_ref = Path::new(&git_dir).join(head_ref);
     if head_ref.exists() {
         println!("cargo:rerun-if-changed={}", head_ref.display());

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -29,7 +29,7 @@ impl Buffer {
         }
     }
 
-    pub fn server_message_target(self, source: message::source::Server) -> message::Target {
+    pub fn server_message_target(self, source: Option<message::source::Server>) -> message::Target {
         match self {
             Self::Server(_) => message::Target::Server {
                 source: message::Source::Server(source),

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -29,11 +29,19 @@ impl Buffer {
         }
     }
 
-    pub fn server_message_source(self) -> message::Source {
+    pub fn server_message_target(self, source: message::source::Server) -> message::Target {
         match self {
-            Self::Server(_) => message::Source::Server,
-            Self::Channel(_, channel) => message::Source::Channel(channel, message::Sender::Server),
-            Self::Query(_, nick) => message::Source::Query(nick, message::Sender::Server),
+            Self::Server(_) => message::Target::Server {
+                source: message::Source::Server(source),
+            },
+            Self::Channel(_, channel) => message::Target::Channel {
+                channel,
+                source: message::Source::Server(source),
+            },
+            Self::Query(_, nick) => message::Target::Query {
+                nick,
+                source: message::Source::Server(source),
+            },
         }
     }
 }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -44,7 +44,7 @@ pub enum Brodcast {
 #[derive(Debug)]
 pub enum Event {
     Single(message::Encoded, Nick),
-    WithSource(message::Encoded, Nick, message::Source),
+    WithTarget(message::Encoded, Nick, message::Target),
     Brodcast(Brodcast),
 }
 
@@ -186,9 +186,9 @@ impl Connection {
             _ if context.as_ref().map(Context::is_whois).unwrap_or_default() => {
                 if let Some(source) = context
                     .map(Context::buffer)
-                    .map(Buffer::server_message_source)
+                    .map(|buffer| buffer.server_message_target(message::source::Server::Other))
                 {
-                    return Some(vec![Event::WithSource(
+                    return Some(vec![Event::WithTarget(
                         message,
                         self.nickname().to_owned(),
                         source,
@@ -200,9 +200,9 @@ impl Connection {
                 if let Some(source) = self
                     .reroute_responses_to
                     .clone()
-                    .map(Buffer::server_message_source)
+                    .map(|buffer| buffer.server_message_target(message::source::Server::Other))
                 {
-                    return Some(vec![Event::WithSource(
+                    return Some(vec![Event::WithTarget(
                         message,
                         self.nickname().to_owned(),
                         source,

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -186,7 +186,7 @@ impl Connection {
             _ if context.as_ref().map(Context::is_whois).unwrap_or_default() => {
                 if let Some(source) = context
                     .map(Context::buffer)
-                    .map(|buffer| buffer.server_message_target(message::source::Server::Other))
+                    .map(|buffer| buffer.server_message_target(None))
                 {
                     return Some(vec![Event::WithTarget(
                         message,
@@ -200,7 +200,7 @@ impl Connection {
                 if let Some(source) = self
                     .reroute_responses_to
                     .clone()
-                    .map(|buffer| buffer.server_message_target(message::source::Server::Other))
+                    .map(|buffer| buffer.server_message_target(None))
                 {
                     return Some(vec![Event::WithTarget(
                         message,

--- a/data/src/compression.rs
+++ b/data/src/compression.rs
@@ -1,26 +1,26 @@
 use std::io;
 use std::io::prelude::*;
 
-use flate2::read::ZlibDecoder;
-use flate2::write::ZlibEncoder;
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
 use flate2::Compression;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 pub fn compress<T: Serialize>(value: &T) -> Result<Vec<u8>, Error> {
-    let bytes = bincode::serialize(&value).map_err(Error::Encode)?;
-    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::fast());
+    let bytes = serde_json::to_vec(&value).map_err(Error::Encode)?;
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
     encoder.write_all(&bytes).map_err(Error::Compression)?;
     encoder.finish().map_err(Error::Compression)
 }
 
 pub fn decompress<T: DeserializeOwned>(data: &[u8]) -> Result<T, Error> {
     let mut bytes = vec![];
-    let mut encoder = ZlibDecoder::new(data);
+    let mut encoder = GzDecoder::new(data);
     encoder
         .read_to_end(&mut bytes)
         .map_err(Error::Decompression)?;
-    bincode::deserialize(&bytes).map_err(Error::Decode)
+    serde_json::from_slice(&bytes).map_err(Error::Decode)
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -30,7 +30,7 @@ pub enum Error {
     #[error("decompression failed")]
     Decompression(io::Error),
     #[error("encoding failed")]
-    Encode(bincode::Error),
+    Encode(serde_json::Error),
     #[error("decoding failed")]
-    Decode(bincode::Error),
+    Decode(serde_json::Error),
 }

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -9,7 +9,6 @@ pub use self::buffer::Buffer;
 pub use self::channel::Channel;
 pub use self::dashboard::Dashboard;
 pub use self::server::Server;
-
 use crate::environment;
 use crate::palette::Palette;
 use crate::server::Map as ServerMap;

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -1,8 +1,13 @@
+use std::collections::HashSet;
+
 use chrono::{DateTime, Local, Utc};
 use serde::Deserialize;
 
 use super::Channel;
-use crate::buffer::{Color, InputVisibility, Nickname, Timestamp};
+use crate::{
+    buffer::{Color, InputVisibility, Nickname, Timestamp},
+    message,
+};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Buffer {
@@ -14,6 +19,8 @@ pub struct Buffer {
     pub input_visibility: InputVisibility,
     #[serde(default)]
     pub channel: Channel,
+    #[serde(default)]
+    pub hidden_server_messages: HashSet<message::source::Server>,
 }
 
 impl Default for Buffer {
@@ -29,6 +36,7 @@ impl Default for Buffer {
             },
             input_visibility: InputVisibility::default(),
             channel: Channel::default(),
+            hidden_server_messages: HashSet::default(),
         }
     }
 }

--- a/data/src/dashboard.rs
+++ b/data/src/dashboard.rs
@@ -47,7 +47,7 @@ fn path() -> Result<PathBuf, Error> {
         std::fs::create_dir_all(&parent)?;
     }
 
-    Ok(parent.join("dashboard"))
+    Ok(parent.join("dashboard.json.gz"))
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -113,7 +113,7 @@ async fn path(server: &server::Server, kind: &Kind) -> Result<PathBuf, Error> {
         fs::create_dir_all(&parent).await?;
     }
 
-    Ok(parent.join(format!("{hashed_name}")))
+    Ok(parent.join(format!("{hashed_name}.json.gz")))
 }
 
 #[derive(Debug)]

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -41,12 +41,12 @@ impl fmt::Display for Kind {
     }
 }
 
-impl From<message::Source> for Kind {
-    fn from(source: message::Source) -> Self {
-        match source {
-            message::Source::Server | message::Source::Status(_) => Kind::Server,
-            message::Source::Channel(channel, _) => Kind::Channel(channel),
-            message::Source::Query(user, _) => Kind::Query(user),
+impl From<message::Target> for Kind {
+    fn from(target: message::Target) -> Self {
+        match target {
+            message::Target::Server { .. } => Kind::Server,
+            message::Target::Channel { channel, .. } => Kind::Channel(channel),
+            message::Target::Query { nick, .. } => Kind::Query(nick),
         }
     }
 }

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -177,7 +177,7 @@ impl Manager {
     pub fn record_message(&mut self, server: &Server, message: crate::Message) {
         self.data.add_message(
             server.clone(),
-            history::Kind::from(message.source.clone()),
+            history::Kind::from(message.target.clone()),
             message,
         );
     }
@@ -213,7 +213,7 @@ impl Manager {
 
     pub fn get_unique_queries(&self, server: &Server) -> Vec<&Nick> {
         let Some(map) = self.data.map.get(server) else {
-            return vec![]
+            return vec![];
         };
 
         let queries = map
@@ -410,7 +410,12 @@ impl Data {
         kind: &history::Kind,
         limit: Option<Limit>,
     ) -> Option<history::View> {
-        let History::Full { messages, opened_at, .. } = self.map.get(server)?.get(kind)? else {
+        let History::Full {
+            messages,
+            opened_at,
+            ..
+        } = self.map.get(server)?.get(kind)?
+        else {
             return None;
         };
 

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -126,16 +126,16 @@ fn target(message: Encoded, our_nick: &Nick) -> Option<Target> {
         | proto::Command::ChannelMODE(channel, _)
         | proto::Command::KICK(channel, _, _) => Some(Target::Channel {
             channel,
-            source: source::Source::Server(source::Server::Other),
+            source: source::Source::Server(None),
         }),
         proto::Command::PART(channel, _) => Some(Target::Channel {
             channel,
-            source: source::Source::Server(source::Server::Part),
+            source: source::Source::Server(Some(source::Server::Part)),
         }),
         proto::Command::SAJOIN(_, channel) | proto::Command::JOIN(channel, _, _) => {
             Some(Target::Channel {
                 channel,
-                source: source::Source::Server(source::Server::Join),
+                source: source::Source::Server(Some(source::Server::Join)),
             })
         }
         proto::Command::Response(
@@ -147,7 +147,7 @@ fn target(message: Encoded, our_nick: &Nick) -> Option<Target> {
             let channel = params.get(1)?.clone();
             Some(Target::Channel {
                 channel,
-                source: source::Source::Server(source::Server::Other),
+                source: source::Source::Server(None),
             })
         }
         proto::Command::Response(proto::Response::RPL_AWAY, params) => {
@@ -209,7 +209,7 @@ fn target(message: Encoded, our_nick: &Nick) -> Option<Target> {
                     })
                 }
                 _ => Some(Target::Server {
-                    source: Source::Server(source::Server::Other),
+                    source: Source::Server(None),
                 }),
             }
         }
@@ -273,7 +273,7 @@ fn target(message: Encoded, our_nick: &Nick) -> Option<Target> {
         | proto::Command::Response(_, _)
         | proto::Command::Raw(_, _)
         | proto::Command::SAQUIT(_, _) => Some(Target::Server {
-            source: Source::Server(source::Server::Other),
+            source: Source::Server(None),
         }),
     }
 }

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -101,13 +101,13 @@ impl Message {
     pub fn received(encoded: Encoded, our_nick: Nick) -> Option<Message> {
         let server_time = server_time(&encoded);
         let text = text(&encoded, &our_nick)?;
-        let source = target(encoded, &our_nick)?;
+        let target = target(encoded, &our_nick)?;
 
         Some(Message {
             received_at: Posix::now(),
             server_time,
             direction: Direction::Received,
-            target: source,
+            target,
             text,
         })
     }

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -3,11 +3,15 @@ use irc::proto;
 use irc::proto::ChannelExt;
 use serde::{Deserialize, Serialize};
 
+pub use self::source::Source;
 use crate::time::{self, Posix};
 use crate::user::{Nick, NickRef};
 use crate::User;
 
 pub type Channel = String;
+
+pub(crate) mod broadcast;
+pub mod source;
 
 #[derive(Debug, Clone)]
 pub struct Encoded(proto::Message);
@@ -57,47 +61,20 @@ impl From<Encoded> for proto::Message {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum Source {
-    Server,
-    Channel(Channel, Sender),
-    Query(Nick, Sender),
-    Status(Status),
+pub enum Target {
+    Server { source: Source },
+    Channel { channel: Channel, source: Source },
+    Query { nick: Nick, source: Source },
 }
 
-impl Source {
-    pub fn sender(&self) -> Option<&Sender> {
+impl Target {
+    pub fn source(&self) -> &Source {
         match self {
-            Source::Server => None,
-            Source::Channel(_, sender) => Some(sender),
-            Source::Query(_, sender) => Some(sender),
-            Source::Status(_) => None,
+            Target::Server { source } => source,
+            Target::Channel { source, .. } => source,
+            Target::Query { source, .. } => source,
         }
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum Sender {
-    User(User),
-    Server,
-    Action,
-    Status(Status),
-}
-
-impl Sender {
-    pub fn user(&self) -> Option<&User> {
-        match self {
-            Sender::User(user) => Some(user),
-            Sender::Server => None,
-            Sender::Action => None,
-            Sender::Status(_) => None,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum Status {
-    Success,
-    Error,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -111,63 +88,56 @@ pub struct Message {
     pub received_at: Posix,
     pub server_time: DateTime<Utc>,
     pub direction: Direction,
-    pub source: Source,
+    pub target: Target,
     pub text: String,
 }
 
 impl Message {
-    pub fn channel(&self) -> Option<&str> {
-        if let Source::Channel(channel, _) = &self.source {
-            Some(channel)
-        } else {
-            None
-        }
-    }
-
-    pub fn sent_by(&self) -> Option<&User> {
-        match &self.source {
-            Source::Server => None,
-            Source::Channel(_, kind) => kind.user(),
-            Source::Query(_, kind) => kind.user(),
-            Source::Status(_) => None,
-        }
-    }
-
     pub fn triggers_unread(&self) -> bool {
         matches!(self.direction, Direction::Received)
-            && matches!(self.source.sender(), Some(Sender::User(_) | Sender::Action))
+            && matches!(self.target.source(), Source::User(_) | Source::Action)
     }
 
     pub fn received(encoded: Encoded, our_nick: Nick) -> Option<Message> {
         let server_time = server_time(&encoded);
         let text = text(&encoded, &our_nick)?;
-        let source = source(encoded, &our_nick)?;
+        let source = target(encoded, &our_nick)?;
 
         Some(Message {
             received_at: Posix::now(),
             server_time,
             direction: Direction::Received,
-            source,
+            target: source,
             text,
         })
     }
 
-    pub fn with_source(self, source: Source) -> Self {
-        Self { source, ..self }
+    pub fn with_target(self, target: Target) -> Self {
+        Self { target, ..self }
     }
 }
 
-fn source(message: Encoded, our_nick: &Nick) -> Option<Source> {
+fn target(message: Encoded, our_nick: &Nick) -> Option<Target> {
     let user = message.user();
 
     match message.0.command {
         // Channel
         proto::Command::TOPIC(channel, _)
-        | proto::Command::PART(channel, _)
         | proto::Command::ChannelMODE(channel, _)
-        | proto::Command::KICK(channel, _, _)
-        | proto::Command::SAJOIN(_, channel)
-        | proto::Command::JOIN(channel, _, _) => Some(Source::Channel(channel, Sender::Server)),
+        | proto::Command::KICK(channel, _, _) => Some(Target::Channel {
+            channel,
+            source: source::Source::Server(source::Server::Other),
+        }),
+        proto::Command::PART(channel, _) => Some(Target::Channel {
+            channel,
+            source: source::Source::Server(source::Server::Part),
+        }),
+        proto::Command::SAJOIN(_, channel) | proto::Command::JOIN(channel, _, _) => {
+            Some(Target::Channel {
+                channel,
+                source: source::Source::Server(source::Server::Join),
+            })
+        }
         proto::Command::Response(
             proto::Response::RPL_TOPIC
             | proto::Response::RPL_TOPICWHOTIME
@@ -175,54 +145,72 @@ fn source(message: Encoded, our_nick: &Nick) -> Option<Source> {
             params,
         ) => {
             let channel = params.get(1)?.clone();
-            Some(Source::Channel(channel, Sender::Server))
+            Some(Target::Channel {
+                channel,
+                source: source::Source::Server(source::Server::Other),
+            })
         }
         proto::Command::Response(proto::Response::RPL_AWAY, params) => {
             let user = params.get(1)?;
             let target = User::try_from(user.as_str()).ok()?;
 
-            Some(Source::Query(target.nickname().to_owned(), Sender::Action))
+            Some(Target::Query {
+                nick: target.nickname().to_owned(),
+                source: Source::Action,
+            })
         }
         proto::Command::PRIVMSG(target, text) => {
             let is_action = is_action(&text);
-            let sender = |user| {
+            let source = |user| {
                 if is_action {
-                    Sender::Action
+                    Source::Action
                 } else {
-                    Sender::User(user)
+                    Source::User(user)
                 }
             };
 
             match (target.is_channel_name(), user) {
-                (true, Some(user)) => Some(Source::Channel(target, sender(user))),
+                (true, Some(user)) => Some(Target::Channel {
+                    channel: target,
+                    source: source(user),
+                }),
                 (false, Some(user)) => {
                     let target = User::try_from(target.as_str()).ok()?;
 
-                    (target.nickname() == *our_nick)
-                        .then(|| Source::Query(user.nickname().to_owned(), sender(user)))
+                    (target.nickname() == *our_nick).then(|| Target::Query {
+                        nick: user.nickname().to_owned(),
+                        source: source(user),
+                    })
                 }
                 _ => None,
             }
         }
         proto::Command::NOTICE(target, text) => {
             let is_action = is_action(&text);
-            let sender = |user| {
+            let source = |user| {
                 if is_action {
-                    Sender::Action
+                    Source::Action
                 } else {
-                    Sender::User(user)
+                    Source::User(user)
                 }
             };
 
             match (target.is_channel_name(), user) {
-                (true, Some(user)) => Some(Source::Channel(target, sender(user))),
+                (true, Some(user)) => Some(Target::Channel {
+                    channel: target,
+                    source: source(user),
+                }),
                 (false, Some(user)) => {
                     let target = User::try_from(target.as_str()).ok()?;
 
-                    (target.nickname() == *our_nick)
-                        .then(|| Source::Query(user.nickname().to_owned(), sender(user)))
+                    (target.nickname() == *our_nick).then(|| Target::Query {
+                        nick: user.nickname().to_owned(),
+                        source: source(user),
+                    })
                 }
-                _ => Some(Source::Server),
+                _ => Some(Target::Server {
+                    source: Source::Server(source::Server::Other),
+                }),
             }
         }
 
@@ -284,7 +272,9 @@ fn source(message: Encoded, our_nick: &Nick) -> Option<Source> {
         | proto::Command::CHGHOST(_, _)
         | proto::Command::Response(_, _)
         | proto::Command::Raw(_, _)
-        | proto::Command::SAQUIT(_, _) => Some(Source::Server),
+        | proto::Command::SAQUIT(_, _) => Some(Target::Server {
+            source: Source::Server(source::Server::Other),
+        }),
     }
 }
 
@@ -424,123 +414,4 @@ pub fn parse_action(nick: NickRef, text: &str) -> Option<String> {
 
 pub fn action_text(nick: NickRef, action: &str) -> String {
     format!(" ∙ {nick} {action}")
-}
-
-pub(crate) mod broadcast {
-    //! Generate messages that can be broadcast into every buffer
-    use chrono::Utc;
-
-    use super::{Direction, Message, Sender, Source, Status};
-    use crate::time::Posix;
-    use crate::user::Nick;
-    use crate::User;
-
-    enum Cause {
-        Server,
-        Status(Status),
-    }
-
-    fn expand(
-        channels: impl IntoIterator<Item = String>,
-        queries: impl IntoIterator<Item = Nick>,
-        include_server: bool,
-        cause: Cause,
-        text: String,
-    ) -> Vec<Message> {
-        let message = |source, text| -> Message {
-            Message {
-                received_at: Posix::now(),
-                server_time: Utc::now(),
-                direction: Direction::Received,
-                source,
-                text,
-            }
-        };
-
-        let (source, sender) = match cause {
-            Cause::Server => (Source::Server, Sender::Server),
-            Cause::Status(status) => (Source::Status(status), Sender::Status(status)),
-        };
-
-        channels
-            .into_iter()
-            .map(|channel| message(Source::Channel(channel, sender.clone()), text.clone()))
-            .chain(
-                queries
-                    .into_iter()
-                    .map(|nick| message(Source::Query(nick, sender.clone()), text.clone())),
-            )
-            .chain(include_server.then(|| message(source, text.clone())))
-            .collect()
-    }
-
-    pub fn connecting() -> Vec<Message> {
-        let text = " ∙ connecting to server...".into();
-        expand([], [], true, Cause::Status(Status::Success), text)
-    }
-
-    pub fn connected() -> Vec<Message> {
-        let text = " ∙ connected".into();
-        expand([], [], true, Cause::Status(Status::Success), text)
-    }
-
-    pub fn connection_failed(error: String) -> Vec<Message> {
-        let text = format!(" ∙ connection to server failed ({error})");
-        expand([], [], true, Cause::Status(Status::Error), text)
-    }
-
-    pub fn disconnected(
-        channels: impl IntoIterator<Item = String>,
-        queries: impl IntoIterator<Item = Nick>,
-        error: Option<String>,
-    ) -> Vec<Message> {
-        let error = error.map(|error| format!(" ({error})")).unwrap_or_default();
-        let text = format!(" ∙ connection to server lost{error}");
-        expand(channels, queries, true, Cause::Status(Status::Error), text)
-    }
-
-    pub fn reconnected(
-        channels: impl IntoIterator<Item = String>,
-        queries: impl IntoIterator<Item = Nick>,
-    ) -> Vec<Message> {
-        let text = " ∙ connection to server restored".into();
-        expand(
-            channels,
-            queries,
-            true,
-            Cause::Status(Status::Success),
-            text,
-        )
-    }
-
-    pub fn quit(
-        channels: impl IntoIterator<Item = String>,
-        queries: impl IntoIterator<Item = Nick>,
-        user: &User,
-        comment: &Option<String>,
-    ) -> Vec<Message> {
-        let comment = comment
-            .as_ref()
-            .map(|comment| format!(" ({comment})"))
-            .unwrap_or_default();
-        let text = format!("⟵ {} has quit{comment}", user.formatted());
-
-        expand(channels, queries, false, Cause::Server, text)
-    }
-
-    pub fn nickname(
-        channels: impl IntoIterator<Item = String>,
-        queries: impl IntoIterator<Item = Nick>,
-        old_nick: &Nick,
-        new_nick: &Nick,
-        ourself: bool,
-    ) -> Vec<Message> {
-        let text = if ourself {
-            format!(" ∙ You're now known as {new_nick}")
-        } else {
-            format!(" ∙ {old_nick} is now known as {new_nick}")
-        };
-
-        expand(channels, queries, false, Cause::Server, text)
-    }
 }

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -7,7 +7,7 @@ use crate::user::Nick;
 use crate::User;
 
 enum Cause {
-    Server(source::Server),
+    Server(Option<source::Server>),
     Status(source::Status),
 }
 
@@ -125,7 +125,7 @@ pub fn quit(
         channels,
         queries,
         false,
-        Cause::Server(source::Server::Other),
+        Cause::Server(Some(source::Server::Quit)),
         text,
     )
 }
@@ -143,11 +143,5 @@ pub fn nickname(
         format!(" ∙ {old_nick} is now known as {new_nick}")
     };
 
-    expand(
-        channels,
-        queries,
-        false,
-        Cause::Server(source::Server::Other),
-        text,
-    )
+    expand(channels, queries, false, Cause::Server(None), text)
 }

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -1,0 +1,153 @@
+//! Generate messages that can be broadcast into every buffer
+use chrono::Utc;
+
+use super::{source, Direction, Message, Source, Target};
+use crate::time::Posix;
+use crate::user::Nick;
+use crate::User;
+
+enum Cause {
+    Server(source::Server),
+    Status(source::Status),
+}
+
+fn expand(
+    channels: impl IntoIterator<Item = String>,
+    queries: impl IntoIterator<Item = Nick>,
+    include_server: bool,
+    cause: Cause,
+    text: String,
+) -> Vec<Message> {
+    let message = |target, text| -> Message {
+        Message {
+            received_at: Posix::now(),
+            server_time: Utc::now(),
+            direction: Direction::Received,
+            target,
+            text,
+        }
+    };
+
+    let source = match cause {
+        Cause::Server(server) => Source::Server(server),
+        Cause::Status(status) => Source::Internal(source::Internal::Status(status)),
+    };
+
+    channels
+        .into_iter()
+        .map(|channel| {
+            message(
+                Target::Channel {
+                    channel,
+                    source: source.clone(),
+                },
+                text.clone(),
+            )
+        })
+        .chain(queries.into_iter().map(|nick| {
+            message(
+                Target::Query {
+                    nick,
+                    source: source.clone(),
+                },
+                text.clone(),
+            )
+        }))
+        .chain(include_server.then(|| {
+            message(
+                Target::Server {
+                    source: source.clone(),
+                },
+                text.clone(),
+            )
+        }))
+        .collect()
+}
+
+pub fn connecting() -> Vec<Message> {
+    let text = " ∙ connecting to server...".into();
+    expand([], [], true, Cause::Status(source::Status::Success), text)
+}
+
+pub fn connected() -> Vec<Message> {
+    let text = " ∙ connected".into();
+    expand([], [], true, Cause::Status(source::Status::Success), text)
+}
+
+pub fn connection_failed(error: String) -> Vec<Message> {
+    let text = format!(" ∙ connection to server failed ({error})");
+    expand([], [], true, Cause::Status(source::Status::Error), text)
+}
+
+pub fn disconnected(
+    channels: impl IntoIterator<Item = String>,
+    queries: impl IntoIterator<Item = Nick>,
+    error: Option<String>,
+) -> Vec<Message> {
+    let error = error.map(|error| format!(" ({error})")).unwrap_or_default();
+    let text = format!(" ∙ connection to server lost{error}");
+    expand(
+        channels,
+        queries,
+        true,
+        Cause::Status(source::Status::Error),
+        text,
+    )
+}
+
+pub fn reconnected(
+    channels: impl IntoIterator<Item = String>,
+    queries: impl IntoIterator<Item = Nick>,
+) -> Vec<Message> {
+    let text = " ∙ connection to server restored".into();
+    expand(
+        channels,
+        queries,
+        true,
+        Cause::Status(source::Status::Success),
+        text,
+    )
+}
+
+pub fn quit(
+    channels: impl IntoIterator<Item = String>,
+    queries: impl IntoIterator<Item = Nick>,
+    user: &User,
+    comment: &Option<String>,
+) -> Vec<Message> {
+    let comment = comment
+        .as_ref()
+        .map(|comment| format!(" ({comment})"))
+        .unwrap_or_default();
+    let text = format!("⟵ {} has quit{comment}", user.formatted());
+
+    expand(
+        channels,
+        queries,
+        false,
+        Cause::Server(source::Server::Other),
+        text,
+    )
+}
+
+pub fn nickname(
+    channels: impl IntoIterator<Item = String>,
+    queries: impl IntoIterator<Item = Nick>,
+    old_nick: &Nick,
+    new_nick: &Nick,
+    ourself: bool,
+) -> Vec<Message> {
+    let text = if ourself {
+        format!(" ∙ You're now known as {new_nick}")
+    } else {
+        format!(" ∙ {old_nick} is now known as {new_nick}")
+    };
+
+    expand(
+        channels,
+        queries,
+        false,
+        Cause::Server(source::Server::Other),
+        text,
+    )
+}

--- a/data/src/message/source.rs
+++ b/data/src/message/source.rs
@@ -5,16 +5,17 @@ use crate::User;
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Source {
     User(User),
-    Server(Server),
+    Server(Option<Server>),
     Action,
     Internal(Internal),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Server {
     Join,
     Part,
-    Other,
+    Quit,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/data/src/message/source.rs
+++ b/data/src/message/source.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+
+use crate::User;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Source {
+    User(User),
+    Server(Server),
+    Action,
+    Internal(Internal),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Server {
+    Join,
+    Part,
+    Other,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Internal {
+    Status(Status),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Status {
+    Success,
+    Error,
+}

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -37,6 +37,7 @@ pub fn view<'a>(
             &state.scroll_view,
             scroll_view::Kind::Channel(&state.server, &state.channel),
             history,
+            config,
             move |message| {
                 let timestamp = config
                     .buffer

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -1,5 +1,5 @@
 use data::server::Server;
-use data::{channel, client, history, Config};
+use data::{channel, client, history, message, Config};
 use iced::widget::{column, container, row, vertical_space};
 use iced::{Command, Length};
 
@@ -43,52 +43,50 @@ pub fn view<'a>(
                     .format_timestamp(&message.server_time)
                     .map(|timestamp| selectable_text(timestamp).style(theme::Text::Transparent));
 
-                match &message.source {
-                    data::message::Source::Channel(_, kind) => match kind {
-                        data::message::Sender::User(user) => {
-                            let nick = user_context::view(
-                                selectable_text(config.buffer.nickname.brackets.format(user))
-                                    .style(theme::Text::Nickname(
-                                        user.color_seed(&config.buffer.nickname.color),
-                                    )),
-                                user.clone(),
-                            )
-                            .map(scroll_view::Message::UserContext);
-                            let row_style = match our_nick {
-                                Some(nick)
-                                    if user.nickname() != nick
-                                        && message.text.contains(nick.as_ref()) =>
-                                {
-                                    theme::Container::Highlight
-                                }
-                                _ => theme::Container::Default,
-                            };
-                            let message = selectable_text(&message.text);
+                match message.target.source() {
+                    message::Source::User(user) => {
+                        let nick = user_context::view(
+                            selectable_text(config.buffer.nickname.brackets.format(user)).style(
+                                theme::Text::Nickname(
+                                    user.color_seed(&config.buffer.nickname.color),
+                                ),
+                            ),
+                            user.clone(),
+                        )
+                        .map(scroll_view::Message::UserContext);
+                        let row_style = match our_nick {
+                            Some(nick)
+                                if user.nickname() != nick
+                                    && message.text.contains(nick.as_ref()) =>
+                            {
+                                theme::Container::Highlight
+                            }
+                            _ => theme::Container::Default,
+                        };
+                        let message = selectable_text(&message.text);
 
-                            Some(
-                                container(row![].push_maybe(timestamp).push(nick).push(message))
-                                    .style(row_style)
-                                    .into(),
-                            )
-                        }
-                        data::message::Sender::Server => {
-                            let message = selectable_text(&message.text).style(theme::Text::Server);
+                        Some(
+                            container(row![].push_maybe(timestamp).push(nick).push(message))
+                                .style(row_style)
+                                .into(),
+                        )
+                    }
+                    message::Source::Server(_) => {
+                        let message = selectable_text(&message.text).style(theme::Text::Server);
 
-                            Some(container(row![].push_maybe(timestamp).push(message)).into())
-                        }
-                        data::message::Sender::Action => {
-                            let message = selectable_text(&message.text).style(theme::Text::Accent);
+                        Some(container(row![].push_maybe(timestamp).push(message)).into())
+                    }
+                    message::Source::Action => {
+                        let message = selectable_text(&message.text).style(theme::Text::Accent);
 
-                            Some(container(row![].push_maybe(timestamp).push(message)).into())
-                        }
-                        data::message::Sender::Status(status) => {
-                            let message =
-                                selectable_text(&message.text).style(theme::Text::Status(*status));
+                        Some(container(row![].push_maybe(timestamp).push(message)).into())
+                    }
+                    message::Source::Internal(message::source::Internal::Status(status)) => {
+                        let message =
+                            selectable_text(&message.text).style(theme::Text::Status(*status));
 
-                            Some(container(row![].push_maybe(timestamp).push(message)).into())
-                        }
-                    },
-                    _ => None,
+                        Some(container(row![].push_maybe(timestamp).push(message)).into())
+                    }
                 }
             },
         )

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -33,6 +33,7 @@ pub fn view<'a>(
             &state.scroll_view,
             scroll_view::Kind::Query(&state.server, &state.nick),
             history,
+            config,
             |message| {
                 let timestamp = config
                     .buffer

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -39,12 +39,8 @@ pub fn view<'a>(
                     .format_timestamp(&message.server_time)
                     .map(|timestamp| selectable_text(timestamp).style(theme::Text::Transparent));
 
-                let message::Source::Query(_, sender) = &message.source else {
-                    return None;
-                };
-
-                match sender {
-                    message::Sender::User(user) => {
+                match message.target.source() {
+                    message::Source::User(user) => {
                         let nick = user_context::view(
                             selectable_text(config.buffer.nickname.brackets.format(user)).style(
                                 theme::Text::Nickname(
@@ -61,17 +57,17 @@ pub fn view<'a>(
                             container(row![].push_maybe(timestamp).push(nick).push(message)).into(),
                         )
                     }
-                    message::Sender::Server => {
+                    message::Source::Server(_) => {
                         let message = selectable_text(&message.text).style(theme::Text::Server);
 
                         Some(container(row![].push_maybe(timestamp).push(message)).into())
                     }
-                    message::Sender::Action => {
+                    message::Source::Action => {
                         let message = selectable_text(&message.text).style(theme::Text::Accent);
 
                         Some(container(row![].push_maybe(timestamp).push(message)).into())
                     }
-                    message::Sender::Status(status) => {
+                    message::Source::Internal(message::source::Internal::Status(status)) => {
                         let message =
                             selectable_text(&message.text).style(theme::Text::Status(*status));
 

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -49,7 +49,8 @@ pub fn view<'a>(
             history.get_channel_messages(server, channel, Some(state.limit))
         }
         Kind::Query(server, user) => history.get_query_messages(server, user, Some(state.limit)),
-    }) else {
+    })
+    else {
         return column![].into();
     };
 

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -1,7 +1,7 @@
 use data::message::Limit;
 use data::server::Server;
 use data::user::Nick;
-use data::{history, time};
+use data::{history, time, Config};
 use iced::widget::{column, container, horizontal_rule, scrollable};
 use iced::{Command, Length};
 
@@ -37,6 +37,7 @@ pub fn view<'a>(
     state: &State,
     kind: Kind,
     history: &'a history::Manager,
+    config: &'a Config,
     format: impl Fn(&'a data::Message) -> Option<Element<'a, Message>> + 'a,
 ) -> Element<'a, Message> {
     let Some(history::View {
@@ -44,11 +45,11 @@ pub fn view<'a>(
         old_messages,
         new_messages,
     }) = (match kind {
-        Kind::Server(server) => history.get_server_messages(server, Some(state.limit)),
+        Kind::Server(server) => history.get_server_messages(server, Some(state.limit), &config.buffer.hidden_server_messages),
         Kind::Channel(server, channel) => {
-            history.get_channel_messages(server, channel, Some(state.limit))
+            history.get_channel_messages(server, channel, Some(state.limit), &config.buffer.hidden_server_messages)
         }
-        Kind::Query(server, user) => history.get_query_messages(server, user, Some(state.limit)),
+        Kind::Query(server, user) => history.get_query_messages(server, user, Some(state.limit), &config.buffer.hidden_server_messages),
     })
     else {
         return column![].into();

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -1,4 +1,4 @@
-use data::{client, history, Config};
+use data::{client, history, message, Config};
 use iced::widget::{column, container, row, vertical_space};
 use iced::{Command, Length};
 
@@ -33,15 +33,15 @@ pub fn view<'a>(
                     .format_timestamp(&message.server_time)
                     .map(|timestamp| selectable_text(timestamp).style(theme::Text::Transparent));
 
-                match message.source {
-                    data::message::Source::Server => {
+                match message.target.source() {
+                    message::Source::Server(_) => {
                         let message = selectable_text(&message.text).style(theme::Text::Server);
 
                         Some(container(row![].push_maybe(timestamp).push(message)).into())
                     }
-                    data::message::Source::Status(status) => {
+                    message::Source::Internal(message::source::Internal::Status(status)) => {
                         let message =
-                            selectable_text(&message.text).style(theme::Text::Status(status));
+                            selectable_text(&message.text).style(theme::Text::Status(*status));
 
                         Some(container(row![].push_maybe(timestamp).push(message)).into())
                     }

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -27,6 +27,7 @@ pub fn view<'a>(
             &state.scroll_view,
             scroll_view::Kind::Server(&state.server),
             history,
+            config,
             |message| {
                 let timestamp = config
                     .buffer

--- a/src/main.rs
+++ b/src/main.rs
@@ -232,7 +232,7 @@ impl Application for Halloy {
         match message {
             Message::Dashboard(message) => {
                 let Screen::Dashboard(dashboard) = &mut self.screen else {
-                    return Command::none()
+                    return Command::none();
                 };
 
                 let command =
@@ -290,7 +290,7 @@ impl Application for Halloy {
                     self.clients.disconnected(server.clone());
 
                     let Screen::Dashboard(dashboard) = &mut self.screen else {
-                        return Command::none()
+                        return Command::none();
                     };
 
                     if is_initial {
@@ -310,7 +310,7 @@ impl Application for Halloy {
                     self.clients.ready(server.clone(), connection);
 
                     let Screen::Dashboard(dashboard) = &mut self.screen else {
-                        return Command::none()
+                        return Command::none();
                     };
 
                     if is_initial {
@@ -323,8 +323,8 @@ impl Application for Halloy {
                 }
                 stream::Update::ConnectionFailed { server, error } => {
                     let Screen::Dashboard(dashboard) = &mut self.screen else {
-                            return Command::none()
-                        };
+                        return Command::none();
+                    };
 
                     dashboard.broadcast_connection_failed(&server, error);
 
@@ -332,7 +332,7 @@ impl Application for Halloy {
                 }
                 stream::Update::MessagesReceived(server, messages) => {
                     let Screen::Dashboard(dashboard) = &mut self.screen else {
-                        return Command::none()
+                        return Command::none();
                     };
 
                     messages.into_iter().for_each(|message| {
@@ -345,12 +345,12 @@ impl Application for Halloy {
                                         dashboard.record_message(&server, message);
                                     }
                                 }
-                                data::client::Event::WithSource(encoded, our_nick, source) => {
+                                data::client::Event::WithTarget(encoded, our_nick, target) => {
                                     if let Some(message) =
                                         data::Message::received(encoded, our_nick)
                                     {
                                         dashboard
-                                            .record_message(&server, message.with_source(source));
+                                            .record_message(&server, message.with_target(target));
                                     }
                                 }
                                 data::client::Event::Brodcast(brodcast) => match brodcast {

--- a/src/screen/welcome.rs
+++ b/src/screen/welcome.rs
@@ -24,7 +24,7 @@ impl Welcome {
         // Create template config file.
         Config::create_template_config();
 
-        Welcome::default()
+        Welcome
     }
 
     pub fn update(&mut self, message: Message) -> Option<Event> {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -171,7 +171,7 @@ pub enum Text {
     Server,
     Error,
     Transparent,
-    Status(message::Status),
+    Status(message::source::Status),
     Nickname(Option<String>),
 }
 
@@ -209,8 +209,8 @@ impl text::StyleSheet for Theme {
             },
             Text::Status(status) => text::Appearance {
                 color: Some(match status {
-                    message::Status::Success => self.colors.success.base,
-                    message::Status::Error => self.colors.error.base,
+                    message::source::Status::Success => self.colors.success.base,
+                    message::source::Status::Error => self.colors.error.base,
                 }),
             },
             Text::Transparent => text::Appearance {


### PR DESCRIPTION
Adds the ability to specify which type of messages you don't want to see. Currently supports `part`, `quit` and `join`.

This refactors message type and is a breaking change. Future changes to message shouldn't break, however my dumb decision to serialize in `bincode` forced us into this. Now I serialize w/ `json` which allows us to use a lot of `serde` magic for forwards compatible changes. 