### PR TITLE
Leave Server when Sending a `/QUIT` Command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Changed:
 - Context menus can be dismissed by pressing Escape
 - Join channels that report themselves as requiring registration after logging in
 
+Fixed:
+
+- No longer automatically reconnects to a server after using the `/QUIT` command.
+
 # 2024.6 (2024-04-05)
 
 Added:

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -140,10 +140,14 @@ impl Client {
         }
     }
 
-    pub async fn quit(mut self) {
+    pub async fn quit(mut self, reason: Option<String>) {
         use tokio::time;
 
-        let _ = self.handle.try_send(command!("QUIT"));
+        if let Some(reason) = reason {
+            let _ = self.handle.try_send(command!("QUIT", reason));
+        } else {
+            let _ = self.handle.try_send(command!("QUIT"));
+        }
 
         // Ensure message is sent before dropping
         time::sleep(Duration::from_secs(1)).await;

--- a/irc/proto/src/parse.rs
+++ b/irc/proto/src/parse.rs
@@ -152,7 +152,7 @@ fn user(input: &str) -> IResult<&str, User> {
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("parsing failed: {input}")]
+    #[error("parsing failed: {:?}", input)]
     Parse { input: String, nom: String },
     #[error("invalid utf-8 encoding")]
     InvalidUtf8(#[from] FromUtf8Error),

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,10 @@ mod window;
 use std::env;
 use std::time::{Duration, Instant};
 
+use chrono::Utc;
 use data::config::{self, Config};
 use data::version::Version;
-use data::{environment, server, version, Server, User};
+use data::{environment, server, version, User};
 use iced::advanced::Application;
 use iced::widget::{column, container};
 use iced::{executor, Command, Length, Renderer, Subscription};
@@ -172,20 +173,6 @@ impl Halloy {
             command,
         )
     }
-
-    fn quit_server(&mut self, server: Server, reason: Option<String>) -> Command<Message> {
-        // Removing from servers kills stream subscription
-        self.servers.remove(&server);
-
-        // Remove from clients pool to fully drop it
-        self.clients
-            .remove(&server)
-            .map(move |connection| async move {
-                connection.quit(reason).await;
-            })
-            .map(|task| Command::perform(task, |_| Message::QuitServer(server)))
-            .unwrap_or_else(Command::none)
-    }
 }
 
 pub enum Screen {
@@ -205,7 +192,6 @@ pub enum Message {
     Event(Event),
     Tick(Instant),
     Version(Option<String>),
-    QuitServer(Server),
     CloseModal,
 }
 
@@ -248,11 +234,6 @@ impl Application for Halloy {
                 // Retrack after dashboard state changes
                 let track = dashboard.track();
 
-                let mut commands = vec![
-                    command.map(Message::Dashboard),
-                    track.map(Message::Dashboard),
-                ];
-
                 if let Some(event) = event {
                     match event {
                         dashboard::Event::ReloadConfiguration => match Config::load() {
@@ -269,7 +250,7 @@ impl Application for Halloy {
                                 self.config = updated;
 
                                 for server in removed_servers {
-                                    commands.push(self.quit_server(server, None));
+                                    self.clients.quit(&server, None);
                                 }
                             }
                             Err(error) => {
@@ -277,12 +258,15 @@ impl Application for Halloy {
                             }
                         },
                         dashboard::Event::QuitServer(server) => {
-                            commands.push(self.quit_server(server, None));
+                            self.clients.quit(&server, None);
                         }
                     }
                 }
 
-                Command::batch(commands)
+                Command::batch(vec![
+                    command.map(Message::Dashboard),
+                    track.map(Message::Dashboard),
+                ])
             }
             Message::Version(remote) => {
                 // Set latest known remote version
@@ -569,8 +553,29 @@ impl Application for Halloy {
 
                     Command::batch(commands)
                 }
-                stream::Update::QuitServer(server, reason) => {
-                    self.quit_server(server, reason)
+                stream::Update::Quit(server, reason) => {
+                    let Screen::Dashboard(dashboard) = &mut self.screen else {
+                        return Command::none();
+                    };
+
+                    self.servers.remove(&server);
+
+                    if let Some(client) = self.clients.remove(&server) {
+                        let user = client.nickname().to_owned().into();
+
+                        let channels = client.channels().to_vec();
+
+                        dashboard.broadcast_quit(
+                            &server,
+                            user,
+                            reason,
+                            channels,
+                            &self.config,
+                            Utc::now(),
+                        );
+                    }
+
+                    Command::none()
                 }
             },
             Message::Event(event) => {
@@ -598,10 +603,6 @@ impl Application for Halloy {
                 } else {
                     Command::none()
                 }
-            }
-            Message::QuitServer(server) => {
-                log::info!("[{server}] quit");
-                Command::none()
             }
             Message::CloseModal => {
                 self.modal = None;

--- a/src/main.rs
+++ b/src/main.rs
@@ -570,9 +570,7 @@ impl Application for Halloy {
                     Command::batch(commands)
                 }
                 stream::Update::QuitServer(server, reason) => {
-                    let _ = self.quit_server(server, reason);
-
-                    Command::none()
+                    self.quit_server(server, reason)
                 }
             },
             Message::Event(event) => {


### PR DESCRIPTION
This is a small change to address #331.  Checks sent user input for a `/QUIT` command, then executes the same code path that is used by the "Leave server" context menu button in that scenario.