### PR TITLE
added `notify-away` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ to ensure future breakages won't occur.**
 
 Added:
 
+- Away-notify extension added for supported servers
 - SASL support for PLAIN & EXTERNAL. The following per-server config keys have been added:
   - PLAIN - `sasl.plain.username` & `sasl.plain.password`
   - EXTERNAL - `sasl.external.cert` is a path to the PEM encoded X509 cert
@@ -16,6 +17,7 @@ Added:
 
 Changed:
 
+- Away users will be appear slightly transparent in nicklist
 - Configuration option `new_buffer` has been renamed to `buffer`. `new_buffer` key will still work for backwards compatibility.
 - Migrated to our own internal IRC backend. This should allow for quicker development against extensions and bug fixes.
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ cargo run --release
 
 Halloy supports the following IRCv3.2 capabilities
 
+- `away-notify`
 - `batch`
 - `server-time`
 - `sasl=PLAIN,EXTERNAL`

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -467,6 +467,8 @@ impl Client {
 
                 if user.nickname() == self.nickname() {
                     self.chanmap.remove(channel);
+
+                    self.last_who_channels.remove(channel);
                 } else if let Some(list) = self.chanmap.get_mut(channel) {
                     list.remove(&user);
                 }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -478,9 +478,8 @@ impl Client {
                     self.chanmap.insert(channel.clone(), Default::default());
 
                     // Sends WHO to get away state on users.
-                    if self.sender.try_send(command!("WHO", channel)).is_ok() {
-                        self.last_who_channels.insert(channel.clone(), None);
-                    }
+                    let _ = self.sender.try_send(command!("WHO", channel));
+                    self.last_who_channels.insert(channel.clone(), None);
                 } else if let Some(list) = self.chanmap.get_mut(channel) {
                     list.insert(user);
                 }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -733,6 +733,14 @@ impl Map {
             })
             .unwrap_or(Status::Unavailable)
     }
+
+    pub fn tick(&mut self, now: Instant) {
+        self.0.values_mut().for_each(|client| {
+            if let State::Ready(client) = client {
+                client.tick(now);
+            }
+        })
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -15,6 +15,7 @@ pub struct User {
     username: Option<String>,
     hostname: Option<String>,
     access_levels: HashSet<AccessLevel>,
+    away: bool,
 }
 
 impl PartialEq for User {
@@ -88,6 +89,7 @@ impl<'a> TryFrom<&'a str> for User {
             username,
             hostname,
             access_levels,
+            away: false,
         })
     }
 }
@@ -112,6 +114,7 @@ impl From<Nick> for User {
             username: None,
             hostname: None,
             access_levels: HashSet::default(),
+            away: false,
         }
     }
 }
@@ -126,6 +129,10 @@ impl User {
                     .unwrap_or_else(|| self.nickname().as_ref().to_string()),
             ),
         }
+    }
+
+    pub fn is_away(&self) -> bool {
+        self.away
     }
 
     pub fn username(&self) -> Option<&str> {
@@ -165,6 +172,10 @@ impl User {
         }
     }
 
+    pub fn update_away(&mut self, away: bool) {
+        self.away = away;
+    }
+
     pub fn formatted(&self) -> String {
         let user = self.username();
         let host = self.hostname();
@@ -186,6 +197,7 @@ impl From<proto::User> for User {
             username: user.username,
             hostname: user.hostname,
             access_levels: HashSet::default(),
+            away: false,
         }
     }
 }

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -228,11 +228,20 @@ mod nick_list {
             users
                 .iter()
                 .map(|user| {
-                    let content = container(row![].padding([0, 4]).push(text(format!(
-                        "{}{}",
-                        user.highest_access_level(),
-                        user.nickname()
-                    ))));
+                    let content = container(
+                        row![].padding([0, 4]).push(
+                            text(format!(
+                                "{}{}",
+                                user.highest_access_level(),
+                                user.nickname()
+                            ))
+                            .style(if user.is_away() {
+                                theme::Text::Transparent
+                            } else {
+                                theme::Text::Default
+                            }),
+                        ),
+                    );
 
                     user_context::view(content, user.clone())
                 })

--- a/src/main.rs
+++ b/src/main.rs
@@ -406,11 +406,7 @@ impl Application for Halloy {
                 }
             }
             Message::Tick(now) => {
-                for entry in self.servers.entries() {
-                    if let Some(client) = self.clients.client_mut(&entry.server) {
-                        client.tick(now);
-                    };
-                }
+                self.clients.tick(now);
 
                 if let Screen::Dashboard(dashboard) = &mut self.screen {
                     dashboard.tick(now).map(Message::Dashboard)

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod theme;
 mod widget;
 
 use std::env;
+use std::time::{Duration, Instant};
 
 use data::config::{self, Config};
 use data::server;
@@ -207,6 +208,7 @@ pub enum Message {
     Welcome(welcome::Message),
     Event(Event),
     FontsLoaded(Result<(), iced::font::Error>),
+    Tick(Instant),
 }
 
 impl Application for Halloy {
@@ -403,6 +405,19 @@ impl Application for Halloy {
                     Command::none()
                 }
             }
+            Message::Tick(now) => {
+                for entry in self.servers.entries() {
+                    if let Some(client) = self.clients.client_mut(&entry.server) {
+                        client.tick(now);
+                    };
+                }
+
+                if let Screen::Dashboard(dashboard) = &mut self.screen {
+                    dashboard.tick(now).map(Message::Dashboard)
+                } else {
+                    Command::none()
+                }
+            }
         }
     }
 
@@ -427,19 +442,11 @@ impl Application for Halloy {
     }
 
     fn subscription(&self) -> Subscription<Message> {
-        let screen_subscription = match &self.screen {
-            Screen::Dashboard(dashboard) => dashboard.subscription().map(Message::Dashboard),
-            Screen::Help(_) => Subscription::none(),
-            Screen::Welcome(_) => Subscription::none(),
-        };
+        let tick = iced::time::every(Duration::from_secs(1)).map(Message::Tick);
 
         let streams =
             Subscription::batch(self.servers.entries().map(stream::run)).map(Message::Stream);
 
-        Subscription::batch(vec![
-            streams,
-            events().map(Message::Event),
-            screen_subscription,
-        ])
+        Subscription::batch(vec![tick, streams, events().map(Message::Event)])
     }
 }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -589,7 +589,7 @@ impl Dashboard {
         )
     }
 
-    pub(crate) fn tick(&mut self, now: Instant) -> Command<Message> {
+    pub fn tick(&mut self, now: Instant) -> Command<Message> {
         let history = Command::batch(
             self.history
                 .tick(now.into())


### PR DESCRIPTION
This adds support for `notify-away` extension.
We call `WHO` when joining a channel to get initial state, and then keeps it synced with `AWAY` responses.
Away users is appear slightly transparent. This idea is stolen from Textual.