### PR TITLE
fix: query messages now correctly show up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Fix:
 - Buttons on help screen is now correctly sized
 - Text input is now disabled when not connected to a channel
 - When someone is kicked, it is now correctly shown
+- Query messages sent by another client will now correctly be displayed
 
 Changed:
 

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -181,12 +181,16 @@ fn target(message: Encoded, our_nick: &Nick) -> Option<Target> {
                     source: source(user),
                 }),
                 (false, Some(user)) => {
-                    let target = User::try_from(target.as_str()).ok()?;
+                    let (nick, source) = if user.nickname() == *our_nick {
+                        // Message from ourself, from another client.
+                        let target = User::try_from(target.as_str()).ok()?;
+                        (target.nickname().to_owned(), source(user))
+                    } else {
+                        // Message from conversation partner.
+                        (user.nickname().to_owned(), source(user))
+                    };
 
-                    (target.nickname() == *our_nick).then(|| Target::Query {
-                        nick: user.nickname().to_owned(),
-                        source: source(user),
-                    })
+                    Some(Target::Query { nick, source })
                 }
                 _ => None,
             }


### PR DESCRIPTION
Fixes #213.

Issue was that we filtered out messages if they were sent by ourself from another client.