### PR TITLE
Add Smart Message Filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Changed:
 - `hidden_server_messages` has been changed to `server_messages` and additional customization has been added:
   - Exclude messages [join, part, quit].
   - Adjust username format. 
+  - Exclude server messages for users who have not messaged in the last X seconds
 
 Fixed:
 

--- a/config.yaml
+++ b/config.yaml
@@ -87,16 +87,18 @@ buffer:
   input_visibility: Always
 
   # Control different server messages.
-  # - exclude [boolean]: exclude the message from showing
+  # - exclude [All, None, !Smart seconds]:
+  #   - Smart will show a server message if the user has sent a message
+  #     in the given time interval (seconds) prior to the server message
   # - user_format [Short, Full]: controls the username formatting
   server_messages:
     join:
-      exclude: true
+      exclude: All
       username_format: Short
     part:
-      exclude: false
+      exclude: None
     quit:
-      exclude: false
+      exclude: None
 
   # Channel buffer settings
   channel:

--- a/config.yaml
+++ b/config.yaml
@@ -98,7 +98,7 @@ buffer:
     part:
       exclude: None
     quit:
-      exclude: None
+      exclude: !Smart 1200
 
   # Channel buffer settings
   channel:

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -21,6 +21,14 @@ pub struct Buffer {
     pub server_messages: ServerMessages,
 }
 
+#[derive(Debug, Copy, Clone, Default, Deserialize)]
+pub enum Exclude {
+    #[default]
+    All,
+    None,
+    Smart(i64),
+}
+
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct ServerMessages {
     #[serde(default)]
@@ -44,7 +52,7 @@ impl ServerMessages {
 #[derive(Debug, Copy, Clone, Default, Deserialize)]
 pub struct ServerMessage {
     #[serde(default)]
-    pub exclude: bool,
+    pub exclude: Exclude,
     #[serde(default)]
     pub username_format: UsernameFormat,
 }

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -40,11 +40,11 @@ pub struct ServerMessages {
 }
 
 impl ServerMessages {
-    pub fn get(&self, server: &source::Server) -> (ServerMessage, Option<crate::user::Nick>) {
+    pub fn get(&self, server: &source::Server) -> ServerMessage {
         match server {
-            source::Server::Join(nick) => (self.join, nick.to_owned()),
-            source::Server::Part(nick) => (self.part, nick.to_owned()),
-            source::Server::Quit(nick) => (self.quit, nick.to_owned()),
+            source::Server::Join(_) => self.join,
+            source::Server::Part(_) => self.part,
+            source::Server::Quit(_) => self.quit,
         }
     }
 }

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -40,11 +40,11 @@ pub struct ServerMessages {
 }
 
 impl ServerMessages {
-    pub fn get(&self, server: &source::Server) -> ServerMessage {
+    pub fn get(&self, server: &source::Server) -> (ServerMessage, Option<crate::user::Nick>) {
         match server {
-            source::Server::Join => self.join,
-            source::Server::Part => self.part,
-            source::Server::Quit => self.quit,
+            source::Server::Join(nick) => (self.join, nick.to_owned()),
+            source::Server::Part(nick) => (self.part, nick.to_owned()),
+            source::Server::Quit(nick) => (self.quit, nick.to_owned()),
         }
     }
 }

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -41,10 +41,10 @@ pub struct ServerMessages {
 
 impl ServerMessages {
     pub fn get(&self, server: &source::Server) -> ServerMessage {
-        match server {
-            source::Server::Join(_) => self.join,
-            source::Server::Part(_) => self.part,
-            source::Server::Quit(_) => self.quit,
+        match server.kind() {
+            source::server::Kind::Join => self.join,
+            source::server::Kind::Part => self.part,
+            source::server::Kind::Quit => self.quit,
         }
     }
 }

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -451,9 +451,9 @@ impl Data {
                         Exclude::None => true,
                         Exclude::Smart(seconds) => {
                             let nick = match source {
-                               message::source::Server::Join(nick) => nick,
-                               message::source::Server::Part(nick) => nick,
-                               message::source::Server::Quit(nick) => nick,
+                                message::source::Server::Join(nick) => nick,
+                                message::source::Server::Part(nick) => nick,
+                                message::source::Server::Quit(nick) => nick,
                             };
 
                             if nick.is_some() {
@@ -552,16 +552,16 @@ fn smart_filter_message(
     seconds: &i64,
     most_recent_message_server_time: Option<&DateTime<Utc>>,
 ) -> bool {
-    if most_recent_message_server_time.is_some() {
-        let duration_seconds = message
-            .server_time
-            .signed_duration_since(*most_recent_message_server_time.unwrap())
-            .num_seconds();
+    let Some(server_time) = most_recent_message_server_time else {
+        return true;
+    };
 
-        duration_seconds > *seconds
-    } else {
-        true
-    }
+    let duration_seconds = message
+        .server_time
+        .signed_duration_since(*server_time)
+        .num_seconds();
+
+    duration_seconds > *seconds
 }
 
 #[derive(Debug, Clone)]

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -450,17 +450,11 @@ impl Data {
                         Exclude::All => false,
                         Exclude::None => true,
                         Exclude::Smart(seconds) => {
-                            let nick = match source {
-                                message::source::Server::Join(nick) => nick,
-                                message::source::Server::Part(nick) => nick,
-                                message::source::Server::Quit(nick) => nick,
-                            };
-
-                            if nick.is_some() {
+                            if let Some(nick) = source.nick() {
                                 !smart_filter_message(
                                     message,
                                     &seconds,
-                                    most_recent_messages.get(&nick.to_owned().unwrap()),
+                                    most_recent_messages.get(nick),
                                 )
                             } else if let Some(nickname) =
                                 message.text.split(' ').collect::<Vec<_>>().get(1)

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -443,13 +443,19 @@ impl Data {
         let filtered = messages
             .iter()
             .filter(|message| match message.target.source() {
-                crate::message::Source::Server(Some(source)) => {
-                    let (source, nick) = server_messages.get(source);
+                message::Source::Server(Some(source)) => {
+                    let source_config = server_messages.get(source);
 
-                    match source.exclude {
+                    match source_config.exclude {
                         Exclude::All => false,
                         Exclude::None => true,
                         Exclude::Smart(seconds) => {
+                            let nick = match source {
+                               message::source::Server::Join(nick) => nick,
+                               message::source::Server::Part(nick) => nick,
+                               message::source::Server::Quit(nick) => nick,
+                            };
+
                             if nick.is_some() {
                                 !smart_filter_message(
                                     message,

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -443,10 +443,10 @@ impl Data {
         let filtered = messages
             .iter()
             .filter(|message| match message.target.source() {
-                crate::message::Source::Server(Some(message_source)) => {
-                    let (message_source, nick) = server_messages.get(message_source);
+                crate::message::Source::Server(Some(source)) => {
+                    let (source, nick) = server_messages.get(source);
 
-                    match message_source.exclude {
+                    match source.exclude {
                         Exclude::All => false,
                         Exclude::None => true,
                         Exclude::Smart(seconds) => {
@@ -455,6 +455,16 @@ impl Data {
                                     message,
                                     &seconds,
                                     most_recent_messages.get(&nick.to_owned().unwrap()),
+                                )
+                            } else if let Some(nickname) =
+                                message.text.split(' ').collect::<Vec<_>>().get(1)
+                            {
+                                let nick = Nick::from(*nickname);
+
+                                !smart_filter_message(
+                                    message,
+                                    &seconds,
+                                    most_recent_messages.get(&nick),
                                 )
                             } else {
                                 true

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -127,11 +127,15 @@ fn target(message: Encoded, our_nick: &Nick) -> Option<Target> {
         }),
         Command::PART(channel, _) => Some(Target::Channel {
             channel,
-            source: source::Source::Server(Some(source::Server::Part)),
+            source: source::Source::Server(Some(source::Server::Part(Some(
+                user?.nickname().to_owned(),
+            )))),
         }),
         Command::JOIN(channel, _) => Some(Target::Channel {
             channel,
-            source: source::Source::Server(Some(source::Server::Join)),
+            source: source::Source::Server(Some(source::Server::Join(Some(
+                user?.nickname().to_owned(),
+            )))),
         }),
         Command::Numeric(RPL_TOPIC | RPL_TOPICWHOTIME | RPL_CHANNELMODEIS, params) => {
             let channel = params.get(1)?.clone();

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -127,15 +127,17 @@ fn target(message: Encoded, our_nick: &Nick) -> Option<Target> {
         }),
         Command::PART(channel, _) => Some(Target::Channel {
             channel,
-            source: source::Source::Server(Some(source::Server::Part(Some(
-                user?.nickname().to_owned(),
-            )))),
+            source: source::Source::Server(Some(source::Server::new(
+                source::server::Kind::Part,
+                Some(user?.nickname().to_owned()),
+            ))),
         }),
         Command::JOIN(channel, _) => Some(Target::Channel {
             channel,
-            source: source::Source::Server(Some(source::Server::Join(Some(
-                user?.nickname().to_owned(),
-            )))),
+            source: source::Source::Server(Some(source::Server::new(
+                source::server::Kind::Join,
+                Some(user?.nickname().to_owned()),
+            ))),
         }),
         Command::Numeric(RPL_TOPIC | RPL_TOPICWHOTIME | RPL_CHANNELMODEIS, params) => {
             let channel = params.get(1)?.clone();

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -129,7 +129,10 @@ pub fn quit(
         channels,
         queries,
         false,
-        Cause::Server(Some(source::Server::Quit(Some(user.nickname().to_owned())))),
+        Cause::Server(Some(source::Server::new(
+            source::server::Kind::Quit,
+            Some(user.nickname().to_owned()),
+        ))),
         text,
     )
 }

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -129,7 +129,7 @@ pub fn quit(
         channels,
         queries,
         false,
-        Cause::Server(Some(source::Server::Quit)),
+        Cause::Server(Some(source::Server::Quit(Some(user.nickname().to_owned())))),
         text,
     )
 }

--- a/data/src/message/source.rs
+++ b/data/src/message/source.rs
@@ -28,29 +28,24 @@ impl<'de> Deserialize<'de> for Server {
         D: Deserializer<'de>,
     {
         #[derive(Debug, Deserialize)]
+        #[serde(rename_all = "lowercase")]
         enum Mapping {
-            #[serde(rename = "join")]
-            JoinWithoutNick,
-            #[serde(rename = "joinwithnick")]
-            Join(Option<Nick>),
-            #[serde(rename = "part")]
-            PartWithoutNick,
-            #[serde(rename = "partwithnick")]
-            Part(Option<Nick>),
-            #[serde(rename = "quit")]
-            QuitWithoutNick,
-            #[serde(rename = "quitwithnick")]
-            Quit(Option<Nick>),
+            Join,
+            JoinWithNick(Option<Nick>),
+            Part,
+            PartWithNick(Option<Nick>),
+            Quit,
+            QuitWithNick(Option<Nick>),
         }
 
         if let Ok(mapping) = Mapping::deserialize(deserializer) {
             match mapping {
-                Mapping::JoinWithoutNick => Ok(Server::Join(None)),
-                Mapping::Join(nick) => Ok(Server::Join(nick)),
-                Mapping::PartWithoutNick => Ok(Server::Part(None)),
-                Mapping::Part(nick) => Ok(Server::Part(nick)),
-                Mapping::QuitWithoutNick => Ok(Server::Quit(None)),
-                Mapping::Quit(nick) => Ok(Server::Quit(nick)),
+                Mapping::Join => Ok(Server::Join(None)),
+                Mapping::JoinWithNick(nick) => Ok(Server::Join(nick)),
+                Mapping::Part => Ok(Server::Part(None)),
+                Mapping::PartWithNick(nick) => Ok(Server::Part(nick)),
+                Mapping::Quit => Ok(Server::Quit(None)),
+                Mapping::QuitWithNick(nick) => Ok(Server::Quit(nick)),
             }
         } else {
             Err(D::Error::custom("could not map to Server enum"))

--- a/data/src/message/source.rs
+++ b/data/src/message/source.rs
@@ -13,10 +13,12 @@ pub enum Source {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
-#[serde(rename_all = "lowercase")]
 pub enum Server {
+    #[serde(rename = "joinwithnick")]
     Join(Option<Nick>),
+    #[serde(rename = "partwithnick")]
     Part(Option<Nick>),
+    #[serde(rename = "quitwithnick")]
     Quit(Option<Nick>),
 }
 
@@ -29,15 +31,15 @@ impl<'de> Deserialize<'de> for Server {
         enum Mapping {
             #[serde(rename = "join")]
             JoinWithoutNick,
-            #[serde(rename = "join")]
+            #[serde(rename = "joinwithnick")]
             Join(Option<Nick>),
             #[serde(rename = "part")]
             PartWithoutNick,
-            #[serde(rename = "part")]
+            #[serde(rename = "partwithnick")]
             Part(Option<Nick>),
             #[serde(rename = "quit")]
             QuitWithoutNick,
-            #[serde(rename = "quit")]
+            #[serde(rename = "quitwithnick")]
             Quit(Option<Nick>),
         }
 

--- a/data/src/message/source.rs
+++ b/data/src/message/source.rs
@@ -1,8 +1,8 @@
-use serde::de::Error;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 
-use crate::user::Nick;
 use crate::User;
+
+pub use self::server::Server;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Source {
@@ -10,47 +10,6 @@ pub enum Source {
     Server(Option<Server>),
     Action,
     Internal(Internal),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
-pub enum Server {
-    #[serde(rename = "joinwithnick")]
-    Join(Option<Nick>),
-    #[serde(rename = "partwithnick")]
-    Part(Option<Nick>),
-    #[serde(rename = "quitwithnick")]
-    Quit(Option<Nick>),
-}
-
-impl<'de> Deserialize<'de> for Server {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        #[derive(Debug, Deserialize)]
-        #[serde(rename_all = "lowercase")]
-        enum Mapping {
-            Join,
-            JoinWithNick(Option<Nick>),
-            Part,
-            PartWithNick(Option<Nick>),
-            Quit,
-            QuitWithNick(Option<Nick>),
-        }
-
-        if let Ok(mapping) = Mapping::deserialize(deserializer) {
-            match mapping {
-                Mapping::Join => Ok(Server::Join(None)),
-                Mapping::JoinWithNick(nick) => Ok(Server::Join(nick)),
-                Mapping::Part => Ok(Server::Part(None)),
-                Mapping::PartWithNick(nick) => Ok(Server::Part(nick)),
-                Mapping::Quit => Ok(Server::Quit(None)),
-                Mapping::QuitWithNick(nick) => Ok(Server::Quit(nick)),
-            }
-        } else {
-            Err(D::Error::custom("could not map to Server enum"))
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -62,4 +21,53 @@ pub enum Internal {
 pub enum Status {
     Success,
     Error,
+}
+
+pub mod server {
+    #![allow(deprecated)]
+    use serde::{Deserialize, Serialize};
+
+    use crate::user::Nick;
+
+    #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    #[serde(untagged)]
+    pub enum Server {
+        #[deprecated(note = "use Server::Details")]
+        Kind(Kind),
+        Details(Details),
+    }
+
+    impl Server {
+        pub fn new(kind: Kind, nick: Option<Nick>) -> Self {
+            Self::Details(Details { kind, nick })
+        }
+
+        pub fn kind(&self) -> Kind {
+            match self {
+                Server::Kind(kind) => *kind,
+                Server::Details(details) => details.kind,
+            }
+        }
+
+        pub fn nick(&self) -> Option<&Nick> {
+            match self {
+                Server::Kind(_) => None,
+                Server::Details(details) => details.nick.as_ref(),
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    #[serde(rename_all = "lowercase")]
+    pub enum Kind {
+        Join,
+        Part,
+        Quit,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    pub struct Details {
+        pub kind: Kind,
+        pub nick: Option<Nick>,
+    }
 }

--- a/data/src/message/source.rs
+++ b/data/src/message/source.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+use crate::user::Nick;
 use crate::User;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -10,12 +11,12 @@ pub enum Source {
     Internal(Internal),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Server {
-    Join,
-    Part,
-    Quit,
+    Join(Option<Nick>),
+    Part(Option<Nick>),
+    Quit(Option<Nick>),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/data/src/message/source.rs
+++ b/data/src/message/source.rs
@@ -1,4 +1,5 @@
-use serde::{Deserialize, Serialize};
+use serde::de::Error;
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::user::Nick;
 use crate::User;
@@ -11,12 +12,48 @@ pub enum Source {
     Internal(Internal),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Server {
     Join(Option<Nick>),
     Part(Option<Nick>),
     Quit(Option<Nick>),
+}
+
+impl<'de> Deserialize<'de> for Server {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Debug, Deserialize)]
+        enum Mapping {
+            #[serde(rename = "join")]
+            JoinWithoutNick,
+            #[serde(rename = "join")]
+            Join(Option<Nick>),
+            #[serde(rename = "part")]
+            PartWithoutNick,
+            #[serde(rename = "part")]
+            Part(Option<Nick>),
+            #[serde(rename = "quit")]
+            QuitWithoutNick,
+            #[serde(rename = "quit")]
+            Quit(Option<Nick>),
+        }
+
+        if let Ok(mapping) = Mapping::deserialize(deserializer) {
+            match mapping {
+                Mapping::JoinWithoutNick => Ok(Server::Join(None)),
+                Mapping::Join(nick) => Ok(Server::Join(nick)),
+                Mapping::PartWithoutNick => Ok(Server::Part(None)),
+                Mapping::Part(nick) => Ok(Server::Part(nick)),
+                Mapping::QuitWithoutNick => Ok(Server::Quit(None)),
+                Mapping::Quit(nick) => Ok(Server::Quit(nick)),
+            }
+        } else {
+            Err(D::Error::custom("could not map to Server enum"))
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]


### PR DESCRIPTION
This is an attempt to address issue #94, which works locally but may need improving.  In particular, I am concerned it will be brittle, since it relies on the formatting of the join/part/quit server messages.  But, I didn't see any other way to get the username for the server message without modifying the data structure of the server message.  If it would be preferable to modify the data structure of the server message, or if there's a better way to get the user nickname of a join/part/quit server message that I've missed, then I'd be happy to rework this implementation.

Serde was updated because I could not get it to recognize the seconds config for the smart filter otherwise.