### PR TITLE
xdg path for macos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Unreleased
+
+Added:
+
 - Allow configuration of internal messages in buffer (see [buffer configuration](https://halloy.squidowl.org/configuration/buffer.html#bufferinternal_messages-section))
 
 Changed:
 
 - Simplified onboarding experience for users without a `config.toml` file
+- MacOS will now also look in `$HOME/.config/halloy` for `config.toml`.
 
 # 2024.6 (2024-04-05)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,6 +947,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml",
+ "xdg",
 ]
 
 [[package]]
@@ -5300,6 +5301,12 @@ name = "xcursor"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a0ccd7b4a5345edfcd0c3535718a4e9ff7798ffc536bb5b5a0e26ff84732911"
+
+[[package]]
+name = "xdg"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "xdg-home"

--- a/book/src/configuration/README.md
+++ b/book/src/configuration/README.md
@@ -2,8 +2,8 @@
 
 To edit configuration parameters, create a `config.toml` file located in your configuration directory:
 
-* Windows: `%AppData%\halloy\config.toml`
-* Mac: `~/Library/Application Support/halloy` or `$HOME/.config`
+* Windows: `%AppData%\halloy`
+* Mac: `~/Library/Application Support/halloy` or `$HOME/.config/halloy`
 * Linux: `$XDG_CONFIG_HOME` or `$HOME/.config`
 
 > 💡 You can easily open the config file directory from command bar in Halloy

--- a/book/src/configuration/README.md
+++ b/book/src/configuration/README.md
@@ -2,8 +2,8 @@
 
 To edit configuration parameters, create a `config.toml` file located in your configuration directory:
 
-* Mac: `~/Library/Application Support/halloy`
 * Windows: `%AppData%\halloy\config.toml`
+* Mac: `~/Library/Application Support/halloy` or `$HOME/.config`
 * Linux: `$XDG_CONFIG_HOME` or `$HOME/.config`
 
 > 💡 You can easily open the config file directory from command bar in Halloy

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -12,6 +12,7 @@ base64 = "0.21.2"
 bytes = "1.5.0"
 chrono = { version = "0.4", features = ['serde'] }
 dirs-next = "2.0.0"
+xdg = "2.5.2"
 flate2 = "1.0"
 futures = "0.3.21"
 hex = "0.4.3"


### PR DESCRIPTION
Fixes #327.

@tarkah can you verify i didn't break anything on linux here?
Main idea here is that `dirs-next` targets `~/Library/Application Support` for macOS, so i've added support to also look at `$HOME/.config` which is also used on macOS. Apple recommends using `Application Support` so I kept it our default location.