### PR TITLE
Choose IDENTIFY Syntax Based on Resolved Nick or Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ Added:
 - Sidebar menu buttons (see [sidebar configuration](https://halloy.squidowl.org/configuration/sidebar.html#sidebarbuttons-section)).
 - Display current version, and latest remote version in command bar
 - Allow reading passwords from files in server configuration.
+- Allow configuration to specify a server's NickServ IDENTIFY command syntax.
 
 Fixed:
 
 - Accept '@' in usernames to support bouncers that use the user@identifier/network convention
 - Prevent rare scenario where broadcast messages' timestamp would not match time the messages are received
-- Handle a greater diversity of IDENTIFY syntaxes (and avoid having to determine the syntax when possible)
 
 Changed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Fixed:
 
 - Accept '@' in usernames to support bouncers that use the user@identifier/network convention
 - Prevent rare scenario where broadcast messages' timestamp would not match time the messages are received
+- Handle a greater diversity of IDENTIFY syntaxes (and avoid having to determine the syntax when possible)
 
 Changed:
 

--- a/book/src/configuration/servers.md
+++ b/book/src/configuration/servers.md
@@ -16,6 +16,7 @@ channels = ["#halloy"]
 | `nickname`                         | The client's nickname.                                                                              | `""`        |
 | `nick_password`                    | The client's NICKSERV password.                                                                     | `""`        |
 | `nick_password_file`               | Alternatively read `nick_password` from the file at the given path.                                 | `""`        |
+| `nick_identify_syntax`             | The server's NICKSERV IDENTIFY syntax. Can be `"nick-then-password"` or `"password-then-nick"`.     | `""`        |
 | `alt_nicks`                        | Alternative nicknames for the client, if the default is taken.                                      | `[""]`      |
 | `username`                         | The client's username.                                                                              | `""`        |
 | `realname`                         | The client's real name.                                                                             | `""`        |

--- a/book/src/configuration/servers.md
+++ b/book/src/configuration/servers.md
@@ -16,7 +16,7 @@ channels = ["#halloy"]
 | `nickname`                         | The client's nickname.                                                                              | `""`        |
 | `nick_password`                    | The client's NICKSERV password.                                                                     | `""`        |
 | `nick_password_file`               | Alternatively read `nick_password` from the file at the given path.                                 | `""`        |
-| `nick_identify_syntax`             | The server's NICKSERV IDENTIFY syntax. Can be `"nick-then-password"` or `"password-then-nick"`.     | `""`        |
+| `nick_identify_syntax`             | The server's NICKSERV IDENTIFY syntax. Can be `"nick-password"` or `"password-nick"`.               | `""`        |
 | `alt_nicks`                        | Alternative nicknames for the client, if the default is taken.                                      | `[""]`      |
 | `username`                         | The client's username.                                                                              | `""`        |
 | `realname`                         | The client's real name.                                                                             | `""`        |

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -489,11 +489,49 @@ impl Client {
                         }
                     }
 
-                    let _ = self.handle.try_send(command!(
-                        "PRIVMSG",
-                        "NickServ",
-                        format!("IDENTIFY {} {nick_pass}", &self.config.nickname)
-                    ));
+                    let _ = if self.resolved_nick == Some(self.config.nickname.clone()) {
+                        // Use nickname-less identification if possible, since it has
+                        // no possible argument order issues.
+                        self.sender.try_send(command!(
+                            "PRIVMSG",
+                            "NickServ",
+                            format!("IDENTIFY {nick_pass}")
+                        ))
+                    } else {
+                        match self.config.server.as_ref() {
+                            "irc.oftc.net" | "irc4.oftc.net" => {
+                                // Servers known to have `IDENTIFY nickname password` syntax
+                                self.sender.try_send(command!(
+                                    "PRIVMSG",
+                                    "NickServ",
+                                    format!("IDENTIFY {nick_pass} {}", &self.config.nickname)
+                                ))
+                            }
+                            "chat.freednode.net"
+                            | "irc.libera.chat"
+                            | "irc.eu.libera.chat"
+                            | "irc.us.libera.chat"
+                            | "irc.au.libera.chat"
+                            | "irc.ea.libera.chat"
+                            | "irc.ipv4.libera.chat"
+                            | "irc.ipv6.libera.chat" => {
+                                // Servers known to have `IDENTIFY password nickname` syntax
+                                self.sender.try_send(command!(
+                                    "PRIVMSG",
+                                    "NickServ",
+                                    format!("IDENTIFY {} {nick_pass}", &self.config.nickname)
+                                ))
+                            }
+                            _ => {
+                                // Default to most common syntax if unknown
+                                self.sender.try_send(command!(
+                                    "PRIVMSG",
+                                    "NickServ",
+                                    format!("IDENTIFY {} {nick_pass}", &self.config.nickname)
+                                ))
+                            }
+                        }
+                    };
                 }
 
                 // Send user modestring

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -491,14 +491,14 @@ impl Client {
 
                     let _ = if let Some(identify_syntax) = &self.config.nick_identify_syntax {
                         match identify_syntax {
-                            config::server::IdentifySyntax::PasswordThenNick => {
+                            config::server::IdentifySyntax::PasswordNick => {
                                 self.handle.try_send(command!(
                                     "PRIVMSG",
                                     "NickServ",
                                     format!("IDENTIFY {nick_pass} {}", &self.config.nickname)
                                 ))
                             }
-                            config::server::IdentifySyntax::NickThenPassword => {
+                            config::server::IdentifySyntax::NickPassword => {
                                 self.handle.try_send(command!(
                                     "PRIVMSG",
                                     "NickServ",

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -13,6 +13,8 @@ pub struct Server {
     pub nick_password: Option<String>,
     /// The client's NICKSERV password file.
     pub nick_password_file: Option<String>,
+    /// The server's NICKSERV IDENTIFY syntax.
+    pub nick_identify_syntax: Option<IdentifySyntax>,
     /// Alternative nicknames for the client, if the default is taken.
     #[serde(default)]
     pub alt_nicks: Vec<String>,
@@ -103,6 +105,13 @@ impl Server {
             security,
         }
     }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum IdentifySyntax {
+    NickThenPassword,
+    PasswordThenNick,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -110,8 +110,8 @@ impl Server {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum IdentifySyntax {
-    NickThenPassword,
-    PasswordThenNick,
+    NickPassword,
+    PasswordNick,
 }
 
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
This is to address #296.  As far as I was able to find, there doesn't seem to be an official standard for NickServ.  From a quick search, the more common syntax seems to be `IDENTIFY nickname password` (Atheme, Anope, Libera, Freenode), while OFTC uses `IDENTIFY password nickname`.  All servers (that I found) accept the `IDENTIFY password` syntax when identifying as the current nickname.

So, the added logic aims to use `IDENTIFY password` whenever possible, then uses the syntax for servers that are known, then finally defaults to the more common `IDENTIFY nickname password` syntax.