### PR TITLE
Features/proxy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Added:
 - User information added to context menu
 - Support for IRCv3 CAP NEW and CAP DEL subcommands
 - Enable support for IRCv3 `multi-prefix`
+- Added support for `socks5` proxy configuration (see [proxy configuration](https://halloy.squidowl.org/configuration/proxy.html))
 
 Changed:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,6 +1278,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast-socks5"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f89f36d4ee12370d30d57b16c7e190950a1a916e7dbbb5fd5a412f5ef913fe84"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "log",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "fast-srgb8"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2158,6 +2178,7 @@ name = "irc"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "fast-socks5",
  "futures",
  "irc_proto",
  "rustls-native-certs",
@@ -2165,7 +2186,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-rustls",
- "tokio-socks",
  "tokio-util",
 ]
 
@@ -4217,18 +4237,6 @@ checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
-name = "tokio-socks"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
-dependencies = [
- "either",
- "futures-util",
- "thiserror",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2165,6 +2165,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-rustls",
+ "tokio-socks",
  "tokio-util",
 ]
 
@@ -4216,6 +4217,18 @@ checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
  "tokio",
 ]
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -10,6 +10,7 @@
   - [Font](configuration/font.md)
   - [Keyboard](configuration/keyboard.md)
   - [Notifications](configuration/notifications.md)
+  - [Proxy](configuration/proxy.md)
   - [Scale factor](configuration/scale-factor.md)
   - [Servers](configuration/servers.md)
   - [Sidebar](configuration/sidebar.md)

--- a/book/src/configuration/proxy.md
+++ b/book/src/configuration/proxy.md
@@ -1,0 +1,20 @@
+# Proxy
+
+## `[proxy]` Section
+
+Example
+
+```toml
+[proxy]
+type = "socks5"
+host = "<string>"
+port = <integer>
+```
+
+| Key        | Description                                       | Default     |
+| :--------- | :------------------------------------------------ | :---------- |
+| `type`     | Proxy type. Only `socks5` is currently supported. | `""`        |
+| `host`     | Proxy host to connect to                          | `""`        |
+| `port`     | Proxy port to connect on                          | `""`        |
+| `username` | Proxy username, optional                          | `""`        |
+| `password` | Proxy password, optional                          | `""`        |

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -10,7 +10,7 @@ pub use self::channel::Channel;
 pub use self::file_transfer::FileTransfer;
 pub use self::keys::Keyboard;
 pub use self::notification::{Notification, Notifications};
-use self::proxy::Proxy;
+pub use self::proxy::Proxy;
 pub use self::server::Server;
 pub use self::sidebar::Sidebar;
 use crate::environment::config_dir;
@@ -157,7 +157,6 @@ impl Config {
         } = toml::from_str(content.as_ref()).map_err(|e| Error::Parse(e.to_string()))?;
 
         servers.read_password_files()?;
-        servers.update_proxy(&proxy)?;
 
         let themes = Self::load_themes(&theme).unwrap_or_default();
 

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -10,7 +10,7 @@ pub use self::channel::Channel;
 pub use self::file_transfer::FileTransfer;
 pub use self::keys::Keyboard;
 pub use self::notification::{Notification, Notifications};
-use self::server::ProxyConfig;
+use self::proxy::Proxy;
 pub use self::server::Server;
 pub use self::sidebar::Sidebar;
 use crate::environment::config_dir;
@@ -23,6 +23,7 @@ pub mod channel;
 pub mod file_transfer;
 mod keys;
 pub mod notification;
+pub mod proxy;
 pub mod server;
 pub mod sidebar;
 
@@ -33,7 +34,7 @@ const DEFAULT_THEME_FILE_NAME: &str = "ferra.toml";
 pub struct Config {
     pub themes: Themes,
     pub servers: ServerMap,
-    pub proxy: Option<ProxyConfig>,
+    pub proxy: Option<Proxy>,
     pub font: Font,
     pub scale_factor: ScaleFactor,
     pub buffer: Buffer,
@@ -119,7 +120,7 @@ impl Config {
             #[serde(default)]
             pub theme: String,
             pub servers: ServerMap,
-            pub proxy: Option<ProxyConfig>,
+            pub proxy: Option<Proxy>,
             #[serde(default)]
             pub font: Font,
             #[serde(default)]

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -10,6 +10,7 @@ pub use self::channel::Channel;
 pub use self::file_transfer::FileTransfer;
 pub use self::keys::Keyboard;
 pub use self::notification::{Notification, Notifications};
+use self::server::ProxyConfig;
 pub use self::server::Server;
 pub use self::sidebar::Sidebar;
 use crate::environment::config_dir;
@@ -32,6 +33,7 @@ const DEFAULT_THEME_FILE_NAME: &str = "ferra.toml";
 pub struct Config {
     pub themes: Themes,
     pub servers: ServerMap,
+    pub proxy: Option<ProxyConfig>,
     pub font: Font,
     pub scale_factor: ScaleFactor,
     pub buffer: Buffer,
@@ -117,6 +119,7 @@ impl Config {
             #[serde(default)]
             pub theme: String,
             pub servers: ServerMap,
+            pub proxy: Option<ProxyConfig>,
             #[serde(default)]
             pub font: Font,
             #[serde(default)]
@@ -142,6 +145,7 @@ impl Config {
             theme,
             mut servers,
             font,
+            proxy,
             scale_factor,
             buffer,
             sidebar,
@@ -152,6 +156,7 @@ impl Config {
         } = toml::from_str(content.as_ref()).map_err(|e| Error::Parse(e.to_string()))?;
 
         servers.read_password_files()?;
+        servers.update_proxy(&proxy)?;
 
         let themes = Self::load_themes(&theme).unwrap_or_default();
 
@@ -159,6 +164,7 @@ impl Config {
             themes,
             servers,
             font,
+            proxy,
             scale_factor,
             buffer,
             sidebar,

--- a/data/src/config/proxy.rs
+++ b/data/src/config/proxy.rs
@@ -9,23 +9,21 @@ pub enum Kind {
 #[derive(Debug, Clone, Deserialize)]
 pub struct Proxy {
     #[serde(rename = "type")]
-    pub proxy_type: Kind,
+    pub kind: Kind,
     pub host: String,
     pub port: u16,
-    #[serde(default)]
-    pub username: String,
-    #[serde(default)]
-    pub password: String,
+    pub username: Option<String>,
+    pub password: Option<String>,
 }
 
-impl Into<irc::connection::Proxy> for Proxy {
-    fn into(self) -> irc::connection::Proxy {
-        match self.proxy_type {
+impl From<Proxy> for irc::connection::Proxy {
+    fn from(proxy: Proxy) -> irc::connection::Proxy {
+        match proxy.kind {
             Kind::Socks5 => irc::connection::Proxy::Socks5 {
-                host: self.host,
-                port: self.port,
-                username: self.username,
-                password: self.password,
+                host: proxy.host,
+                port: proxy.port,
+                username: proxy.username,
+                password: proxy.password,
             },
         }
     }

--- a/data/src/config/proxy.rs
+++ b/data/src/config/proxy.rs
@@ -1,0 +1,32 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Kind {
+    Socks5,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Proxy {
+    #[serde(rename = "type")]
+    pub proxy_type: Kind,
+    pub host: String,
+    pub port: u16,
+    #[serde(default)]
+    pub username: String,
+    #[serde(default)]
+    pub password: String,
+}
+
+impl Into<irc::connection::Proxy> for Proxy {
+    fn into(self) -> irc::connection::Proxy {
+        match self.proxy_type {
+            Kind::Socks5 => irc::connection::Proxy::Socks5 {
+                host: self.host,
+                port: self.port,
+                username: self.username,
+                password: self.password,
+            },
+        }
+    }
+}

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -27,6 +27,8 @@ pub struct Server {
     /// The port to connect on.
     #[serde(default = "default_port")]
     pub port: u16,
+    /// Proxy configuration to use for connecting to the server.
+    pub proxy: Option<ProxyConfig>,
     /// The password to connect to the server.
     pub password: Option<String>,
     /// The file with the password to connect to the server.
@@ -105,6 +107,24 @@ impl Server {
             security,
         }
     }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProxyConfigType {
+    Socks5,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ProxyConfig {
+    #[serde(rename = "type")]
+    pub proxy_type: ProxyConfigType,
+    pub host: String,
+    pub port: u16,
+    #[serde(default)]
+    pub username: String,
+    #[serde(default)]
+    pub password: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use irc::connection;
 use serde::{Deserialize, Deserializer};
 
-use super::proxy::Proxy;
+use crate::config;
 
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct Server {
@@ -29,8 +29,6 @@ pub struct Server {
     /// The port to connect on.
     #[serde(default = "default_port")]
     pub port: u16,
-    /// Proxy configuration to use for connecting to the server.
-    pub proxy: Option<Proxy>,
     /// The password to connect to the server.
     pub password: Option<String>,
     /// The file with the password to connect to the server.
@@ -91,7 +89,7 @@ pub struct Server {
 }
 
 impl Server {
-    pub fn connection(&self) -> connection::Config {
+    pub fn connection(&self, proxy: Option<config::Proxy>) -> connection::Config {
         let security = if self.use_tls {
             connection::Security::Secured {
                 accept_invalid_certs: self.dangerously_accept_invalid_certs,
@@ -103,13 +101,11 @@ impl Server {
             connection::Security::Unsecured
         };
 
-        let proxy = self.proxy.clone().map(|p| p.into());
-
         connection::Config {
             server: &self.server,
             port: self.port,
             security,
-            proxy,
+            proxy: proxy.map(From::from),
         }
     }
 }

--- a/data/src/file_transfer/task.rs
+++ b/data/src/file_transfer/task.rs
@@ -11,7 +11,7 @@ use futures::{
     channel::mpsc::{self, Receiver, Sender},
     SinkExt, Stream,
 };
-use irc::{connection, proto::command, BytesCodec, Connection};
+use irc::{connection::{self, Proxy}, proto::command, BytesCodec, Connection};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 use tokio::{
@@ -109,9 +109,11 @@ impl Task {
         self,
         server: Option<Server>,
         timeout: Duration,
+        proxy: &Option<Proxy>,
     ) -> (Handle, impl Stream<Item = Update>) {
         let (action_sender, action_receiver) = mpsc::channel(1);
         let (update_sender, update_receiver) = mpsc::channel(100);
+        let proxy = proxy.clone();
 
         let task = tokio::spawn(async move {
             let mut update = update_sender.clone();
@@ -132,6 +134,7 @@ impl Task {
                         update_sender,
                         server,
                         timeout,
+                        &proxy,
                     )
                     .await
                     {
@@ -157,6 +160,7 @@ impl Task {
                         update_sender,
                         server,
                         timeout,
+                        &proxy,
                     )
                     .await
                     {
@@ -214,6 +218,7 @@ async fn receive(
     mut update: Sender<Update>,
     server: Option<Server>,
     timeout: Duration,
+    proxy: &Option<Proxy>,
 ) -> Result<(), Error> {
     // Wait for approval
     let Some(Action::Approve { save_to }) = action.next().await else {
@@ -281,6 +286,7 @@ async fn receive(
                 server: &host.to_string(),
                 port: port.get(),
                 security: connection::Security::Unsecured,
+                proxy: proxy.clone(),
             },
             BytesCodec::new(),
         )
@@ -356,6 +362,7 @@ async fn send(
     mut update: Sender<Update>,
     server: Option<Server>,
     timeout: Duration,
+    proxy: &Option<Proxy>,
 ) -> Result<(), Error> {
     let mut file = File::open(path).await?;
     let size = file.metadata().await?.len();
@@ -394,6 +401,7 @@ async fn send(
                 server: &host.to_string(),
                 port: port.get(),
                 security: connection::Security::Unsecured,
+                proxy: proxy.clone(),
             },
             BytesCodec::new(),
         )

--- a/data/src/server.rs
+++ b/data/src/server.rs
@@ -7,8 +7,9 @@ use irc::proto;
 use serde::{Deserialize, Serialize};
 
 use crate::config;
-use crate::config::Error;
+use crate::config::server::ProxyConfig;
 use crate::config::server::Sasl;
+use crate::config::Error;
 
 pub type Handle = Sender<proto::Message>;
 
@@ -62,18 +63,29 @@ impl Map {
         self.0.iter().map(Entry::from)
     }
 
+    pub fn update_proxy(&mut self, proxy: &Option<ProxyConfig>) -> Result<(), Error> {
+        for (_, config) in self.0.iter_mut() {
+            config.proxy = proxy.clone();
+        }
+        Ok(())
+    }
+
     pub fn read_password_files(&mut self) -> Result<(), Error> {
         for (_, config) in self.0.iter_mut() {
             if let Some(pass_file) = &config.password_file {
                 if config.password.is_some() {
-                    return Err(Error::Parse("Only one of password and password_file can be set.".to_string()));
+                    return Err(Error::Parse(
+                        "Only one of password and password_file can be set.".to_string(),
+                    ));
                 }
                 let pass = fs::read_to_string(pass_file)?;
                 config.password = Some(pass);
             }
             if let Some(nick_pass_file) = &config.nick_password_file {
                 if config.nick_password.is_some() {
-                    return Err(Error::Parse("Only one of nick_password and nick_password_file can be set.".to_string()));
+                    return Err(Error::Parse(
+                        "Only one of nick_password and nick_password_file can be set.".to_string(),
+                    ));
                 }
                 let nick_pass = fs::read_to_string(nick_pass_file)?;
                 config.nick_password = Some(nick_pass);

--- a/data/src/server.rs
+++ b/data/src/server.rs
@@ -7,7 +7,7 @@ use irc::proto;
 use serde::{Deserialize, Serialize};
 
 use crate::config;
-use crate::config::server::ProxyConfig;
+use crate::config::proxy::Proxy;
 use crate::config::server::Sasl;
 use crate::config::Error;
 
@@ -63,7 +63,7 @@ impl Map {
         self.0.iter().map(Entry::from)
     }
 
-    pub fn update_proxy(&mut self, proxy: &Option<ProxyConfig>) -> Result<(), Error> {
+    pub fn update_proxy(&mut self, proxy: &Option<Proxy>) -> Result<(), Error> {
         for (_, config) in self.0.iter_mut() {
             config.proxy = proxy.clone();
         }

--- a/data/src/server.rs
+++ b/data/src/server.rs
@@ -7,7 +7,6 @@ use irc::proto;
 use serde::{Deserialize, Serialize};
 
 use crate::config;
-use crate::config::proxy::Proxy;
 use crate::config::server::Sasl;
 use crate::config::Error;
 
@@ -61,13 +60,6 @@ impl Map {
 
     pub fn entries(&self) -> impl Iterator<Item = Entry> + '_ {
         self.0.iter().map(Entry::from)
-    }
-
-    pub fn update_proxy(&mut self, proxy: &Option<Proxy>) -> Result<(), Error> {
-        for (_, config) in self.0.iter_mut() {
-            config.proxy = proxy.clone();
-        }
-        Ok(())
     }
 
     pub fn read_password_files(&mut self) -> Result<(), Error> {

--- a/irc/Cargo.toml
+++ b/irc/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 
 [dependencies]
 bytes = "1.4.0"
+fast-socks5 = "0.9.6"
 futures = "0.3.28"
 thiserror = "1.0.30"
 tokio = { version = "1.29", features = ["net", "full"] }
 tokio-rustls = { version = "0.26.0", default-features = false, features = ["tls12", "ring"] }
-tokio-socks = "0.5.1"
 tokio-util = { version = "0.7", features = ["codec"] }
 rustls-native-certs = "0.7.0"
 rustls-pemfile = "2.1.1"

--- a/irc/Cargo.toml
+++ b/irc/Cargo.toml
@@ -10,6 +10,7 @@ futures = "0.3.28"
 thiserror = "1.0.30"
 tokio = { version = "1.29", features = ["net", "full"] }
 tokio-rustls = { version = "0.26.0", default-features = false, features = ["tls12", "ring"] }
+tokio-socks = "0.5.1"
 tokio-util = { version = "0.7", features = ["codec"] }
 rustls-native-certs = "0.7.0"
 rustls-pemfile = "2.1.1"

--- a/irc/src/connection/proxy.rs
+++ b/irc/src/connection/proxy.rs
@@ -1,0 +1,52 @@
+use fast_socks5::client::{Config as Socks5Config, Socks5Stream};
+use thiserror::Error;
+use tokio::net::TcpStream;
+
+#[derive(Debug, Clone)]
+pub enum Proxy {
+    Socks5 {
+        host: String,
+        port: u16,
+        username: Option<String>,
+        password: Option<String>,
+    },
+}
+
+pub async fn connect_socks5(
+    proxy_server: String,
+    proxy_port: u16,
+    target_server: String,
+    target_port: u16,
+    username: Option<String>,
+    password: Option<String>,
+) -> Result<TcpStream, Error> {
+    let stream = if let Some((username, password)) = username.zip(password) {
+        Socks5Stream::connect_with_password(
+            (proxy_server, proxy_port),
+            target_server,
+            target_port,
+            username,
+            password,
+            Socks5Config::default(),
+        )
+        .await?
+        .get_socket()
+    } else {
+        Socks5Stream::connect(
+            (proxy_server, proxy_port),
+            target_server,
+            target_port,
+            Socks5Config::default(),
+        )
+        .await?
+        .get_socket()
+    };
+
+    Ok(stream)
+}
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("socks5 error: {0}")]
+    Socks5(#[from] fast_socks5::SocksError),
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -645,8 +645,12 @@ impl Application for Halloy {
     fn subscription(&self) -> Subscription<Message> {
         let tick = iced::time::every(Duration::from_secs(1)).map(Message::Tick);
 
-        let streams =
-            Subscription::batch(self.servers.entries().map(stream::run)).map(Message::Stream);
+        let streams = Subscription::batch(
+            self.servers
+                .entries()
+                .map(|entry| stream::run(entry, self.config.proxy.clone())),
+        )
+        .map(Message::Stream);
 
         Subscription::batch(vec![tick, streams, events().map(Message::Event)])
     }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -60,6 +60,7 @@ pub enum Event {
 impl Dashboard {
     pub fn empty(config: &Config) -> (Self, Command<Message>) {
         let (panes, _) = pane_grid::State::new(Pane::new(Buffer::Empty, config));
+        let proxy = config.proxy.clone().map(|p| p.into());
 
         let mut dashboard = Dashboard {
             panes,
@@ -68,7 +69,7 @@ impl Dashboard {
             history: history::Manager::default(),
             last_changed: None,
             command_bar: None,
-            file_transfers: file_transfer::Manager::new(config.file_transfer.clone()),
+            file_transfers: file_transfer::Manager::new(config.file_transfer.clone(), proxy),
         };
 
         let command = dashboard.track();
@@ -1276,6 +1277,8 @@ impl Dashboard {
             }
         }
 
+        let proxy = config.proxy.clone().map(|p| p.into());
+
         Self {
             panes: pane_grid::State::with_configuration(configuration(dashboard.pane)),
             focus: None,
@@ -1283,7 +1286,7 @@ impl Dashboard {
             history: history::Manager::default(),
             last_changed: None,
             command_bar: None,
-            file_transfers: file_transfer::Manager::new(config.file_transfer.clone()),
+            file_transfers: file_transfer::Manager::new(config.file_transfer.clone(), proxy),
         }
     }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,11 +1,11 @@
-use data::server;
 pub use data::stream::{self, *};
+use data::{config, server};
 use iced::{subscription, Subscription};
 
-pub fn run(entry: server::Entry) -> Subscription<stream::Update> {
+pub fn run(entry: server::Entry, proxy: Option<config::Proxy>) -> Subscription<stream::Update> {
     // Channel messages are batched every 50ms so channel size 10 ~= 500ms which
     // app thread should more than easily keep up with
     subscription::channel(entry.server.clone(), 10, move |sender| {
-        stream::run(entry, sender)
+        stream::run(entry, proxy, sender)
     })
 }


### PR DESCRIPTION
Fixes #301.

following from #301, this PR provides the support for `socks5` proxy. the main idea is to initiate the `TcpStream` in `irc::connection` module using the `tokio-socks`'s `Socks5Stream`. 

P.S: the initial implementation might not be efficient in favor of cloning the proxy configuration a couple of times. 