### PR TITLE
double clicking a user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Added:
 - Configurable keyboard shortcuts for common actions, such as changing buffer focus, maximize / restoring buffer size, 
   cycling channels in the buffer and more! A new `keys` section has been added to the config file, reference the 
   [wiki](https://github.com/squidowl/halloy/wiki/Keyboard-shortcuts) for more details.
-- Double clicking on a user will open a query with them
+- Single clicking on a user will insert nickname to input
 
 Fixed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Added:
 - Configurable keyboard shortcuts for common actions, such as changing buffer focus, maximize / restoring buffer size, 
   cycling channels in the buffer and more! A new `keys` section has been added to the config file, reference the 
   [wiki](https://github.com/squidowl/halloy/wiki/Keyboard-shortcuts) for more details.
+- Double clicking on a user will open a query with them
 
 Fixed:
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,5 +1,5 @@
 pub use data::buffer::Settings;
-use data::{buffer, history, Config};
+use data::{buffer, history, Config, User};
 use iced::Command;
 
 use self::channel::Channel;
@@ -156,6 +156,20 @@ impl Buffer {
             Buffer::Channel(channel) => channel.reset().map(Message::Channel),
             Buffer::Server(server) => server.reset().map(Message::Server),
             Buffer::Query(query) => query.reset().map(Message::Query),
+        }
+    }
+
+    pub fn insert_user_to_input(&mut self, user: User) -> Command<Message> {
+        match self {
+            Buffer::Empty | Buffer::Server(_) => Command::none(),
+            Buffer::Channel(channel) => channel
+                .input_view
+                .insert_user(user)
+                .map(|message| Message::Channel(channel::Message::InputView(message))),
+            Buffer::Query(query) => query
+                .input_view
+                .insert_user(user)
+                .map(|message| Message::Channel(channel::Message::InputView(message))),
         }
     }
 

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -147,7 +147,7 @@ pub struct Channel {
     pub channel: String,
     pub topic: Option<String>,
     pub scroll_view: scroll_view::State,
-    input_view: input_view::State,
+    pub input_view: input_view::State,
 }
 
 impl Channel {

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -215,7 +215,7 @@ impl Channel {
 
 mod nick_list {
     use data::User;
-    use iced::widget::{column, container, row, scrollable, text};
+    use iced::widget::{column, container, scrollable, text};
     use iced::Length;
     use user_context::Message;
 
@@ -228,20 +228,16 @@ mod nick_list {
             users
                 .iter()
                 .map(|user| {
-                    let content = container(
-                        row![].padding([0, 4]).push(
-                            text(format!(
-                                "{}{}",
-                                user.highest_access_level(),
-                                user.nickname()
-                            ))
-                            .style(if user.is_away() {
-                                theme::Text::Transparent
-                            } else {
-                                theme::Text::Default
-                            }),
-                        ),
-                    );
+                    let content = text(format!(
+                        "{}{}",
+                        user.highest_access_level(),
+                        user.nickname()
+                    ))
+                    .style(if user.is_away() {
+                        theme::Text::Transparent
+                    } else {
+                        theme::Text::Primary
+                    });
 
                     user_context::view(content, user.clone())
                 })

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -91,4 +91,14 @@ impl State {
     pub fn reset(&self) -> Command<Message> {
         input::reset(self.input_id.clone())
     }
+
+    pub fn insert_user(&mut self, user: User) -> Command<Message> {
+        if self.input.is_empty() {
+            self.input = format!("{}: ", user.nickname());
+        } else {
+            self.input = format!("{} {}", self.input, user.nickname());
+        }
+
+        input::move_cursor_to_end(self.input_id.clone())
+    }
 }

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -43,6 +43,12 @@ pub struct State {
     input: String,
 }
 
+impl Default for State {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl State {
     pub fn new() -> Self {
         Self {

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -120,7 +120,7 @@ pub struct Query {
     pub server: Server,
     pub nick: Nick,
     pub scroll_view: scroll_view::State,
-    input_view: input_view::State,
+    pub input_view: input_view::State,
 }
 
 impl Query {

--- a/src/buffer/user_context.rs
+++ b/src/buffer/user_context.rs
@@ -2,7 +2,7 @@ use data::User;
 use iced::widget::{button, text};
 
 use crate::theme;
-use crate::widget::{context_menu, double_click, Element};
+use crate::widget::{context_menu, Element};
 
 #[derive(Debug, Clone, Copy)]
 enum Entry {
@@ -20,28 +20,31 @@ impl Entry {
 pub enum Message {
     Whois(User),
     Query(User),
-    DoubleClick(User),
+    SingleClick(User),
 }
 
 #[derive(Debug, Clone)]
 pub enum Event {
     SendWhois(User),
     OpenQuery(User),
-    DoubleClick(User),
+    SingleClick(User),
 }
 
 pub fn update(message: Message) -> Event {
     match message {
         Message::Whois(user) => Event::SendWhois(user),
         Message::Query(user) => Event::OpenQuery(user),
-        Message::DoubleClick(user) => Event::DoubleClick(user),
+        Message::SingleClick(user) => Event::SingleClick(user),
     }
 }
 
 pub fn view<'a>(content: impl Into<Element<'a, Message>>, user: User) -> Element<'a, Message> {
     let entries = Entry::list();
 
-    let content = double_click(content, Message::DoubleClick(user.clone()));
+    let content = button(content)
+        .padding(0)
+        .style(theme::Button::Bare)
+        .on_press(Message::SingleClick(user.clone()));
 
     context_menu(content, entries, move |entry, length| {
         let (content, message) = match entry {

--- a/src/buffer/user_context.rs
+++ b/src/buffer/user_context.rs
@@ -2,7 +2,7 @@ use data::User;
 use iced::widget::{button, text};
 
 use crate::theme;
-use crate::widget::{context_menu, Element};
+use crate::widget::{context_menu, double_click, Element};
 
 #[derive(Debug, Clone, Copy)]
 enum Entry {
@@ -20,23 +20,28 @@ impl Entry {
 pub enum Message {
     Whois(User),
     Query(User),
+    DoubleClick(User),
 }
 
 #[derive(Debug, Clone)]
 pub enum Event {
     SendWhois(User),
     OpenQuery(User),
+    DoubleClick(User),
 }
 
 pub fn update(message: Message) -> Event {
     match message {
         Message::Whois(user) => Event::SendWhois(user),
         Message::Query(user) => Event::OpenQuery(user),
+        Message::DoubleClick(user) => Event::DoubleClick(user),
     }
 }
 
 pub fn view<'a>(content: impl Into<Element<'a, Message>>, user: User) -> Element<'a, Message> {
     let entries = Entry::list();
+
+    let content = double_click(content, Message::DoubleClick(user.clone()));
 
     context_menu(content, entries, move |entry, length| {
         let (content, message) = match entry {

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -127,7 +127,8 @@ impl Dashboard {
                                         }
                                     }
                                 }
-                                buffer::user_context::Event::OpenQuery(user) => {
+                                buffer::user_context::Event::OpenQuery(user)
+                                | buffer::user_context::Event::DoubleClick(user) => {
                                     if let Some(data) = pane.buffer.data() {
                                         let buffer = data::Buffer::Query(
                                             data.server().clone(),

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -127,8 +127,7 @@ impl Dashboard {
                                         }
                                     }
                                 }
-                                buffer::user_context::Event::OpenQuery(user)
-                                | buffer::user_context::Event::DoubleClick(user) => {
+                                buffer::user_context::Event::OpenQuery(user) => {
                                     if let Some(data) = pane.buffer.data() {
                                         let buffer = data::Buffer::Query(
                                             data.server().clone(),
@@ -136,6 +135,17 @@ impl Dashboard {
                                         );
                                         return self.open_buffer(buffer, config);
                                     }
+                                }
+                                buffer::user_context::Event::SingleClick(user) => {
+                                    let Some((_, pane)) = self.get_focused_mut() else {
+                                        return Command::none();
+                                    };
+
+                                    return pane.buffer.insert_user_to_input(user).map(
+                                        move |message| {
+                                            Message::Pane(pane::Message::Buffer(id, message))
+                                        },
+                                    );
                                 }
                             }
                         }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -309,6 +309,7 @@ pub enum Button {
         selected: bool,
     },
     Context,
+    Bare,
 }
 
 impl button::StyleSheet for Theme {
@@ -361,6 +362,10 @@ impl button::StyleSheet for Theme {
                 border_radius: 4.0.into(),
                 ..Default::default()
             },
+            Button::Bare => button::Appearance {
+                background: Some(Background::Color(Color::TRANSPARENT)),
+                ..Default::default()
+            },
         }
     }
 
@@ -372,6 +377,7 @@ impl button::StyleSheet for Theme {
             Button::SideMenu { selected: _ } => button::Appearance { ..active },
             Button::Pane { selected: _ } => button::Appearance { ..active },
             Button::Context => button::Appearance { ..active },
+            Button::Bare => button::Appearance { ..active },
         }
     }
 
@@ -415,6 +421,7 @@ impl button::StyleSheet for Theme {
                 background: Some(Background::Color(self.colors.background.darker)),
                 ..active
             },
+            Button::Bare => button::Appearance { ..active },
         }
     }
 

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -2,6 +2,7 @@
 pub use self::anchored_overlay::anchored_overlay;
 pub use self::collection::Collection;
 pub use self::context_menu::context_menu;
+pub use self::double_click::double_click;
 pub use self::double_pass::double_pass;
 pub use self::hover::hover;
 pub use self::input::input;
@@ -13,6 +14,7 @@ use crate::Theme;
 pub mod anchored_overlay;
 pub mod collection;
 pub mod context_menu;
+pub mod double_click;
 mod double_pass;
 pub mod hover;
 pub mod input;

--- a/src/widget/double_click.rs
+++ b/src/widget/double_click.rs
@@ -1,0 +1,193 @@
+use std::time;
+
+use iced::advanced::widget::{self, tree, Tree};
+use iced::advanced::{mouse, overlay, renderer, Clipboard, Layout, Shell, Widget};
+use iced::{advanced, event, Rectangle};
+
+const TIMEOUT_MILLIS: u64 = 250;
+
+use crate::widget::Renderer;
+use crate::{Element, Theme};
+
+pub struct DoubleClick<'a, Message> {
+    content: Element<'a, Message>,
+    message: Message,
+}
+
+#[derive(Clone, Debug)]
+struct Internal {
+    instant: time::Instant,
+}
+
+impl Default for Internal {
+    fn default() -> Self {
+        Internal {
+            instant: time::Instant::now(),
+        }
+    }
+}
+
+impl<'a, Message> Widget<Message, Renderer> for DoubleClick<'a, Message>
+where
+    Message: Clone,
+{
+    fn width(&self) -> iced::Length {
+        self.content.as_widget().width()
+    }
+
+    fn height(&self) -> iced::Length {
+        self.content.as_widget().height()
+    }
+
+    fn layout(
+        &self,
+        renderer: &Renderer,
+        limits: &advanced::layout::Limits,
+    ) -> advanced::layout::Node {
+        self.content.as_widget().layout(renderer, limits)
+    }
+
+    fn tag(&self) -> widget::tree::Tag {
+        tree::Tag::of::<Internal>()
+    }
+
+    fn state(&self) -> tree::State {
+        tree::State::new(Internal::default())
+    }
+
+    fn children(&self) -> Vec<widget::Tree> {
+        vec![widget::Tree::new(&self.content)]
+    }
+
+    fn diff(&self, tree: &mut widget::Tree) {
+        tree.diff_children(&[&self.content]);
+    }
+
+    fn draw(
+        &self,
+        tree: &widget::Tree,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &iced::Rectangle,
+    ) {
+        self.content.as_widget().draw(
+            &tree.children[0],
+            renderer,
+            theme,
+            style,
+            layout,
+            cursor,
+            viewport,
+        )
+    }
+
+    fn on_event(
+        &mut self,
+        tree: &mut Tree,
+        event: event::Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
+    ) -> event::Status {
+        let status = self.content.as_widget_mut().on_event(
+            &mut tree.children[0],
+            event.clone(),
+            layout,
+            cursor,
+            renderer,
+            clipboard,
+            shell,
+            viewport,
+        );
+
+        if matches!(status, event::Status::Captured) {
+            return event::Status::Captured;
+        }
+
+        if !cursor.is_over(layout.bounds()) {
+            return event::Status::Ignored;
+        }
+
+        let event::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) = event else {
+          return event::Status::Ignored;
+        };
+
+        let state = tree.state.downcast_mut::<Internal>();
+        let now = time::Instant::now();
+        let timeout = time::Duration::from_millis(TIMEOUT_MILLIS);
+        let diff = now - state.instant;
+
+        if diff <= timeout {
+            shell.publish(self.message.clone());
+            event::Status::Captured
+        } else {
+            state.instant = time::Instant::now();
+            event::Status::Ignored
+        }
+    }
+
+    fn mouse_interaction(
+        &self,
+        tree: &widget::Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &iced::Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        self.content.as_widget().mouse_interaction(
+            &tree.children[0],
+            layout,
+            cursor,
+            viewport,
+            renderer,
+        )
+    }
+
+    fn operate(
+        &self,
+        tree: &mut widget::Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn widget::Operation<Message>,
+    ) {
+        self.content
+            .as_widget()
+            .operate(&mut tree.children[0], layout, renderer, operation)
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        tree: &'b mut widget::Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+    ) -> Option<overlay::Element<'b, Message, Renderer>> {
+        self.content
+            .as_widget_mut()
+            .overlay(&mut tree.children[0], layout, renderer)
+    }
+}
+
+impl<'a, Message> From<DoubleClick<'a, Message>> for Element<'a, Message>
+where
+    Message: Clone + 'a,
+{
+    fn from(double_click: DoubleClick<'a, Message>) -> Self {
+        Element::new(double_click)
+    }
+}
+
+pub fn double_click<'a, Message>(
+    content: impl Into<Element<'a, Message>>,
+    message: Message,
+) -> DoubleClick<'a, Message> {
+    DoubleClick {
+        content: content.into(),
+        message,
+    }
+}


### PR DESCRIPTION
I was implementing https://github.com/squidowl/halloy/issues/119 - initially I wanted to insert user to text input on single click, and open query on double click. But I didn't like having two actions on left click during testing. I found the single click feature quite useless now we have good autocompletion of nicknames, it simply feel faster to just type it rather than using your mouse, and then move hands back to the keyboard to continue the sentence.

However, double clicking to open a query was quite common across other clients so i've kept that.