### PR TITLE
maximum message length

### DIFF
--- a/irc/proto/src/format.rs
+++ b/irc/proto/src/format.rs
@@ -2,6 +2,9 @@ use itertools::Itertools;
 
 use crate::{Message, Tag};
 
+/// Most IRC servers limit messages to 512 bytes in length, including the trailing CR-LF characters.
+pub const BYTE_LIMIT: usize = 512;
+
 pub fn message(message: Message) -> String {
     let command = message.command.command();
 


### PR DESCRIPTION
Fixes #128.

This ensures we do not go above a certain message byte length.
- If its a regular message, we truncate it.
- If its a command, we alert to user that command is too long.