### PR TITLE
Add portable mode

### DIFF
--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -38,7 +38,7 @@ pub struct Font {
 
 impl Config {
     pub fn config_dir() -> PathBuf {
-        let dir = environment::config_dir().join("halloy");
+        let dir = environment::config_dir();
 
         if !dir.exists() {
             std::fs::create_dir(dir.as_path())
@@ -60,7 +60,7 @@ impl Config {
     }
 
     fn path() -> PathBuf {
-        Self::config_dir().join("config.yaml")
+        Self::config_dir().join(environment::CONFIG_FILE_NAME)
     }
 
     pub fn load() -> Result<Self, Error> {

--- a/data/src/dashboard.rs
+++ b/data/src/dashboard.rs
@@ -39,9 +39,7 @@ impl Dashboard {
 }
 
 fn path() -> Result<PathBuf, Error> {
-    let data_dir = environment::data_dir();
-
-    let parent = data_dir.join("halloy");
+    let parent = environment::data_dir();
 
     if !parent.exists() {
         std::fs::create_dir_all(&parent)?;

--- a/data/src/environment.rs
+++ b/data/src/environment.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 pub const VERSION: &str = env!("VERSION");
 pub const GIT_HASH: Option<&str> = option_env!("GIT_HASH");
+pub const CONFIG_FILE_NAME: &str = "config.yaml";
 
 pub fn formatted_version() -> String {
     let hash = GIT_HASH
@@ -12,10 +13,29 @@ pub fn formatted_version() -> String {
     format!("{}{hash}", VERSION)
 }
 
-pub(crate) fn config_dir() -> PathBuf {
-    dirs_next::config_dir().expect("expected valid config dir")
+pub fn config_dir() -> PathBuf {
+    portable_dir().unwrap_or_else(|| {
+        dirs_next::config_dir()
+            .expect("expected valid config dir")
+            .join("halloy")
+    })
 }
 
-pub(crate) fn data_dir() -> PathBuf {
-    dirs_next::data_dir().expect("expected valid data dir")
+pub fn data_dir() -> PathBuf {
+    portable_dir().unwrap_or_else(|| {
+        dirs_next::data_dir()
+            .expect("expected valid data dir")
+            .join("halloy")
+    })
+}
+
+/// Checks if a config file exists in the same directory as the executable.
+/// If so, it'll use that directory for both config & data dirs.
+fn portable_dir() -> Option<PathBuf> {
+    let exe = env::current_exe().ok()?;
+    let dir = exe.parent()?;
+
+    dir.join(CONFIG_FILE_NAME)
+        .is_file()
+        .then(|| dir.to_path_buf())
 }

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -107,7 +107,7 @@ async fn path(server: &server::Server, kind: &Kind) -> Result<PathBuf, Error> {
     };
     let hashed_name = seahash::hash(name.as_bytes());
 
-    let parent = data_dir.join("halloy").join("history");
+    let parent = data_dir.join("history");
 
     if !parent.exists() {
         fs::create_dir_all(&parent).await?;

--- a/data/src/log.rs
+++ b/data/src/log.rs
@@ -17,9 +17,7 @@ pub fn file() -> Result<fs::File, Error> {
 }
 
 fn path() -> Result<PathBuf, Error> {
-    let data_dir = environment::data_dir();
-
-    let parent = data_dir.join("halloy");
+    let parent = environment::data_dir();
 
     if !parent.exists() {
         fs::create_dir_all(&parent)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use std::env;
 use std::time::{Duration, Instant};
 
 use data::config::{self, Config};
-use data::server;
+use data::{environment, server};
 use iced::widget::container;
 use iced::{executor, window, Application, Command, Length, Subscription};
 use screen::{dashboard, help, welcome};
@@ -34,7 +34,7 @@ pub fn main() -> iced::Result {
         .unwrap_or_default();
 
     if version {
-        println!("halloy {}", data::environment::formatted_version());
+        println!("halloy {}", environment::formatted_version());
 
         return Ok(());
     }
@@ -45,10 +45,9 @@ pub fn main() -> iced::Result {
     let is_debug = false;
 
     logger::setup(is_debug).expect("setup logging");
-    log::info!(
-        "halloy {} has started",
-        data::environment::formatted_version()
-    );
+    log::info!("halloy {} has started", environment::formatted_version());
+    log::info!("config dir: {:?}", environment::config_dir());
+    log::info!("data dir: {:?}", environment::data_dir());
 
     // Create themes directory
     config::create_themes_dir();


### PR DESCRIPTION
Resolves #141 

Checks if there is a `config.yaml` in the same directory as the running executable. If so, it sets the halloy config & data directories to that directory. This allows users to have a "portable" mode where all data is used / saved alongside the executable.