### PR TITLE
Add Send Time to Broadcast Messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Fixed:
 
 - Accept '@' in usernames to support bouncers that use the user@identifier/network convention
+- Prevent rare scenario where broadcast messages' timestamp would not match time the messages are received
 
 # 2024.5 (2024-03-21)
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -45,17 +45,20 @@ pub enum Broadcast {
         user: User,
         comment: Option<String>,
         channels: Vec<String>,
+        sent_time: DateTime<Utc>,
     },
     Nickname {
         old_user: User,
         new_nick: Nick,
         ourself: bool,
         channels: Vec<String>,
+        sent_time: DateTime<Utc>,
     },
     Invite {
         inviter: User,
         channel: String,
         user_channels: Vec<String>,
+        sent_time: DateTime<Utc>,
     },
 }
 
@@ -400,6 +403,7 @@ impl Client {
                     inviter,
                     channel: channel.clone(),
                     user_channels,
+                    sent_time: server_time(&message),
                 })]);
             }
             Command::NICK(nick) => {
@@ -425,6 +429,7 @@ impl Client {
                     new_nick,
                     ourself,
                     channels,
+                    sent_time: server_time(&message)
                 })]);
             }
             Command::Numeric(ERR_NICKNAMEINUSE | ERR_ERRONEUSNICKNAME, _)
@@ -505,6 +510,7 @@ impl Client {
                     user,
                     comment: comment.clone(),
                     channels,
+                    sent_time: server_time(&message)
                 })]);
             }
             Command::PART(channel, _) => {

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -267,7 +267,7 @@ impl Manager {
         server: &Server,
         broadcast: Broadcast,
         config: &Config,
-        sent_time: Option<DateTime<Utc>>,
+        sent_time: DateTime<Utc>,
     ) {
         let map = self.data.map.entry(server.clone()).or_default();
 
@@ -309,7 +309,7 @@ impl Manager {
             } => {
                 let user_query = queries.find(|nick| user.nickname() == *nick);
 
-                message::broadcast::quit(user_channels, user_query, &user, &comment, config)
+                message::broadcast::quit(user_channels, user_query, &user, &comment, config, sent_time)
             }
             Broadcast::Nickname {
                 old_nick,
@@ -325,6 +325,7 @@ impl Manager {
                         &old_nick,
                         &new_nick,
                         ourself,
+                        sent_time,
                     )
                 } else {
                     // Otherwise just the query channel of the user w/ nick change
@@ -335,6 +336,7 @@ impl Manager {
                         &old_nick,
                         &new_nick,
                         ourself,
+                        sent_time,
                     )
                 }
             }
@@ -342,7 +344,7 @@ impl Manager {
                 inviter,
                 channel,
                 user_channels,
-            } => message::broadcast::invite(inviter, channel, user_channels),
+            } => message::broadcast::invite(inviter, channel, user_channels, sent_time),
         };
 
         messages.into_iter().for_each(|message| {

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -17,12 +17,12 @@ fn expand(
     include_server: bool,
     cause: Cause,
     text: String,
-    sent_time: Option<DateTime<Utc>>,
+    sent_time: DateTime<Utc>,
 ) -> Vec<Message> {
     let message = |target, text| -> Message {
         Message {
             received_at: Posix::now(),
-            server_time: sent_time.unwrap_or(Utc::now()),
+            server_time: sent_time,
             direction: Direction::Received,
             target,
             text,
@@ -65,7 +65,7 @@ fn expand(
         .collect()
 }
 
-pub fn connecting(sent_time: Option<DateTime<Utc>>) -> Vec<Message> {
+pub fn connecting(sent_time: DateTime<Utc>) -> Vec<Message> {
     let text = " ∙ connecting to server...".into();
     expand(
         [],
@@ -77,7 +77,7 @@ pub fn connecting(sent_time: Option<DateTime<Utc>>) -> Vec<Message> {
     )
 }
 
-pub fn connected(sent_time: Option<DateTime<Utc>>) -> Vec<Message> {
+pub fn connected(sent_time: DateTime<Utc>) -> Vec<Message> {
     let text = " ∙ connected".into();
     expand(
         [],
@@ -89,7 +89,7 @@ pub fn connected(sent_time: Option<DateTime<Utc>>) -> Vec<Message> {
     )
 }
 
-pub fn connection_failed(error: String, sent_time: Option<DateTime<Utc>>) -> Vec<Message> {
+pub fn connection_failed(error: String, sent_time: DateTime<Utc>) -> Vec<Message> {
     let text = format!(" ∙ connection to server failed ({error})");
     expand(
         [],
@@ -105,7 +105,7 @@ pub fn disconnected(
     channels: impl IntoIterator<Item = String>,
     queries: impl IntoIterator<Item = Nick>,
     error: Option<String>,
-    sent_time: Option<DateTime<Utc>>,
+    sent_time: DateTime<Utc>,
 ) -> Vec<Message> {
     let error = error.map(|error| format!(" ({error})")).unwrap_or_default();
     let text = format!(" ∙ connection to server lost{error}");
@@ -122,7 +122,7 @@ pub fn disconnected(
 pub fn reconnected(
     channels: impl IntoIterator<Item = String>,
     queries: impl IntoIterator<Item = Nick>,
-    sent_time: Option<DateTime<Utc>>,
+    sent_time: DateTime<Utc>,
 ) -> Vec<Message> {
     let text = " ∙ connection to server restored".into();
     expand(
@@ -141,6 +141,7 @@ pub fn quit(
     user: &User,
     comment: &Option<String>,
     config: &Config,
+    sent_time: DateTime<Utc>,
 ) -> Vec<Message> {
     let comment = comment
         .as_ref()
@@ -160,7 +161,7 @@ pub fn quit(
             Some(user.nickname().to_owned()),
         ))),
         text,
-        None,
+        sent_time,
     )
 }
 
@@ -170,6 +171,7 @@ pub fn nickname(
     old_nick: &Nick,
     new_nick: &Nick,
     ourself: bool,
+    sent_time: DateTime<Utc>,
 ) -> Vec<Message> {
     let text = if ourself {
         format!(" ∙ You're now known as {new_nick}")
@@ -177,15 +179,16 @@ pub fn nickname(
         format!(" ∙ {old_nick} is now known as {new_nick}")
     };
 
-    expand(channels, queries, false, Cause::Server(None), text, None)
+    expand(channels, queries, false, Cause::Server(None), text, sent_time)
 }
 
 pub fn invite(
     inviter: Nick,
     channel: String,
     channels: impl IntoIterator<Item = String>,
+    sent_time: DateTime<Utc>,
 ) -> Vec<Message> {
     let text = format!(" ∙ {inviter} invited you to join {channel}");
 
-    expand(channels, [], false, Cause::Server(None), text, None)
+    expand(channels, [], false, Cause::Server(None), text, sent_time)
 }

--- a/data/src/stream.rs
+++ b/data/src/stream.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use std::time::Duration;
 
 use futures::channel::mpsc;
@@ -25,15 +26,18 @@ pub enum Update {
         server: Server,
         client: Client,
         is_initial: bool,
+        sent_time: DateTime<Utc>,
     },
     Disconnected {
         server: Server,
         is_initial: bool,
         error: Option<String>,
+        sent_time: DateTime<Utc>,
     },
     ConnectionFailed {
         server: Server,
         error: String,
+        sent_time: DateTime<Utc>,
     },
     MessagesReceived(Server, Vec<message::Encoded>),
 }
@@ -77,6 +81,7 @@ pub async fn run(server: server::Entry, mut sender: mpsc::Sender<Update>) -> Nev
             server: server.clone(),
             is_initial,
             error: None,
+            sent_time: Utc::now(),
         })
         .await;
 
@@ -100,6 +105,7 @@ pub async fn run(server: server::Entry, mut sender: mpsc::Sender<Update>) -> Nev
                                 server: server.clone(),
                                 client,
                                 is_initial,
+                                sent_time: Utc::now(),
                             })
                             .await;
 
@@ -125,6 +131,7 @@ pub async fn run(server: server::Entry, mut sender: mpsc::Sender<Update>) -> Nev
                             .send(Update::ConnectionFailed {
                                 server: server.clone(),
                                 error,
+                                sent_time: Utc::now(),
                             })
                             .await;
 
@@ -177,6 +184,7 @@ pub async fn run(server: server::Entry, mut sender: mpsc::Sender<Update>) -> Nev
                                     server: server.clone(),
                                     is_initial,
                                     error: Some(error),
+                                    sent_time: Utc::now(),
                                 })
                                 .await;
                             state = State::Disconnected {
@@ -197,6 +205,7 @@ pub async fn run(server: server::Entry, mut sender: mpsc::Sender<Update>) -> Nev
                                 server: server.clone(),
                                 is_initial,
                                 error: Some(e.to_string()),
+                                sent_time: Utc::now(),
                             })
                             .await;
                         state = State::Disconnected {
@@ -228,6 +237,7 @@ pub async fn run(server: server::Entry, mut sender: mpsc::Sender<Update>) -> Nev
                                 server: server.clone(),
                                 is_initial,
                                 error: Some("ping timeout".into()),
+                                sent_time: Utc::now(),
                             })
                             .await;
                         state = State::Disconnected {

--- a/src/main.rs
+++ b/src/main.rs
@@ -293,7 +293,7 @@ impl Application for Halloy {
 
                     if is_initial {
                         // Intial is sent when first trying to connect
-                        dashboard.broadcast_connecting(&server, &self.config, Some(sent_time));
+                        dashboard.broadcast_connecting(&server, &self.config, sent_time);
                     } else {
                         let notification = &self.config.notifications.disconnected;
 
@@ -305,7 +305,7 @@ impl Application for Halloy {
                             &server,
                             error,
                             &self.config,
-                            Some(sent_time),
+                            sent_time,
                         );
                     }
 
@@ -330,7 +330,7 @@ impl Application for Halloy {
                             notification::show("Connected", &server, notification.sound());
                         }
 
-                        dashboard.broadcast_connected(&server, &self.config, Some(sent_time));
+                        dashboard.broadcast_connected(&server, &self.config, sent_time);
                     } else {
                         let notification = &self.config.notifications.reconnected;
 
@@ -338,7 +338,7 @@ impl Application for Halloy {
                             notification::show("Reconnected", &server, notification.sound());
                         }
 
-                        dashboard.broadcast_reconnected(&server, &self.config, Some(sent_time));
+                        dashboard.broadcast_reconnected(&server, &self.config, sent_time);
                     }
 
                     Command::none()
@@ -356,7 +356,7 @@ impl Application for Halloy {
                         &server,
                         error,
                         &self.config,
-                        Some(sent_time),
+                        sent_time,
                     );
 
                     Command::none()
@@ -402,6 +402,7 @@ impl Application for Halloy {
                                         user,
                                         comment,
                                         channels,
+                                        sent_time,
                                     } => {
                                         dashboard.broadcast_quit(
                                             &server,
@@ -409,6 +410,7 @@ impl Application for Halloy {
                                             comment,
                                             channels,
                                             &self.config,
+                                            sent_time,
                                         );
                                     }
                                     data::client::Broadcast::Nickname {
@@ -416,6 +418,7 @@ impl Application for Halloy {
                                         new_nick,
                                         ourself,
                                         channels,
+                                        sent_time,
                                     } => {
                                         let old_nick = old_user.nickname();
 
@@ -426,12 +429,14 @@ impl Application for Halloy {
                                             ourself,
                                             channels,
                                             &self.config,
+                                            sent_time,
                                         );
                                     }
                                     data::client::Broadcast::Invite {
                                         inviter,
                                         channel,
                                         user_channels,
+                                        sent_time,
                                     } => {
                                         let inviter = inviter.nickname();
 
@@ -441,6 +446,7 @@ impl Application for Halloy {
                                             channel,
                                             user_channels,
                                             &self.config,
+                                            sent_time,
                                         );
                                     }
                                 },

--- a/src/main.rs
+++ b/src/main.rs
@@ -283,6 +283,7 @@ impl Application for Halloy {
                     server,
                     is_initial,
                     error,
+                    sent_time,
                 } => {
                     self.clients.disconnected(server.clone());
 
@@ -292,7 +293,7 @@ impl Application for Halloy {
 
                     if is_initial {
                         // Intial is sent when first trying to connect
-                        dashboard.broadcast_connecting(&server, &self.config);
+                        dashboard.broadcast_connecting(&server, &self.config, Some(sent_time));
                     } else {
                         let notification = &self.config.notifications.disconnected;
 
@@ -300,7 +301,12 @@ impl Application for Halloy {
                             notification::show("Disconnected", &server, notification.sound());
                         };
 
-                        dashboard.broadcast_disconnected(&server, error, &self.config);
+                        dashboard.broadcast_disconnected(
+                            &server,
+                            error,
+                            &self.config,
+                            Some(sent_time),
+                        );
                     }
 
                     Command::none()
@@ -309,6 +315,7 @@ impl Application for Halloy {
                     server,
                     client: connection,
                     is_initial,
+                    sent_time,
                 } => {
                     self.clients.ready(server.clone(), connection);
 
@@ -323,7 +330,7 @@ impl Application for Halloy {
                             notification::show("Connected", &server, notification.sound());
                         }
 
-                        dashboard.broadcast_connected(&server, &self.config);
+                        dashboard.broadcast_connected(&server, &self.config, Some(sent_time));
                     } else {
                         let notification = &self.config.notifications.reconnected;
 
@@ -331,17 +338,26 @@ impl Application for Halloy {
                             notification::show("Reconnected", &server, notification.sound());
                         }
 
-                        dashboard.broadcast_reconnected(&server, &self.config);
+                        dashboard.broadcast_reconnected(&server, &self.config, Some(sent_time));
                     }
 
                     Command::none()
                 }
-                stream::Update::ConnectionFailed { server, error } => {
+                stream::Update::ConnectionFailed {
+                    server,
+                    error,
+                    sent_time,
+                } => {
                     let Screen::Dashboard(dashboard) = &mut self.screen else {
                         return Command::none();
                     };
 
-                    dashboard.broadcast_connection_failed(&server, error, &self.config);
+                    dashboard.broadcast_connection_failed(
+                        &server,
+                        error,
+                        &self.config,
+                        Some(sent_time),
+                    );
 
                     Command::none()
                 }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -2,6 +2,7 @@ mod command_bar;
 pub mod pane;
 pub mod sidebar;
 
+use chrono::{DateTime, Utc};
 use std::time::{Duration, Instant};
 
 use data::history::manager::Broadcast;
@@ -744,6 +745,7 @@ impl Dashboard {
                 user_channels,
             },
             config,
+            None,
         );
     }
 
@@ -765,6 +767,7 @@ impl Dashboard {
                 user_channels,
             },
             config,
+            None,
         );
     }
 
@@ -784,16 +787,28 @@ impl Dashboard {
                 user_channels,
             },
             config,
+            None,
         );
     }
 
-    pub fn broadcast_connecting(&mut self, server: &Server, config: &Config) {
+    pub fn broadcast_connecting(
+        &mut self,
+        server: &Server,
+        config: &Config,
+        sent_time: Option<DateTime<Utc>>,
+    ) {
         self.history
-            .broadcast(server, Broadcast::Connecting, config);
+            .broadcast(server, Broadcast::Connecting, config, sent_time);
     }
 
-    pub fn broadcast_connected(&mut self, server: &Server, config: &Config) {
-        self.history.broadcast(server, Broadcast::Connected, config);
+    pub fn broadcast_connected(
+        &mut self,
+        server: &Server,
+        config: &Config,
+        sent_time: Option<DateTime<Utc>>,
+    ) {
+        self.history
+            .broadcast(server, Broadcast::Connected, config, sent_time);
     }
 
     pub fn broadcast_disconnected(
@@ -801,19 +816,35 @@ impl Dashboard {
         server: &Server,
         error: Option<String>,
         config: &Config,
+        sent_time: Option<DateTime<Utc>>,
     ) {
         self.history
-            .broadcast(server, Broadcast::Disconnected { error }, config);
+            .broadcast(server, Broadcast::Disconnected { error }, config, sent_time);
     }
 
-    pub fn broadcast_reconnected(&mut self, server: &Server, config: &Config) {
+    pub fn broadcast_reconnected(
+        &mut self,
+        server: &Server,
+        config: &Config,
+        sent_time: Option<DateTime<Utc>>,
+    ) {
         self.history
-            .broadcast(server, Broadcast::Reconnected, config);
+            .broadcast(server, Broadcast::Reconnected, config, sent_time);
     }
 
-    pub fn broadcast_connection_failed(&mut self, server: &Server, error: String, config: &Config) {
-        self.history
-            .broadcast(server, Broadcast::ConnectionFailed { error }, config);
+    pub fn broadcast_connection_failed(
+        &mut self,
+        server: &Server,
+        error: String,
+        config: &Config,
+        sent_time: Option<DateTime<Utc>>,
+    ) {
+        self.history.broadcast(
+            server,
+            Broadcast::ConnectionFailed { error },
+            config,
+            sent_time,
+        );
     }
 
     fn get_focused_mut(&mut self) -> Option<(pane_grid::Pane, &mut Pane)> {

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -736,6 +736,7 @@ impl Dashboard {
         comment: Option<String>,
         user_channels: Vec<String>,
         config: &Config,
+        sent_time: DateTime<Utc>,
     ) {
         self.history.broadcast(
             server,
@@ -745,7 +746,7 @@ impl Dashboard {
                 user_channels,
             },
             config,
-            None,
+            sent_time,
         );
     }
 
@@ -757,6 +758,7 @@ impl Dashboard {
         ourself: bool,
         user_channels: Vec<String>,
         config: &Config,
+        sent_time: DateTime<Utc>,
     ) {
         self.history.broadcast(
             server,
@@ -767,7 +769,7 @@ impl Dashboard {
                 user_channels,
             },
             config,
-            None,
+            sent_time,
         );
     }
 
@@ -778,6 +780,7 @@ impl Dashboard {
         channel: String,
         user_channels: Vec<String>,
         config: &Config,
+        sent_time: DateTime<Utc>,
     ) {
         self.history.broadcast(
             server,
@@ -787,7 +790,7 @@ impl Dashboard {
                 user_channels,
             },
             config,
-            None,
+            sent_time,
         );
     }
 
@@ -795,7 +798,7 @@ impl Dashboard {
         &mut self,
         server: &Server,
         config: &Config,
-        sent_time: Option<DateTime<Utc>>,
+        sent_time: DateTime<Utc>,
     ) {
         self.history
             .broadcast(server, Broadcast::Connecting, config, sent_time);
@@ -805,7 +808,7 @@ impl Dashboard {
         &mut self,
         server: &Server,
         config: &Config,
-        sent_time: Option<DateTime<Utc>>,
+        sent_time: DateTime<Utc>,
     ) {
         self.history
             .broadcast(server, Broadcast::Connected, config, sent_time);
@@ -816,7 +819,7 @@ impl Dashboard {
         server: &Server,
         error: Option<String>,
         config: &Config,
-        sent_time: Option<DateTime<Utc>>,
+        sent_time: DateTime<Utc>,
     ) {
         self.history
             .broadcast(server, Broadcast::Disconnected { error }, config, sent_time);
@@ -826,7 +829,7 @@ impl Dashboard {
         &mut self,
         server: &Server,
         config: &Config,
-        sent_time: Option<DateTime<Utc>>,
+        sent_time: DateTime<Utc>,
     ) {
         self.history
             .broadcast(server, Broadcast::Reconnected, config, sent_time);
@@ -837,7 +840,7 @@ impl Dashboard {
         server: &Server,
         error: String,
         config: &Config,
-        sent_time: Option<DateTime<Utc>>,
+        sent_time: DateTime<Utc>,
     ) {
         self.history.broadcast(
             server,


### PR DESCRIPTION
This is an attempt to address the Halloy side of #226 by adding a `sent_time` to those broadcast messages.  Other broadcast messages I expect will not have such long times between send and receive, so I have not added `sent_time` to those messages, instead it defaults to `Utc::now()` at receive time (previous behavior).