### PR TITLE
simplified onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+Changed:
+
+- Simplified onboarding experience for users without a `config.toml` file
+
 # 2024.6 (2024-04-05)
 
 Added:

--- a/config.toml
+++ b/config.toml
@@ -1,13 +1,9 @@
-# Halloy config template.
+# Halloy config.
 #
 # For a complete list of available options,
 # please visit https://halloy.squidowl.org/configuration/index.html
 
-theme = "ferra"
-
 [servers.liberachat]
 nickname = "__NICKNAME__"
 server = "irc.libera.chat"
-port = 6697
-use_tls = true
 channels = ["#halloy"]

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -221,7 +221,7 @@ impl Config {
         Ok(Themes { default, all })
     }
 
-    pub fn create_template_config() {
+    pub fn create_initial_config() {
         // Checks if a config file is there
         let config_file = Self::path();
         if config_file.exists() {
@@ -234,13 +234,13 @@ impl Config {
         let rand_nick = format!("halloy{rand_digit}");
 
         // Replace placeholder nick with unique nick
-        let config_template_string = CONFIG_TEMPLATE.replace("__NICKNAME__", rand_nick.as_str());
-        let config_template_bytes = config_template_string.as_bytes();
+        let config_string = CONFIG_TEMPLATE.replace("__NICKNAME__", rand_nick.as_str());
+        let config_bytes = config_string.as_bytes();
 
-        // Create configuration template path.
-        let config_template_path = Self::config_dir().join("config.template.toml");
+        // Create configuration path.
+        let config_path = Self::config_dir().join("config.toml");
 
-        let _ = fs::write(config_template_path, config_template_bytes);
+        let _ = fs::write(config_path, config_bytes);
     }
 }
 

--- a/src/screen/migration.rs
+++ b/src/screen/migration.rs
@@ -24,7 +24,7 @@ pub struct Migration;
 impl Migration {
     pub fn new() -> Self {
         // Create template config file.
-        Config::create_template_config();
+        Config::create_initial_config();
 
         Migration
     }

--- a/src/screen/welcome.rs
+++ b/src/screen/welcome.rs
@@ -23,8 +23,8 @@ pub struct Welcome;
 
 impl Welcome {
     pub fn new() -> Self {
-        // Create template config file.
-        Config::create_template_config();
+        // Create initial config file.
+        Config::create_initial_config();
 
         Welcome
     }
@@ -49,27 +49,27 @@ impl Welcome {
         let config_dir = String::from(Config::config_dir().to_string_lossy());
 
         let config_button = button(
-            container(text("Open Config Directory"))
+            container(text(config_dir))
                 .align_x(alignment::Horizontal::Center)
-                .width(Length::Fill),
+                .width(Length::Shrink),
         )
-        .padding(5)
-        .width(Length::Fill)
+        .padding([5, 20])
+        .width(Length::Shrink)
         .style(theme::button::secondary)
         .on_press(Message::OpenConfigurationDirectory);
 
-        let wiki_button = button(
-            container(text("Open Wiki Website"))
+        let documentation_button = button(
+            container(text("Open Documentation Website"))
                 .align_x(alignment::Horizontal::Center)
                 .width(Length::Fill),
         )
         .padding(5)
         .width(Length::Fill)
-        .style(theme::button::secondary)
+        .style(theme::button::primary)
         .on_press(Message::OpenWikiWebsite);
 
-        let refresh_button = button(
-            container(text("Refresh Halloy"))
+        let reload_button = button(
+            container(text("Reload Config File"))
                 .align_x(alignment::Horizontal::Center)
                 .width(Length::Fill),
         )
@@ -89,48 +89,25 @@ impl Welcome {
             .push(vertical_space().height(10))
             .push(text("Welcome to Halloy!").font(font::MONO_BOLD.clone()))
             .push(vertical_space().height(4))
-            .push(text(
-                "To get started with, simply follow the steps below",
-            ))
-            .push(vertical_space().height(8))
+            .push(text("Halloy is configured through a config file."))
             .push(
-                column![]
-                    .push(row![
-                        text("1. ").style(theme::text::accent),
-                        text("Go to "),
-                        text(config_dir).style(theme::text::info)
-                    ])
-                    .push(row![
-                        text("2. ").style(theme::text::accent),
-                        text("Create "),
+                row![
+                        text("You can find the "),
                         text("config.toml").style(theme::text::info),
-                        text(" using "),
-                        text("config.template.toml").style(theme::text::info),
-                        text(" as a base"),
-                    ])
-                    .push(row![
-                        text("3. ").style(theme::text::accent),
-                        text("Join "),
-                        text("#halloy").style(theme::text::info),
-                        text(" on "),
-                        text("libera.chat").style(theme::text::info),
-                        text(" and say hello"),
-                    ])
-                    .spacing(2)
-                    .align_items(iced::Alignment::Start),
+                        text(" file at the following path:"),
+                    ]
             )
+            .push(vertical_space().height(8))
+            .push(config_button)
             .push(vertical_space().height(10))
-            .push(text(
-                "For more information, please visit the Wiki website",
-            ))
+            .push(text("To begin and view config options, see below."))
             .push(vertical_space().height(10))
             .push(
                 column![]
                     .width(250)
                     .spacing(4)
-                    .push(config_button)
-                    .push(wiki_button)
-                    .push(refresh_button),
+                    .push(documentation_button)
+                    .push(reload_button),
             )
             .align_items(iced::Alignment::Center);
 


### PR DESCRIPTION
Previously we create a `config.template.toml` and had the user rename it.
This wasn't super elegant, so I changed it slightly so we just create a `config.toml` for them directly.
I also updated the text on the welcome screen to match this new change.

![image](https://github.com/squidowl/halloy/assets/2248455/463624f4-9ace-41ab-9a59-e827409a16d2)
