### PR TITLE
Add "Drafts" to Input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Added:
 
 - Configuration option to enable a topic banner in channels. This can be enabled under `buffer.channel.topic`
-- Messages typed into the input will persist until sent.  Typed messages are saved when switching a pane to another buffer, then
+- Messages typed into the input will persist until sent. Typed messages are saved when switching a pane to another buffer, then
   are restored when that buffer is returned to.
 
 Fix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Added:
 
 - Configuration option to enable a topic banner in channels. This can be enabled under `buffer.channel.topic`
+- Messages typed into the input will persist until sent.  Typed messages are saved when switching a pane to another buffer, then
+  are restored when that buffer is returned to.
 
 Fix:
 

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -275,17 +275,32 @@ pub struct View<'a> {
 }
 
 #[derive(Debug, Clone, Default)]
-struct Input(HashMap<Buffer, Vec<String>>);
+struct Input {
+    sent: HashMap<Buffer, Vec<String>>,
+    draft: HashMap<Buffer, String>,
+}
 
 impl Input {
     fn get<'a>(&'a self, buffer: &Buffer) -> &'a [String] {
-        self.0.get(buffer).map(Vec::as_slice).unwrap_or_default()
+        self.sent.get(buffer).map(Vec::as_slice).unwrap_or_default()
     }
 
     fn push(&mut self, buffer: &Buffer, text: String) {
-        let history = self.0.entry(buffer.clone()).or_default();
+        self.draft.remove(buffer);
+        let history = self.sent.entry(buffer.clone()).or_default();
         history.insert(0, text);
         history.truncate(INPUT_HISTORY_LENGTH);
+    }
+
+    fn store_draft(&mut self, buffer: &Buffer, text: String) {
+        self.draft.insert(buffer.clone(), text);
+    }
+
+    fn load_draft<'a>(&'a self, buffer: &Buffer) -> &'a str {
+        self.draft
+            .get(buffer)
+            .map(|d| d.as_ref())
+            .unwrap_or_default()
     }
 }
 

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -9,6 +9,7 @@ use tokio::time::Instant;
 use crate::config;
 use crate::config::buffer::Exclude;
 use crate::history::{self, History};
+use crate::input::InputDraft;
 use crate::message::{self, Limit};
 use crate::time::Posix;
 use crate::user::{Nick, NickRef};
@@ -177,6 +178,12 @@ impl Manager {
         }
     }
 
+    pub fn record_input_draft(&mut self, input: InputDraft) {
+        self.data
+            .input
+            .store_draft(input.buffer(), input.text().to_string());
+    }
+
     pub fn record_message(&mut self, server: &Server, message: crate::Message) {
         self.data.add_message(
             server.clone(),
@@ -341,6 +348,10 @@ impl Manager {
 
     pub fn input_history<'a>(&'a self, buffer: &Buffer) -> &'a [String] {
         self.data.input.get(buffer)
+    }
+
+    pub fn input_draft<'a>(&'a self, buffer: &Buffer) -> &'a str {
+        self.data.input.load_draft(buffer)
     }
 }
 

--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -103,6 +103,26 @@ impl Input {
 }
 
 #[derive(Debug, Clone)]
+pub struct InputDraft {
+    buffer: Buffer,
+    text: String,
+}
+
+impl InputDraft {
+    pub fn new(buffer: Buffer, text: String) -> Self {
+        InputDraft { buffer, text }
+    }
+
+    pub fn buffer(&self) -> &Buffer {
+        &self.buffer
+    }
+
+    pub fn text(&self) -> &str {
+        self.text.as_ref()
+    }
+}
+
+#[derive(Debug, Clone)]
 enum Content {
     Text(String),
     Command(Command),

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -40,18 +40,6 @@ impl Buffer {
         Self::Empty
     }
 
-    pub fn with_draft(buffer: data::Buffer, history: &history::Manager) -> Self {
-        match buffer {
-            data::Buffer::Server(server) => Self::Server(Server::with_draft(server, history)),
-            data::Buffer::Channel(server, channel) => {
-                Self::Channel(Channel::with_draft(server, channel, history))
-            }
-            data::Buffer::Query(server, user) => {
-                Self::Query(Query::with_draft(server, user, history))
-            }
-        }
-    }
-
     pub fn data(&self) -> Option<data::Buffer> {
         match self {
             Buffer::Empty => None,
@@ -171,17 +159,25 @@ impl Buffer {
         }
     }
 
-    pub fn insert_user_to_input(&mut self, user: User) -> Command<Message> {
-        match self {
-            Buffer::Empty | Buffer::Server(_) => Command::none(),
-            Buffer::Channel(channel) => channel
-                .input_view
-                .insert_user(user)
-                .map(|message| Message::Channel(channel::Message::InputView(message))),
-            Buffer::Query(query) => query
-                .input_view
-                .insert_user(user)
-                .map(|message| Message::Query(query::Message::InputView(message))),
+    pub fn insert_user_to_input(
+        &mut self,
+        user: User,
+        history: &mut history::Manager,
+    ) -> Command<Message> {
+        if let Some(buffer) = self.data() {
+            match self {
+                Buffer::Empty | Buffer::Server(_) => Command::none(),
+                Buffer::Channel(channel) => channel
+                    .input_view
+                    .insert_user(user, buffer, history)
+                    .map(|message| Message::Channel(channel::Message::InputView(message))),
+                Buffer::Query(query) => query
+                    .input_view
+                    .insert_user(user, buffer, history)
+                    .map(|message| Message::Query(query::Message::InputView(message))),
+            }
+        } else {
+            Command::none()
         }
     }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -40,6 +40,18 @@ impl Buffer {
         Self::Empty
     }
 
+    pub fn with_draft(buffer: data::Buffer, history: &history::Manager) -> Self {
+        match buffer {
+            data::Buffer::Server(server) => Self::Server(Server::with_draft(server, history)),
+            data::Buffer::Channel(server, channel) => {
+                Self::Channel(Channel::with_draft(server, channel, history))
+            }
+            data::Buffer::Query(server, user) => {
+                Self::Query(Query::with_draft(server, user, history))
+            }
+        }
+    }
+
     pub fn data(&self) -> Option<data::Buffer> {
         match self {
             Buffer::Empty => None,

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -32,7 +32,7 @@ pub fn view<'a>(
     is_focused: bool,
 ) -> Element<'a, Message> {
     let buffer = state.buffer();
-    let input_history = history.input_history(&buffer);
+    let input = history.input(&buffer);
     let our_nick = clients.nickname(&state.server);
 
     let messages = container(
@@ -125,15 +125,19 @@ pub fn view<'a>(
     let topic = topic(state, clients, users, settings, config).unwrap_or_else(|| column![].into());
 
     let text_input = show_text_input.then(|| {
-        input_view::view(
-            &state.input_view,
-            buffer,
-            users,
-            channels,
-            input_history,
-            is_focused,
-        )
-        .map(Message::InputView)
+        column![
+            vertical_space(4),
+            input_view::view(
+                &state.input_view,
+                buffer,
+                input,
+                users,
+                channels,
+                is_focused
+            )
+            .map(Message::InputView)
+        ]
+        .width(Length::Fill)
     });
 
     let content = column![topic, messages].spacing(4);
@@ -178,14 +182,6 @@ impl Channel {
             scroll_view: scroll_view::State::new(),
             input_view: input_view::State::new(),
         }
-    }
-
-    pub fn with_draft(server: Server, channel: String, history: &history::Manager) -> Self {
-        let mut channel = Channel::new(server, channel);
-        channel
-            .input_view
-            .set(history.input_draft(&channel.buffer()));
-        channel
     }
 
     pub fn buffer(&self) -> data::Buffer {

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -126,7 +126,6 @@ pub fn view<'a>(
 
     let text_input = show_text_input.then(|| {
         column![
-            vertical_space(4),
             input_view::view(
                 &state.input_view,
                 buffer,

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -125,18 +125,15 @@ pub fn view<'a>(
     let topic = topic(state, clients, users, settings, config).unwrap_or_else(|| column![].into());
 
     let text_input = show_text_input.then(|| {
-        column![
-            input_view::view(
-                &state.input_view,
-                buffer,
-                input,
-                users,
-                channels,
-                is_focused
-            )
-            .map(Message::InputView)
-        ]
-        .width(Length::Fill)
+        input_view::view(
+            &state.input_view,
+            buffer,
+            input,
+            users,
+            channels,
+            is_focused
+        )
+        .map(Message::InputView)
     });
 
     let content = column![topic, messages].spacing(4);

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -180,6 +180,14 @@ impl Channel {
         }
     }
 
+    pub fn with_draft(server: Server, channel: String, history: &history::Manager) -> Self {
+        let mut channel = Channel::new(server, channel);
+        channel
+            .input_view
+            .set(history.input_draft(&channel.buffer()));
+        channel
+    }
+
     pub fn buffer(&self) -> data::Buffer {
         data::Buffer::Channel(self.server.clone(), self.channel.clone())
     }

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -1,3 +1,4 @@
+use data::input::InputDraft;
 use data::user::User;
 use data::{client, history, Buffer, Input};
 use iced::Command;
@@ -10,9 +11,9 @@ pub enum Event {
 
 #[derive(Debug, Clone)]
 pub enum Message {
-    Input(String),
+    Input(InputDraft),
     Send(Input),
-    Completion(String),
+    Completion(InputDraft),
 }
 
 pub fn view<'a>(
@@ -65,7 +66,9 @@ impl State {
     ) -> (Command<Message>, Option<Event>) {
         match message {
             Message::Input(input) => {
-                self.input = input;
+                self.input = input.text().to_string();
+
+                history.record_input_draft(input);
 
                 (Command::none(), None)
             }
@@ -83,7 +86,9 @@ impl State {
                 (Command::none(), Some(Event::InputSent))
             }
             Message::Completion(input) => {
-                self.input = input;
+                self.input = input.text().to_string();
+
+                history.record_input_draft(input);
 
                 (input::move_cursor_to_end(self.input_id.clone()), None)
             }
@@ -108,5 +113,9 @@ impl State {
         }
 
         input::move_cursor_to_end(self.input_id.clone())
+    }
+
+    pub fn set(&mut self, text: &str) {
+        self.input = text.to_string();
     }
 }

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -1,4 +1,4 @@
-use data::input::InputDraft;
+use data::input::{Cache, Draft};
 use data::user::User;
 use data::{client, history, Buffer, Input};
 use iced::Command;
@@ -11,26 +11,26 @@ pub enum Event {
 
 #[derive(Debug, Clone)]
 pub enum Message {
-    Input(InputDraft),
+    Input(Draft),
     Send(Input),
-    Completion(InputDraft),
+    Completion(Draft),
 }
 
 pub fn view<'a>(
     state: &'a State,
     buffer: Buffer,
+    cache: Cache<'a>,
     users: &'a [User],
     channels: &'a [String],
-    history: &'a [String],
     buffer_focused: bool,
 ) -> Element<'a, Message> {
     input(
         state.input_id.clone(),
         buffer,
-        &state.input,
+        cache.draft,
+        cache.history,
         users,
         channels,
-        history,
         buffer_focused,
         Message::Input,
         Message::Send,
@@ -41,7 +41,6 @@ pub fn view<'a>(
 #[derive(Debug, Clone)]
 pub struct State {
     input_id: input::Id,
-    input: String,
 }
 
 impl Default for State {
@@ -54,7 +53,6 @@ impl State {
     pub fn new() -> Self {
         Self {
             input_id: input::Id::unique(),
-            input: String::default(),
         }
     }
 
@@ -65,16 +63,12 @@ impl State {
         history: &mut history::Manager,
     ) -> (Command<Message>, Option<Event>) {
         match message {
-            Message::Input(input) => {
-                self.input = input.text().to_string();
-
-                history.record_input_draft(input);
+            Message::Input(draft) => {
+                history.record_draft(draft);
 
                 (Command::none(), None)
             }
             Message::Send(input) => {
-                self.input.clear();
-
                 if let Some(encoded) = input.encoded() {
                     clients.send(input.buffer(), encoded);
                 }
@@ -85,10 +79,8 @@ impl State {
 
                 (Command::none(), Some(Event::InputSent))
             }
-            Message::Completion(input) => {
-                self.input = input.text().to_string();
-
-                history.record_input_draft(input);
+            Message::Completion(draft) => {
+                history.record_draft(draft);
 
                 (input::move_cursor_to_end(self.input_id.clone()), None)
             }
@@ -103,19 +95,24 @@ impl State {
         input::reset(self.input_id.clone())
     }
 
-    pub fn insert_user(&mut self, user: User) -> Command<Message> {
-        if self.input.is_empty() {
-            self.input = format!("{}: ", user.nickname());
-        } else if self.input.ends_with(' ') {
-            self.input = format!("{}{}", self.input, user.nickname());
+    pub fn insert_user(
+        &mut self,
+        user: User,
+        buffer: Buffer,
+        history: &mut history::Manager,
+    ) -> Command<Message> {
+        let mut text = history.input(&buffer).draft.to_string();
+
+        if text.is_empty() {
+            text = format!("{}: ", user.nickname());
+        } else if text.ends_with(' ') {
+            text = format!("{}{}", text, user.nickname());
         } else {
-            self.input = format!("{} {}", self.input, user.nickname());
+            text = format!("{} {}", text, user.nickname());
         }
 
-        input::move_cursor_to_end(self.input_id.clone())
-    }
+        history.record_draft(Draft { buffer, text });
 
-    pub fn set(&mut self, text: &str) {
-        self.input = text.to_string();
+        input::move_cursor_to_end(self.input_id.clone())
     }
 }

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -27,7 +27,7 @@ pub fn view<'a>(
     is_focused: bool,
 ) -> Element<'a, Message> {
     let buffer = state.buffer();
-    let input_history = history.input_history(&buffer);
+    let input = history.input(&buffer);
 
     let messages = container(
         scroll_view::view(
@@ -101,15 +101,8 @@ pub fn view<'a>(
     let text_input = show_text_input.then(|| {
         column![
             vertical_space(4),
-            input_view::view(
-                &state.input_view,
-                buffer,
-                &[],
-                channels,
-                input_history,
-                is_focused
-            )
-            .map(Message::InputView)
+            input_view::view(&state.input_view, buffer, input, &[], channels, is_focused)
+                .map(Message::InputView)
         ]
         .width(Length::Fill)
     });
@@ -141,12 +134,6 @@ impl Query {
             scroll_view: scroll_view::State::new(),
             input_view: input_view::State::new(),
         }
-    }
-
-    pub fn with_draft(server: Server, nick: Nick, history: &history::Manager) -> Self {
-        let mut query = Query::new(server, nick);
-        query.input_view.set(history.input_draft(&query.buffer()));
-        query
     }
 
     pub fn buffer(&self) -> data::Buffer {

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -143,6 +143,12 @@ impl Query {
         }
     }
 
+    pub fn with_draft(server: Server, nick: Nick, history: &history::Manager) -> Self {
+        let mut query = Query::new(server, nick);
+        query.input_view.set(history.input_draft(&query.buffer()));
+        query
+    }
+
     pub fn buffer(&self) -> data::Buffer {
         data::Buffer::Query(self.server.clone(), self.nick.clone())
     }

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -93,7 +93,7 @@ pub fn view<'a>(
 pub struct Server {
     pub server: data::server::Server,
     pub scroll_view: scroll_view::State,
-    input_view: input_view::State,
+    pub input_view: input_view::State,
 }
 
 impl Server {
@@ -103,6 +103,12 @@ impl Server {
             scroll_view: scroll_view::State::new(),
             input_view: input_view::State::new(),
         }
+    }
+
+    pub fn with_draft(server: data::server::Server, history: &history::Manager) -> Self {
+        let mut server = Server::new(server);
+        server.input_view.set(history.input_draft(&server.buffer()));
+        server
     }
 
     pub fn buffer(&self) -> data::Buffer {

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -21,7 +21,7 @@ pub fn view<'a>(
     is_focused: bool,
 ) -> Element<'a, Message> {
     let buffer = state.buffer();
-    let input_history = history.input_history(&buffer);
+    let input = history.input(&buffer);
 
     let messages = container(
         scroll_view::view(
@@ -65,15 +65,8 @@ pub fn view<'a>(
     let text_input = show_text_input.then(|| {
         column![
             vertical_space(4),
-            input_view::view(
-                &state.input_view,
-                buffer,
-                &[],
-                channels,
-                input_history,
-                is_focused
-            )
-            .map(Message::InputView)
+            input_view::view(&state.input_view, buffer, input, &[], channels, is_focused)
+                .map(Message::InputView)
         ]
         .width(Length::Fill)
     });
@@ -103,12 +96,6 @@ impl Server {
             scroll_view: scroll_view::State::new(),
             input_view: input_view::State::new(),
         }
-    }
-
-    pub fn with_draft(server: data::server::Server, history: &history::Manager) -> Self {
-        let mut server = Server::new(server);
-        server.input_view.set(history.input_draft(&server.buffer()));
-        server
     }
 
     pub fn buffer(&self) -> data::Buffer {

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -428,7 +428,7 @@ impl Dashboard {
                         let all_buffers = all_buffers(clients, &self.history);
                         let open_buffers = open_buffers(self);
 
-                        if let Some((pane, state, history)) = self.get_focused_mut_with_history() {
+                        if let Some((pane, state, history)) = self.get_focused_with_history_mut() {
                             if let Some(buffer) = cycle_next_buffer(
                                 state.buffer.data().as_ref(),
                                 all_buffers,
@@ -444,7 +444,7 @@ impl Dashboard {
                         let all_buffers = all_buffers(clients, &self.history);
                         let open_buffers = open_buffers(self);
 
-                        if let Some((pane, state, history)) = self.get_focused_mut_with_history() {
+                        if let Some((pane, state, history)) = self.get_focused_with_history_mut() {
                             if let Some(buffer) = cycle_previous_buffer(
                                 state.buffer.data().as_ref(),
                                 all_buffers,
@@ -785,7 +785,7 @@ impl Dashboard {
         self.panes.get_mut(pane).map(|state| (pane, state))
     }
 
-    fn get_focused_mut_with_history(
+    fn get_focused_with_history_mut(
         &mut self,
     ) -> Option<(pane_grid::Pane, &mut Pane, &history::Manager)> {
         let pane = self.focus?;

--- a/src/widget/input.rs
+++ b/src/widget/input.rs
@@ -21,9 +21,9 @@ pub fn input<'a, Message>(
     channels: &'a [String],
     history: &'a [String],
     buffer_focused: bool,
-    on_input: impl Fn(String) -> Message + 'a,
+    on_input: impl Fn(data::input::InputDraft) -> Message + 'a,
     on_submit: impl Fn(data::Input) -> Message + 'a,
-    on_completion: impl Fn(String) -> Message + 'a,
+    on_completion: impl Fn(data::input::InputDraft) -> Message + 'a,
 ) -> Element<'a, Message>
 where
     Message: 'a + Clone,
@@ -66,9 +66,9 @@ pub struct Input<'a, Message> {
     channels: &'a [String],
     history: &'a [String],
     buffer_focused: bool,
-    on_input: Box<dyn Fn(String) -> Message + 'a>,
+    on_input: Box<dyn Fn(data::input::InputDraft) -> Message + 'a>,
     on_submit: Box<dyn Fn(data::Input) -> Message + 'a>,
-    on_completion: Box<dyn Fn(String) -> Message + 'a>,
+    on_completion: Box<dyn Fn(data::input::InputDraft) -> Message + 'a>,
 }
 
 #[derive(Default)]
@@ -95,7 +95,9 @@ where
 
                 state.completion.process(&input, self.users, self.channels);
 
-                Some((self.on_input)(input))
+                let input_draft = data::input::InputDraft::new(self.buffer.clone(), input);
+
+                Some((self.on_input)(input_draft))
             }
             Event::Send => {
                 // Reset error state
@@ -105,7 +107,10 @@ where
 
                 if let Some(entry) = state.completion.select() {
                     let new_input = entry.complete_input(self.input);
-                    Some((self.on_completion)(new_input))
+
+                    let input_draft = data::input::InputDraft::new(self.buffer.clone(), new_input);
+
+                    Some((self.on_completion)(input_draft))
                 } else if !self.input.is_empty() {
                     state.completion.reset();
 
@@ -126,7 +131,10 @@ where
             Event::Tab => {
                 if let Some(entry) = state.completion.tab() {
                     let new_input = entry.complete_input(self.input);
-                    Some((self.on_completion)(new_input))
+
+                    let input_draft = data::input::InputDraft::new(self.buffer.clone(), new_input);
+
+                    Some((self.on_completion)(input_draft))
                 } else {
                     None
                 }
@@ -150,7 +158,9 @@ where
                         .completion
                         .process(&new_input, self.users, self.channels);
 
-                    return Some((self.on_completion)(new_input));
+                    let input_draft = data::input::InputDraft::new(self.buffer.clone(), new_input);
+
+                    return Some((self.on_completion)(input_draft));
                 }
 
                 None
@@ -171,7 +181,9 @@ where
                         new_input
                     };
 
-                    return Some((self.on_completion)(new_input));
+                    let input_draft = data::input::InputDraft::new(self.buffer.clone(), new_input);
+
+                    return Some((self.on_completion)(input_draft));
                 }
 
                 None

--- a/src/widget/input.rs
+++ b/src/widget/input.rs
@@ -17,13 +17,13 @@ pub fn input<'a, Message>(
     id: Id,
     buffer: Buffer,
     input: &'a str,
+    history: &'a [String],
     users: &'a [User],
     channels: &'a [String],
-    history: &'a [String],
     buffer_focused: bool,
-    on_input: impl Fn(data::input::InputDraft) -> Message + 'a,
+    on_input: impl Fn(input::Draft) -> Message + 'a,
     on_submit: impl Fn(data::Input) -> Message + 'a,
-    on_completion: impl Fn(data::input::InputDraft) -> Message + 'a,
+    on_completion: impl Fn(input::Draft) -> Message + 'a,
 ) -> Element<'a, Message>
 where
     Message: 'a + Clone,
@@ -66,9 +66,9 @@ pub struct Input<'a, Message> {
     channels: &'a [String],
     history: &'a [String],
     buffer_focused: bool,
-    on_input: Box<dyn Fn(data::input::InputDraft) -> Message + 'a>,
+    on_input: Box<dyn Fn(data::input::Draft) -> Message + 'a>,
     on_submit: Box<dyn Fn(data::Input) -> Message + 'a>,
-    on_completion: Box<dyn Fn(data::input::InputDraft) -> Message + 'a>,
+    on_completion: Box<dyn Fn(data::input::Draft) -> Message + 'a>,
 }
 
 #[derive(Default)]
@@ -95,9 +95,10 @@ where
 
                 state.completion.process(&input, self.users, self.channels);
 
-                let input_draft = data::input::InputDraft::new(self.buffer.clone(), input);
-
-                Some((self.on_input)(input_draft))
+                Some((self.on_input)(input::Draft {
+                    buffer: self.buffer.clone(),
+                    text: input,
+                }))
             }
             Event::Send => {
                 // Reset error state
@@ -108,9 +109,10 @@ where
                 if let Some(entry) = state.completion.select() {
                     let new_input = entry.complete_input(self.input);
 
-                    let input_draft = data::input::InputDraft::new(self.buffer.clone(), new_input);
-
-                    Some((self.on_completion)(input_draft))
+                    Some((self.on_completion)(input::Draft {
+                        buffer: self.buffer.clone(),
+                        text: new_input,
+                    }))
                 } else if !self.input.is_empty() {
                     state.completion.reset();
 
@@ -132,9 +134,10 @@ where
                 if let Some(entry) = state.completion.tab() {
                     let new_input = entry.complete_input(self.input);
 
-                    let input_draft = data::input::InputDraft::new(self.buffer.clone(), new_input);
-
-                    Some((self.on_completion)(input_draft))
+                    Some((self.on_completion)(input::Draft {
+                        buffer: self.buffer.clone(),
+                        text: new_input,
+                    }))
                 } else {
                     None
                 }
@@ -158,9 +161,10 @@ where
                         .completion
                         .process(&new_input, self.users, self.channels);
 
-                    let input_draft = data::input::InputDraft::new(self.buffer.clone(), new_input);
-
-                    return Some((self.on_completion)(input_draft));
+                    return Some((self.on_completion)(input::Draft {
+                        buffer: self.buffer.clone(),
+                        text: new_input,
+                    }));
                 }
 
                 None
@@ -181,9 +185,10 @@ where
                         new_input
                     };
 
-                    let input_draft = data::input::InputDraft::new(self.buffer.clone(), new_input);
-
-                    return Some((self.on_completion)(input_draft));
+                    return Some((self.on_completion)(input::Draft {
+                        buffer: self.buffer.clone(),
+                        text: new_input,
+                    }));
                 }
 
                 None


### PR DESCRIPTION
This PR is to automatically store the contents of the input view, such that non-sent messages will persist when switching between channels/queries/servers.  I.e. if I type out a part of a message for a channel, switch to another channel to reference other messages, then when I switch back to the original channel the part of the message that I typed will be restored.  Previously, when switching channels the input is cleared and anything that has been typed is lost.