### PR TITLE
Dismiss Context Menu with Escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changed:
 
 - Simplified onboarding experience for users without a `config.toml` file
 - MacOS will now also look in `$HOME/.config/halloy` for `config.toml`.
+- Context menus can be dismissed by pressing Escape
 
 # 2024.6 (2024-04-05)
 


### PR DESCRIPTION
A small change to allow context menus to be dismissed by pressing escape.  This is my first time implementing an operation in iced, but it seems to work.