### PR TITLE
Accept ZNC Client Identifier Format Usernames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+Fixed:
+
+- Accept '@' in usernames to support bouncers that use the user@identifier/network convention
+
 # 2024.5 (2024-03-21)
 
 **BREAKING** Configuration file format has switched from `YAML` to `TOML`. Please vist the migration guide here: [halloy.squidowl.org/guides/migrating-from-yaml](https://halloy.squidowl.org/guides/migrating-from-yaml.html).

--- a/irc/proto/src/parse.rs
+++ b/irc/proto/src/parse.rs
@@ -168,6 +168,7 @@ mod test {
     fn user() {
         let tests = [
             "dan!d@localhost",
+            "dan@id/network!d@remote.host",
             "test!test@5555:5555:0:55:5555:5555:5555:5555",
             "[asdf]!~asdf@user/asdf/x-5555555",
         ];
@@ -190,6 +191,14 @@ mod test {
                     nickname: "dan".into(),
                     username: Some("d".into()),
                     hostname: Some("localhost".into()),
+                }),
+            ),
+            (
+                ":dan@id/network!d@remote.host ",
+                Source::User(User {
+                    nickname: "dan@id/network".into(),
+                    username: Some("d".into()),
+                    hostname: Some("remote.host".into()),
                 }),
             ),
             (

--- a/irc/proto/src/parse.rs
+++ b/irc/proto/src/parse.rs
@@ -126,8 +126,8 @@ fn space(input: &str) -> IResult<&str, ()> {
 fn user(input: &str) -> IResult<&str, User> {
     // <sequence of any characters except NUL, CR, LF, and SPACE> and @
     let username = recognize(many1_count(none_of("\0\r\n @")));
-    // "-", "[", "]", "\", "`", "_", "^", "{", "|", "}", "*", "/"
-    let special = one_of("-[]\\`_^{|}*/");
+    // "-", "[", "]", "\", "`", "_", "^", "{", "|", "}", "*", "/", "@"
+    let special = one_of("-[]\\`_^{|}*/@");
     // *( <letter> | <number> | <special> )
     let nickname = recognize(many1_count(alt((
         satisfy(|c| c.is_ascii_alphanumeric()),


### PR DESCRIPTION
ZNC allows usernames of the format `username@identifier/network` where the identifier tells ZNC which client is accessing the bouncer.  From what I can tell adding `@` to the list of special characters accepted for nicknames seems to make that format work with Halloy, with the expected `!` for the username protecting us from accidentally adding the hostname to the nickname.