### PR TITLE
aligned topic and divider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Fix:
 - Context menus now shows buttons as expected
 - Buttons on help screen is now correctly sized
 
+Changed:
+
+- Various UI changes
+  - Ensured consistent padding in channel buffer 
+  - Unified styling for dividers
+
 Security:
 
 - `chrono` [RUSTSEC-2020-0071](https://rustsec.org/advisories/RUSTSEC-2020-0071)

--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -58,7 +58,7 @@ pub fn view<'a>(
             column![container(scrollable)].width(Length::Fill),
         ),
         vertical_space(4),
-        horizontal_rule(1).style(theme::Rule::Default)
+        container(horizontal_rule(1)).width(Length::Fill).padding([2, 12])
     ]
     .into()
 }

--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use data::user::Nick;
 use data::{Config, User};
-use iced::widget::{column, container, horizontal_rule, row, scrollable, vertical_space};
+use iced::widget::{column, container, horizontal_rule, row, scrollable};
 use iced::Length;
 
 use super::user_context;
@@ -57,8 +57,7 @@ pub fn view<'a>(
                 .padding(padding()),
             column![container(scrollable)].width(Length::Fill),
         ),
-        vertical_space(4),
-        container(horizontal_rule(1)).width(Length::Fill).padding([2, 12])
+        container(horizontal_rule(1)).width(Length::Fill).padding([8, 11])
     ]
     .into()
 }

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -84,12 +84,20 @@ pub fn view<'a>(
         let font_size = config.font.size.map(f32::from).unwrap_or(theme::TEXT_SIZE) - 1.0;
 
         let divider = row![
-            container(horizontal_rule(1)).width(Length::Fill).padding([0, 6, 0, 0]),
-            text("backlog").size(font_size).style(theme::Text::Transparent),
-            container(horizontal_rule(1)).width(Length::Fill).padding([0, 0, 0, 6])
-        ].padding(5).align_items(iced::Alignment::Center);
+            container(horizontal_rule(1))
+                .width(Length::Fill)
+                .padding([0, 6, 0, 0]),
+            text("backlog")
+                .size(font_size)
+                .style(theme::Text::Transparent),
+            container(horizontal_rule(1))
+                .width(Length::Fill)
+                .padding([0, 0, 0, 6])
+        ]
+        .padding(2)
+        .align_items(iced::Alignment::Center);
 
-        column![column(old), divider, column(new)]
+        column![column(old), container(divider), column(new)]
     } else {
         column![column(old), column(new)]
     };

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -2,7 +2,7 @@ use data::message::Limit;
 use data::server::Server;
 use data::user::Nick;
 use data::{history, time, Config};
-use iced::widget::{column, container, horizontal_rule, scrollable};
+use iced::widget::{column, container, horizontal_rule, row, scrollable, text};
 use iced::{Command, Length};
 
 use super::user_context;
@@ -81,9 +81,14 @@ pub fn view<'a>(
     let show_divider = !new.is_empty() || matches!(status, Status::Idle(Anchor::Bottom));
 
     let content = if show_divider {
-        let divider = container(horizontal_rule(1).style(theme::Rule::Unread))
-            .width(Length::Fill)
-            .padding(5);
+        let font_size = config.font.size.map(f32::from).unwrap_or(theme::TEXT_SIZE) - 1.0;
+
+        let divider = row![
+            container(horizontal_rule(1)).width(Length::Fill).padding([0, 6, 0, 0]),
+            text("backlog").size(font_size).style(theme::Text::Transparent),
+            container(horizontal_rule(1)).width(Length::Fill).padding([0, 0, 0, 6])
+        ].padding(5).align_items(iced::Alignment::Center);
+
         column![column(old), divider, column(new)]
     } else {
         column![column(old), column(new)]

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -71,8 +71,7 @@ impl application::StyleSheet for Theme {
 #[derive(Debug, Clone, Default)]
 pub enum Rule {
     #[default]
-    Default,
-    Unread,
+    Default
 }
 
 impl rule::StyleSheet for Theme {
@@ -85,13 +84,7 @@ impl rule::StyleSheet for Theme {
                 width: 1,
                 radius: 0.0.into(),
                 fill_mode: rule::FillMode::Full,
-            },
-            Rule::Unread => rule::Appearance {
-                color: self.colors().accent.base,
-                width: 1,
-                radius: 0.0.into(),
-                fill_mode: rule::FillMode::Full,
-            },
+            }
         }
     }
 }


### PR DESCRIPTION
Adjusted padding slightly of our dividers, and added "backlog" text to the backlog divider.

![image](https://github.com/squidowl/halloy/assets/2248455/441f4eb9-f3d6-4348-82c6-4d7574cd6435)
