### PR TITLE
Message Tags Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Added:
 - Allow configuration of internal messages in buffer (see [buffer configuration](https://halloy.squidowl.org/configuration/buffer.html#bufferinternal_messages-section))
 - User information added to context menu
 - Support for IRCv3 `CAP NEW` and `CAP DEL` subcommands
-- Enable support for IRCv3 `multi-prefix`, `WHOX`, and `UTF8ONLY`
+- Enable support for IRCv3 `multi-prefix`, `message-tags`, `WHOX`, and `UTF8ONLY`
 - Dynamic commands and tooltips added to command auto-completion via `ISUPPORT` 
 - Added support for `socks5` proxy configuration (see [proxy configuration](https://halloy.squidowl.org/configuration/proxy.html))
 - Added support for `http` proxy configuration (see [proxy configuration](https://halloy.squidowl.org/configuration/proxy.html))

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Join **#halloy** on libera.chat if you have questions or looking for help.
     * [sasl-3.1](https://ircv3.net/specs/extensions/sasl-3.1)
     * [cap-notify](https://ircv3.net/specs/extensions/capability-negotiation.html#cap-notify)
     * [multi-prefix](https://ircv3.net/specs/extensions/multi-prefix)
+    * [message-tags](https://ircv3.net/specs/extensions/message-tags)
     * [`WHOX`](https://ircv3.net/specs/extensions/whox)
     * [`UTF8ONLY`](https://ircv3.net/specs/extensions/utf8-only)
 * SASL support

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -15,6 +15,7 @@
     * [sasl-3.1](https://ircv3.net/specs/extensions/sasl-3.1)
     * [cap-notify](https://ircv3.net/specs/extensions/capability-negotiation.html#cap-notify)
     * [multi-prefix](https://ircv3.net/specs/extensions/multi-prefix)
+    * [message-tags](https://ircv3.net/specs/extensions/message-tags)
     * [`WHOX`](https://ircv3.net/specs/extensions/whox)
     * [`UTF8ONLY`](https://ircv3.net/specs/extensions/utf8-only)
 * SASL support

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -304,6 +304,9 @@ impl Client {
                     if contains("away-notify") {
                         requested.push("away-notify");
                     }
+                    if contains("message-tags") {
+                        requested.push("message-tags");
+                    }
                     if contains("server-time") {
                         requested.push("server-time");
                     }
@@ -392,6 +395,9 @@ impl Client {
                 }
                 if newly_contains("away-notify") {
                     requested.push("away-notify");
+                }
+                if newly_contains("message-tags") {
+                    requested.push("message-tags");
                 }
                 if newly_contains("server-time") {
                     requested.push("server-time");
@@ -927,6 +933,9 @@ impl Client {
                     }
                 });
 
+                return None;
+            }
+            Command::TAGMSG(_) => {
                 return None;
             }
             _ => {}

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -302,6 +302,7 @@ fn target(
         | Command::CNOTICE(_, _, _)
         | Command::CPRIVMSG(_, _, _)
         | Command::KNOCK(_, _)
+        | Command::TAGMSG(_)
         | Command::USERIP(_)
         | Command::HELP(_)
         | Command::MODE(_, _, _)

--- a/irc/proto/src/command.rs
+++ b/irc/proto/src/command.rs
@@ -102,6 +102,8 @@ pub enum Command {
     CPRIVMSG(String, String, String),
     /// <channel> [<message>]
     KNOCK(String, Option<String>),
+    /// <msgtarget>
+    TAGMSG(String),
     /// <nickname>
     USERIP(String),
 
@@ -193,6 +195,7 @@ impl Command {
             "CNOTICE" if len > 2 => CNOTICE(req!(), req!(), req!()),
             "CPRIVMSG" if len > 2 => CPRIVMSG(req!(), req!(), req!()),
             "KNOCK" if len > 0 => KNOCK(req!(), opt!()),
+            "TAGMSG" if len > 0 => TAGMSG(req!()),
             "USERIP" if len > 0 => USERIP(req!()),
             _ => Self::Unknown(tag, params.collect()),
         }
@@ -246,6 +249,7 @@ impl Command {
             Command::CNOTICE(a, b, c) => vec![a, b, c],
             Command::CPRIVMSG(a, b, c) => vec![a, b, c],
             Command::KNOCK(a, b) => std::iter::once(a).chain(b).collect(),
+            Command::TAGMSG(a) => vec![a],
             Command::USERIP(a) => vec![a],
             Command::Numeric(_, params) => params,
             Command::Unknown(_, params) => params,
@@ -300,6 +304,7 @@ impl Command {
             CNOTICE(_, _, _) => "CNOTICE".to_string(),
             CPRIVMSG(_, _, _) => "CPRIVMSG".to_string(),
             KNOCK(_, _) => "KNOCK".to_string(),
+            TAGMSG(_) => "TAGMSG".to_string(),
             USERIP(_) => "USERIP".to_string(),
             Numeric(numeric, _) => format!("{:03}", *numeric as u16),
             Unknown(tag, _) => tag.clone(),


### PR DESCRIPTION
Reading through [`message-tags`](https://ircv3.net/specs/extensions/message-tags) and looking at `irc/proto/src/parse.rs` I believe tags are already rigorously parsed by the current implementation.  I believe all we need in addition to that is support for the `CLIENTTAGDENY` ISUPPORT parameter and `TAGMSG` command.

In the [client-only tags registry](https://ircv3.net/registry#tags) there appears to be one active and three draft client-only tags.  If/when we implement those features I believe we should disable them if they're covered in the `CLIENTTAGDENY` ISUPPORT parameter, but as it stands (with none of those features implemented, yet) I think parsing `CLIENTTAGDENY` (added in #349) should be sufficient.

This PR adds the `TAGMSG` command.  As with `CLIENTTAGDENY` there's nothing for us to utilize `TAGMSG` for yet, so I think its addition is all we currently need.