### PR TITLE
Accept '*' as a legal special symbol for usernames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+Fixed:
+
+- Accept '*' as a legal special symbol for usernames
+
 # 2023.5 (2023-11-12)
 
 Added:

--- a/irc/proto/src/parse.rs
+++ b/irc/proto/src/parse.rs
@@ -126,8 +126,8 @@ fn space(input: &str) -> IResult<&str, ()> {
 fn user(input: &str) -> IResult<&str, User> {
     // <sequence of any characters except NUL, CR, LF, and SPACE> and @
     let username = recognize(many1_count(none_of("\0\r\n @")));
-    // "-" "[", "]", "\", "`", "_", "^", "{", "|", "}"
-    let special = one_of("-[]\\`_^{|}");
+    // "-", "[", "]", "\", "`", "_", "^", "{", "|", "}", "*"
+    let special = one_of("-[]\\`_^{|}*");
     // *( <letter> | <number> | <special> )
     let nickname = recognize(many1_count(alt((
         satisfy(|c| c.is_ascii_alphanumeric()),


### PR DESCRIPTION
Special usernames as *status are used to control ZNC

Fixes #217 