### PR TITLE
fix: create configuration directory correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Fixed:
 
 - Accept '*' as a legal special symbol for usernames
 - Accept '/' in usernames, ensuring correct parsing for bouncers using the nick/server convention
+- Create the configuration directory correctly, if it does not exist yet.
 
 
 # 2023.5 (2023-11-12)

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -62,7 +62,7 @@ impl Config {
         let dir = environment::config_dir();
 
         if !dir.exists() {
-            std::fs::create_dir(dir.as_path())
+            std::fs::create_dir_all(dir.as_path())
                 .expect("expected permissions to create config folder");
         }
 
@@ -73,7 +73,7 @@ impl Config {
         let dir = Self::config_dir().join("themes");
 
         if !dir.exists() {
-            std::fs::create_dir(dir.as_path())
+            std::fs::create_dir_all(dir.as_path())
                 .expect("expected permissions to create themes folder");
         }
 


### PR DESCRIPTION
Correctly creates the configuration directory, if it does not exist yet.

This fixes the following confusing error:
```
thread 'main' panicked at data/src/config.rs:66:18:
expected permissions to create config folder: Os { code: 2, kind: NotFound, message: "No such fi}
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

```