### PR TITLE
fix config error on missing nickname color

### DIFF
--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -75,6 +75,7 @@ pub struct Timestamp {
 
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct Nickname {
+    #[serde(default)]
     pub color: Color,
     #[serde(default)]
     pub brackets: Brackets,


### PR DESCRIPTION
config errors if `buffer.nickname.color` is missing, but `Color::Unique` variant is set as default.

![06_11_2023-00_26_halloy_iBQ9nwq](https://github.com/squidowl/halloy/assets/36301891/d01020e7-9f2b-4abc-8777-6622fab48d26)
