### PR TITLE
Option to configure display of server status success & errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- Allow configuration of internal messages in buffer (see [buffer configuration](https://halloy.squidowl.org/configuration/buffer.html#bufferinternal_messages-section))
 
 # 2024.6 (2024-04-05)
 

--- a/book/src/configuration/buffer.md
+++ b/book/src/configuration/buffer.md
@@ -2,7 +2,7 @@
 
 ## `[buffer]` Section
 
-## `[buffer.nickname]` Section 
+## `[buffer.nickname]` Section
 
 ```toml
 [buffer.nickname]
@@ -15,7 +15,6 @@ brackets = { left = "<string>", right = "<string>" }
 | `color`    | Nickname colors. Can be `"unique"` or `"solid"`. | `"unique"`                  |
 | `brackets` | Brackets for nicknames.                          | `{ left = "", right = "" }` |
 
-
 ## `[buffer.timestamp]` Section
 
 ```toml
@@ -24,10 +23,10 @@ format = "<string>"
 brackets = { left = "<string>", right = "<string>" }
 ```
 
-| Key        | Description                                                                                                                                     | Default                     |
-| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
-| `format`   | Format expected is  [strftime]( https://pubs.opengroup.org/onlinepubs/007908799/xsh/strftime.html ). To disable, simply pass empty string `""`. | `"%R"`                      |
-| `brackets` | Brackets for nicknames                                                                                                                          | `{ left = "", right = "" }` |
+| Key        | Description                                                                                                                                  | Default                     |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| `format`   | Format expected is [strftime](https://pubs.opengroup.org/onlinepubs/007908799/xsh/strftime.html). To disable, simply pass empty string `""`. | `"%R"`                      |
+| `brackets` | Brackets for nicknames                                                                                                                       | `{ left = "", right = "" }` |
 
 ## `[buffer.text_input]` Section
 
@@ -98,20 +97,27 @@ username_format = "full" | "short"
 enabled = true | false
 ```
 
+| Key               | Description                                                                                                                                                      | Default   |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| `enabled`         | Control if the server message should appear in buffers or not                                                                                                    | `true`    |
+| `smart`           | Only show server message if the user has sent a message in the given time interval (seconds) prior to the server message.                                        | `not set` |
+| `username_format` | Adjust how the username should look. Can be `"full"` (shows the longest username available (nickname, username and hostname) or `"short"` (only shows nickname). | `"full"`  |
+
+## `[buffer.internal_messages]` Section
+
 ```toml
-[buffer.server_messages.status_success]
+[buffer.internal_messages.success]
 enabled = true | false
 smart = <integer>
 ```
 
 ```toml
-[buffer.server_messages.status_error]
+[buffer.internal_messages.error]
 enabled = true | false
 smart = <integer>
 ```
 
-| Key         | Description                                                        | Default |
-| ----------- | ------------------------------------------------------------------ | ------- |
-| `enabled`   | Control if the server message should appear in buffers or not      | `true` |
-| `smart`                                                  | Only show server message if the user has sent a message in the given time interval (seconds) prior to the server message.                                        | `not set` |
-| `username_format`                                        | Adjust how the username should look. Can be `"full"` (shows the longest username available (nickname, username and hostname) or `"short"` (only shows nickname). | `"full"`  |
+| Key       | Description                                                                      | Default   |
+| --------- | -------------------------------------------------------------------------------- | --------- |
+| `enabled` | Control if the internal message should appear in buffers or not                  | `true`    |
+| `smart`   | Only show internal message if received within the given time duration (seconds). | `not set` |

--- a/book/src/configuration/buffer.md
+++ b/book/src/configuration/buffer.md
@@ -98,6 +98,18 @@ username_format = "full" | "short"
 enabled = true | false
 ```
 
+```toml
+[buffer.server_messages.status_success]
+enabled = true | false
+smart = <integer>
+```
+
+```toml
+[buffer.server_messages.status_error]
+enabled = true | false
+smart = <integer>
+```
+
 | Key         | Description                                                        | Default |
 | ----------- | ------------------------------------------------------------------ | ------- |
 | `enabled`   | Control if the server message should appear in buffers or not      | `true` |

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -31,6 +31,10 @@ pub struct ServerMessages {
     pub part: ServerMessage,
     #[serde(default)]
     pub quit: ServerMessage,
+    #[serde(default)]
+    pub status_success: ServerMessage,
+    #[serde(default)]
+    pub status_error: ServerMessage,
 }
 
 impl ServerMessages {
@@ -40,6 +44,8 @@ impl ServerMessages {
             source::server::Kind::Part => Some(self.part),
             source::server::Kind::Quit => Some(self.quit),
             source::server::Kind::Join => Some(self.join),
+            source::server::Kind::StatusSuccess => Some(self.status_success),
+            source::server::Kind::StatusError => Some(self.status_error),
         }
     }
 }

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -19,6 +19,8 @@ pub struct Buffer {
     pub channel: Channel,
     #[serde(default)]
     pub server_messages: ServerMessages,
+    #[serde(default)]
+    pub internal_messages: InternalMessages,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -31,10 +33,6 @@ pub struct ServerMessages {
     pub part: ServerMessage,
     #[serde(default)]
     pub quit: ServerMessage,
-    #[serde(default)]
-    pub status_success: ServerMessage,
-    #[serde(default)]
-    pub status_error: ServerMessage,
 }
 
 impl ServerMessages {
@@ -44,8 +42,6 @@ impl ServerMessages {
             source::server::Kind::Part => Some(self.part),
             source::server::Kind::Quit => Some(self.quit),
             source::server::Kind::Join => Some(self.join),
-            source::server::Kind::StatusSuccess => Some(self.status_success),
-            source::server::Kind::StatusError => Some(self.status_error),
         }
     }
 }
@@ -70,6 +66,40 @@ impl Default for ServerMessage {
     }
 }
 
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct InternalMessages {
+    #[serde(default)]
+    pub success: InternalMessage,
+    #[serde(default)]
+    pub error: InternalMessage,
+}
+
+impl InternalMessages {
+    pub fn get(&self, server: &source::Status) -> Option<InternalMessage> {
+        match server {
+            source::Status::Success => Some(self.success),
+            source::Status::Error => Some(self.error),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Deserialize)]
+pub struct InternalMessage {
+    #[serde(default = "default_bool_true")]
+    pub enabled: bool,
+    #[serde(default)]
+    pub smart: Option<i64>,
+}
+
+impl Default for InternalMessage {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            smart: Default::default(),
+        }
+    }
+}
+
 #[derive(Debug, Copy, Clone, Default, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum UsernameFormat {
@@ -89,6 +119,7 @@ impl Default for Buffer {
             text_input: Default::default(),
             channel: Channel::default(),
             server_messages: Default::default(),
+            internal_messages: Default::default(),
         }
     }
 }

--- a/data/src/message/source.rs
+++ b/data/src/message/source.rs
@@ -38,14 +38,8 @@ pub mod server {
     }
 
     impl Server {
-        pub fn new(
-            kind: Kind,
-            nick: Option<Nick>,
-        ) -> Self {
-            Self::Details(Details {
-                kind,
-                nick,
-            })
+        pub fn new(kind: Kind, nick: Option<Nick>) -> Self {
+            Self::Details(Details { kind, nick })
         }
 
         pub fn kind(&self) -> Kind {
@@ -70,6 +64,8 @@ pub mod server {
         Part,
         Quit,
         ReplyTopic,
+        StatusSuccess,
+        StatusError,
     }
 
     #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/data/src/message/source.rs
+++ b/data/src/message/source.rs
@@ -64,8 +64,6 @@ pub mod server {
         Part,
         Quit,
         ReplyTopic,
-        StatusSuccess,
-        StatusError,
     }
 
     #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]


### PR DESCRIPTION
Added options to configure server status success & error messages. I was getting a lot of noisy `connection to server lost` and `connection to server restored` messages in my channels. Figured I'd try my hand at adding the options to Halloy.

<img width="448" alt="Screenshot 2024-03-28 at 13 07 00" src="https://github.com/squidowl/halloy/assets/15840269/1b23d00d-1231-4265-9d49-44ea144e1129">

Added two new configuration settings:
- `buffer.server_messages.status_success`
- `buffer.server_messages.status_error`

Both use the existing `buffer.server_messages.x` options. Specifically:

```
[buffer.server_messages.status_success]
enabled = true
smart = 7200

[buffer.server_messages.status_error]
enabled = true
smart = 7200
```

Related to issue #305 