### PR TITLE
autocomplete joined channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Added:
 - Configuration option `buffer.input_visibility` to control input field visibility: always shown or following the focused buffer.
 - Upon joining a channel, display the channel mode in the buffer
 - When querying an away user, you will see an away message
+- Autocomplete on joined channels
 
 Changed:
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -397,6 +397,12 @@ impl Map {
             .unwrap_or_default()
     }
 
+    pub fn get_our_channels<'a>(&'a self, server: &Server) -> &'a [String] {
+        self.connection(server)
+            .map(|connection| connection.channels())
+            .unwrap_or_default()
+    }
+
     pub fn iter(&self) -> std::collections::btree_map::Iter<Server, State> {
         self.0.iter()
     }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -397,7 +397,7 @@ impl Map {
             .unwrap_or_default()
     }
 
-    pub fn get_our_channels<'a>(&'a self, server: &Server) -> &'a [String] {
+    pub fn get_channels<'a>(&'a self, server: &Server) -> &'a [String] {
         self.connection(server)
             .map(|connection| connection.channels())
             .unwrap_or_default()

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -110,12 +110,13 @@ impl Buffer {
             Buffer::Server(state) => {
                 let status = clients.status(&state.server);
 
-                server::view(state, status, history, config, is_focused).map(Message::Server)
+                server::view(state, status, clients, history, config, is_focused)
+                    .map(Message::Server)
             }
             Buffer::Query(state) => {
                 let status = clients.status(&state.server);
 
-                query::view(state, status, history, config, is_focused).map(Message::Query)
+                query::view(state, status, clients, history, config, is_focused).map(Message::Query)
             }
         }
     }

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -98,7 +98,7 @@ pub fn view<'a>(
     .height(Length::Fill);
 
     let users = clients.get_channel_users(&state.server, &state.channel);
-    let channels = clients.get_our_channels(&state.server);
+    let channels = clients.get_channels(&state.server);
     let nick_list = nick_list::view(users).map(Message::UserContext);
 
     let show_text_input = match config.buffer.input_visibility {

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -98,6 +98,7 @@ pub fn view<'a>(
     .height(Length::Fill);
 
     let users = clients.get_channel_users(&state.server, &state.channel);
+    let channels = clients.get_our_channels(&state.server);
     let nick_list = nick_list::view(users).map(Message::UserContext);
 
     let show_text_input = match config.buffer.input_visibility {
@@ -108,8 +109,15 @@ pub fn view<'a>(
     let text_input = show_text_input.then(|| {
         column![
             vertical_space(4),
-            input_view::view(&state.input_view, buffer, users, input_history, is_focused)
-                .map(Message::InputView)
+            input_view::view(
+                &state.input_view,
+                buffer,
+                users,
+                channels,
+                input_history,
+                is_focused
+            )
+            .map(Message::InputView)
         ]
     });
 

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -19,6 +19,7 @@ pub fn view<'a>(
     state: &'a State,
     buffer: Buffer,
     users: &'a [User],
+    channels: &'a [String],
     history: &'a [String],
     buffer_focused: bool,
 ) -> Element<'a, Message> {
@@ -27,6 +28,7 @@ pub fn view<'a>(
         buffer,
         &state.input,
         users,
+        channels,
         history,
         buffer_focused,
         Message::Input,

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -21,6 +21,7 @@ pub enum Event {
 pub fn view<'a>(
     state: &'a Query,
     status: client::Status,
+    clients: &'a data::client::Map,
     history: &'a history::Manager,
     config: &'a Config,
     is_focused: bool,
@@ -89,11 +90,20 @@ pub fn view<'a>(
         data::buffer::InputVisibility::Always => status.connected(),
     };
 
+    let channels = clients.get_our_channels(&state.server);
+
     let text_input = show_text_input.then(|| {
         column![
             vertical_space(4),
-            input_view::view(&state.input_view, buffer, &[], input_history, is_focused)
-                .map(Message::InputView)
+            input_view::view(
+                &state.input_view,
+                buffer,
+                &[],
+                channels,
+                input_history,
+                is_focused
+            )
+            .map(Message::InputView)
         ]
     });
 

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -90,7 +90,7 @@ pub fn view<'a>(
         data::buffer::InputVisibility::Always => status.connected(),
     };
 
-    let channels = clients.get_our_channels(&state.server);
+    let channels = clients.get_channels(&state.server);
 
     let text_input = show_text_input.then(|| {
         column![

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -59,7 +59,7 @@ pub fn view<'a>(
         data::buffer::InputVisibility::Always => status.connected(),
     };
 
-    let channels = clients.get_our_channels(&state.server);
+    let channels = clients.get_channels(&state.server);
 
     let text_input = show_text_input.then(|| {
         column![

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -15,6 +15,7 @@ pub enum Message {
 pub fn view<'a>(
     state: &'a Server,
     status: client::Status,
+    clients: &'a data::client::Map,
     history: &'a history::Manager,
     config: &'a Config,
     is_focused: bool,
@@ -58,11 +59,20 @@ pub fn view<'a>(
         data::buffer::InputVisibility::Always => status.connected(),
     };
 
+    let channels = clients.get_our_channels(&state.server);
+
     let text_input = show_text_input.then(|| {
         column![
             vertical_space(4),
-            input_view::view(&state.input_view, buffer, &[], input_history, is_focused)
-                .map(Message::InputView)
+            input_view::view(
+                &state.input_view,
+                buffer,
+                &[],
+                channels,
+                input_history,
+                is_focused
+            )
+            .map(Message::InputView)
         ]
     });
 

--- a/src/widget/input.rs
+++ b/src/widget/input.rs
@@ -17,6 +17,7 @@ pub fn input<'a, Message>(
     buffer: Buffer,
     input: &'a str,
     users: &'a [User],
+    channels: &'a [String],
     history: &'a [String],
     buffer_focused: bool,
     on_input: impl Fn(String) -> Message + 'a,
@@ -31,6 +32,7 @@ where
         buffer,
         input,
         users,
+        channels,
         history,
         buffer_focused,
         on_input: Box::new(on_input),
@@ -60,6 +62,7 @@ pub struct Input<'a, Message> {
     buffer: Buffer,
     input: &'a str,
     users: &'a [User],
+    channels: &'a [String],
     history: &'a [String],
     buffer_focused: bool,
     on_input: Box<dyn Fn(String) -> Message + 'a>,
@@ -89,7 +92,7 @@ where
                 // Reset selected history
                 state.selected_history = None;
 
-                state.completion.process(&input, self.users);
+                state.completion.process(&input, self.users, self.channels);
 
                 Some((self.on_input)(input))
             }
@@ -142,7 +145,9 @@ where
                         .get(state.selected_history.unwrap())
                         .unwrap()
                         .clone();
-                    state.completion.process(&new_input, self.users);
+                    state
+                        .completion
+                        .process(&new_input, self.users, self.channels);
 
                     return Some((self.on_completion)(new_input));
                 }
@@ -159,7 +164,9 @@ where
                     } else {
                         *index -= 1;
                         let new_input = self.history.get(*index).unwrap().clone();
-                        state.completion.process(&new_input, self.users);
+                        state
+                            .completion
+                            .process(&new_input, self.users, self.channels);
                         new_input
                     };
 

--- a/src/widget/input/completion.rs
+++ b/src/widget/input/completion.rs
@@ -13,7 +13,7 @@ const MAX_SHOWN_ENTRIES: usize = 5;
 #[derive(Debug, Clone, Default)]
 pub struct Completion {
     commands: Commands,
-    users: Users,
+    text: Text,
 }
 
 impl Completion {
@@ -22,18 +22,36 @@ impl Completion {
     }
 
     /// Process input and update the completion state
-    pub fn process(&mut self, input: &str, users: &[User]) {
-        if input.starts_with('/') {
+    pub fn process(&mut self, input: &str, users: &[User], channels: &[String]) {
+        let last_char_is_space = input
+            .chars()
+            .last()
+            .map(|last| last.is_whitespace())
+            .unwrap_or_default();
+        let words: Vec<&str> = input.split_whitespace().collect();
+        let is_channel = !last_char_is_space
+            && words
+                .last()
+                .map(|word| word.starts_with('#'))
+                .unwrap_or_default();
+        let is_command = input.starts_with('/');
+
+        if is_command {
             self.commands.process(input);
 
             // Disallow user completions when selecting a command
             if matches!(self.commands, Commands::Selecting { .. }) {
-                self.users = Users::default();
+                self.text = Text::default();
+            } else if is_channel {
+                self.text.process_channels(input, channels);
             } else {
-                self.users.process(input, users);
+                self.text.process_users(input, users);
             }
+        } else if is_channel {
+            self.text.process_channels(input, channels);
+            self.commands = Commands::default();
         } else {
-            self.users.process(input, users);
+            self.text.process_users(input, users);
             self.commands = Commands::default();
         }
     }
@@ -44,7 +62,7 @@ impl Completion {
 
     pub fn tab(&mut self) -> Option<Entry> {
         if !self.commands.tab() {
-            self.users.tab().map(Entry::User)
+            self.text.tab().map(Entry::Text)
         } else {
             None
         }
@@ -58,16 +76,16 @@ impl Completion {
 #[derive(Debug, Clone)]
 pub enum Entry {
     Command(Command),
-    User(String),
+    Text(String),
 }
 
 impl Entry {
     pub fn complete_input(&self, input: &str) -> String {
         match self {
             Entry::Command(command) => format!("/{}", command.title),
-            Entry::User(nickname) => match input.rsplit_once(' ') {
-                Some((left, _)) => format!("{left} {nickname}"),
-                None => nickname.clone(),
+            Entry::Text(value) => match input.rsplit_once(' ') {
+                Some((left, _)) => format!("{left} {value}"),
+                None => value.clone(),
             },
         }
     }
@@ -296,14 +314,14 @@ impl fmt::Display for Arg {
 }
 
 #[derive(Debug, Clone, Default)]
-struct Users {
+struct Text {
     prompt: String,
     filtered: Vec<String>,
     selected: Option<usize>,
 }
 
-impl Users {
-    fn process(&mut self, input: &str, users: &[User]) {
+impl Text {
+    fn process_users(&mut self, input: &str, users: &[User]) {
         let (_, rest) = input.rsplit_once(' ').unwrap_or(("", input));
 
         if rest.is_empty() {
@@ -322,6 +340,25 @@ impl Users {
                 lower_nick
                     .starts_with(&nick)
                     .then(|| user.nickname().to_string())
+            })
+            .collect();
+    }
+
+    fn process_channels(&mut self, input: &str, channels: &[String]) {
+        let Some((head, rest)) = input.split_once('#') else {
+            *self = Self::default();
+            return;
+        };
+
+        let channel = format!("#{}", rest.to_lowercase());
+
+        self.selected = None;
+        self.prompt = rest.to_string();
+        self.filtered = channels
+            .iter()
+            .filter_map(|c| {
+                let lower_channel = c.to_lowercase();
+                lower_channel.starts_with(&channel).then(|| c.to_string())
             })
             .collect();
     }

--- a/src/widget/input/completion.rs
+++ b/src/widget/input/completion.rs
@@ -345,7 +345,7 @@ impl Text {
     }
 
     fn process_channels(&mut self, input: &str, channels: &[String]) {
-        let Some((head, rest)) = input.split_once('#') else {
+        let Some((_, rest)) = input.split_once('#') else {
             *self = Self::default();
             return;
         };


### PR DESCRIPTION
Fixes #138.

This adds the possibility to autocomplete channels. To trigger you have to write a <kbd>#</kbd> followed by <kbd>Tab</kbd>.   
Eg: <kbd>#</kbd><kbd>h</kbd><kbd>Tab</kbd> => `#halloy`.