### PR TITLE
Minor Username-Click → Input Tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Fixed:
 
 - Input not visible on Server and Query (DM) buffers
 
+Changed:
+- Improved user experience in text input when auto-completing a nickname.
+
 # 2024.1 (2024-02-07)
 
 Added:

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -89,7 +89,7 @@ pub struct Brackets {
 
 impl Brackets {
     pub fn format(&self, content: impl fmt::Display) -> String {
-        format!("{}{}{} ", self.left, content, self.right)
+        format!("{}{}{}", self.left, content, self.right)
     }
 }
 

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -77,9 +77,12 @@ impl Default for Buffer {
 impl Buffer {
     pub fn format_timestamp(&self, date_time: &DateTime<Utc>) -> Option<String> {
         self.timestamp.as_ref().map(|timestamp| {
-            timestamp
-                .brackets
-                .format(date_time.with_timezone(&Local).format(&timestamp.format))
+            format!(
+                "{} ",
+                timestamp
+                    .brackets
+                    .format(date_time.with_timezone(&Local).format(&timestamp.format))
+            )
         })
     }
 }

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -67,7 +67,7 @@ pub fn view<'a>(
                             }
                             _ => theme::Container::Default,
                         };
-                        let message = selectable_text(&message.text);
+                        let message = selectable_text(format!(" {}", message.text));
 
                         Some(
                             container(row![].push_maybe(timestamp).push(nick).push(message))

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -101,6 +101,8 @@ impl State {
     pub fn insert_user(&mut self, user: User) -> Command<Message> {
         if self.input.is_empty() {
             self.input = format!("{}: ", user.nickname());
+        } else if self.input.ends_with(' ') {
+            self.input = format!("{}{}", self.input, user.nickname());
         } else {
             self.input = format!("{} {}", self.input, user.nickname());
         }

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -53,7 +53,7 @@ pub fn view<'a>(
                         )
                         .map(scroll_view::Message::UserContext);
 
-                        let message = selectable_text(&message.text);
+                        let message = selectable_text(format!(" {}", message.text));
 
                         Some(
                             container(row![].push_maybe(timestamp).push(nick).push(message)).into(),


### PR DESCRIPTION
Two minor QoL changes to how clicking on a username adds the username to the input.  These are very minor and slightly related, so I'm grouping them together to hopefully be less busywork.

1.  Remove the space after the username from the click target.  (The only reason I noticed this is because that space is where I aim when starting a selection for an entire message.)

2.  If clicking on a username and there is already text in the input, then check whether the input ends in a space;  if it doesn't end in a space then insert a space followed by the username (current behavior), otherwise insert just the username (no space).