### PR TITLE
Hide Output of `NAMES` that Result from `JOIN`

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -757,6 +757,24 @@ impl Client {
                             channel.users.insert(user);
                         }
                     }
+
+                    // Don't save to history if names list was triggered by JOIN
+                    if !channel.names_init {
+                        return None;
+                    }
+                }
+            }
+            Command::Numeric(RPL_ENDOFNAMES, args) => {
+                let target = args.get(1)?;
+
+                if proto::is_channel(target) {
+                    if let Some(channel) = self.chanmap.get_mut(target) {
+                        if !channel.names_init {
+                            channel.names_init = true;
+
+                            return None;
+                        }
+                    }
                 }
             }
             Command::TOPIC(channel, topic) => {
@@ -1133,6 +1151,7 @@ pub struct Channel {
     pub users: HashSet<User>,
     pub last_who: Option<WhoStatus>,
     pub topic: Topic,
+    pub names_init: bool,
 }
 
 #[derive(Default, Debug, Clone)]


### PR DESCRIPTION
A small change to hide the results of the `NAMES` commands that are automatically triggered when the user joins a channel.  According to https://modern.ircdocs.horse/#join-message servers must send those `RPL_NAMREPLY` and `RPL_ENDOFNAMES` messages automatically.  I think this change fits with the hiding of `RPL_WHOREPLY` due to automatic polling, and it produces a nice clean server buffer.  I think we can skip a changelog entry for this one, assuming the new behavior is desirable.