### PR TITLE
User Context Tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Changed:
     - `enabled = bool`
     - `smart = number`
 - Use primary text color instead of accent color for `Solid` nicknames
+- Op and Voice context menu items hidden in channels where the user is not an Op
 
 # 2024.4 (2024-03-15)
 

--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -15,6 +15,7 @@ pub fn view<'a>(
     max_lines: u16,
     users: &'a [User],
     buffer: &Buffer,
+    our_user: Option<&'a User>,
     config: &'a Config,
 ) -> Element<'a, user_context::Message> {
     let set_by = who.and_then(|who| {
@@ -31,6 +32,7 @@ pub fn view<'a>(
                 }),
                 user,
                 buffer.clone(),
+                our_user,
             )
         } else {
             selectable_text(who)

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -58,6 +58,7 @@ pub fn view<'a>(
                             ),
                             user,
                             state.buffer(),
+                            None,
                         )
                         .map(scroll_view::Message::UserContext);
 


### PR DESCRIPTION
Two minor tweaks related to the new user context functionality:

1.  Only show the operator actions when the user is an operator.  
2.  The context menu for usernames in the history view would always show the user with default access levels.  As far as I can tell, that's because the user from `message::Source::User(user)` is being constructed from proto::User, which always has the default access levels.  I didn't see a simple way to add the user lookup to `message::Source::User` construction, so I added it to the channel view.

I can split these up if one is desirable and the other is not.