### PR TITLE
fix MODE command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changed:
 Fixed:
 
 - Set the window application id on Linux to `org.squidowl.halloy`
+- Correctly display all arguments when receiving MODE command
 
 # 2023.3 (2023-07-27)
 

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -284,7 +284,7 @@ fn text(message: &Encoded, our_nick: &Nick) -> Option<String> {
             (user.nickname() != *our_nick)
                 .then(|| format!("⟶ {} has joined the channel", user.formatted()))
         }
-        Command::MODE(target, modes, _) if proto::is_channel(target) => {
+        Command::MODE(target, modes, args) if proto::is_channel(target) => {
             let user = user?;
             let modes = modes
                 .iter()
@@ -292,7 +292,13 @@ fn text(message: &Encoded, our_nick: &Nick) -> Option<String> {
                 .collect::<Vec<_>>()
                 .join(" ");
 
-            Some(format!(" ∙ {user} sets mode {modes}"))
+            let args = args
+                .iter()
+                .map(|arg| arg.to_string())
+                .collect::<Vec<_>>()
+                .join(" ");
+
+            Some(format!(" ∙ {user} sets mode {modes} {args}"))
         }
         Command::PRIVMSG(_, text) => {
             // Check if a synthetic action message


### PR DESCRIPTION
Noticed that we didn't show arguments in MODE command if there were any.   
Previous to this PR it wasn't possible to see who had their mode changed. See image below.

<img width="429" alt="Screenshot 2023-08-03 at 09 49 06" src="https://github.com/squidowl/halloy/assets/2248455/727720bd-0234-43ac-89dc-6a37dcfec8e1">


When setting a user mode we want to display it as:

> [sender] sets mode [mode(s)] [target(s)]

When setting a channel mode we want to display it as:

> [sender] sets mode [mode(s)]

This is now fixed as shown in the image below.

<img width="323" alt="Screenshot 2023-08-03 at 09 48 36" src="https://github.com/squidowl/halloy/assets/2248455/43c892ca-c031-44c7-9aeb-51231aef475e">
