### PR TITLE
invite-notify (and userhost-in-names)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+Added:
+
+- IRCv3 capability `userhost-in-names` support added
+- IRCv3 capability `invite-notify` support added
+
 # 2023.4 (2023-08-03)
 
 Added:

--- a/README.md
+++ b/README.md
@@ -47,12 +47,16 @@ cargo run --release
 
 Halloy supports the following IRCv3.2 capabilities
 
-- `away-notify`
-- `batch`
-- `server-time`
-- `sasl=PLAIN,EXTERNAL`
-- `labeled-response`
-- `echo-message` (server must also support `labeled-response`)
+| Capabilities                                                              |
+|---------------------------------------------------------------------------|
+| [away-notify](https://ircv3.net/specs/extensions/away-notify)             |
+| [batch](https://ircv3.net/specs/extensions/batch)                         |
+| [server-time](https://ircv3.net/specs/extensions/server-time)             |
+| [labeled-response](https://ircv3.net/specs/extensions/labeled-response)   |
+| [echo-message](https://ircv3.net/specs/extensions/echo-message)           |
+| [invite-notify](https://ircv3.net/specs/extensions/invite-notify)         |
+| [userhost-in-names](https://ircv3.net/specs/extensions/userhost-in-names) |
+| [sasl-3.1](https://ircv3.net/specs/extensions/sasl-3.1)                   |
 
 ## Why?
 <div align="center">
@@ -65,10 +69,6 @@ Halloy supports the following IRCv3.2 capabilities
 ## License
 
 Halloy is released under the GPL-3.0 License. For more details, see the [LICENSE](LICENSE) file.
-
-## Disclaimer
-
-Halloy is still in the early stages of development. Bugs and incomplete features may be present. Use it at your own risk.
 
 ## Contact
 

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -320,6 +320,11 @@ impl Manager {
                     )
                 }
             }
+            Broadcast::Invite {
+                inviter,
+                channel,
+                user_channels,
+            } => message::broadcast::invite(inviter, channel, user_channels),
         };
 
         messages.into_iter().for_each(|message| {
@@ -517,6 +522,11 @@ pub enum Broadcast {
         old_nick: Nick,
         new_nick: Nick,
         ourself: bool,
+        user_channels: Vec<String>,
+    },
+    Invite {
+        inviter: Nick,
+        channel: String,
         user_channels: Vec<String>,
     },
 }

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -145,3 +145,13 @@ pub fn nickname(
 
     expand(channels, queries, false, Cause::Server(None), text)
 }
+
+pub fn invite(
+    inviter: Nick,
+    channel: String,
+    channels: impl IntoIterator<Item = String>,
+) -> Vec<Message> {
+    let text = format!(" ∙ {inviter} invited you to join {channel}");
+
+    expand(channels, [], false, Cause::Server(None), text)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -338,6 +338,20 @@ impl Application for Halloy {
                                             channels,
                                         );
                                     }
+                                    data::client::Brodcast::Invite {
+                                        inviter,
+                                        channel,
+                                        user_channels,
+                                    } => {
+                                        let inviter = inviter.nickname();
+
+                                        dashboard.broadcast_invite(
+                                            &server,
+                                            inviter.to_owned(),
+                                            channel,
+                                            user_channels,
+                                        );
+                                    }
                                 },
                             }
                         }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -707,6 +707,23 @@ impl Dashboard {
         );
     }
 
+    pub fn broadcast_invite(
+        &mut self,
+        server: &Server,
+        inviter: Nick,
+        channel: String,
+        user_channels: Vec<String>,
+    ) {
+        self.history.broadcast(
+            server,
+            Broadcast::Invite {
+                inviter,
+                channel,
+                user_channels,
+            },
+        );
+    }
+
     pub fn broadcast_connecting(&mut self, server: &Server) {
         self.history.broadcast(server, Broadcast::Connecting);
     }


### PR DESCRIPTION
This adds support for `invite-notify` and `userhost-in-names`.
For the latter, nothing has to be done.

<img width="392" alt="Screenshot 2023-08-03 at 22 00 36" src="https://github.com/squidowl/halloy/assets/2248455/92dbc1fc-8782-43d7-917d-ad58a7df7efe">