### PR TITLE
Focus Pane on Launch

### DIFF
--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -64,7 +64,12 @@ impl Dashboard {
     pub fn restore(dashboard: data::Dashboard) -> (Self, Command<Message>) {
         let mut dashboard = Dashboard::from(dashboard);
 
-        let command = dashboard.track();
+        let command;
+        if let Some((pane, _)) = dashboard.panes.panes.iter().next() {
+            command = Command::batch(vec![dashboard.focus_pane(*pane),dashboard.track()]);
+        } else {
+            command = dashboard.track();
+        }
 
         (dashboard, command)
     }


### PR DESCRIPTION
No pane is focused on launch, even if panes are restored from a previous session.  When in this state, clicking a channel in the sidebar a opens a new pane even when ReplacePane is configured as the default action.  It is rare, in my experience, to enter into a no-pane-selected state while using Halloy, so this launch behavior is unexpected from my point of view.  This small change is to address that.