### PR TITLE
Fix float precision issue in double pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+Fix:
+
+- Context menus now shows buttons as expected
+
 Security:
 
 - `chrono` [RUSTSEC-2020-0071](https://rustsec.org/advisories/RUSTSEC-2020-0071)

--- a/src/buffer/user_context.rs
+++ b/src/buffer/user_context.rs
@@ -54,7 +54,6 @@ pub fn view<'a>(content: impl Into<Element<'a, Message>>, user: User) -> Element
 
         button(text(content).style(theme::Text::Primary))
             .width(length)
-            .height(length)
             .style(theme::Button::Context)
             .on_press(message)
             .into()

--- a/src/screen/dashboard/side_menu.rs
+++ b/src/screen/dashboard/side_menu.rs
@@ -240,7 +240,6 @@ fn buffer_button<'a>(
 
             button(text(content).style(theme::Text::Primary))
                 .width(length)
-                .height(length)
                 .style(theme::Button::Context)
                 .on_press(message)
                 .into()

--- a/src/widget/double_pass.rs
+++ b/src/widget/double_pass.rs
@@ -50,7 +50,14 @@ impl<'a, Message> Widget<Message, Theme, Renderer> for DoublePass<'a, Message> {
             limits,
         );
 
-        let new_limits = layout::Limits::new(Size::ZERO, layout.size());
+        let new_limits = layout::Limits::new(
+            Size::ZERO,
+            layout
+                .size()
+                // eliminate float precision issues if second pass
+                // is fill
+                .expand(Size::new(1.0, 1.0)),
+        );
 
         self.second_pass
             .as_widget()


### PR DESCRIPTION
If second pass is fill and we provide the fixed
size from the first pass, it's possible fill doesn't return the same layout within those limits due to
flex / float precision. Expanding the limits by 1
pixel appears to completely resolve this.