### PR TITLE
Fix/group joins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Fix:
 - Text input is now disabled when not connected to a channel
 - When someone is kicked, it is now correctly shown
 - Query messages sent by another client will now correctly be displayed
+- Prevent flooding server by grouping channels together in as few JOIN messages as possible
 
 Changed:
 


### PR DESCRIPTION
Example of how it's grouped. Channels w/ keys are grouped into a separate message(s) to preserve key association

```
    channels:
      - '#test'
      - "#halloy"
      - '##popeytest-01'
      - '##popeytest-02'
      - '##popeytest-03'
      - '##popeytest-04'
      - '##popeytest-05'
      - '##popeytest-06'
      - '##popeytest-07'
      - '##popeytest-08'
      - '##popeytest-09'
      - '##popeytest-10'
      - '##popeytest-11'
      - '##popeytest-12'
      - '##popeytest-13'
      - '##popeytest-14'
      - '##popeytest-15'
      - '##popeytest-16'
      - '##popeytest-17'
      - '##popeytest-18'
      - '##popeytest-19'
      - '##popeytest-20'
    channel_keys:
      '##popeytest-17': one
      '##popeytest-18': two
      '##popeytest-19': three
      '##popeytest-20': four


JOIN #test,#halloy,##popeytest-01,##popeytest-02,##popeytest-03,##popeytest-04,##popeytest-05,##popeytest-06,##popeytest-07,##popeytest-08,##popeyt
est-09,##popeytest-10,##popeytest-11,##popeytest-12,##popeytest-13,##popeytest-14,##popeytest-15,##popeytest-16

JOIN ##popeytest-17,##popeytest-18,##popeytest-19,##popeytest-20 one,two,three,four
```

I also tested with a much smaller byte limit than 512 to confirm it creates multiple messages instead of trying to send one