### PR TITLE
Correct transparency for colored nicks

### DIFF
--- a/data/src/theme.rs
+++ b/data/src/theme.rs
@@ -55,6 +55,10 @@ impl Colors {
             success: Subpalette::from_color(palette.success, palette),
         }
     }
+
+    pub fn is_dark_theme(&self) -> bool {
+        self.background.is_dark()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -50,6 +50,7 @@ pub fn view<'a>(
                             selectable_text(config.buffer.nickname.brackets.format(user)).style(
                                 theme::Text::Nickname(
                                     user.color_seed(&config.buffer.nickname.color),
+                                    false,
                                 ),
                             ),
                             user.clone(),
@@ -218,7 +219,7 @@ impl Channel {
 }
 
 mod nick_list {
-    use data::{User, Config};
+    use data::{Config, User};
     use iced::widget::{column, container, scrollable, text};
     use iced::Length;
     use user_context::Message;
@@ -227,20 +228,17 @@ mod nick_list {
     use crate::theme;
     use crate::widget::Element;
 
-    pub fn view<'a>(users: &[User], config: &'a Config) -> Element<'a,Message> {
+    pub fn view<'a>(users: &[User], config: &'a Config) -> Element<'a, Message> {
         let column = column(users.iter().map(|user| {
             let content = text(format!(
                 "{}{}",
                 user.highest_access_level(),
                 user.nickname()
             ))
-            .style(if user.is_away() {
-                theme::Text::Transparent
-            } else {
-                theme::Text::Nickname(
-                    user.color_seed(&config.buffer.channel.users.color)
-                )
-            });
+            .style(theme::Text::Nickname(
+                user.color_seed(&config.buffer.channel.users.color),
+                user.is_away(),
+            ));
 
             user_context::view(content, user.clone())
         }))

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -47,6 +47,7 @@ pub fn view<'a>(
                             selectable_text(config.buffer.nickname.brackets.format(user)).style(
                                 theme::Text::Nickname(
                                     user.color_seed(&config.buffer.nickname.color),
+                                    false,
                                 ),
                             ),
                             user.clone(),

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,5 +1,5 @@
 use data::message;
-use data::theme::{randomize_color, Colors};
+use data::theme::{alpha, randomize_color, Colors};
 use iced::widget::{button, container, pane_grid, rule, scrollable, text, text_input};
 use iced::{application, overlay, Background, Border, Color};
 
@@ -108,7 +108,7 @@ pub enum Text {
     Error,
     Transparent,
     Status(message::source::Status),
-    Nickname(Option<String>),
+    Nickname(Option<String>, bool),
 }
 
 impl text::StyleSheet for Theme {
@@ -132,11 +132,18 @@ impl text::StyleSheet for Theme {
             Text::Error => text::Appearance {
                 color: Some(self.colors().error.base),
             },
-            Text::Nickname(seed) => {
+            Text::Nickname(seed, transparent) => {
                 let original_color = self.colors().action.base;
-                let color = seed
+                let randomized_color = seed
                     .map(|seed| randomize_color(original_color, seed.as_str()))
                     .unwrap_or_else(|| original_color);
+
+                let color = if transparent {
+                    let dark_theme = self.colors().is_dark_theme();
+                    alpha(randomized_color, if dark_theme { 0.2 } else { 0.4 })
+                } else {
+                    randomized_color
+                };
 
                 text::Appearance { color: Some(color) }
             }
@@ -226,7 +233,7 @@ impl container::StyleSheet for Theme {
                 border: Border {
                     radius: 4.0.into(),
                     width: 1.0,
-                    color: if self.colors().background.is_dark() {
+                    color: if self.colors().is_dark_theme() {
                         self.colors().background.lighter
                     } else {
                         self.colors().background.darker
@@ -322,7 +329,7 @@ impl button::StyleSheet for Theme {
             Button::Pane { .. } => button::Appearance {
                 background: Some(Background::Color(self.colors().background.dark)),
                 border: Border {
-                    color: if self.colors().background.is_dark() {
+                    color: if self.colors().is_dark_theme() {
                         self.colors().background.lightest
                     } else {
                         self.colors().background.darkest
@@ -394,7 +401,7 @@ impl button::StyleSheet for Theme {
                 ..active
             },
             Button::Pane { .. } => button::Appearance {
-                background: Some(Background::Color(if self.colors().background.is_dark() {
+                background: Some(Background::Color(if self.colors().is_dark_theme() {
                     self.colors().background.light
                 } else {
                     self.colors().background.darker
@@ -654,7 +661,7 @@ impl overlay::menu::StyleSheet for Theme {
                 border: Border {
                     width: 1.0,
                     radius: 4.0.into(),
-                    color: if self.colors().background.is_dark() {
+                    color: if self.colors().is_dark_theme() {
                         self.colors().background.lighter
                     } else {
                         self.colors().background.darker


### PR DESCRIPTION
After https://github.com/squidowl/halloy/pull/232 it was hard to see if a username was away.
This is now fixed, while keeping the faded colors.

<img width="212" alt="Screenshot 2024-02-28 at 21 08 12" src="https://github.com/squidowl/halloy/assets/2248455/53e72f89-f0e8-4cfa-aaa1-e4ccf5307fda">
