### PR TITLE
fix typo in installation docs

### DIFF
--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -23,7 +23,7 @@ Download pre-built binaries from [GitHub](https://github.com/squidowl/halloy/rel
 
 ### macOS
 
-The following third party repositories are available for Linux
+The following third party repositories are available for macOS
 
 #### MacPorts
 


### PR DESCRIPTION
Noticed this typo, here that I assume is just a copy and paste issue.