### PR TITLE
when channel doesnt exist we disable text input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Fix:
 - Context menus now shows buttons as expected
 - Buttons on help screen is now correctly sized
 - Text input is now disabled when not connected to a channel
+- When someone is kicked, it is now correctly shown
 
 Changed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Fix:
 
 - Context menus now shows buttons as expected
 - Buttons on help screen is now correctly sized
+- Text input is now disabled when not connected to a channel
 
 Changed:
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -536,6 +536,13 @@ impl Client {
                     channel.users.insert(user);
                 }
             }
+            Command::KICK(channel, victim, _) => {
+                if victim == self.nickname().as_ref() {
+                    self.chanmap.remove(channel);
+                } else if let Some(channel) = self.chanmap.get_mut(channel) {
+                    channel.users.remove(&User::from(Nick::from(victim.as_str())));
+                }
+            }
             Command::Numeric(RPL_WHOREPLY, args) => {
                 let target = args.get(1)?;
 

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -304,6 +304,20 @@ fn text(message: &Encoded, our_nick: &Nick, config: &Config) -> Option<String> {
                 )
             })
         }
+        Command::KICK(_, victim, comment) => {
+            let user = user?;
+            let comment = comment
+                .as_ref()
+                .map(|comment| format!(" ({comment})"))
+                .unwrap_or_default();
+            let target = if victim == our_nick.as_ref() {
+                "you have".to_string()
+            } else {
+                format!("{victim} has")
+            };
+
+            Some(format!("⟵ {target} been kicked by {user}{comment}"))
+        }
         Command::MODE(target, modes, args) if proto::is_channel(target) => {
             let user = user?;
             let modes = modes

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -94,11 +94,8 @@ impl Buffer {
         match self {
             Buffer::Empty => empty::view(),
             Buffer::Channel(state) => {
-                let status = clients.status(&state.server);
-
                 channel::view(
                     state,
-                    status,
                     clients,
                     history,
                     &settings.channel,
@@ -108,15 +105,11 @@ impl Buffer {
                 .map(Message::Channel)
             }
             Buffer::Server(state) => {
-                let status = clients.status(&state.server);
-
-                server::view(state, status, clients, history, config, is_focused)
+                server::view(state, clients, history, config, is_focused)
                     .map(Message::Server)
             }
             Buffer::Query(state) => {
-                let status = clients.status(&state.server);
-
-                query::view(state, status, clients, history, config, is_focused).map(Message::Query)
+                query::view(state, clients, history, config, is_focused).map(Message::Query)
             }
         }
     }

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -24,7 +24,6 @@ pub enum Event {
 
 pub fn view<'a>(
     state: &'a Channel,
-    status: client::Status,
     clients: &'a data::client::Map,
     history: &'a history::Manager,
     settings: &'a channel::Settings,
@@ -118,13 +117,17 @@ pub fn view<'a>(
     .width(Length::FillPortion(2))
     .height(Length::Fill);
 
+    let is_connected_to_channel = clients
+        .get_channels(&state.server)
+        .iter()
+        .any(|c| c == &state.channel);
     let users = clients.get_channel_users(&state.server, &state.channel);
     let channels = clients.get_channels(&state.server);
     let nick_list = nick_list::view(users, config).map(Message::UserContext);
 
     let show_text_input = match config.buffer.input_visibility {
-        data::buffer::InputVisibility::Focused => is_focused && status.connected(),
-        data::buffer::InputVisibility::Always => status.connected(),
+        data::buffer::InputVisibility::Focused => is_focused,
+        data::buffer::InputVisibility::Always => true,
     };
 
     // If topic toggles from None to Some then it messes with messages' scroll state,
@@ -138,7 +141,8 @@ pub fn view<'a>(
             input,
             users,
             channels,
-            is_focused
+            is_focused,
+            !is_connected_to_channel,
         )
         .map(Message::InputView)
     });

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -1,6 +1,6 @@
 use data::server::Server;
 use data::User;
-use data::{channel, client, history, message, Config};
+use data::{channel, history, message, Config};
 use iced::widget::{column, container, row};
 use iced::{Command, Length};
 

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -23,6 +23,7 @@ pub fn view<'a>(
     users: &'a [User],
     channels: &'a [String],
     buffer_focused: bool,
+    disabled: bool,
 ) -> Element<'a, Message> {
     input(
         state.input_id.clone(),
@@ -32,6 +33,7 @@ pub fn view<'a>(
         users,
         channels,
         buffer_focused,
+        disabled,
         Message::Input,
         Message::Send,
         Message::Completion,

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -1,5 +1,5 @@
 use data::user::Nick;
-use data::{client, history, message, Config, Server};
+use data::{history, message, Config, Server};
 use iced::widget::{column, container, row, vertical_space};
 use iced::{Command, Length};
 
@@ -20,12 +20,12 @@ pub enum Event {
 
 pub fn view<'a>(
     state: &'a Query,
-    status: client::Status,
     clients: &'a data::client::Map,
     history: &'a history::Manager,
     config: &'a Config,
     is_focused: bool,
 ) -> Element<'a, Message> {
+    let status = clients.status(&state.server);
     let buffer = state.buffer();
     let input = history.input(&buffer);
 
@@ -100,8 +100,8 @@ pub fn view<'a>(
     .height(Length::Fill);
 
     let show_text_input = match config.buffer.input_visibility {
-        data::buffer::InputVisibility::Focused => is_focused && status.connected(),
-        data::buffer::InputVisibility::Always => status.connected(),
+        data::buffer::InputVisibility::Focused => is_focused,
+        data::buffer::InputVisibility::Always => true,
     };
 
     let channels = clients.get_channels(&state.server);
@@ -109,8 +109,16 @@ pub fn view<'a>(
     let text_input = show_text_input.then(|| {
         column![
             vertical_space().height(4),
-            input_view::view(&state.input_view, buffer, input, &[], channels, is_focused)
-                .map(Message::InputView)
+            input_view::view(
+                &state.input_view,
+                buffer,
+                input,
+                &[],
+                channels,
+                is_focused,
+                !status.connected()
+            )
+            .map(Message::InputView)
         ]
         .width(Length::Fill)
     });

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -1,4 +1,4 @@
-use data::{client, history, message, Config};
+use data::{history, message, Config};
 use iced::widget::{column, container, row, vertical_space};
 use iced::{Command, Length};
 
@@ -14,12 +14,12 @@ pub enum Message {
 
 pub fn view<'a>(
     state: &'a Server,
-    status: client::Status,
     clients: &'a data::client::Map,
     history: &'a history::Manager,
     config: &'a Config,
     is_focused: bool,
 ) -> Element<'a, Message> {
+    let status = clients.status(&state.server);
     let buffer = state.buffer();
     let input = history.input(&buffer);
 
@@ -60,8 +60,8 @@ pub fn view<'a>(
     .height(Length::Fill);
 
     let show_text_input = match config.buffer.input_visibility {
-        data::buffer::InputVisibility::Focused => is_focused && status.connected(),
-        data::buffer::InputVisibility::Always => status.connected(),
+        data::buffer::InputVisibility::Focused => is_focused,
+        data::buffer::InputVisibility::Always => true,
     };
 
     let channels = clients.get_channels(&state.server);
@@ -69,8 +69,16 @@ pub fn view<'a>(
     let text_input = show_text_input.then(|| {
         column![
             vertical_space().height(4),
-            input_view::view(&state.input_view, buffer, input, &[], channels, is_focused)
-                .map(Message::InputView)
+            input_view::view(
+                &state.input_view,
+                buffer,
+                input,
+                &[],
+                channels,
+                is_focused,
+                !status.connected()
+            )
+            .map(Message::InputView)
         ]
         .width(Length::Fill)
     });

--- a/src/theme/text_input.rs
+++ b/src/theme/text_input.rs
@@ -20,7 +20,7 @@ pub fn primary(theme: &Theme, status: Status) -> Appearance {
             color: Color::TRANSPARENT,
             // XXX Not currently displayed in application.
         },
-        icon: theme.colors().info.base,
+        icon: theme.colors().text.base,
         placeholder: theme.colors().text.low_alpha,
         value: theme.colors().text.base,
         selection: theme.colors().accent.high_alpha,
@@ -29,9 +29,9 @@ pub fn primary(theme: &Theme, status: Status) -> Appearance {
     match status {
         Status::Active | Status::Hovered | Status::Focused => active,
         Status::Disabled => Appearance {
-            background: Background::Color(theme.colors().background.light),
+            background: Background::Color(theme.colors().background.low_alpha),
             border: Border {
-                radius: 0.0.into(),
+                radius: 4.0.into(),
                 width: 0.0,
                 color: Color::TRANSPARENT,
                 // XXX Not currently displayed in application.
@@ -47,9 +47,9 @@ pub fn error(theme: &Theme, status: Status) -> Appearance {
     match status {
         Status::Active | Status::Hovered | Status::Focused => Appearance {
             border: Border {
+                radius: 4.0.into(),
                 width: 1.0,
                 color: theme.colors().error.base,
-                ..Default::default()
             },
             ..primary
         },

--- a/src/widget/input.rs
+++ b/src/widget/input.rs
@@ -21,6 +21,7 @@ pub fn input<'a, Message>(
     users: &'a [User],
     channels: &'a [String],
     buffer_focused: bool,
+    disabled: bool,
     on_input: impl Fn(input::Draft) -> Message + 'a,
     on_submit: impl Fn(data::Input) -> Message + 'a,
     on_completion: impl Fn(input::Draft) -> Message + 'a,
@@ -36,6 +37,7 @@ where
         channels,
         history,
         buffer_focused,
+        disabled,
         on_input: Box::new(on_input),
         on_submit: Box::new(on_submit),
         on_completion: Box::new(on_completion),
@@ -66,6 +68,7 @@ pub struct Input<'a, Message> {
     channels: &'a [String],
     history: &'a [String],
     buffer_focused: bool,
+    disabled: bool,
     on_input: Box<dyn Fn(data::input::Draft) -> Message + 'a>,
     on_submit: Box<dyn Fn(data::Input) -> Message + 'a>,
     on_completion: Box<dyn Fn(data::input::Draft) -> Message + 'a>,
@@ -203,12 +206,15 @@ where
             theme::text_input::primary
         };
 
-        let text_input = text_input("Send message...", self.input)
-            .on_input(Event::Input)
+        let mut text_input = text_input("Send message...", self.input)
             .on_submit(Event::Send)
             .id(self.id.clone())
             .padding(8)
             .style(style);
+
+        if !self.disabled {
+            text_input = text_input.on_input(Event::Input);
+        }
 
         // Add tab support
         let mut input = key_press(
@@ -252,7 +258,7 @@ fn error<'a, Message: 'a>(error: impl ToString) -> Element<'a, Message> {
     container(text(error).style(theme::text::error))
         .center_y()
         .padding(8)
-        .style(theme::container::primary)
+        .style(theme::container::context)
         .into()
 }
 


### PR DESCRIPTION
We disable text_input rather than remove it if we are not connected.
This also fixes #161 where you would still be able to chat into the void if being kicked while offline.