### PR TITLE
Remove Message Wrapping Offset Introduced by PR #239

### DIFF
--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -68,12 +68,20 @@ pub fn view<'a>(
                             }
                             _ => theme::Container::Default,
                         };
-                        let message = selectable_text(format!(" {}", message.text));
+
+                        let space = selectable_text(" ");
+                        let message = selectable_text(&message.text);
 
                         Some(
-                            container(row![].push_maybe(timestamp).push(nick).push(message))
-                                .style(row_style)
-                                .into(),
+                            container(
+                                row![]
+                                    .push_maybe(timestamp)
+                                    .push(nick)
+                                    .push(space)
+                                    .push(message),
+                            )
+                            .style(row_style)
+                            .into(),
                         )
                     }
                     message::Source::Server(_) => {

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -54,10 +54,18 @@ pub fn view<'a>(
                         )
                         .map(scroll_view::Message::UserContext);
 
-                        let message = selectable_text(format!(" {}", message.text));
+                        let space = selectable_text(" ");
+                        let message = selectable_text(&message.text);
 
                         Some(
-                            container(row![].push_maybe(timestamp).push(nick).push(message)).into(),
+                            container(
+                                row![]
+                                    .push_maybe(timestamp)
+                                    .push(nick)
+                                    .push(space)
+                                    .push(message),
+                            )
+                            .into(),
                         )
                     }
                     message::Source::Server(_) => {


### PR DESCRIPTION
With the commits added in #239 I forgot to account for each `selectable_text` being used for text wrapping.  So when wrapping a message, the first line is indented by a space but none of the following lines are indented.  This PR removes the offset by moving the space between the username and message to its own `selectable_text`.  All the style changes are from `rustfmt`.