### PR TITLE
on connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Added:
   cycling channels in the buffer and more! A new `keys` section has been added to the config file, reference the 
   [wiki](https://github.com/squidowl/halloy/wiki/Keyboard-shortcuts) for more details.
 - Single clicking on a user will insert nickname to input
+- Configuration option `on_connect` to execute commands once connected to a server, reference the 
+  [wiki](https://github.com/squidowl/halloy/wiki/Configuration#on-connect) for more details.
 
 Fixed:
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -411,15 +411,6 @@ impl Client {
                 let nick = args.first()?;
                 self.resolved_nick = Some(nick.to_string());
 
-                // Loop on connect commands.
-                for command in self.config.on_connect.iter() {
-                    if let Ok(cmd) = crate::command::parse(command, None) {
-                        if let Ok(command) = proto::Command::try_from(cmd) {
-                            let _ = self.sender.try_send(command.into());
-                        };
-                    };
-                }
-
                 // Send nick password & ghost
                 if let Some(nick_pass) = self.config.nick_password.as_ref() {
                     // Try ghost recovery if we couldn't claim our nick
@@ -443,6 +434,15 @@ impl Client {
                 // Send user modestring
                 if let Some(modestring) = self.config.umodes.as_ref() {
                     let _ = self.sender.try_send(command!("MODE", nick, modestring));
+                }
+
+                // Loop on connect commands
+                for command in self.config.on_connect.iter() {
+                    if let Ok(cmd) = crate::command::parse(command, None) {
+                        if let Ok(command) = proto::Command::try_from(cmd) {
+                            let _ = self.sender.try_send(command.into());
+                        };
+                    };
                 }
 
                 // Send JOIN

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -411,6 +411,15 @@ impl Client {
                 let nick = args.first()?;
                 self.resolved_nick = Some(nick.to_string());
 
+                // Loop on connect commands.
+                for command in self.config.on_connect.iter() {
+                    if let Ok(cmd) = crate::command::parse(command, None) {
+                        if let Ok(command) = proto::Command::try_from(cmd) {
+                            let _ = self.sender.try_send(command.into());
+                        };
+                    };
+                }
+
                 // Send nick password & ghost
                 if let Some(nick_pass) = self.config.nick_password.as_ref() {
                     // Try ghost recovery if we couldn't claim our nick

--- a/data/src/command.rs
+++ b/data/src/command.rs
@@ -57,7 +57,7 @@ pub enum Command {
     Unknown(String, Vec<String>),
 }
 
-pub fn parse(s: &str, buffer: &Buffer) -> Result<Command, Error> {
+pub fn parse(s: &str, buffer: Option<&Buffer>) -> Result<Command, Error> {
     let (head, rest) = s.split_once('/').ok_or(Error::MissingSlash)?;
     // Don't allow leading whitespace before slash
     if !head.is_empty() {
@@ -88,7 +88,7 @@ pub fn parse(s: &str, buffer: &Buffer) -> Result<Command, Error> {
                 validated::<2, 0, true>(args, |[target, msg], []| Command::Msg(target, msg))
             }
             Kind::Me => {
-                if let Some(target) = buffer.target() {
+                if let Some(target) = buffer.and_then(|b| b.target()) {
                     validated::<1, 0, true>(args, |[text], _| Command::Me(target, text))
                 } else {
                     Ok(unknown())

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -62,6 +62,9 @@ pub struct Server {
     root_cert_path: Option<PathBuf>,
     /// Sasl authentication
     pub sasl: Option<Sasl>,
+    /// Commands which are executed once connected.
+    #[serde(default)]
+    pub on_connect: Vec<String>,
 }
 
 impl Server {

--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -6,7 +6,7 @@ use crate::user::NickRef;
 use crate::{command, message, Buffer, Command, Message, Server, User};
 
 pub fn parse(buffer: Buffer, input: &str) -> Result<Input, command::Error> {
-    let content = match command::parse(input, &buffer) {
+    let content = match command::parse(input, Some(&buffer)) {
         Ok(command) => Content::Command(command),
         Err(command::Error::MissingSlash) => Content::Text(input.to_string()),
         Err(error) => return Err(error),


### PR DESCRIPTION
This adds the option to add commands which will be executed once connected.
I've kept it to use same format as our commands in Halloy to make it similar.

Eg;
```yaml
servers:
  libera:
    nickname: casperstorm
    server: irc.libera.chat
    port: 6697
    use_tls: true
    on_connect:
      - "/msg tarkah hello halloy is pretty great"
      - "/msg NickServ IDENTIFY foo bar"
```

Fixes #67 