### PR TITLE
Request `multi-prefix` when Available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 Added:
 
 - Allow configuration of internal messages in buffer (see [buffer configuration](https://halloy.squidowl.org/configuration/buffer.html#bufferinternal_messages-section))
-- User information added to context menu.
-- Support for IRCv3 CAP NEW and CAP DEL subcommands.
+- User information added to context menu
+- Support for IRCv3 CAP NEW and CAP DEL subcommands
+- Enable support for IRCv3 `multi-prefix`
 
 Changed:
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Join **#halloy** on libera.chat if you have questions or looking for help.
     * [userhost-in-names](https://ircv3.net/specs/extensions/userhost-in-names)
     * [sasl-3.1](https://ircv3.net/specs/extensions/sasl-3.1)
     * [cap-notify](https://ircv3.net/specs/extensions/capability-negotiation.html#cap-notify)
+    * [multi-prefix](https://ircv3.net/specs/extensions/multi-prefix)
 * SASL support
 * DCC Send
 * Keyboard shortcuts

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -13,6 +13,8 @@
     * [invite-notify](https://ircv3.net/specs/extensions/invite-notify)
     * [userhost-in-names](https://ircv3.net/specs/extensions/userhost-in-names)
     * [sasl-3.1](https://ircv3.net/specs/extensions/sasl-3.1)
+    * [cap-notify](https://ircv3.net/specs/extensions/capability-negotiation.html#cap-notify)
+    * [multi-prefix](https://ircv3.net/specs/extensions/multi-prefix)
 * SASL support
 * DCC Send
 * Keyboard shortcuts

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -316,6 +316,9 @@ impl Client {
                     if self.listed_caps.iter().any(|cap| cap.starts_with("sasl")) {
                         requested.push("sasl");
                     }
+                    if contains("multi-prefix") {
+                        requested.push("multi-prefix");
+                    }
 
                     if !requested.is_empty() {
                         // Request
@@ -400,6 +403,9 @@ impl Client {
                     if newly_contains("echo-message") {
                         requested.push("echo-message");
                     }
+                }
+                if newly_contains("multi-prefix") {
+                    requested.push("multi-prefix");
                 }
 
                 if !requested.is_empty() {


### PR DESCRIPTION
Was looking at https://ircv3.net/software/clients to see if we can turn a few more table cells green, and I think we can enable `multi-prefix` with the current code base by just adding it to the capabilities we request when available (which is what this PR does).  `multi-prefix` (https://ircv3.net/specs/extensions/multi-prefix) modifies the output of `NAMES`, `WHO`, and `WHOIS` to include all user prefixes for each user (instead of just the highest ranking prefix).

`NAMES` (via `RPL_NAMREPLY`) passes the [prefix]nick strs to `User::try_from`, which does not make any assumptions about the number of prefixes present.

`WHO` only updates users' away state from the flags, it does not parse the rest of flags.  So the additional prefixes in flags shouldn't effect its operation.

`WHOIS` is not parsed at all, its output is just sent to the user.

All three work in my testing.