### PR TITLE
Revert "Trim password files to remove leading / trailing whitespace"

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -25,3 +25,4 @@
 - [Connect with ZNC](guides/connect-with-znc.md)
 - [Portable mode](guides/portable-mode.md)
 - [Multiple servers](guides/multiple-servers.md)
+- [Storing passwords in a File](guides/password-file.md)

--- a/book/src/guides/password-file.md
+++ b/book/src/guides/password-file.md
@@ -1,0 +1,14 @@
+# Storing passwords in a File
+
+If you need to commit your configuration file to a public repository, you can keep your passwords in a separate file for security. Below is an example of using a file for nickname password for NICKSERV.
+
+
+> 💡 Avoid adding extra lines in the password file, as they will be treated as part of the password.
+
+```toml
+[servers.liberachat]
+nickname = "foobar"
+nick_password_file = "~./config/halloy/password"
+server = "irc.libera.chat"
+channels = ["#halloy"]
+```

--- a/data/src/server.rs
+++ b/data/src/server.rs
@@ -7,8 +7,8 @@ use irc::proto;
 use serde::{Deserialize, Serialize};
 
 use crate::config;
-use crate::config::server::Sasl;
 use crate::config::Error;
+use crate::config::server::Sasl;
 
 pub type Handle = Sender<proto::Message>;
 
@@ -63,26 +63,20 @@ impl Map {
     }
 
     pub fn read_password_files(&mut self) -> Result<(), Error> {
-        let trimmed = |s: String| s.trim().to_string();
-
         for (_, config) in self.0.iter_mut() {
             if let Some(pass_file) = &config.password_file {
                 if config.password.is_some() {
-                    return Err(Error::Parse(
-                        "Only one of password and password_file can be set.".to_string(),
-                    ));
+                    return Err(Error::Parse("Only one of password and password_file can be set.".to_string()));
                 }
                 let pass = fs::read_to_string(pass_file)?;
-                config.password = Some(trimmed(pass));
+                config.password = Some(pass);
             }
             if let Some(nick_pass_file) = &config.nick_password_file {
                 if config.nick_password.is_some() {
-                    return Err(Error::Parse(
-                        "Only one of nick_password and nick_password_file can be set.".to_string(),
-                    ));
+                    return Err(Error::Parse("Only one of nick_password and nick_password_file can be set.".to_string()));
                 }
                 let nick_pass = fs::read_to_string(nick_pass_file)?;
-                config.nick_password = Some(trimmed(nick_pass));
+                config.nick_password = Some(nick_pass);
             }
             if let Some(sasl) = &mut config.sasl {
                 match sasl {
@@ -99,7 +93,7 @@ impl Map {
                         ..
                     } => {
                         let pass = fs::read_to_string(pass_file)?;
-                        *password = Some(trimmed(pass));
+                        *password = Some(pass);
                     }
                     _ => {}
                 }


### PR DESCRIPTION
Reverts squidowl/halloy#323

As stated in the conversation on #323 trimming the passwords is bad as some people might use white-space intentionally in their passwords, which get removed then without this behavior being documented. Instead of removing white-space from password files to help people enter their password correctly we should add more documentation on how to specify your password via a file (e.g. do not add white-space like a new line to the file as the whole file contents are treated as the password).