### PR TITLE
[DRAFT] Fix #214: Separate user cert-chain from PKCS#8 key

### DIFF
--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -74,6 +74,7 @@ impl Server {
                 accept_invalid_certs: self.dangerously_accept_invalid_certs,
                 root_cert_path: self.root_cert_path.as_ref(),
                 client_cert_path: self.sasl.as_ref().and_then(Sasl::external_cert),
+                client_key_path: self.sasl.as_ref().and_then(Sasl::external_key),
             }
         } else {
             connection::Security::Unsecured
@@ -97,8 +98,10 @@ pub enum Sasl {
         password: String,
     },
     External {
-        /// The path to PEM encoded X509 certificate for external auth
+        /// The path to PEM encoded X509 user certificate for external auth
         cert: PathBuf,
+        /// The path to PEM encoded PKCS#8 private key corresponding to the user certificate for external auth
+        key: PathBuf,
     },
 }
 
@@ -122,8 +125,16 @@ impl Sasl {
     }
 
     fn external_cert(&self) -> Option<&PathBuf> {
-        if let Self::External { cert } = self {
+        if let Self::External { cert, .. } = self {
             Some(cert)
+        } else {
+            None
+        }
+    }
+
+    fn external_key(&self) -> Option<&PathBuf> {
+        if let Self::External { key, .. } = self {
+            Some(key)
         } else {
             None
         }

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -101,7 +101,7 @@ pub enum Sasl {
         /// The path to PEM encoded X509 user certificate for external auth
         cert: PathBuf,
         /// The path to PEM encoded PKCS#8 private key corresponding to the user certificate for external auth
-        key: PathBuf,
+        key: Option<PathBuf>,
     },
 }
 
@@ -133,8 +133,8 @@ impl Sasl {
     }
 
     fn external_key(&self) -> Option<&PathBuf> {
-        if let Self::External { key, .. } = self {
-            Some(key)
+        if let Self::External { cert, key, .. } = self {
+            Some(key.as_ref().unwrap_or(cert))
         } else {
             None
         }


### PR DESCRIPTION
This adds a new config option `sasl.external.key` which is required to properly support SASL External using PKCS#8.  PKCS#8 is a format that's used exclusively for keys and not user-certs.  As such, when using `from_pkcs8()` from native-tls, both a user-cert (in PEM) and the PKCS#8 key must be provided. This was implemented before through one file which contained both the PKCS#8 key and the user-cert, concatenated. Strict implementations will either complain about the key-file containing certificates, vice-versa or duplicate certificates: since "both" the key-file and cert-file contain the same certificates due to being identical.

The code is probably not ideal, e.g.,

1. the `external_cert` and `external_key` functions could possibly be merged, or
2. the fields `client_cert_path` and `client_key_path` in `Security` be wrapped as a tuple `(client_cert_path, client_key_path)` with similar changes
3. there could be support for combined PKCS#8 key files + PEM cert chains, as well as
4. support for PKCS#12 combined identity files.

Further, the documentation in the Wiki linking to Libera may need to be updated.