### PR TITLE
CAP NEW and CAP DEL Subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Added:
 
 - Allow configuration of internal messages in buffer (see [buffer configuration](https://halloy.squidowl.org/configuration/buffer.html#bufferinternal_messages-section))
 - User information added to context menu.
+- Support for IRCv3 CAP NEW and CAP DEL subcommands.
 
 Changed:
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Join **#halloy** on libera.chat if you have questions or looking for help.
     * [invite-notify](https://ircv3.net/specs/extensions/invite-notify)
     * [userhost-in-names](https://ircv3.net/specs/extensions/userhost-in-names)
     * [sasl-3.1](https://ircv3.net/specs/extensions/sasl-3.1)
+    * [cap-notify](https://ircv3.net/specs/extensions/capability-negotiation.html#cap-notify)
 * SASL support
 * DCC Send
 * Keyboard shortcuts


### PR DESCRIPTION
A first implementation for adding support for the IRCv3 `CAP NEW` and `CAP DEL` subcommands.  The intention is to follow the existing logic for the other `CAP` subcommands, with the one exception being that `sasl` is ignored when provided via `CAP NEW` since I assumed it would be too late to authenticate via SASL.

Works with my ZNC bouncer (v1.9.0), which only provides `away-notify` via `CAP NEW` (resulting in `WHO` polling for Libera which was not needed).