### PR TITLE
Strip ZNC Server when Resolving Nickname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changed:
 Fixed:
 
 - Accept '*' as a legal special symbol for usernames
+- Handle ZNC 'username/server' style usernames
 
 # 2023.5 (2023-11-12)
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -448,7 +448,8 @@ impl Client {
             Command::Numeric(RPL_WELCOME, args) => {
                 // Updated actual nick
                 let nick = args.first()?;
-                self.resolved_nick = Some(nick.to_string());
+                // Strip ZNC server when resolving nick if necessary
+                self.resolved_nick = Some(nick.to_string().split('/').nth(0)?.to_string());
 
                 // Send nick password & ghost
                 if let Some(nick_pass) = self.config.nick_password.as_ref() {


### PR DESCRIPTION
When connecting using a ZNC style 'username/server' username, no channels appear in the sidebar despite channels being configured both in Halloy and on the ZNC server.  I believe this is because comparisons against the user's username are failing, since the servers connected via ZNC report just 'username';  e.g. if I'm connected to irc.libera.chat then my ZNC username is 'andymandias/libera', but JOIN reports 'andymandias' has joined a channel and is not recognized as mine.

This change is to strip the server portion of the username such that the failing checks correctly resolve as true, while not interfering with non-ZNC users nor with the ZNC login.  Doing so when setting resolved_nick in the client was the best place I could find for that, and it has been working for me in testing so far (testing with a regular username as well as a 'username/server' username).