### PR TITLE
WIP: IRC formatting

### DIFF
--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -1,14 +1,11 @@
 use data::server::Server;
 use data::{channel, client, history, message, Config};
-use iced::{
-    color,
-    widget::{column, container, row, vertical_space},
-};
+use iced::widget::{column, container, row, vertical_space};
 use iced::{Command, Length};
 
 use super::{input_view, scroll_view, user_context};
-use crate::theme;
 use crate::widget::{selectable_text, Collection, Element};
+use crate::{message::format_message, theme};
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -20,167 +17,6 @@ pub enum Message {
 #[derive(Debug, Clone)]
 pub enum Event {
     UserContext(user_context::Event),
-}
-
-#[derive(Debug)]
-enum Style {
-    Bold,
-    Italic,
-    Underline,
-    Strikethrough,
-    Monospace,
-    Color(IrcColor, Option<IrcColor>),
-    Reset,
-}
-
-#[derive(Debug)]
-enum IrcColor {
-    White,
-    Black,
-    Blue,
-    Green,
-    Red,
-    Brown,
-    Magenta,
-    Orange,
-    Yellow,
-    LightGreen,
-    Cyan,
-    LightCyan,
-    LightBlue,
-    Pink,
-    Grey,
-    LightGrey,
-    Extended(u8),
-}
-
-impl IrcColor {
-    fn from_code(c: u8) -> Self {
-        match c {
-            0 => Self::White,
-            1 => Self::Black,
-            2 => Self::Blue,
-            3 => Self::Green,
-            4 => Self::Red,
-            5 => Self::Brown,
-            6 => Self::Magenta,
-            7 => Self::Orange,
-            8 => Self::Yellow,
-            9 => Self::LightGreen,
-            10 => Self::Cyan,
-            11 => Self::LightCyan,
-            12 => Self::LightBlue,
-            13 => Self::Pink,
-            14 => Self::Grey,
-            15 => Self::LightGrey,
-            c => Self::Extended(c),
-        }
-    }
-}
-
-impl From<u8> for IrcColor {
-    fn from(value: u8) -> Self {
-        Self::from_code(value)
-    }
-}
-
-impl From<IrcColor> for iced::Color {
-    fn from(value: IrcColor) -> Self {
-        // TODO: don't hardcode, move into theme
-        match value {
-            IrcColor::White => color!(255, 255, 255),
-            IrcColor::Black => color!(0, 0, 0),
-            IrcColor::Blue => color!(0, 0, 127),
-            IrcColor::Green => color!(0, 147, 0),
-            IrcColor::Red => color!(255, 0, 0),
-            IrcColor::Brown => color!(127, 0, 0),
-            IrcColor::Magenta => color!(156, 0, 156),
-            IrcColor::Orange => color!(252, 127, 0),
-            IrcColor::Yellow => color!(255, 255, 0),
-            IrcColor::LightGreen => color!(0, 252, 0),
-            IrcColor::Cyan => color!(0, 147, 147),
-            IrcColor::LightCyan => color!(0, 255, 255),
-            IrcColor::LightBlue => color!(0, 0, 252),
-            IrcColor::Pink => color!(255, 0, 255),
-            IrcColor::Grey => color!(127, 127, 127),
-            IrcColor::LightGrey => color!(210, 210, 210),
-            IrcColor::Extended(_) => todo!(),
-        }
-    }
-}
-
-fn style_part<'a, Message: 'a>(style: Style, text: String) -> Element<'a, Message> {
-    let text = selectable_text(text);
-    match style {
-        Style::Color(fg, bg) => {
-            let text = text.style(theme::Text::Custom(Some(fg.into())));
-            if let Some(bg) = bg {
-                container(text)
-                    .style(theme::Container::Custom {
-                        background: Some(bg.into()),
-                    })
-                    .into()
-            } else {
-                text.into()
-            }
-        }
-        _ => text.into(),
-    }
-}
-
-fn format_message<'a, Message: 'a>(text: &'a str) -> Element<'a, Message> {
-    let mut parts = row![];
-    let mut current = String::new();
-    let mut style = Style::Reset;
-    let mut chars = text.chars().peekable();
-
-    while let Some(c) = chars.next() {
-        let new_style = match c {
-            '\x0f' => Style::Reset,
-            '\x02' => Style::Bold,
-            '\x1d' => Style::Italic,
-            '\x1f' => Style::Underline,
-            '\x1e' => Style::Strikethrough,
-            '\x11' => Style::Monospace,
-            '\x03' => {
-                let mut fg = String::new();
-                while let Some(&c @ '0'..='9') = chars.peek() {
-                    chars.next();
-                    fg.push(c);
-                    if fg.len() >= 2 {
-                        break;
-                    }
-                }
-                let mut bg = String::new();
-                if chars.next_if(|&c| c == ',').is_some() {
-                    while let Some(&c @ '0'..='9') = chars.peek() {
-                        chars.next();
-                        bg.push(c);
-                        if bg.len() >= 2 {
-                            break;
-                        }
-                    }
-                }
-                let Some(fg) = fg.parse().ok().map(IrcColor::from_code) else {
-                    continue;
-                };
-                Style::Color(fg, bg.parse().ok().map(IrcColor::from_code))
-            }
-            c => {
-                current.push(c);
-                continue;
-            }
-        };
-
-        parts = parts.push(style_part(
-            std::mem::replace(&mut style, new_style),
-            std::mem::take(&mut current),
-        ));
-    }
-
-    parts = parts.push(style_part(style, current));
-
-    parts.into()
 }
 
 pub fn view<'a>(
@@ -231,7 +67,7 @@ pub fn view<'a>(
                             }
                             _ => theme::Container::Default,
                         };
-                        let message = format_message(&message.text);
+                        let message = format_message(&message.text, theme::Text::Default);
 
                         Some(
                             container(row![].push_maybe(timestamp).push(nick).push(message))
@@ -240,18 +76,17 @@ pub fn view<'a>(
                         )
                     }
                     message::Source::Server(_) => {
-                        let message = selectable_text(&message.text).style(theme::Text::Server);
+                        let message = format_message(&message.text, theme::Text::Server);
 
                         Some(container(row![].push_maybe(timestamp).push(message)).into())
                     }
                     message::Source::Action => {
-                        let message = selectable_text(&message.text).style(theme::Text::Accent);
+                        let message = format_message(&message.text, theme::Text::Accent);
 
                         Some(container(row![].push_maybe(timestamp).push(message)).into())
                     }
                     message::Source::Internal(message::source::Internal::Status(status)) => {
-                        let message =
-                            selectable_text(&message.text).style(theme::Text::Status(*status));
+                        let message = format_message(&message.text, theme::Text::Status(*status));
 
                         Some(container(row![].push_maybe(timestamp).push(message)).into())
                     }

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -1,6 +1,9 @@
 use data::server::Server;
 use data::{channel, client, history, message, Config};
-use iced::widget::{column, container, row, vertical_space};
+use iced::{
+    color,
+    widget::{column, container, row, vertical_space},
+};
 use iced::{Command, Length};
 
 use super::{input_view, scroll_view, user_context};
@@ -17,6 +20,167 @@ pub enum Message {
 #[derive(Debug, Clone)]
 pub enum Event {
     UserContext(user_context::Event),
+}
+
+#[derive(Debug)]
+enum Style {
+    Bold,
+    Italic,
+    Underline,
+    Strikethrough,
+    Monospace,
+    Color(IrcColor, Option<IrcColor>),
+    Reset,
+}
+
+#[derive(Debug)]
+enum IrcColor {
+    White,
+    Black,
+    Blue,
+    Green,
+    Red,
+    Brown,
+    Magenta,
+    Orange,
+    Yellow,
+    LightGreen,
+    Cyan,
+    LightCyan,
+    LightBlue,
+    Pink,
+    Grey,
+    LightGrey,
+    Extended(u8),
+}
+
+impl IrcColor {
+    fn from_code(c: u8) -> Self {
+        match c {
+            0 => Self::White,
+            1 => Self::Black,
+            2 => Self::Blue,
+            3 => Self::Green,
+            4 => Self::Red,
+            5 => Self::Brown,
+            6 => Self::Magenta,
+            7 => Self::Orange,
+            8 => Self::Yellow,
+            9 => Self::LightGreen,
+            10 => Self::Cyan,
+            11 => Self::LightCyan,
+            12 => Self::LightBlue,
+            13 => Self::Pink,
+            14 => Self::Grey,
+            15 => Self::LightGrey,
+            c => Self::Extended(c),
+        }
+    }
+}
+
+impl From<u8> for IrcColor {
+    fn from(value: u8) -> Self {
+        Self::from_code(value)
+    }
+}
+
+impl From<IrcColor> for iced::Color {
+    fn from(value: IrcColor) -> Self {
+        // TODO: don't hardcode, move into theme
+        match value {
+            IrcColor::White => color!(255, 255, 255),
+            IrcColor::Black => color!(0, 0, 0),
+            IrcColor::Blue => color!(0, 0, 127),
+            IrcColor::Green => color!(0, 147, 0),
+            IrcColor::Red => color!(255, 0, 0),
+            IrcColor::Brown => color!(127, 0, 0),
+            IrcColor::Magenta => color!(156, 0, 156),
+            IrcColor::Orange => color!(252, 127, 0),
+            IrcColor::Yellow => color!(255, 255, 0),
+            IrcColor::LightGreen => color!(0, 252, 0),
+            IrcColor::Cyan => color!(0, 147, 147),
+            IrcColor::LightCyan => color!(0, 255, 255),
+            IrcColor::LightBlue => color!(0, 0, 252),
+            IrcColor::Pink => color!(255, 0, 255),
+            IrcColor::Grey => color!(127, 127, 127),
+            IrcColor::LightGrey => color!(210, 210, 210),
+            IrcColor::Extended(_) => todo!(),
+        }
+    }
+}
+
+fn style_part<'a, Message: 'a>(style: Style, text: String) -> Element<'a, Message> {
+    let text = selectable_text(text);
+    match style {
+        Style::Color(fg, bg) => {
+            let text = text.style(theme::Text::Custom(Some(fg.into())));
+            if let Some(bg) = bg {
+                container(text)
+                    .style(theme::Container::Custom {
+                        background: Some(bg.into()),
+                    })
+                    .into()
+            } else {
+                text.into()
+            }
+        }
+        _ => text.into(),
+    }
+}
+
+fn format_message<'a, Message: 'a>(text: &'a str) -> Element<'a, Message> {
+    let mut parts = row![];
+    let mut current = String::new();
+    let mut style = Style::Reset;
+    let mut chars = text.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        let new_style = match c {
+            '\x0f' => Style::Reset,
+            '\x02' => Style::Bold,
+            '\x1d' => Style::Italic,
+            '\x1f' => Style::Underline,
+            '\x1e' => Style::Strikethrough,
+            '\x11' => Style::Monospace,
+            '\x03' => {
+                let mut fg = String::new();
+                while let Some(&c @ '0'..='9') = chars.peek() {
+                    chars.next();
+                    fg.push(c);
+                    if fg.len() >= 2 {
+                        break;
+                    }
+                }
+                let mut bg = String::new();
+                if chars.next_if(|&c| c == ',').is_some() {
+                    while let Some(&c @ '0'..='9') = chars.peek() {
+                        chars.next();
+                        bg.push(c);
+                        if bg.len() >= 2 {
+                            break;
+                        }
+                    }
+                }
+                let Some(fg) = fg.parse().ok().map(IrcColor::from_code) else {
+                    continue;
+                };
+                Style::Color(fg, bg.parse().ok().map(IrcColor::from_code))
+            }
+            c => {
+                current.push(c);
+                continue;
+            }
+        };
+
+        parts = parts.push(style_part(
+            std::mem::replace(&mut style, new_style),
+            std::mem::take(&mut current),
+        ));
+    }
+
+    parts = parts.push(style_part(style, current));
+
+    parts.into()
 }
 
 pub fn view<'a>(
@@ -67,7 +231,7 @@ pub fn view<'a>(
                             }
                             _ => theme::Container::Default,
                         };
-                        let message = selectable_text(&message.text);
+                        let message = format_message(&message.text);
 
                         Some(
                             container(row![].push_maybe(timestamp).push(nick).push(message))

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -4,8 +4,8 @@ use iced::widget::{column, container, row, vertical_space};
 use iced::{Command, Length};
 
 use super::{input_view, scroll_view, user_context};
-use crate::theme;
 use crate::widget::{selectable_text, Collection, Element};
+use crate::{message::format_message, theme};
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -53,25 +53,24 @@ pub fn view<'a>(
                         )
                         .map(scroll_view::Message::UserContext);
 
-                        let message = selectable_text(&message.text);
+                        let message = format_message(&message.text, theme::Text::Default);
 
                         Some(
                             container(row![].push_maybe(timestamp).push(nick).push(message)).into(),
                         )
                     }
                     message::Source::Server(_) => {
-                        let message = selectable_text(&message.text).style(theme::Text::Server);
+                        let message = format_message(&message.text, theme::Text::Server);
 
                         Some(container(row![].push_maybe(timestamp).push(message)).into())
                     }
                     message::Source::Action => {
-                        let message = selectable_text(&message.text).style(theme::Text::Accent);
+                        let message = format_message(&message.text, theme::Text::Accent);
 
                         Some(container(row![].push_maybe(timestamp).push(message)).into())
                     }
                     message::Source::Internal(message::source::Internal::Status(status)) => {
-                        let message =
-                            selectable_text(&message.text).style(theme::Text::Status(*status));
+                        let message = format_message(&message.text, theme::Text::Status(*status));
 
                         Some(container(row![].push_maybe(timestamp).push(message)).into())
                     }

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -3,8 +3,8 @@ use iced::widget::{column, container, row, vertical_space};
 use iced::{Command, Length};
 
 use super::{input_view, scroll_view};
-use crate::theme;
 use crate::widget::{selectable_text, Collection, Element};
+use crate::{message::format_message, theme};
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -37,13 +37,12 @@ pub fn view<'a>(
 
                 match message.target.source() {
                     message::Source::Server(_) => {
-                        let message = selectable_text(&message.text).style(theme::Text::Server);
+                        let message = format_message(&message.text, theme::Text::Server);
 
                         Some(container(row![].push_maybe(timestamp).push(message)).into())
                     }
                     message::Source::Internal(message::source::Internal::Status(status)) => {
-                        let message =
-                            selectable_text(&message.text).style(theme::Text::Status(*status));
+                        let message = format_message(&message.text, theme::Text::Status(*status));
 
                         Some(container(row![].push_maybe(timestamp).push(message)).into())
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod event;
 mod font;
 mod icon;
 mod logger;
+mod message;
 mod notification;
 mod screen;
 mod stream;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,0 +1,175 @@
+use iced::{
+    color,
+    widget::{container, row},
+};
+
+use crate::theme;
+use crate::widget::{selectable_text, Element};
+
+#[derive(Debug)]
+enum Style {
+    Bold,
+    Italic,
+    Underline,
+    Strikethrough,
+    Monospace,
+    Color(IrcColor, Option<IrcColor>),
+    Reset,
+}
+
+#[derive(Debug)]
+enum IrcColor {
+    White,
+    Black,
+    Blue,
+    Green,
+    Red,
+    Brown,
+    Magenta,
+    Orange,
+    Yellow,
+    LightGreen,
+    Cyan,
+    LightCyan,
+    LightBlue,
+    Pink,
+    Grey,
+    LightGrey,
+    Extended(u8),
+}
+
+impl IrcColor {
+    fn from_code(c: u8) -> Self {
+        match c {
+            0 => Self::White,
+            1 => Self::Black,
+            2 => Self::Blue,
+            3 => Self::Green,
+            4 => Self::Red,
+            5 => Self::Brown,
+            6 => Self::Magenta,
+            7 => Self::Orange,
+            8 => Self::Yellow,
+            9 => Self::LightGreen,
+            10 => Self::Cyan,
+            11 => Self::LightCyan,
+            12 => Self::LightBlue,
+            13 => Self::Pink,
+            14 => Self::Grey,
+            15 => Self::LightGrey,
+            c => Self::Extended(c),
+        }
+    }
+}
+
+impl From<u8> for IrcColor {
+    fn from(value: u8) -> Self {
+        Self::from_code(value)
+    }
+}
+
+impl From<IrcColor> for iced::Color {
+    fn from(value: IrcColor) -> Self {
+        // TODO: don't hardcode, move into theme
+        match value {
+            IrcColor::White => color!(255, 255, 255),
+            IrcColor::Black => color!(0, 0, 0),
+            IrcColor::Blue => color!(0, 0, 127),
+            IrcColor::Green => color!(0, 147, 0),
+            IrcColor::Red => color!(255, 0, 0),
+            IrcColor::Brown => color!(127, 0, 0),
+            IrcColor::Magenta => color!(156, 0, 156),
+            IrcColor::Orange => color!(252, 127, 0),
+            IrcColor::Yellow => color!(255, 255, 0),
+            IrcColor::LightGreen => color!(0, 252, 0),
+            IrcColor::Cyan => color!(0, 147, 147),
+            IrcColor::LightCyan => color!(0, 255, 255),
+            IrcColor::LightBlue => color!(0, 0, 252),
+            IrcColor::Pink => color!(255, 0, 255),
+            IrcColor::Grey => color!(127, 127, 127),
+            IrcColor::LightGrey => color!(210, 210, 210),
+            IrcColor::Extended(_) => todo!(),
+        }
+    }
+}
+
+fn style_part<'a, Message: 'a>(
+    style: Style,
+    text: String,
+    default: &theme::Text,
+) -> Element<'a, Message> {
+    let text = selectable_text(text);
+    match style {
+        Style::Color(fg, bg) => {
+            let text = text.style(theme::Text::Custom(Some(fg.into())));
+            if let Some(bg) = bg {
+                container(text)
+                    .style(theme::Container::Custom {
+                        background: Some(bg.into()),
+                    })
+                    .into()
+            } else {
+                text.into()
+            }
+        }
+        _ => text.style(default.clone()).into(),
+    }
+}
+pub fn format_message<'a, Message: 'a>(
+    text: &'a str,
+    default: theme::Text,
+) -> Element<'a, Message> {
+    let mut parts = row![];
+    let mut current = String::new();
+    let mut style = Style::Reset;
+    let mut chars = text.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        let new_style = match c {
+            '\x0f' => Style::Reset,
+            '\x02' => Style::Bold,
+            '\x1d' => Style::Italic,
+            '\x1f' => Style::Underline,
+            '\x1e' => Style::Strikethrough,
+            '\x11' => Style::Monospace,
+            '\x03' => {
+                let mut fg = String::new();
+                while let Some(&c @ '0'..='9') = chars.peek() {
+                    chars.next();
+                    fg.push(c);
+                    if fg.len() >= 2 {
+                        break;
+                    }
+                }
+                let mut bg = String::new();
+                if chars.next_if(|&c| c == ',').is_some() {
+                    while let Some(&c @ '0'..='9') = chars.peek() {
+                        chars.next();
+                        bg.push(c);
+                        if bg.len() >= 2 {
+                            break;
+                        }
+                    }
+                }
+                let Some(fg) = fg.parse().ok().map(IrcColor::from_code) else {
+                    continue;
+                };
+                Style::Color(fg, bg.parse().ok().map(IrcColor::from_code))
+            }
+            c => {
+                current.push(c);
+                continue;
+            }
+        };
+
+        parts = parts.push(style_part(
+            std::mem::replace(&mut style, new_style),
+            std::mem::take(&mut current),
+            &default,
+        ));
+    }
+
+    parts = parts.push(style_part(style, current, &default));
+
+    parts.into()
+}

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -109,6 +109,7 @@ pub enum Text {
     Transparent,
     Status(message::source::Status),
     Nickname(Option<String>),
+    Custom(Option<Color>),
 }
 
 impl text::StyleSheet for Theme {
@@ -152,6 +153,7 @@ impl text::StyleSheet for Theme {
             Text::Transparent => text::Appearance {
                 color: Some(self.colors().text.low_alpha),
             },
+            Text::Custom(color) => text::Appearance { color },
         }
     }
 }
@@ -171,6 +173,7 @@ pub enum Container {
     Context,
     Highlight,
     SemiTransparent,
+    Custom { background: Option<Color> },
 }
 
 impl container::StyleSheet for Theme {
@@ -240,6 +243,10 @@ impl container::StyleSheet for Theme {
                 ),
                 ..Default::default()
             },
+            Container::Custom { background } => container::Appearance {
+                background: background.map(Background::Color),
+                ..Default::default()
+            }
         }
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -173,7 +173,9 @@ pub enum Container {
     Context,
     Highlight,
     SemiTransparent,
-    Custom { background: Option<Color> },
+    Custom {
+        background: Option<Color>,
+    },
 }
 
 impl container::StyleSheet for Theme {
@@ -246,7 +248,7 @@ impl container::StyleSheet for Theme {
             Container::Custom { background } => container::Appearance {
                 background: background.map(Background::Color),
                 ..Default::default()
-            }
+            },
         }
     }
 }

--- a/src/widget/double_click.rs
+++ b/src/widget/double_click.rs
@@ -115,7 +115,7 @@ where
         }
 
         let event::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) = event else {
-          return event::Status::Ignored;
+            return event::Status::Ignored;
         };
 
         let state = tree.state.downcast_mut::<Internal>();


### PR DESCRIPTION
Adds support for formatting via IRC escapes

Bots especially use these for formatting their messages, and currently they render as boxes plus numbers, which is a bit annoying

## Progress

Currently parses most escapes except hex colors. Only the 0-15 colors are currently implemented, everything else is ignored. A default for these colors also needs to be discussed (I just put the mIRC ones for now). Let me know if this looks good and I'll continue on!