### PR TITLE
Font Fallback for Left Arrow in Empty Buffer Text

### DIFF
--- a/src/buffer/empty.rs
+++ b/src/buffer/empty.rs
@@ -7,7 +7,7 @@ pub fn view<'a, Message: 'a>() -> Element<'a, Message> {
     // TODO: Consider if we can completetly remove this buffer.
 
     let content = column![]
-        .push(text("⟵ select buffer"))
+        .push(text("⟵ select buffer").shaping(text::Shaping::Advanced))
         .align_items(iced::Alignment::Center);
 
     container(content)


### PR DESCRIPTION
When using a font without U+27F5 a missing-glyph character appears in the "⟵ select buffer" text that is shown when no buffer is selected.  This minor change is to add advanced text shaping to that text to enable font fallback.

Edit: Didn't think this was worth a changelog entry, so not adding one was on purpose this time :sweat_smile:.