### PR TITLE
`chathistory` Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Added:
 - In-app theme editor with ability to with share it via a halloy:// URL.
 - New configuration options
   - Ability to include or exclude channels for server messages (join, part, etc.). See [configuration](https://halloy.squidowl.org/configuration/buffer/server_messages/index.html).
-- Enable support for IRCv3 `chathistory`
+- Enable support for IRCv3 `chathistory` and `msgid`
 
 Fixed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Added:
 - Configurable shortcuts for "Leave Buffer" and "Toggle Sidebar" actions (see [keyboard shortcuts configuration](https://halloy.squidowl.org/configuration/keyboard.html)).
 - Ability to remember window position and size when reopened.
 - Ability to hide unread indicators in sidebar (see [sidemenu configuration](https://halloy.squidowl.org/configuration/sidebar.html))
+- Support for IRCv3 `chathistory`.
 
 Fixed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Added:
 - In-app theme editor with ability to with share it via a halloy:// URL.
 - New configuration options
   - Ability to include or exclude channels for server messages (join, part, etc.). See [configuration](https://halloy.squidowl.org/configuration/buffer/server_messages/index.html).
+- Enable support for IRCv3 `chathistory`
 
 Fixed:
 
@@ -91,7 +92,6 @@ Added:
 - Configurable shortcuts for "Leave Buffer" and "Toggle Sidebar" actions (see [keyboard shortcuts configuration](https://halloy.squidowl.org/configuration/keyboard.html)).
 - Ability to remember window position and size when reopened.
 - Ability to hide unread indicators in sidebar (see [sidemenu configuration](https://halloy.squidowl.org/configuration/sidebar.html))
-- Support for IRCv3 `chathistory`.
 
 Fixed:
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Halloy is also available from [Flathub](https://flathub.org/apps/org.squidowl.ha
     * [away-notify](https://ircv3.net/specs/extensions/away-notify)
     * [batch](https://ircv3.net/specs/extensions/batch)
     * [cap-notify](https://ircv3.net/specs/extensions/capability-negotiation.html#cap-notify)
+    * [chathistory](https://ircv3.net/specs/extensions/chathistory)
     * [chghost](https://ircv3.net/specs/extensions/chghost)
     * [echo-message](https://ircv3.net/specs/extensions/echo-message)
     * [extended-join](https://ircv3.net/specs/extensions/extended-join)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Halloy is also available from [Flathub](https://flathub.org/apps/org.squidowl.ha
     * [labeled-response](https://ircv3.net/specs/extensions/labeled-response)
     * [message-tags](https://ircv3.net/specs/extensions/message-tags)
     * [Monitor](https://ircv3.net/specs/extensions/monitor)
+    * [msgid](https://ircv3.net/specs/extensions/message-ids)
     * [multi-prefix](https://ircv3.net/specs/extensions/multi-prefix)
     * [sasl-3.1](https://ircv3.net/specs/extensions/sasl-3.1)
     * [server-time](https://ircv3.net/specs/extensions/server-time)

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -19,6 +19,7 @@
     * [labeled-response](https://ircv3.net/specs/extensions/labeled-response)
     * [message-tags](https://ircv3.net/specs/extensions/message-tags)
     * [Monitor](https://ircv3.net/specs/extensions/monitor)
+    * [msgid](https://ircv3.net/specs/extensions/message-ids)
     * [multi-prefix](https://ircv3.net/specs/extensions/multi-prefix)
     * [sasl-3.1](https://ircv3.net/specs/extensions/sasl-3.1)
     * [server-time](https://ircv3.net/specs/extensions/server-time)

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -11,6 +11,7 @@
     * [away-notify](https://ircv3.net/specs/extensions/away-notify)
     * [batch](https://ircv3.net/specs/extensions/batch)
     * [cap-notify](https://ircv3.net/specs/extensions/capability-negotiation.html#cap-notify)
+    * [chathistory](https://ircv3.net/specs/extensions/chathistory)
     * [chghost](https://ircv3.net/specs/extensions/chghost)
     * [echo-message](https://ircv3.net/specs/extensions/echo-message)
     * [extended-join](https://ircv3.net/specs/extensions/extended-join)

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -75,7 +75,8 @@ pub enum Broadcast {
 
 #[derive(Debug, Clone)]
 pub enum HistoryRequest {
-    Targets,
+    Targets(DateTime<Utc>),
+    Queries(Vec<isupport::MessageReferenceType>, DateTime<Utc>),
     Recent(String, Vec<isupport::MessageReferenceType>, DateTime<Utc>),
     Older(String, Vec<isupport::MessageReferenceType>),
 }
@@ -587,9 +588,15 @@ impl Client {
                 if caps.contains(&"chathistory") || caps.contains(&"draft/chathistory") {
                     self.supports_chathistory = true;
 
-                    return Some(vec![Event::ChatHistoryRequestFromHistory(
-                        HistoryRequest::Targets,
-                    )]);
+                    return Some(vec![
+                        Event::ChatHistoryRequestFromHistory(HistoryRequest::Targets(server_time(
+                            &message,
+                        ))),
+                        Event::ChatHistoryRequestFromHistory(HistoryRequest::Queries(
+                            self.chathistory_message_reference_types(),
+                            server_time(&message),
+                        )),
+                    ]);
                 }
             }
             Command::CAP(_, sub, a, b) if sub == "NAK" => {

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1619,7 +1619,7 @@ impl Client {
                         "LATEST",
                         target,
                         command_message_reference.to_string(),
-                        limit.to_string()
+                        limit.to_string(),
                     ));
                 }
                 ChatHistorySubcommand::Before(target, message_reference, limit) => {
@@ -1637,7 +1637,7 @@ impl Client {
                         "BEFORE",
                         target,
                         command_message_reference.to_string(),
-                        limit.to_string()
+                        limit.to_string(),
                     ));
                 }
                 ChatHistorySubcommand::Between(
@@ -1665,7 +1665,7 @@ impl Client {
                         target,
                         command_start_message_reference.to_string(),
                         command_end_message_reference.to_string(),
-                        limit.to_string()
+                        limit.to_string(),
                     ));
                 }
                 ChatHistorySubcommand::Targets(
@@ -1701,7 +1701,7 @@ impl Client {
                         "TARGETS",
                         command_start_message_reference.to_string(),
                         command_end_message_reference.to_string(),
-                        limit.to_string()
+                        limit.to_string(),
                     ));
                 }
             }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -443,6 +443,14 @@ impl Client {
                                     target,
                                 )]
                             }
+                            Command::PRIVMSG(_, text) | Command::NOTICE(_, text) => {
+                                if ctcp::is_query(text) && !message::is_action(text) {
+                                    // Ignore historical CTCP queries/responses except for ACTIONs
+                                    vec![]
+                                } else {
+                                    vec![Event::Single(message, self.nickname().to_owned())]
+                                }
+                            }
                             _ => vec![Event::Single(message, self.nickname().to_owned())],
                         }
                     }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -282,7 +282,9 @@ impl Client {
                             Some("chathistory") => params
                                 .get(1)
                                 .map(|target| ChatHistoryBatch::Target(target.clone())),
-                            Some("draft/chathistory-targets") => Some(ChatHistoryBatch::Targets),
+                            Some("chathistory-targets") | Some("draft/chathistory-targets") => {
+                                Some(ChatHistoryBatch::Targets)
+                            }
                             _ => None,
                         };
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -884,7 +884,7 @@ impl Client {
                                 self.nickname().to_owned(),
                                 Notification::Highlight(user, channel.clone()),
                             )]);
-                        } else if user.nickname()
+                        } else if user.nickname() == self.nickname()
                             && context.is_some()
                             && message_id(&message).is_none()
                         {

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -418,6 +418,7 @@ impl Client {
                                 let target = message::Target::Channel {
                                     channel: target,
                                     source: source::Source::Server(None),
+                                    prefix: None,
                                 };
 
                                 vec![Event::WithTarget(
@@ -435,6 +436,7 @@ impl Client {
                                             .user()
                                             .map(|user| Nick::from(user.nickname().as_ref())),
                                     ))),
+                                    prefix: None,
                                 };
 
                                 vec![Event::WithTarget(
@@ -1522,7 +1524,7 @@ impl Client {
                 if sub == "TARGETS" {
                     let target = args.first()?;
 
-                    if !proto::is_channel(target) {
+                    if proto::parse_channel_from_target(target).is_none() {
                         return Some(vec![Event::ChatHistoryRequestFromHistory(
                             HistoryRequest::Recent(
                                 target.clone(),

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1524,7 +1524,17 @@ impl Client {
                 if sub == "TARGETS" {
                     let target = args.first()?;
 
-                    if proto::parse_channel_from_target(target).is_none() {
+                    if let Some((prefix, channel)) = proto::parse_channel_from_target(target) {
+                        if prefix.is_some() && self.chanmap.contains_key(&channel) {
+                            return Some(vec![Event::ChatHistoryRequestFromHistory(
+                                HistoryRequest::Recent(
+                                    target.clone(),
+                                    self.chathistory_message_reference_types(),
+                                    server_time(&message),
+                                ),
+                            )]);
+                        }
+                    } else {
                         return Some(vec![Event::ChatHistoryRequestFromHistory(
                             HistoryRequest::Recent(
                                 target.clone(),

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -95,7 +95,6 @@ pub enum Event {
     ChatHistoryRequestFromHistory(HistoryRequest),
     ChatHistoryRequestReceived(ChatHistorySubcommand, usize),
     ChatHistoryTargetsReceived(DateTime<Utc>),
-    CheckForStoredUnread(String),
 }
 
 struct ChatHistoryRequest {
@@ -1102,8 +1101,6 @@ impl Client {
                             state.last_who = Some(WhoStatus::Requested(Instant::now(), None));
                         }
                         log::debug!("[{}] {channel} - WHO requested", self.server);
-
-                        events.push(Event::CheckForStoredUnread(channel.clone()));
 
                         if self.supports_chathistory
                             && self.isupport.contains_key(&isupport::Kind::MSGREFTYPES)

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -83,7 +83,7 @@ pub enum Event {
     ChatHistoryCommand(
         ChatHistorySubcommand,
         String,
-        isupport::MessageReferenceType,
+        Vec<isupport::MessageReferenceType>,
     ),
     ChatHistoryBatchFilter,
     ChatHistorySingle(
@@ -344,8 +344,7 @@ impl Client {
                                                 finished.events.push(Event::ChatHistoryCommand(
                                                     subcommand.clone(),
                                                     chathistory_target.to_string(),
-                                                    self.chathistory_message_reference_type()
-                                                        .clone(),
+                                                    self.chathistory_message_reference_types(),
                                                 ));
                                             }
                                         }
@@ -1058,7 +1057,7 @@ impl Client {
                             return Some(vec![Event::ChatHistoryCommand(
                                 ChatHistorySubcommand::Latest(server_time(&message)),
                                 channel.clone(),
-                                self.chathistory_message_reference_type(),
+                                self.chathistory_message_reference_types(),
                             )]);
                         }
                     }
@@ -1479,14 +1478,14 @@ impl Client {
         CLIENT_CHATHISTORY_LIMIT
     }
 
-    pub fn chathistory_message_reference_type(&self) -> isupport::MessageReferenceType {
+    pub fn chathistory_message_reference_types(&self) -> Vec<isupport::MessageReferenceType> {
         if let Some(isupport::Parameter::MSGREFTYPES(message_reference_types)) =
             self.isupport.get(&isupport::Kind::MSGREFTYPES)
         {
-            return message_reference_types.first().cloned().unwrap_or_default();
+            message_reference_types.clone()
+        } else {
+            vec![]
         }
-
-        isupport::MessageReferenceType::default()
     }
 
     pub fn chathistory_request(&self, target: &str) -> Option<ChatHistoryRequest> {
@@ -1828,12 +1827,12 @@ impl Map {
             .unwrap_or_default()
     }
 
-    pub fn get_server_chathistory_message_reference_type(
+    pub fn get_server_chathistory_message_reference_types(
         &self,
         server: &Server,
-    ) -> isupport::MessageReferenceType {
+    ) -> Vec<isupport::MessageReferenceType> {
         self.client(server)
-            .map(|client| client.chathistory_message_reference_type())
+            .map(|client| client.chathistory_message_reference_types())
             .unwrap_or_default()
     }
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -858,8 +858,12 @@ impl Client {
                                 self.nickname().to_owned(),
                                 Notification::Highlight(user, channel.clone()),
                             )]);
-                        } else if user.nickname() == self.nickname() && context.is_some() {
-                            // If we sent (echo) & context exists (we sent from this client), ignore
+                        } else if user.nickname()
+                            && context.is_some()
+                            && !self.supports_chathistory
+                        {
+                            // If we sent (echo), context exists (we sent from this client),
+                            // & chathistory is not supported (we don't need its msgid), ignore
                             return None;
                         }
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -868,10 +868,11 @@ impl Client {
                             )]);
                         } else if user.nickname()
                             && context.is_some()
-                            && !self.supports_chathistory
+                            && message_id(&message).is_none()
                         {
-                            // If we sent (echo), context exists (we sent from this client),
-                            // & chathistory is not supported (we don't need its msgid), ignore
+                            // If we sent (echo) & context exists (we sent from this client),
+                            // then ignore unless it has a message id (in which case the local
+                            // copy should be updated with the message id)
                             return None;
                         }
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1320,9 +1320,7 @@ impl Client {
                         channel.topic.content = Some(message::parse_fragments(text.clone()));
                     }
 
-                    channel.topic.who = message
-                        .user()
-                        .map(|user| user.nickname().to_string());
+                    channel.topic.who = message.user().map(|user| user.nickname().to_string());
                     channel.topic.time = Some(server_time(&message));
                 }
             }
@@ -1383,7 +1381,7 @@ impl Client {
                                             parameter
                                         );
 
-                                        self.isupport.insert(kind.clone(), parameter);
+                                        self.isupport.insert(kind.clone(), parameter.clone());
 
                                         if kind == isupport::Kind::MSGREFTYPES
                                             && self.supports_chathistory

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -95,6 +95,7 @@ pub enum Event {
     ChatHistoryRequestFromHistory(HistoryRequest),
     ChatHistoryRequestReceived(ChatHistorySubcommand, usize),
     ChatHistoryTargetsReceived(DateTime<Utc>),
+    LoadReadMarker(String),
 }
 
 struct ChatHistoryRequest {
@@ -1075,6 +1076,8 @@ impl Client {
 
                 if user.nickname() == self.nickname() {
                     self.chanmap.insert(channel.clone(), Channel::default());
+
+                    events.push(Event::LoadReadMarker(channel.clone()));
 
                     if let Some(state) = self.chanmap.get_mut(channel) {
                         // Sends WHO to get away state on users.

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -315,13 +315,17 @@ impl Client {
                                                 let continue_request = if matches!(
                                                     subcommand,
                                                     ChatHistorySubcommand::Latest(_)
-                                                ) && !matches!(
-                                                    message_reference,
-                                                    MessageReference::None
                                                 ) {
                                                     finished.events.reverse();
 
-                                                    finished.events.len() == limit as usize
+                                                    if matches!(
+                                                        message_reference,
+                                                        MessageReference::None
+                                                    ) {
+                                                        false
+                                                    } else {
+                                                        finished.events.len() == limit as usize
+                                                    }
                                                 } else {
                                                     false
                                                 };

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -144,7 +144,7 @@ impl Default for InternalMessage {
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct ChatHistory {
     #[serde(default)]
-    pub request_older_messages_at_scroll_top: bool,
+    pub infinite_scroll: bool,
 }
 
 #[derive(Debug, Copy, Clone, Default, Deserialize)]

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -118,7 +118,7 @@ pub struct InternalMessages {
 impl InternalMessages {
     pub fn get(&self, server: &source::Status) -> Option<&InternalMessage> {
         match server {
-            source::Status::Success | source::Status::Pending => Some(&self.success),
+            source::Status::Success => Some(&self.success),
             source::Status::Error => Some(&self.error),
         }
     }

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -118,7 +118,7 @@ pub struct InternalMessages {
 impl InternalMessages {
     pub fn get(&self, server: &source::Status) -> Option<&InternalMessage> {
         match server {
-            source::Status::Success => Some(&self.success),
+            source::Status::Success | source::Status::Pending => Some(&self.success),
             source::Status::Error => Some(&self.error),
         }
     }

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -23,6 +23,8 @@ pub struct Buffer {
     pub internal_messages: InternalMessages,
     #[serde(default)]
     pub status_message_prefix: StatusMessagePrefix,
+    #[serde(default)]
+    pub chathistory: ChatHistory,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -137,6 +139,12 @@ impl Default for InternalMessage {
             smart: Default::default(),
         }
     }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ChatHistory {
+    #[serde(default)]
+    pub request_older_messages_at_scroll_top: bool,
 }
 
 #[derive(Debug, Copy, Clone, Default, Deserialize)]

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -681,7 +681,8 @@ fn has_matching_content(message: &Message, other: &Message) -> bool {
                 | message::source::server::Kind::Quit => {
                     return true;
                 }
-                message::source::server::Kind::ReplyTopic => (),
+                message::source::server::Kind::ReplyTopic
+                | message::source::server::Kind::ChangeHost => (),
             }
         }
 
@@ -845,6 +846,7 @@ mod test {
             target: message::Target::Channel {
                 channel: "test".to_string(),
                 source: message::Source::Server(None),
+                prefix: None,
             },
             content: message::parse_fragments(text.to_string()),
             id: id.map(String::from),

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -562,6 +562,7 @@ pub enum Error {
 
 #[cfg(test)]
 mod test {
+    use crate::time::Posix;
     use rand::seq::SliceRandom;
 
     use super::*;
@@ -571,27 +572,27 @@ mod test {
     fn test_insert_message() {
         let mut messages = vec![];
 
-        insert_message(&mut messages, message(1, None, "one"), None);
+        insert_message(&mut messages, message(1, None, "one"), &None);
 
         assert_eq!(messages.len(), 1);
 
         // Insert before single message
-        insert_message(&mut messages, message(0, None, "zero"), None);
+        insert_message(&mut messages, message(0, None, "zero"), &None);
         assert_eq!(messages[0].text, "zero".to_string());
         messages.remove(0);
 
         // Insert after single message
-        insert_message(&mut messages, message(2, None, "two"), None);
+        insert_message(&mut messages, message(2, None, "two"), &None);
         assert_eq!(messages[1].text, "two".to_string());
         messages.remove(1);
 
         // Insert way before (search slice will be empty)
-        insert_message(&mut messages, message(-3_000_000_000, None, "past"), None);
+        insert_message(&mut messages, message(-3_000_000_000, None, "past"), &None);
         assert_eq!(messages[0].text, "past".to_string());
         messages.remove(0);
 
         // Insert way after (search slice will be empty)
-        insert_message(&mut messages, message(3_000_000_000, None, "future"), None);
+        insert_message(&mut messages, message(3_000_000_000, None, "future"), &None);
         assert_eq!(messages[1].text, "future".to_string());
         messages.remove(1);
 
@@ -608,7 +609,7 @@ mod test {
                 insert_message(
                     &mut messages,
                     message(millis, Some(&test.to_string()), millis),
-                    None,
+                    &None,
                 );
             }
 
@@ -626,7 +627,7 @@ mod test {
             insert_message(
                 &mut messages,
                 message(millis, Some(&5000.to_string()), diff),
-                None,
+                &None,
             );
             assert_eq!(messages.len(), 10_000);
             assert_eq!(messages[5000].text, diff.to_string());
@@ -639,7 +640,7 @@ mod test {
             insert_message(
                 &mut messages,
                 message(millis, Some(&5000.to_string()), diff),
-                None,
+                &None,
             );
             assert_eq!(messages.len(), 10_000 + i + 1);
         }
@@ -648,13 +649,13 @@ mod test {
         let now = Posix::now();
 
         // REPLACE - timestamp & content match
-        insert_message(&mut messages, message(0, None, 0), None);
+        insert_message(&mut messages, message(0, None, 0), &None);
         assert_eq!(messages.len(), 10_002);
         assert!(messages[0].id.is_none());
         assert!(messages[0].received_at >= now);
 
         // INSERT - timestamp matches but not content
-        insert_message(&mut messages, message(0, None, "BAR"), None);
+        insert_message(&mut messages, message(0, None, "BAR"), &None);
         assert_eq!(messages.len(), 10_003);
         assert!(messages[1].id.is_none());
         assert_eq!(messages[1].text, "BAR".to_string());

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -485,21 +485,13 @@ fn is_referenceable_message(
 ) -> bool {
     if matches!(message.target.source(), message::Source::Internal(_)) {
         false
+    } else if matches!(
+        message_reference_type,
+        Some(isupport::MessageReferenceType::MessageId)
+    ) {
+        message.id.is_some()
     } else {
-        match message_reference_type {
-            Some(isupport::MessageReferenceType::MessageId) => message
-                .id
-                .as_ref()
-                .is_some_and(|message_id| !message_id.starts_with(':')),
-            Some(isupport::MessageReferenceType::Timestamp) => message
-                .id
-                .as_ref()
-                .is_some_and(|message_id| message_id.starts_with(':') && message_id != ":"),
-            None => message
-                .id
-                .as_ref()
-                .is_some_and(|message_id| message_id != ":"),
-        }
+        true
     }
 }
 

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -643,22 +643,34 @@ mod test {
 
         // Insert before single message
         insert_message(&mut messages, message(0, None, "zero"), &None);
-        assert_eq!(messages[0].text, "zero".to_string());
+        assert_eq!(
+            messages[0].content,
+            message::parse_fragments("zero".to_string())
+        );
         messages.remove(0);
 
         // Insert after single message
         insert_message(&mut messages, message(2, None, "two"), &None);
-        assert_eq!(messages[1].text, "two".to_string());
+        assert_eq!(
+            messages[1].content,
+            message::parse_fragments("two".to_string())
+        );
         messages.remove(1);
 
         // Insert way before (search slice will be empty)
         insert_message(&mut messages, message(-3_000_000_000, None, "past"), &None);
-        assert_eq!(messages[0].text, "past".to_string());
+        assert_eq!(
+            messages[0].content,
+            message::parse_fragments("past".to_string())
+        );
         messages.remove(0);
 
         // Insert way after (search slice will be empty)
         insert_message(&mut messages, message(3_000_000_000, None, "future"), &None);
-        assert_eq!(messages[1].text, "future".to_string());
+        assert_eq!(
+            messages[1].content,
+            message::parse_fragments("future".to_string())
+        );
         messages.remove(1);
 
         // Insert in random order, assert messages are ordered
@@ -681,7 +693,10 @@ mod test {
             assert_eq!(messages.len(), 10_000);
 
             for i in 0usize..10_000 {
-                assert_eq!(messages[i].text, (i * 1000).to_string());
+                assert_eq!(
+                    messages[i].content,
+                    message::parse_fragments((i * 1000).to_string())
+                );
             }
         }
 
@@ -695,7 +710,10 @@ mod test {
                 &None,
             );
             assert_eq!(messages.len(), 10_000);
-            assert_eq!(messages[5000].text, diff.to_string());
+            assert_eq!(
+                messages[5000].content,
+                message::parse_fragments(diff.to_string())
+            );
         }
 
         // INSERT - id match outside FUZZ duration (1 second)
@@ -723,7 +741,10 @@ mod test {
         insert_message(&mut messages, message(0, None, "BAR"), &None);
         assert_eq!(messages.len(), 10_003);
         assert!(messages[1].id.is_none());
-        assert_eq!(messages[1].text, "BAR".to_string());
+        assert_eq!(
+            messages[1].content,
+            message::parse_fragments("BAR".to_string())
+        );
     }
 
     fn message(millis: i64, id: Option<&str>, text: impl ToString) -> Message {
@@ -735,7 +756,7 @@ mod test {
                 channel: "test".to_string(),
                 source: message::Source::Server(None),
             },
-            text: text.to_string(),
+            content: message::parse_fragments(text.to_string()),
             id: id.map(String::from),
         }
     }

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -595,7 +595,7 @@ fn has_matching_content(message: &Message, other: &Message) -> bool {
             }
         }
 
-        message.text == other.text
+        message.content == other.content
     } else {
         false
     }

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -403,14 +403,9 @@ impl History {
                             .iter()
                             .rev()
                             .position(|message| message_reference == *message)
-                            .and_then(|reference_position| {
-                                if reference_position > 0 {
-                                    Some(messages.len() - reference_position + 1)
-                                } else {
-                                    None
-                                }
-                            })
-                            .map(|split_position| messages.split_off(split_position)),
+                            .map(|reference_position| {
+                                messages.split_off(messages.len() - reference_position)
+                            }),
                     });
                 let opened_at = unread_messages
                     .as_ref()

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -682,7 +682,9 @@ fn has_matching_content(message: &Message, other: &Message) -> bool {
                     return true;
                 }
                 message::source::server::Kind::ReplyTopic
-                | message::source::server::Kind::ChangeHost => (),
+                | message::source::server::Kind::ChangeHost
+                | message::source::server::Kind::MonitoredOnline
+                | message::source::server::Kind::MonitoredOffline => (),
             }
         }
 

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -80,10 +80,10 @@ pub fn load_read_marker(server: &server::Server, kind: &Kind) -> Option<DateTime
     }
 }
 
-pub fn load_targets_marker(server: &server::Server) -> Option<DateTime<Utc>> {
-    let path = targets_marker_path(server);
+pub async fn load_targets_marker(server: server::Server) -> Option<DateTime<Utc>> {
+    let path = targets_marker_path(&server);
 
-    if let Ok(bytes) = std::fs::read(path) {
+    if let Ok(bytes) = fs::read(path).await {
         serde_json::from_slice(&bytes).unwrap_or_default()
     } else {
         None
@@ -115,7 +115,7 @@ pub async fn overwrite(
     fs::write(read_marker_path(server, kind), &bytes).await?;
 
     if let Some(read_marker) = read_marker {
-        let targets_marker = load_targets_marker(server);
+        let targets_marker = load_targets_marker(server.clone()).await;
 
         if !targets_marker.is_some_and(|targets_marker| targets_marker >= *read_marker) {
             let _ = overwrite_targets_marker(server.clone(), *read_marker).await;

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -86,7 +86,9 @@ pub async fn append(
     }
 
     let mut all_messages = load(server, kind).await?;
-    all_messages.extend(messages);
+    messages.into_iter().for_each(|message| {
+        insert_message(&mut all_messages, message);
+    });
 
     overwrite(server, kind, &all_messages).await
 }
@@ -358,7 +360,7 @@ fn is_referenceable_message(
 /// Deduplication is only checked +/- 1 second around the server time
 /// of the incoming message. Either message IDs match, or server times
 /// have an exact match + target & content.
-fn insert_message(messages: &mut Vec<Message>, message: Message) -> bool {
+pub fn insert_message(messages: &mut Vec<Message>, message: Message) -> bool {
     let message_triggers_unread = message.triggers_unread();
 
     if messages.is_empty() {

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -187,11 +187,16 @@ impl History {
             } => {
                 let insert_position = match subcommand {
                     ChatHistorySubcommand::Latest | ChatHistorySubcommand::After => {
-                        if message.id.is_some()
-                            && messages
+                        if message.id.is_some() {
+                            if messages
                                 .iter()
                                 .any(|existing_message| existing_message.id == message.id)
-                        {
+                            {
+                                return;
+                            }
+                        } else if messages.iter().any(|existing_message| {
+                            existing_message.server_time == message.server_time
+                        }) {
                             return;
                         }
 
@@ -208,12 +213,16 @@ impl History {
                         }
                     }
                     ChatHistorySubcommand::Before => {
-                        if message.id.is_some()
-                            && messages
+                        if message.id.is_some() {
+                            if messages
                                 .iter()
-                                .rev()
                                 .any(|existing_message| existing_message.id == message.id)
-                        {
+                            {
+                                return;
+                            }
+                        } else if messages.iter().any(|existing_message| {
+                            existing_message.server_time == message.server_time
+                        }) {
                             return;
                         }
 
@@ -239,11 +248,16 @@ impl History {
             } => {
                 let insert_position = match subcommand {
                     ChatHistorySubcommand::Latest | ChatHistorySubcommand::After => {
-                        if message.id.is_some()
-                            && messages
+                        if message.id.is_some() {
+                            if messages
                                 .iter()
                                 .any(|existing_message| existing_message.id == message.id)
-                        {
+                            {
+                                return;
+                            }
+                        } else if messages.iter().any(|existing_message| {
+                            existing_message.server_time == message.server_time
+                        }) {
                             return;
                         }
 
@@ -260,12 +274,16 @@ impl History {
                         }
                     }
                     ChatHistorySubcommand::Before => {
-                        if message.id.is_some()
-                            && messages
+                        if message.id.is_some() {
+                            if messages
                                 .iter()
-                                .rev()
                                 .any(|existing_message| existing_message.id == message.id)
-                        {
+                            {
+                                return;
+                            }
+                        } else if messages.iter().any(|existing_message| {
+                            existing_message.server_time == message.server_time
+                        }) {
                             return;
                         }
 

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -657,6 +657,7 @@ pub fn insert_message(
     if let Some(index) = replace_at {
         if has_matching_content(&messages[index], &message) {
             messages[index].id = message.id;
+            messages[index].received_at = message.received_at;
             false
         } else {
             messages[index] = message;

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, TimeDelta, Utc};
 use irc::proto;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -308,8 +308,7 @@ pub async fn get_latest_message_reference(
                         message
                             .server_time
                             .signed_duration_since(before_server_time)
-                            .num_seconds()
-                            < 0
+                            < TimeDelta::zero()
                             && is_referenceable_message(message, Some(message_reference_type))
                     })
                     .map(|latest_message| (latest_message, message_reference_type))
@@ -366,8 +365,7 @@ pub async fn get_latest_connected_message_reference(
                 message
                     .server_time
                     .signed_duration_since(before_server_time)
-                    .num_seconds()
-                    < 0
+                    < TimeDelta::zero()
                     && matches!(
                         message.target.source(),
                         message::Source::Internal(message::source::Internal::Status(

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -488,22 +488,24 @@ impl Data {
                     });
                 }
                 _ => {
+                    let read_marker = history::load_read_marker(&server, &kind);
                     entry.insert(History::Full {
                         server,
                         kind,
                         messages,
                         last_received_at: None,
-                        read_marker: None,
+                        read_marker,
                     });
                 }
             },
             hash_map::Entry::Vacant(entry) => {
+                let read_marker = history::load_read_marker(&server, &kind);
                 entry.insert(History::Full {
                     server,
                     kind,
                     messages,
                     last_received_at: None,
-                    read_marker: None,
+                    read_marker,
                 });
             }
         }

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -8,7 +8,7 @@ use itertools::Itertools;
 use tokio::{self, time::Instant};
 
 use crate::history::{self, History};
-use crate::isupport::{ChatHistorySubcommand, MessageReference};
+use crate::isupport::MessageReference;
 use crate::message::{self, Limit};
 use crate::time::Posix;
 use crate::user::Nick;
@@ -185,20 +185,6 @@ impl Manager {
     }
 
     pub fn record_message(&mut self, server: &Server, message: crate::Message) {
-        self.data.add_message(
-            server.clone(),
-            history::Kind::from(message.target.clone()),
-            message,
-        );
-    }
-
-    pub fn record_chathistory_message(
-        &mut self,
-        server: &Server,
-        message: crate::Message,
-        subcommand: ChatHistorySubcommand,
-        message_reference: MessageReference,
-    ) {
         self.data.add_message(
             server.clone(),
             history::Kind::from(message.target.clone()),

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -199,12 +199,10 @@ impl Manager {
         subcommand: ChatHistorySubcommand,
         message_reference: MessageReference,
     ) {
-        self.data.add_chathistory_message(
+        self.data.add_message(
             server.clone(),
             history::Kind::from(message.target.clone()),
             message,
-            subcommand,
-            message_reference,
         );
     }
 
@@ -726,22 +724,6 @@ impl Data {
             .entry(kind.clone())
             .or_insert_with(|| History::partial(server, kind, None, message.received_at))
             .add_message(message)
-    }
-
-    fn add_chathistory_message(
-        &mut self,
-        server: server::Server,
-        kind: history::Kind,
-        message: crate::Message,
-        subcommand: ChatHistorySubcommand,
-        message_reference: MessageReference,
-    ) {
-        self.map
-            .entry(server.clone())
-            .or_default()
-            .entry(kind.clone())
-            .or_insert_with(|| History::partial(server, kind, None, message.received_at))
-            .add_chathistory_message(message, subcommand, message_reference)
     }
 
     fn untrack(

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -673,7 +673,9 @@ impl Data {
 
         let split_at = limited
             .iter()
-            .position(|message| message.received_at >= *opened_at)
+            .rev()
+            .position(|message| message.received_at < *opened_at)
+            .map(|position| limited.len() - position)
             .unwrap_or(limited.len());
 
         let (old, new) = limited.split_at(split_at);

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -186,13 +186,17 @@ impl Manager {
         )
     }
 
+    pub fn get_read_marker(&self, server: &Server, kind: &history::Kind) -> Option<DateTime<Utc>> {
+        self.data.get_read_marker(server, kind)
+    }
+
     pub fn update_read_marker(
         &mut self,
         server: &Server,
         kind: &history::Kind,
         read_marker: Option<DateTime<Utc>>,
-    ) {
-        self.data.update_read_marker(server, kind, read_marker);
+    ) -> bool {
+        self.data.update_read_marker(server, kind, read_marker)
     }
 
     pub fn inc_unread_count(&mut self, server: &Server, kind: &history::Kind, increment: usize) {
@@ -704,18 +708,26 @@ impl Data {
         }
     }
 
+    fn get_read_marker(
+        &self,
+        server: &server::Server,
+        kind: &history::Kind,
+    ) -> Option<DateTime<Utc>> {
+        self.map.get(server)?.get(kind)?.get_read_marker()
+    }
+
     fn update_read_marker(
         &mut self,
         server: &server::Server,
         kind: &history::Kind,
         read_marker: Option<DateTime<Utc>>,
-    ) {
+    ) -> bool {
         self.map
             .entry(server.clone())
             .or_default()
             .entry(kind.clone())
             .or_insert_with(|| History::partial(server.clone(), kind.clone(), None))
-            .update_read_marker(read_marker);
+            .update_read_marker(read_marker)
     }
 
     fn untrack(

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -249,7 +249,7 @@ impl Manager {
         &self,
         server: &Server,
         target: &str,
-        message_reference_type: isupport::MessageReferenceType,
+        message_reference_type: &isupport::MessageReferenceType,
         join_server_time: DateTime<Utc>,
     ) -> Option<&crate::Message> {
         let kind = if proto::is_channel(target) {
@@ -269,7 +269,7 @@ impl Manager {
         &self,
         server: &Server,
         target: &str,
-        message_reference_type: isupport::MessageReferenceType,
+        message_reference_type: &isupport::MessageReferenceType,
     ) -> Option<&crate::Message> {
         let kind = if proto::is_channel(target) {
             history::Kind::Channel(target.to_string())

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -466,7 +466,10 @@ impl Data {
                 } => {
                     let last_received_at = *last_received_at;
                     let opened_at = *opened_at;
-                    messages.extend(std::mem::take(new_messages));
+                    let new_messages = std::mem::take(new_messages);
+                    new_messages.into_iter().for_each(|new_message| {
+                        history::insert_message(&mut messages, new_message);
+                    });
                     entry.insert(History::Full {
                         server,
                         kind,

--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -107,7 +107,7 @@ impl Input {
                 target: to_target(&target, message::Source::Action)?,
                 content: message::action_text(user.nickname(), Some(&action)),
                 id: None,
-            }),
+            }]),
             _ => None,
         }
     }

--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -96,6 +96,7 @@ impl Input {
                         direction: message::Direction::Sent,
                         target,
                         content: message::parse_fragments(text.clone()),
+                        id: None,
                     })
                     .collect(),
             ),
@@ -105,7 +106,8 @@ impl Input {
                 direction: message::Direction::Sent,
                 target: to_target(&target, message::Source::Action)?,
                 content: message::action_text(user.nickname(), Some(&action)),
-            }]),
+                id: None,
+            }),
             _ => None,
         }
     }

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Utc};
+use chrono::{format::SecondsFormat, DateTime, Utc};
 use irc::proto;
 use std::fmt;
 use std::str::FromStr;
@@ -663,7 +663,7 @@ impl fmt::Display for MessageReference {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             MessageReference::Timestamp(server_time) => {
-                write!(f, "timestamp={}", server_time.to_rfc3339())
+                write!(f, "timestamp={}", server_time.to_rfc3339_opts(SecondsFormat::Millis, true))
             }
             MessageReference::MessageId(id) => write!(f, "msgid={}", id),
             MessageReference::None => write!(f, "*"),

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -653,7 +653,7 @@ pub struct CommandTargetLimit {
 
 #[derive(Clone, Debug)]
 pub enum MessageReference {
-    Timestamp(DateTime<Utc>, String),
+    Timestamp(DateTime<Utc>),
     MessageId(String),
     None,
 }
@@ -661,7 +661,7 @@ pub enum MessageReference {
 impl fmt::Display for MessageReference {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            MessageReference::Timestamp(server_time, _) => write!(
+            MessageReference::Timestamp(server_time) => write!(
                 f,
                 "timestamp={}",
                 server_time.to_rfc3339_opts(SecondsFormat::Millis, true)
@@ -675,9 +675,7 @@ impl fmt::Display for MessageReference {
 impl PartialEq<Message> for MessageReference {
     fn eq(&self, other: &Message) -> bool {
         match self {
-            MessageReference::Timestamp(server_time, client_id) => {
-                other.server_time == *server_time && other.id.as_deref() == Some(client_id.as_str())
-            }
+            MessageReference::Timestamp(server_time) => other.server_time == *server_time,
             MessageReference::MessageId(id) => other.id.as_deref() == Some(id.as_str()),
             MessageReference::None => false,
         }

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -653,7 +653,7 @@ pub struct CommandTargetLimit {
 
 #[derive(Clone, Debug)]
 pub enum MessageReference {
-    Timestamp(DateTime<Utc>),
+    Timestamp(DateTime<Utc>, String),
     MessageId(String),
     None,
 }
@@ -661,7 +661,7 @@ pub enum MessageReference {
 impl fmt::Display for MessageReference {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            MessageReference::Timestamp(server_time) => write!(
+            MessageReference::Timestamp(server_time, _) => write!(
                 f,
                 "timestamp={}",
                 server_time.to_rfc3339_opts(SecondsFormat::Millis, true)
@@ -675,7 +675,9 @@ impl fmt::Display for MessageReference {
 impl PartialEq<Message> for MessageReference {
     fn eq(&self, other: &Message) -> bool {
         match self {
-            MessageReference::Timestamp(server_time) => other.server_time == *server_time,
+            MessageReference::Timestamp(server_time, client_id) => {
+                other.server_time == *server_time && other.id.as_deref() == Some(client_id.as_str())
+            }
             MessageReference::MessageId(id) => other.id.as_deref() == Some(id.as_str()),
             MessageReference::None => false,
         }

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -634,8 +634,19 @@ pub struct ChannelMode {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum ChatHistorySubcommand {
-    Latest(DateTime<Utc>),
-    Before,
+    Latest(String, MessageReference, u16),
+    Before(String, MessageReference, u16),
+    Between(String, MessageReference, MessageReference, u16),
+}
+
+impl ChatHistorySubcommand {
+    pub fn target(&self) -> Option<&str> {
+        match self {
+            ChatHistorySubcommand::Latest(target, _, _)
+            | ChatHistorySubcommand::Before(target, _, _)
+            | ChatHistorySubcommand::Between(target, _, _, _) => Some(target),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -651,7 +662,7 @@ pub struct CommandTargetLimit {
     pub limit: Option<u16>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum MessageReference {
     Timestamp(DateTime<Utc>),
     MessageId(String),

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -634,8 +634,7 @@ pub struct ChannelMode {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum ChatHistorySubcommand {
-    Latest,
-    After,
+    Latest(DateTime<Utc>),
     Before,
 }
 
@@ -662,9 +661,11 @@ pub enum MessageReference {
 impl fmt::Display for MessageReference {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            MessageReference::Timestamp(server_time) => {
-                write!(f, "timestamp={}", server_time.to_rfc3339_opts(SecondsFormat::Millis, true))
-            }
+            MessageReference::Timestamp(server_time) => write!(
+                f,
+                "timestamp={}",
+                server_time.to_rfc3339_opts(SecondsFormat::Millis, true)
+            ),
             MessageReference::MessageId(id) => write!(f, "msgid={}", id),
             MessageReference::None => write!(f, "*"),
         }
@@ -699,6 +700,8 @@ pub struct PrefixMap {
     pub prefix: char,
     pub mode: char,
 }
+
+pub const CHATHISTORY_FUZZ_SECONDS: i64 = 1;
 
 const DEFAULT_BAN_EXCEPTION_CHANNEL_LETTER: char = 'e';
 

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -746,15 +746,9 @@ fn content(
             let new_nick = Nick::from(nick.as_str());
             let ourself = *our_nick == old_nick;
 
-            Some(parse_fragments(nickname_text(
-                &old_nick, &new_nick, ourself,
-            )))
+            Some(nickname_text(&old_nick, &new_nick, ourself))
         }
-        Command::QUIT(comment) => Some(parse_fragments(quit_text(
-            &message.user()?,
-            comment,
-            config,
-        ))),
+        Command::QUIT(comment) => Some(quit_text(&message.user()?, comment, config)),
         Command::NOTICE(_, text) => Some(parse_fragments(text.clone())),
         Command::Numeric(RPL_TOPIC, params) => {
             let topic = params.get(2)?;
@@ -966,22 +960,22 @@ fn monitored_targets_text(targets: Vec<String>) -> Option<String> {
 
 pub fn nickname_text(old_nick: &Nick, new_nick: &Nick, ourself: bool) -> String {
     if ourself {
-        format!(" ∙ You're now known as {new_nick}")
+        plain(format!(" ∙ You're now known as {new_nick}"))
     } else {
-        format!(" ∙ {old_nick} is now known as {new_nick}")
+        plain(format!(" ∙ {old_nick} is now known as {new_nick}"))
     }
 }
 
-pub fn quit_text(user: &User, comment: &Option<String>, config: &Config) -> String {
+pub fn quit_text(user: &User, comment: &Option<String>, config: &Config) -> Content {
     let comment = comment
         .as_ref()
         .map(|comment| format!(" ({comment})"))
         .unwrap_or_default();
 
-    format!(
+    parse_fragments(format!(
         "⟵ {} has quit{comment}",
         user.formatted(config.buffer.server_messages.quit.username_format)
-    )
+    ))
 }
 
 pub fn reference_user(sender: NickRef, own_nick: NickRef, message: &Message) -> bool {

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -276,6 +276,7 @@ impl<'de> Deserialize<'de> for Message {
             content: Option<Content>,
             // Old field before we had fragments
             text: Option<String>,
+            id: Option<String>,
         }
 
         let Data {
@@ -285,6 +286,7 @@ impl<'de> Deserialize<'de> for Message {
             target,
             content,
             text,
+            id,
         } = Data::deserialize(deserializer)?;
 
         let content = if let Some(content) = content {
@@ -303,6 +305,7 @@ impl<'de> Deserialize<'de> for Message {
             direction,
             target,
             content,
+            id,
         })
     }
 }
@@ -743,9 +746,15 @@ fn content(
             let new_nick = Nick::from(nick.as_str());
             let ourself = *our_nick == old_nick;
 
-            Some(nickname_text(&old_nick, &new_nick, ourself))
+            Some(parse_fragments(nickname_text(
+                &old_nick, &new_nick, ourself,
+            )))
         }
-        Command::QUIT(comment) => Some(quit_text(&message.user()?, comment, config)),
+        Command::QUIT(comment) => Some(parse_fragments(quit_text(
+            &message.user()?,
+            comment,
+            config,
+        ))),
         Command::NOTICE(_, text) => Some(parse_fragments(text.clone())),
         Command::Numeric(RPL_TOPIC, params) => {
             let topic = params.get(2)?;

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -14,6 +14,7 @@ pub use self::formatting::Formatting;
 pub use self::source::Source;
 
 use crate::config::buffer::UsernameFormat;
+use crate::history::after_read_marker;
 use crate::time::{self, Posix};
 use crate::user::{Nick, NickRef};
 use crate::{ctcp, Config, User};
@@ -152,7 +153,7 @@ pub struct Message {
 }
 
 impl Message {
-    pub fn triggers_unread(&self) -> bool {
+    pub fn triggers_unread(&self, read_marker: &Option<DateTime<Utc>>) -> bool {
         matches!(self.direction, Direction::Received)
             && match self.target.source() {
                 Source::User(_) => true,
@@ -166,6 +167,7 @@ impl Message {
                 }
                 _ => false,
             }
+            && after_read_marker(self, read_marker)
     }
 
     pub fn received(

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -7,7 +7,9 @@ use irc::proto::Command;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use regex::{Regex, RegexBuilder};
+use seahash::SeaHasher;
 use serde::{Deserialize, Deserializer, Serialize};
+use std::hash::{Hash, Hasher};
 use url::Url;
 
 pub use self::formatting::Formatting;
@@ -61,7 +63,7 @@ pub(crate) mod broadcast;
 pub mod formatting;
 pub mod source;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash)]
 pub struct Encoded(proto::Message);
 
 impl Encoded {
@@ -173,9 +175,10 @@ impl Message {
         our_nick: Nick,
         config: &Config,
         resolve_attributes: impl Fn(&User, &str) -> Option<User>,
+        generate_missing_id: bool,
     ) -> Option<Message> {
         let server_time = server_time(&encoded);
-        let id = message_id(&encoded);
+        let id = message_id(&encoded).or(generate_missing_id.then_some(client_id(&encoded)));
         let content = content(&encoded, &our_nick, config, &resolve_attributes)?;
         let target = target(encoded, &our_nick, &resolve_attributes)?;
 
@@ -603,6 +606,16 @@ fn target(
             source: Source::Server(None),
         }),
     }
+}
+
+pub fn client_id(message: &Encoded) -> String {
+    let mut hasher = SeaHasher::new();
+
+    message.hash(&mut hasher);
+
+    // Prefix hash with ':' fort client id, since that character
+    // is not allowed in message ids provided by servers
+    format!(":{:x}", hasher.finish())
 }
 
 pub fn message_id(message: &Encoded) -> Option<String> {

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -593,7 +593,6 @@ fn target(
         | Command::ACCOUNT(_)
         | Command::BATCH(_, _)
         | Command::CHATHISTORY(_, _)
-        | Command::CHGHOST(_, _)
         | Command::CNOTICE(_, _, _)
         | Command::CPRIVMSG(_, _, _)
         | Command::KNOCK(_, _)

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -957,11 +957,11 @@ fn monitored_targets_text(targets: Vec<String>) -> Option<String> {
     }
 }
 
-pub fn nickname_text(old_nick: &Nick, new_nick: &Nick, ourself: bool) -> String {
+pub fn nickname_text(old_nick: &Nick, new_nick: &Nick, ourself: bool) -> Content {
     if ourself {
-        plain(format!(" ∙ You're now known as {new_nick}"))
+        plain(format!("You're now known as {new_nick}"))
     } else {
-        plain(format!(" ∙ {old_nick} is now known as {new_nick}"))
+        plain(format!("{old_nick} is now known as {new_nick}"))
     }
 }
 

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, TimeDelta, Utc};
 use const_format::concatcp;
 use irc::proto;
 use irc::proto::Command;
@@ -622,6 +622,20 @@ pub fn server_time(message: &Encoded) -> DateTime<Utc> {
         .and_then(|rfc3339| DateTime::parse_from_rfc3339(&rfc3339).ok())
         .map(|dt| dt.with_timezone(&Utc))
         .unwrap_or_else(Utc::now)
+}
+
+pub const FUZZ_SECONDS: i64 = 1;
+
+pub fn fuzz_start_server_time(server_time: DateTime<Utc>) -> DateTime<Utc> {
+    TimeDelta::try_seconds(FUZZ_SECONDS)
+        .and_then(|time_delta| server_time.checked_sub_signed(time_delta))
+        .map_or(server_time, |fuzzed_server_time| fuzzed_server_time)
+}
+
+pub fn fuzz_end_server_time(server_time: DateTime<Utc>) -> DateTime<Utc> {
+    TimeDelta::try_seconds(FUZZ_SECONDS)
+        .and_then(|time_delta| server_time.checked_add_signed(time_delta))
+        .map_or(server_time, |fuzzed_server_time| fuzzed_server_time)
 }
 
 fn content(

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -27,6 +27,7 @@ fn expand(
             direction: Direction::Received,
             target,
             content,
+            id: None,
         }
     };
 

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -74,7 +74,7 @@ pub fn connecting(sent_time: DateTime<Utc>) -> Vec<Message> {
         [],
         [],
         true,
-        Cause::Status(source::Status::Pending),
+        Cause::Status(source::Status::Success),
         content,
         sent_time,
     )

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -74,7 +74,7 @@ pub fn connecting(sent_time: DateTime<Utc>) -> Vec<Message> {
         [],
         [],
         true,
-        Cause::Status(source::Status::Success),
+        Cause::Status(source::Status::Pending),
         content,
         sent_time,
     )

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -1,7 +1,7 @@
 //! Generate messages that can be broadcast into every buffer
 use chrono::{DateTime, Utc};
 
-use super::{nickname_text, parse_fragments, plain, quit_text, source, Content, Direction, Message, Source, Target};
+use super::{nickname_text, plain, quit_text, source, Content, Direction, Message, Source, Target};
 use crate::config::buffer::UsernameFormat;
 use crate::time::Posix;
 use crate::user::Nick;

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -1,7 +1,7 @@
 //! Generate messages that can be broadcast into every buffer
 use chrono::{DateTime, Utc};
 
-use super::{parse_fragments, plain, source, Content, Direction, Message, Source, Target};
+use super::{nickname_text, parse_fragments, plain, quit_text, source, Content, Direction, Message, Source, Target};
 use crate::config::buffer::UsernameFormat;
 use crate::time::Posix;
 use crate::user::Nick;
@@ -146,15 +146,7 @@ pub fn quit(
     config: &Config,
     sent_time: DateTime<Utc>,
 ) -> Vec<Message> {
-    let comment = comment
-        .as_ref()
-        .map(|comment| format!(" ({comment})"))
-        .unwrap_or_default();
-
-    let content = parse_fragments(format!(
-        "⟵ {} has quit{comment}",
-        user.formatted(config.buffer.server_messages.quit.username_format)
-    ));
+    let content = quit_text(user, comment, config);
 
     expand(
         channels,
@@ -177,11 +169,7 @@ pub fn nickname(
     ourself: bool,
     sent_time: DateTime<Utc>,
 ) -> Vec<Message> {
-    let content = if ourself {
-        plain(format!("You're now known as {new_nick}"))
-    } else {
-        plain(format!("{old_nick} is now known as {new_nick}"))
-    };
+    let content = nickname_text(old_nick, new_nick, ourself);
 
     expand(
         channels,

--- a/data/src/message/source.rs
+++ b/data/src/message/source.rs
@@ -21,6 +21,7 @@ pub enum Internal {
 pub enum Status {
     Success,
     Error,
+    Pending,
 }
 
 pub mod server {

--- a/data/src/message/source.rs
+++ b/data/src/message/source.rs
@@ -21,7 +21,6 @@ pub enum Internal {
 pub enum Status {
     Success,
     Error,
-    Pending,
 }
 
 pub mod server {

--- a/irc/proto/src/command.rs
+++ b/irc/proto/src/command.rs
@@ -99,6 +99,8 @@ pub enum Command {
     ACCOUNT(String),
     /* IRC extensions */
     BATCH(String, Vec<String>),
+    /// <subcommand> [<params>]
+    CHATHISTORY(String, Vec<String>),
     /// <new_username> <new_hostname>
     CHGHOST(String, String),
     /// <nickname> <channel> :<message>
@@ -201,6 +203,7 @@ impl Command {
             "WALLOPS" if len > 0 => WALLOPS(req!()),
             "ACCOUNT" if len > 0 => ACCOUNT(req!()),
             "BATCH" if len > 0 => BATCH(req!(), params.collect()),
+            "CHATHISTORY" if len > 0 => CHATHISTORY(req!(), params.collect()),
             "CHGHOST" if len > 1 => CHGHOST(req!(), req!()),
             "CNOTICE" if len > 2 => CNOTICE(req!(), req!(), req!()),
             "CPRIVMSG" if len > 2 => CPRIVMSG(req!(), req!(), req!()),
@@ -261,6 +264,7 @@ impl Command {
             Command::WALLOPS(a) => vec![a],
             Command::ACCOUNT(a) => vec![a],
             Command::BATCH(a, rest) => std::iter::once(a).chain(rest).collect(),
+            Command::CHATHISTORY(a, b) => std::iter::once(a).chain(b).collect(),
             Command::CHGHOST(a, b) => vec![a, b],
             Command::CNOTICE(a, b, c) => vec![a, b, c],
             Command::CPRIVMSG(a, b, c) => vec![a, b, c],
@@ -320,6 +324,7 @@ impl Command {
             WALLOPS(_) => "WALLOPS".to_string(),
             ACCOUNT(_) => "ACCOUNT".to_string(),
             BATCH(_, _) => "BATCH".to_string(),
+            CHATHISTORY(_, _) => "CHATHISTORY".to_string(),
             CHGHOST(_, _) => "CHGHOST".to_string(),
             CNOTICE(_, _, _) => "CNOTICE".to_string(),
             CPRIVMSG(_, _, _) => "CPRIVMSG".to_string(),

--- a/irc/proto/src/command.rs
+++ b/irc/proto/src/command.rs
@@ -1,5 +1,5 @@
 #[allow(non_camel_case_types)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Command {
     /* Connection Messages */
     /// [*] <subcommand> [*] [<param>]
@@ -340,7 +340,7 @@ impl Command {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u16)]
 pub enum Numeric {
     RPL_WELCOME = 1,

--- a/irc/proto/src/lib.rs
+++ b/irc/proto/src/lib.rs
@@ -4,7 +4,7 @@ pub mod command;
 pub mod format;
 pub mod parse;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Message {
     pub tags: Vec<Tag>,
     pub source: Option<Source>,
@@ -21,19 +21,19 @@ impl From<Command> for Message {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Tag {
     pub key: String,
     pub value: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Source {
     Server(String),
     User(User),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct User {
     pub nickname: String,
     pub username: Option<String>,

--- a/irc/proto/src/lib.rs
+++ b/irc/proto/src/lib.rs
@@ -4,7 +4,7 @@ pub mod command;
 pub mod format;
 pub mod parse;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Message {
     pub tags: Vec<Tag>,
     pub source: Option<Source>,
@@ -21,19 +21,19 @@ impl From<Command> for Message {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Tag {
     pub key: String,
     pub value: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Source {
     Server(String),
     User(User),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct User {
     pub nickname: String,
     pub username: Option<String>,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -40,8 +40,7 @@ pub enum Message {
 #[derive(Debug, Clone)]
 pub enum Event {
     UserContext(user_context::Event),
-    ScrolledToTop,
-    ChatHistoryBeforeRequest,
+    RequestOlderChatHistory,
 }
 
 impl Buffer {
@@ -73,8 +72,7 @@ impl Buffer {
 
                 let event = event.map(|event| match event {
                     channel::Event::UserContext(event) => Event::UserContext(event),
-                    channel::Event::ScrolledToTop => Event::ScrolledToTop,
-                    channel::Event::ChatHistoryBeforeRequest => Event::ChatHistoryBeforeRequest,
+                    channel::Event::RequestOlderChatHistory => Event::RequestOlderChatHistory,
                 });
 
                 (command.map(Message::Channel), event)
@@ -89,8 +87,7 @@ impl Buffer {
 
                 let event = event.map(|event| match event {
                     query::Event::UserContext(event) => Event::UserContext(event),
-                    query::Event::ScrolledToTop => Event::ScrolledToTop,
-                    query::Event::ChatHistoryBeforeRequest => Event::ChatHistoryBeforeRequest,
+                    query::Event::RequestOlderChatHistory => Event::RequestOlderChatHistory,
                 });
 
                 (command.map(Message::Query), event)

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -41,6 +41,7 @@ pub enum Message {
 pub enum Event {
     UserContext(user_context::Event),
     ScrolledToTop,
+    ChatHistoryBeforeRequest,
 }
 
 impl Buffer {
@@ -73,6 +74,7 @@ impl Buffer {
                 let event = event.map(|event| match event {
                     channel::Event::UserContext(event) => Event::UserContext(event),
                     channel::Event::ScrolledToTop => Event::ScrolledToTop,
+                    channel::Event::ChatHistoryBeforeRequest => Event::ChatHistoryBeforeRequest,
                 });
 
                 (command.map(Message::Channel), event)

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -40,6 +40,7 @@ pub enum Message {
 #[derive(Debug, Clone)]
 pub enum Event {
     UserContext(user_context::Event),
+    ScrolledToTop,
 }
 
 impl Buffer {
@@ -71,6 +72,7 @@ impl Buffer {
 
                 let event = event.map(|event| match event {
                     channel::Event::UserContext(event) => Event::UserContext(event),
+                    channel::Event::ScrolledToTop => Event::ScrolledToTop,
                 });
 
                 (command.map(Message::Channel), event)

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -89,6 +89,8 @@ impl Buffer {
 
                 let event = event.map(|event| match event {
                     query::Event::UserContext(event) => Event::UserContext(event),
+                    query::Event::ScrolledToTop => Event::ScrolledToTop,
+                    query::Event::ChatHistoryBeforeRequest => Event::ChatHistoryBeforeRequest,
                 });
 
                 (command.map(Message::Query), event)

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -47,9 +47,9 @@ pub fn view<'a>(
     let chathistory_before_button = if clients.get_server_supports_chathistory(&state.server) {
         Some((
             clients
-                .get_channel_chathistory_request(&state.server, &state.channel)
+                .get_chathistory_request(&state.server, &state.channel)
                 .is_some(),
-            clients.get_channel_chathistory_before_exhausted(&state.server, &state.channel),
+            clients.get_chathistory_exhausted(&state.server, &state.channel),
         ))
     } else {
         None

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -21,8 +21,7 @@ pub enum Message {
 #[derive(Debug, Clone)]
 pub enum Event {
     UserContext(user_context::Event),
-    ScrolledToTop,
-    ChatHistoryBeforeRequest,
+    RequestOlderChatHistory,
 }
 
 pub fn view<'a>(
@@ -326,12 +325,11 @@ impl Channel {
     ) -> (Task<Message>, Option<Event>) {
         match message {
             Message::ScrollView(message) => {
-                let (command, event) = self.scroll_view.update(message);
+                let (command, event) = self.scroll_view.update(message, config.buffer.chathistory.infinite_scroll);
 
                 let event = event.map(|event| match event {
                     scroll_view::Event::UserContext(event) => Event::UserContext(event),
-                    scroll_view::Event::ScrolledToTop => Event::ScrolledToTop,
-                    scroll_view::Event::ChatHistoryBeforeRequest => Event::ChatHistoryBeforeRequest,
+                    scroll_view::Event::RequestOlderChatHistory => Event::RequestOlderChatHistory,
                 });
 
                 (command.map(Message::ScrollView), event)

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -21,6 +21,7 @@ pub enum Message {
 #[derive(Debug, Clone)]
 pub enum Event {
     UserContext(user_context::Event),
+    ScrolledToTop,
 }
 
 pub fn view<'a>(
@@ -317,6 +318,7 @@ impl Channel {
 
                 let event = event.map(|event| match event {
                     scroll_view::Event::UserContext(event) => Event::UserContext(event),
+                    scroll_view::Event::ScrolledToTop => Event::ScrolledToTop,
                 });
 
                 (command.map(Message::ScrollView), event)

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -231,6 +231,7 @@ impl Query {
                 let event = event.and_then(|event| match event {
                     scroll_view::Event::UserContext(event) => Some(Event::UserContext(event)),
                     scroll_view::Event::ScrolledToTop => None,
+                    scroll_view::Event::ChatHistoryBeforeRequest => None,
                 });
 
                 (command.map(Message::ScrollView), event)

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -228,8 +228,9 @@ impl Query {
             Message::ScrollView(message) => {
                 let (command, event) = self.scroll_view.update(message);
 
-                let event = event.map(|event| match event {
-                    scroll_view::Event::UserContext(event) => Event::UserContext(event),
+                let event = event.and_then(|event| match event {
+                    scroll_view::Event::UserContext(event) => Some(Event::UserContext(event)),
+                    scroll_view::Event::ScrolledToTop => None,
                 });
 
                 (command.map(Message::ScrollView), event)

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -16,8 +16,7 @@ pub enum Message {
 #[derive(Debug, Clone)]
 pub enum Event {
     UserContext(user_context::Event),
-    ScrolledToTop,
-    ChatHistoryBeforeRequest,
+    RequestOlderChatHistory,
 }
 
 pub fn view<'a>(
@@ -239,12 +238,11 @@ impl Query {
     ) -> (Task<Message>, Option<Event>) {
         match message {
             Message::ScrollView(message) => {
-                let (command, event) = self.scroll_view.update(message);
+                let (command, event) = self.scroll_view.update(message, config.buffer.chathistory.infinite_scroll);
 
                 let event = event.map(|event| match event {
                     scroll_view::Event::UserContext(event) => Event::UserContext(event),
-                    scroll_view::Event::ScrolledToTop => Event::ScrolledToTop,
-                    scroll_view::Event::ChatHistoryBeforeRequest => Event::ChatHistoryBeforeRequest,
+                    scroll_view::Event::RequestOlderChatHistory => Event::RequestOlderChatHistory,
                 });
 
                 (command.map(Message::ScrollView), event)

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -25,6 +25,7 @@ pub enum Message {
 #[derive(Debug, Clone)]
 pub enum Event {
     UserContext(user_context::Event),
+    ScrolledToTop,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -219,6 +220,8 @@ impl State {
                         scrollable::scroll_to(self.scrollable.clone(), new_offset),
                         None,
                     );
+                } else if matches!(self.limit, Limit::Top(_)) && relative_offset == 0.0 {
+                    return (Command::none(), Some(Event::ScrolledToTop));
                 }
             }
             Message::UserContext(message) => {

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -88,9 +88,9 @@ pub fn view<'a>(
 
             Some(
                 row![horizontal_space(), top_row_button, horizontal_space()]
-                    .padding([2, 0, 6, 0])
+                    .padding(padding::top(2).bottom(6))
                     .width(Length::Fill)
-                    .align_items(iced::Alignment::Center),
+                    .align_y(iced::Alignment::Center),
             )
         } else {
             None
@@ -268,7 +268,7 @@ impl State {
                     && matches!(self.limit, Limit::Top(_))
                     && relative_offset == 0.0
                 {
-                    return (Command::none(), Some(Event::RequestOlderChatHistory));
+                    return (Task::none(), Some(Event::RequestOlderChatHistory));
                 }
             }
             Message::UserContext(message) => {
@@ -281,7 +281,7 @@ impl State {
                 let _ = open::that_detached(link);
             }
             Message::RequestOlderChatHistory => {
-                return (Command::none(), Some(Event::RequestOlderChatHistory))
+                return (Task::none(), Some(Event::RequestOlderChatHistory))
             }
         }
 

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -84,13 +84,14 @@ pub fn view<'a>(
 
         let font_size = config.font.size.map(f32::from).unwrap_or(theme::TEXT_SIZE) - 1.0;
 
-        let top_row_button = button(text(content).size(font_size).style(theme::text::primary))
-            .padding(5)
+        let top_row_button = button(text(content).size(font_size))
+            .padding([3, 5])
             .style(theme::button::primary)
             .on_press_maybe(message);
 
         Some(
             row![horizontal_space(), top_row_button, horizontal_space()]
+                .padding([2, 0, 6, 0])
                 .width(Length::Fill)
                 .align_items(iced::Alignment::Center),
         )

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -2,8 +2,10 @@ use data::message::Limit;
 use data::server::Server;
 use data::user::Nick;
 use data::{history, time, Config};
-use iced::widget::{button, column, container, horizontal_rule, row, scrollable, text, Scrollable};
-use iced::{alignment, padding, Length, Task};
+use iced::widget::{
+    button, column, container, horizontal_rule, horizontal_space, row, scrollable, text, Scrollable,
+};
+use iced::{padding, Length, Task};
 
 use super::user_context;
 use crate::widget::{Element, MESSAGE_MARKER_TEXT};
@@ -83,7 +85,7 @@ pub fn view<'a>(
 
             let top_row_button = button(text(content).size(font_size))
                 .padding([3, 5])
-                .style(theme::button::primary)
+                .style(|theme, status| theme::button::primary(theme, status, false))
                 .on_press_maybe(message);
 
             Some(

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -3,7 +3,7 @@ use data::server::Server;
 use data::user::Nick;
 use data::{history, time, Config};
 use iced::widget::{button, column, container, horizontal_rule, row, scrollable, text, Scrollable};
-use iced::{padding, Length, Task};
+use iced::{alignment, padding, Length, Task};
 
 use super::user_context;
 use crate::widget::{Element, MESSAGE_MARKER_TEXT};

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -122,7 +122,7 @@ impl Server {
     ) -> Task<Message> {
         match message {
             Message::ScrollView(message) => {
-                let (command, _) = self.scroll_view.update(message);
+                let (command, _) = self.scroll_view.update(message, false);
                 command.map(Message::ScrollView)
             }
             Message::InputView(message) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -521,14 +521,40 @@ impl Halloy {
                                         if let Some(message) =
                                             data::Message::received(encoded, our_nick, &self.config, resolve_user_attributes)
                                         {
-                                            dashboard.record_message(&server, message);
+                                            if let Some(history::manager::Event::LoadReadMarker(server, kind)) =
+                                                dashboard.record_message(&server, message)
+                                            {
+                                                commands.push(Task::perform(
+                                                    history::load_read_marker(server.clone(), kind.clone()),
+                                                    move |read_marker| {
+                                                        Message::UpdateReadMarker(
+                                                            server.clone(),
+                                                            kind.clone(),
+                                                            read_marker,
+                                                        )
+                                                    },
+                                                ));
+                                            }
                                         }
                                     }
                                     data::client::Event::WithTarget(encoded, our_nick, target) => {
                                         if let Some(message) =
                                             data::Message::received(encoded, our_nick, &self.config, resolve_user_attributes)
                                         {
-                                            dashboard.record_message(&server, message.with_target(target));
+                                            if let Some(history::manager::Event::LoadReadMarker(server, kind)) =
+                                                dashboard.record_message(&server, message.with_target(target))
+                                            {
+                                                commands.push(Task::perform(
+                                                    history::load_read_marker(server.clone(), kind.clone()),
+                                                    move |read_marker| {
+                                                        Message::UpdateReadMarker(
+                                                            server.clone(),
+                                                            kind.clone(),
+                                                            read_marker,
+                                                        )
+                                                    },
+                                                ));
+                                            }
                                         }
                                     }
                                     data::client::Event::Broadcast(broadcast) => match broadcast {
@@ -607,7 +633,20 @@ impl Halloy {
                                         if let Some(message) =
                                             data::Message::received(encoded, our_nick, &self.config, resolve_user_attributes)
                                         {
-                                            dashboard.record_message(&server, message);
+                                            if let Some(history::manager::Event::LoadReadMarker(server, kind)) =
+                                                dashboard.record_message(&server, message)
+                                            {
+                                                commands.push(Task::perform(
+                                                    history::load_read_marker(server.clone(), kind.clone()),
+                                                    move |read_marker| {
+                                                        Message::UpdateReadMarker(
+                                                            server.clone(),
+                                                            kind.clone(),
+                                                            read_marker,
+                                                        )
+                                                    },
+                                                ));
+                                            }
                                         }
 
                                         match notification {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use std::time::{Duration, Instant};
 
 use chrono::Utc;
 use data::config::{self, Config};
-use data::isupport::{ChatHistorySubcommand, MessageReference};
+use data::isupport::ChatHistorySubcommand;
 use data::version::Version;
 use data::{environment, history, server, version, Url, User};
 use iced::widget::{column, container};
@@ -649,41 +649,15 @@ impl Halloy {
                                         message_reference_type,
                                         limit,
                                     ) => match subcommand {
-                                        ChatHistorySubcommand::Latest => {
-                                            let latest_message_reference = dashboard
-                                                .get_latest_message_reference(
-                                                    &server,
-                                                    channel.clone(),
-                                                    message_reference_type,
-                                                );
+                                        ChatHistorySubcommand::Latest(join_server_time) => {
+                                            dashboard.load_history(server.clone(), channel.clone());
 
-                                            if matches!(
-                                                latest_message_reference,
-                                                MessageReference::None
-                                            ) {
-                                                self.clients.get_channel_chathistory(
-                                                    subcommand,
-                                                    &server,
-                                                    channel.as_str(),
-                                                    latest_message_reference,
-                                                    limit,
-                                                )
-                                            } else {
-                                                self.clients.get_channel_chathistory(
-                                                    ChatHistorySubcommand::After,
-                                                    &server,
-                                                    channel.as_str(),
-                                                    latest_message_reference,
-                                                    limit,
-                                                )
-                                            }
-                                        }
-                                        ChatHistorySubcommand::After => {
                                             let latest_message_reference = dashboard
                                                 .get_latest_message_reference(
                                                     &server,
                                                     channel.clone(),
                                                     message_reference_type,
+                                                    join_server_time,
                                                 );
 
                                             self.clients.get_channel_chathistory(

--- a/src/main.rs
+++ b/src/main.rs
@@ -643,19 +643,23 @@ impl Halloy {
                                                 let server = server.clone();
                                                 let limit = self.clients.get_server_chathistory_limit(&server);
 
-                                                let start_message_reference = history::load_targets_marker(&server)
-                                                    .map_or(MessageReference::None, |targets_marker| {
-                                                        MessageReference::Timestamp(targets_marker)
-                                                    });
+                                                commands.push(Task::perform(
+                                                    history::load_targets_marker(server.clone()),
+                                                    move |targets_marker| {
+                                                        let start_message_reference = targets_marker.map_or(MessageReference::None, |targets_marker| {
+                                                            MessageReference::Timestamp(targets_marker)
+                                                        });
 
-                                                self.clients.send_chathistory_request(
-                                                    &server,
-                                                    ChatHistorySubcommand::Targets(
-                                                        start_message_reference,
-                                                        MessageReference::None,
-                                                        limit,
-                                                    ),
-                                                );
+                                                        Message::ChatHistoryRequest(
+                                                            server.clone(),
+                                                            ChatHistorySubcommand::Targets(
+                                                                start_message_reference,
+                                                                MessageReference::None,
+                                                                limit,
+                                                            )
+                                                        )
+                                                    }
+                                                ));
                                             }
                                             data::client::HistoryRequest::Queries(
                                                 message_reference_types,

--- a/src/main.rs
+++ b/src/main.rs
@@ -721,6 +721,19 @@ impl Halloy {
                                                     end_message_reference,
                                                 );
                                             }
+                                            ChatHistorySubcommand::Targets(
+                                                start_message_reference,
+                                                end_message_reference,
+                                                _,
+                                            ) => {
+                                                log::debug!(
+                                                    "[{}] received {} targets between {} and {}",
+                                                    server,
+                                                    batch_len,
+                                                    start_message_reference,
+                                                    end_message_reference,
+                                                );
+                                            }
                                         }
 
                                         if let Some(target) = subcommand.target() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -643,26 +643,6 @@ impl Halloy {
                                             commands.push(command.map(Message::Dashboard));
                                         }
                                     }
-                                    data::client::Event::ChatHistorySingle(
-                                        encoded,
-                                        our_nick,
-                                        subcommand,
-                                        message_reference,
-                                    ) => {
-                                        if let Some(message) = data::Message::received(
-                                            encoded,
-                                            our_nick,
-                                            &self.config,
-                                            resolve_user_attributes,
-                                        ) {
-                                            dashboard.record_chathistory_message(
-                                                &server,
-                                                message,
-                                                subcommand,
-                                                message_reference,
-                                            );
-                                        }
-                                    }
                                     data::client::Event::ChatHistoryCommand(
                                         subcommand,
                                         channel,
@@ -731,6 +711,47 @@ impl Halloy {
                                             )
                                         }
                                     },
+                                    data::client::Event::ChatHistorySingle(
+                                        encoded,
+                                        our_nick,
+                                        subcommand,
+                                        message_reference,
+                                    ) => {
+                                        if let Some(message) = data::Message::received(
+                                            encoded,
+                                            our_nick,
+                                            &self.config,
+                                            resolve_user_attributes,
+                                        ) {
+                                            dashboard.record_chathistory_message(
+                                                &server,
+                                                message,
+                                                subcommand,
+                                                message_reference,
+                                            );
+                                        }
+                                    }
+                                    data::client::Event::ChatHistoryWithTarget(
+                                        encoded,
+                                        our_nick,
+                                        target,
+                                        subcommand,
+                                        message_reference,
+                                    ) => {
+                                        if let Some(message) = data::Message::received(
+                                            encoded,
+                                            our_nick,
+                                            &self.config,
+                                            resolve_user_attributes,
+                                        ) {
+                                            dashboard.record_chathistory_message(
+                                                &server,
+                                                message.with_target(target),
+                                                subcommand,
+                                                message_reference,
+                                            );
+                                        }
+                                    }
                                 }
                             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -465,26 +465,20 @@ impl Halloy {
                         .flat_map(|message| {
                             let mut commands = vec![];
 
-                            let supports_chathistory = self.clients.get_server_supports_chathistory(&server);
-
                             let mut events = self.clients.receive(&server, message);
 
                             if let Some(data::client::Event::ChatHistoryBatchFilter) = events.first() {
                                 if let Some(reference_position) = events.iter().position(|event| match event {
                                     data::client::Event::ChatHistorySingle(encoded, _, _, message_reference)
                                     | data::client::Event::ChatHistoryWithTarget(encoded, _, _, _, message_reference) => {
-                                        if let MessageReference::Timestamp(reference_server_time, reference_client_id) =
-                                            message_reference
-                                        {
+                                        if let MessageReference::Timestamp(reference_server_time) = message_reference {
                                             log::trace!(
                                                 "{:?} message_reference {:?} encoded {:?}",
-                                                data::message::server_time(encoded) == *reference_server_time
-                                                    && data::message::client_id(encoded) == *reference_client_id,
-                                                    message_reference,
-                                                    encoded
-                                                    );
+                                                data::message::server_time(encoded) == *reference_server_time,
+                                                message_reference,
+                                                encoded,
+                                            );
                                             data::message::server_time(encoded) == *reference_server_time
-                                                && data::message::client_id(encoded) == *reference_client_id
                                         } else {
                                             false
                                         }
@@ -518,24 +512,16 @@ impl Halloy {
 
                                 match event {
                                     data::client::Event::Single(encoded, our_nick) => {
-                                        if let Some(message) = data::Message::received(
-                                            encoded,
-                                            our_nick,
-                                            &self.config,
-                                            resolve_user_attributes,
-                                            supports_chathistory,
-                                        ) {
+                                        if let Some(message) =
+                                            data::Message::received(encoded, our_nick, &self.config, resolve_user_attributes)
+                                        {
                                             dashboard.record_message(&server, message);
                                         }
                                     }
                                     data::client::Event::WithTarget(encoded, our_nick, target) => {
-                                        if let Some(message) = data::Message::received(
-                                            encoded,
-                                            our_nick,
-                                            &self.config,
-                                            resolve_user_attributes,
-                                            supports_chathistory,
-                                        ) {
+                                        if let Some(message) =
+                                            data::Message::received(encoded, our_nick, &self.config, resolve_user_attributes)
+                                        {
                                             dashboard.record_message(&server, message.with_target(target));
                                         }
                                     }
@@ -605,13 +591,9 @@ impl Halloy {
                                         }
                                     },
                                     data::client::Event::Notification(encoded, our_nick, notification) => {
-                                        if let Some(message) = data::Message::received(
-                                            encoded,
-                                            our_nick,
-                                            &self.config,
-                                            resolve_user_attributes,
-                                            supports_chathistory,
-                                        ) {
+                                        if let Some(message) =
+                                            data::Message::received(encoded, our_nick, &self.config, resolve_user_attributes)
+                                        {
                                             dashboard.record_message(&server, message);
                                         }
 
@@ -717,13 +699,9 @@ impl Halloy {
                                         subcommand,
                                         message_reference,
                                     ) => {
-                                        if let Some(message) = data::Message::received(
-                                            encoded,
-                                            our_nick,
-                                            &self.config,
-                                            resolve_user_attributes,
-                                            true,
-                                        ) {
+                                        if let Some(message) =
+                                            data::Message::received(encoded, our_nick, &self.config, resolve_user_attributes)
+                                        {
                                             dashboard.record_chathistory_message(
                                                 &server,
                                                 message,
@@ -739,13 +717,9 @@ impl Halloy {
                                         subcommand,
                                         message_reference,
                                     ) => {
-                                        if let Some(message) = data::Message::received(
-                                            encoded,
-                                            our_nick,
-                                            &self.config,
-                                            resolve_user_attributes,
-                                            true,
-                                        ) {
+                                        if let Some(message) =
+                                            data::Message::received(encoded, our_nick, &self.config, resolve_user_attributes)
+                                        {
                                             dashboard.record_chathistory_message(
                                                 &server,
                                                 message.with_target(target),
@@ -754,17 +728,17 @@ impl Halloy {
                                             );
                                         }
                                     }
-                                    data::client::Event::ChatHistoryBatchFinished(
-                                        subcommand,
-                                        target,
-                                        message_reference,
-                                    ) => {
+                                    data::client::Event::ChatHistoryBatchFinished(subcommand, target, message_reference) => {
                                         match subcommand {
                                             ChatHistorySubcommand::Latest(_) => {
-                                                log::debug!("[{server}] received latest messages in {target} since {message_reference}",)
+                                                log::debug!(
+                                                    "[{server}] received latest messages in {target} since {message_reference}",
+                                                )
                                             }
                                             ChatHistorySubcommand::Before => {
-                                                log::debug!("[{server}] received messages in {target} before {message_reference}",)
+                                                log::debug!(
+                                                    "[{server}] received messages in {target} before {message_reference}",
+                                                )
                                             }
                                         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -672,7 +672,7 @@ impl Halloy {
                                                     .for_each(|query| {
                                                         let server = server.clone();
                                                         let limit = self.clients.get_server_chathistory_limit(&server);
-                                                        commands.push(Command::perform(
+                                                        commands.push(Task::perform(
                                                             history::get_latest_message_reference(
                                                                 server.clone(),
                                                                 query.clone(),
@@ -683,7 +683,7 @@ impl Halloy {
                                                                 Message::ChatHistoryRequest(
                                                                     server.clone(),
                                                                     ChatHistorySubcommand::Latest(
-                                                                        query,
+                                                                        query.clone(),
                                                                         latest_message_reference,
                                                                         limit,
                                                                     ),
@@ -701,7 +701,7 @@ impl Halloy {
                                                 let limit = self.clients.get_server_chathistory_limit(&server);
 
                                                 commands.push(
-                                                    Command::perform(
+                                                    Task::perform(
                                                         history::get_latest_message_reference(
                                                             server.clone(),
                                                             target.clone(),
@@ -710,7 +710,7 @@ impl Halloy {
                                                         ),
                                                         move |latest_message_reference| {
                                                             Message::ChatHistoryRequest(
-                                                                server,
+                                                                server.clone(),
                                                                 ChatHistorySubcommand::Latest(
                                                                     target.clone(),
                                                                     latest_message_reference,
@@ -755,9 +755,9 @@ impl Halloy {
                                     data::client::Event::ChatHistoryTargetsReceived(server_time) => {
                                         let server = server.clone();
 
-                                        commands.push(Command::perform(
+                                        commands.push(Task::perform(
                                             history::overwrite_targets_marker(server.clone(), server_time),
-                                            move |result| Message::ChatHistoryTargetsMarked(server, result),
+                                            move |result| Message::ChatHistoryTargetsMarked(server.clone(), result),
                                         ));
                                     }
                                     data::client::Event::ChatHistoryRequestReceived(
@@ -821,7 +821,7 @@ impl Halloy {
                                         let server = server.clone();
 
                                         commands.push(
-                                            Command::perform(
+                                            Task::perform(
                                                 history::num_stored_unread_messages(
                                                     server.clone(),
                                                     target.clone(),
@@ -829,8 +829,8 @@ impl Halloy {
                                                 move |num_stored_unread_messages| {
                                                     Message::Dashboard(
                                                         dashboard::Message::StoredUnread(
-                                                            server,
-                                                            target,
+                                                            server.clone(),
+                                                            target.clone(),
                                                             num_stored_unread_messages,
                                                         ),
                                                     )
@@ -987,7 +987,7 @@ impl Halloy {
             Message::ChatHistoryRequest(server, subcommand) => {
                 self.clients.send_chathistory_request(&server, subcommand);
 
-                Command::none()
+                Task::none()
             }
             Message::ChatHistoryTargetsMarked(server, result) => {
                 match result {
@@ -997,7 +997,7 @@ impl Halloy {
                     }
                 }
 
-                Command::none()
+                Task::none()
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -764,10 +764,10 @@ impl Halloy {
                                     ) => {
                                         match subcommand {
                                             ChatHistorySubcommand::Latest(_) => {
-                                                log::debug!("received latest messages in {channel} since {message_reference}",)
+                                                log::debug!("[{server}] received latest messages in {channel} since {message_reference}",)
                                             }
                                             ChatHistorySubcommand::Before => {
-                                                log::debug!("received messages in {channel} before {message_reference}",)
+                                                log::debug!("[{server}] received messages in {channel} before {message_reference}",)
                                             }
                                         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -476,6 +476,13 @@ impl Halloy {
                                         if let MessageReference::Timestamp(reference_server_time, reference_client_id) =
                                             message_reference
                                         {
+                                            log::debug!(
+                                                "{:?} message_reference {:?} encoded {:?}",
+                                                data::message::server_time(encoded) == *reference_server_time
+                                                    && data::message::client_id(encoded) == *reference_client_id,
+                                                    message_reference,
+                                                    encoded
+                                                    );
                                             data::message::server_time(encoded) == *reference_server_time
                                                 && data::message::client_id(encoded) == *reference_client_id
                                         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -675,7 +675,7 @@ impl Halloy {
                                             commands.push(command.map(Message::Dashboard));
                                         }
                                     }
-                                    data::client::Event::ChatHistoryCommand(subcommand, target, message_reference_type) => {
+                                    data::client::Event::ChatHistoryCommand(subcommand, target, message_reference_types) => {
                                         match subcommand {
                                             ChatHistorySubcommand::Latest(join_server_time) => {
                                                 dashboard.load_history_now(server.clone(), &target);
@@ -683,7 +683,7 @@ impl Halloy {
                                                 let latest_message_reference = dashboard.get_latest_message_reference(
                                                     &server,
                                                     &target,
-                                                    message_reference_type,
+                                                    &message_reference_types,
                                                     join_server_time,
                                                 );
 
@@ -698,7 +698,7 @@ impl Halloy {
                                                 let oldest_message_reference = dashboard.get_oldest_message_reference(
                                                     &server,
                                                     &target,
-                                                    message_reference_type,
+                                                    &message_reference_types,
                                                 );
 
                                                 self.clients.send_chathistory_request(

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -289,14 +289,11 @@ impl Dashboard {
                                                         message_reference_type,
                                                     );
 
-                                                let limit = clients.get_server_chathistory_limit(server);
-
-                                                clients.get_channel_chathistory(
+                                                clients.send_channel_chathistory_request(
                                                     ChatHistorySubcommand::Before,
                                                     server,
                                                     channel.as_str(),
                                                     oldest_message_reference,
-                                                    limit,
                                                 );
                                             }
                                         }
@@ -971,14 +968,11 @@ impl Dashboard {
                                 message_reference_type,
                             );
 
-                            let limit = clients.get_server_chathistory_limit(&server);
-
-                            clients.get_channel_chathistory(
+                            clients.send_channel_chathistory_request(
                                 ChatHistorySubcommand::Before,
                                 &server,
                                 channel.as_str(),
                                 oldest_message_reference,
-                                limit,
                             );
                         }
                     }
@@ -1181,9 +1175,28 @@ impl Dashboard {
             .record_chathistory_message(server, message, subcommand, message_reference);
     }
 
-    pub fn load_history(&mut self, server: Server, channel: String) {
+    pub fn is_open(&self, server: Server, channel: String) -> bool {
+        self.panes.iter().any(|(_, pane)| {
+            pane.buffer.data() == Some(data::Buffer::Channel(server.clone(), channel.clone()))
+        })
+    }
+
+    pub fn load_history_now(&mut self, server: Server, channel: String) {
         self.history
-            .load(server, history::Kind::Channel(channel.clone()));
+            .load_now(server, history::Kind::Channel(channel.clone()));
+    }
+
+    pub fn make_history_partial_now(
+        &mut self,
+        server: Server,
+        channel: String,
+        message_reference: Option<isupport::MessageReference>,
+    ) {
+        self.history.make_partial_now(
+            server,
+            history::Kind::Channel(channel.clone()),
+            message_reference,
+        );
     }
 
     pub fn get_latest_message_reference(

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1242,10 +1242,12 @@ impl Dashboard {
                     self.get_oldest_message_reference(server, &target, &message_reference_types);
 
                 clients.send_chathistory_request(
-                    ChatHistorySubcommand::Before,
                     server,
-                    &target,
-                    oldest_message_reference,
+                    ChatHistorySubcommand::Before(
+                        target.clone(),
+                        oldest_message_reference,
+                        clients.get_server_chathistory_limit(server),
+                    ),
                 );
             }
         }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1197,10 +1197,7 @@ impl Dashboard {
                     }
                 }
                 isupport::MessageReferenceType::Timestamp => {
-                    return MessageReference::Timestamp(
-                        latest_message.server_time,
-                        latest_message.id.clone().unwrap_or(":".to_string()),
-                    );
+                    return MessageReference::Timestamp(latest_message.server_time);
                 }
             }
         }
@@ -1232,10 +1229,7 @@ impl Dashboard {
                     }
                 }
                 isupport::MessageReferenceType::Timestamp => {
-                    return MessageReference::Timestamp(
-                        oldest_message.server_time,
-                        oldest_message.id.clone().unwrap_or(":".to_string()),
-                    );
+                    return MessageReference::Timestamp(oldest_message.server_time);
                 }
             }
         }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1142,6 +1142,10 @@ impl Dashboard {
         })
     }
 
+    pub fn get_unique_queries(&self, server: &Server) -> Vec<&Nick> {
+        self.history.get_unique_queries(server)
+    }
+
     pub fn get_oldest_message_reference(
         &self,
         server: &Server,

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -274,29 +274,61 @@ impl Dashboard {
                                             );
                                         }
                                     }
-                                    Some(buffer::Event::ScrolledToTop) => {
-                                        if let Some(data::Buffer::Channel(server, channel)) =
-                                            &pane.buffer.data()
-                                        {
-                                            if clients.get_server_supports_chathistory(server) {
-                                                let message_reference_type = clients
-                                                    .get_server_chathistory_message_reference_type(server);
-
-                                                let oldest_message_reference = self
-                                                    .get_oldest_message_reference(
-                                                        server,
-                                                        channel.clone(),
-                                                        message_reference_type,
-                                                    );
-
-                                                clients.send_channel_chathistory_request(
-                                                    ChatHistorySubcommand::Before,
+                                }
+                            }
+                            Some(buffer::Event::ScrolledToTop) => {
+                                if config
+                                    .buffer
+                                    .chathistory
+                                    .request_older_messages_at_scroll_top
+                                {
+                                    if let Some(data::Buffer::Channel(server, channel)) =
+                                        &pane.buffer.data()
+                                    {
+                                        if clients.get_server_supports_chathistory(server) {
+                                            let message_reference_type = clients
+                                                .get_server_chathistory_message_reference_type(
                                                     server,
-                                                    channel.as_str(),
-                                                    oldest_message_reference,
                                                 );
-                                            }
+
+                                            let oldest_message_reference = self
+                                                .get_oldest_message_reference(
+                                                    server,
+                                                    channel.clone(),
+                                                    message_reference_type,
+                                                );
+
+                                            clients.send_channel_chathistory_request(
+                                                ChatHistorySubcommand::Before,
+                                                server,
+                                                channel.as_str(),
+                                                oldest_message_reference,
+                                            );
                                         }
+                                    }
+                                }
+                            }
+                            Some(buffer::Event::ChatHistoryBeforeRequest) => {
+                                if let Some(data::Buffer::Channel(server, channel)) =
+                                    &pane.buffer.data()
+                                {
+                                    if clients.get_server_supports_chathistory(server) {
+                                        let message_reference_type = clients
+                                            .get_server_chathistory_message_reference_type(server);
+
+                                        let oldest_message_reference = self
+                                            .get_oldest_message_reference(
+                                                server,
+                                                channel.clone(),
+                                                message_reference_type,
+                                            );
+
+                                        clients.send_channel_chathistory_request(
+                                            ChatHistorySubcommand::Before,
+                                            server,
+                                            channel.as_str(),
+                                            oldest_message_reference,
+                                        );
                                     }
                                 }
                             }
@@ -956,24 +988,30 @@ impl Dashboard {
             }
             Copy => selectable_text::selected(Message::SelectedText),
             Home => {
-                if let Some((_, pane)) = self.get_focused_mut() {
-                    if let Some(data::Buffer::Channel(server, channel)) = pane.buffer.data() {
-                        if clients.get_server_supports_chathistory(&server) {
-                            let message_reference_type =
-                                clients.get_server_chathistory_message_reference_type(&server);
+                if config
+                    .buffer
+                    .chathistory
+                    .request_older_messages_at_scroll_top
+                {
+                    if let Some((_, pane)) = self.get_focused_mut() {
+                        if let Some(data::Buffer::Channel(server, channel)) = pane.buffer.data() {
+                            if clients.get_server_supports_chathistory(&server) {
+                                let message_reference_type =
+                                    clients.get_server_chathistory_message_reference_type(&server);
 
-                            let oldest_message_reference = self.get_oldest_message_reference(
-                                &server,
-                                channel.clone(),
-                                message_reference_type,
-                            );
+                                let oldest_message_reference = self.get_oldest_message_reference(
+                                    &server,
+                                    channel.clone(),
+                                    message_reference_type,
+                                );
 
-                            clients.send_channel_chathistory_request(
-                                ChatHistorySubcommand::Before,
-                                &server,
-                                channel.as_str(),
-                                oldest_message_reference,
-                            );
+                                clients.send_channel_chathistory_request(
+                                    ChatHistorySubcommand::Before,
+                                    &server,
+                                    channel.as_str(),
+                                    oldest_message_reference,
+                                );
+                            }
                         }
                     }
                 }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1239,7 +1239,10 @@ impl Dashboard {
                 }
             }
 
-            MessageReference::Timestamp(latest_message.server_time)
+            MessageReference::Timestamp(
+                latest_message.server_time,
+                latest_message.id.clone().unwrap_or(":".to_string()),
+            )
         } else {
             MessageReference::None
         }
@@ -1281,7 +1284,10 @@ impl Dashboard {
                 }
             }
 
-            MessageReference::Timestamp(oldest_message.server_time)
+            MessageReference::Timestamp(
+                oldest_message.server_time,
+                oldest_message.id.clone().unwrap_or(":".to_string()),
+            )
         } else {
             MessageReference::None
         }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1142,58 +1142,6 @@ impl Dashboard {
         })
     }
 
-    pub fn load_history_now(&mut self, server: Server, target: &str) {
-        self.history.load_now(server, target);
-    }
-
-    pub fn make_history_partial_now(
-        &mut self,
-        server: Server,
-        target: &str,
-        message_reference: Option<isupport::MessageReference>,
-    ) {
-        self.history
-            .make_partial_now(server, target, message_reference);
-    }
-
-    pub fn get_latest_message_reference(
-        &self,
-        server: &Server,
-        target: &str,
-        message_reference_types: &[isupport::MessageReferenceType],
-        join_server_time: DateTime<Utc>,
-    ) -> MessageReference {
-        let latest_message_finding =
-            message_reference_types
-                .iter()
-                .find_map(|message_reference_type| {
-                    self.history
-                        .get_latest_message(
-                            server,
-                            target,
-                            message_reference_type,
-                            join_server_time,
-                        )
-                        .map(|latest_message| (latest_message, message_reference_type))
-                });
-
-        if let Some((latest_message, message_reference_type)) = latest_message_finding {
-            log::debug!("[{server}] {target} - latest_message {:?}", latest_message);
-            match message_reference_type {
-                isupport::MessageReferenceType::MessageId => {
-                    if let Some(id) = &latest_message.id {
-                        return MessageReference::MessageId(id.clone());
-                    }
-                }
-                isupport::MessageReferenceType::Timestamp => {
-                    return MessageReference::Timestamp(latest_message.server_time);
-                }
-            }
-        }
-
-        MessageReference::None
-    }
-
     pub fn get_oldest_message_reference(
         &self,
         server: &Server,

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1268,6 +1268,7 @@ impl Dashboard {
         };
 
         if let Some(latest_message) = latest_message {
+            log::debug!("[{server}] {channel} - latest_message {:?}", latest_message);
             if matches!(
                 message_reference_type,
                 isupport::MessageReferenceType::MessageId
@@ -1313,6 +1314,7 @@ impl Dashboard {
         };
 
         if let Some(oldest_message) = oldest_message {
+            log::debug!("[{server}] {channel} - oldest_message {:?}", oldest_message);
             if matches!(
                 message_reference_type,
                 isupport::MessageReferenceType::MessageId

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1181,11 +1181,17 @@ impl Dashboard {
             .record_chathistory_message(server, message, subcommand, message_reference);
     }
 
+    pub fn load_history(&mut self, server: Server, channel: String) {
+        self.history
+            .load(server, history::Kind::Channel(channel.clone()));
+    }
+
     pub fn get_latest_message_reference(
         &self,
         server: &Server,
         channel: String,
         message_reference_type: isupport::MessageReferenceType,
+        join_server_time: DateTime<Utc>,
     ) -> MessageReference {
         let latest_message = match message_reference_type {
             isupport::MessageReferenceType::MessageId => self
@@ -1194,16 +1200,19 @@ impl Dashboard {
                     server,
                     &history::Kind::Channel(channel.clone()),
                     isupport::MessageReferenceType::MessageId,
+                    join_server_time,
                 )
                 .or(self.history.get_latest_message(
                     server,
                     &history::Kind::Channel(channel.clone()),
                     isupport::MessageReferenceType::Timestamp,
+                    join_server_time,
                 )),
             isupport::MessageReferenceType::Timestamp => self.history.get_latest_message(
                 server,
                 &history::Kind::Channel(channel.clone()),
                 isupport::MessageReferenceType::Timestamp,
+                join_server_time,
             ),
         };
 

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1135,8 +1135,12 @@ impl Dashboard {
         }
     }
 
-    pub fn record_message(&mut self, server: &Server, message: data::Message) {
-        self.history.record_message(server, message);
+    pub fn record_message(
+        &mut self,
+        server: &Server,
+        message: data::Message,
+    ) -> Option<history::manager::Event> {
+        self.history.record_message(server, message)
     }
 
     pub fn get_unique_queries(&self, server: &Server) -> Vec<&Nick> {

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1131,17 +1131,6 @@ impl Dashboard {
         self.history.record_message(server, message);
     }
 
-    pub fn record_chathistory_message(
-        &mut self,
-        server: &Server,
-        message: data::Message,
-        subcommand: ChatHistorySubcommand,
-        message_reference: MessageReference,
-    ) {
-        self.history
-            .record_chathistory_message(server, message, subcommand, message_reference);
-    }
-
     pub fn is_open(&self, server: Server, target: &str) -> bool {
         self.panes.iter().any(|(_, pane)| {
             pane.buffer.data() == Some(data::Buffer::Channel(server.clone(), target.to_string()))

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -957,7 +957,7 @@ impl Dashboard {
                             .scroll_to_start()
                             .map(move |message| Message::Pane(pane::Message::Buffer(id, message)))
                     })
-                    .unwrap_or_else(Command::none)
+                    .unwrap_or_else(Task::none)
             }
             End => self
                 .get_focused_mut(main_window)

--- a/src/theme/button.rs
+++ b/src/theme/button.rs
@@ -128,6 +128,7 @@ pub fn bare(_theme: &Theme, status: Status) -> Style {
                         a: 0.2,
                         ..active.text_color
                     },
+                    radius: active.border.radius,
                     ..Default::default()
                 },
                 ..active


### PR DESCRIPTION
Work in progress PR to add IRCv3 CHATHISTORY support (i.e. #206).  Since it's not a widely available feature yet, the goal is to minimize the any effects on Halloy's operation when CHATHISTORY is not available.  Testing on ircs://irc.ergo.chat:6697/ to start.

Currently (more-or-less) implemented:
- Request up to the latest 500 messages or all messages since latest message in channel history when joining a channel.
- Request up to 500 messages to add to channel history when scrolling to the top of a channel buffer.
- Basic message deduplication.

 Planned:
- [x] Enable `event-playback` to allow replay of channel events (`JOIN`/`PART`/`QUIT`/etc).  `HistServ` appears to be non-standard, so all its messages are filtered out for now for parity of experience.  ~~Convert `HistServ` PRIVMSG messages into the appropriate `JOIN`/`PART`/`QUIT`/etc messages.~~
- [x] Ensure history is loaded before requesting latest messages after `JOIN`.
- [x] Ensure messages received when starting Halloy are marked as new.
- [x] Request messages when reconnecting to a server (without closing Halloy; current testing shows this is covered by `JOIN` messages request(s)). 
- [x] Improve UX for loading additional channel history (button at end of history & config option to automatically request when scrolling to top of history).
- [x] Do not move the backlog divider when adding older messages to a buffer.
- [x] Test multi-request `LATEST` functionality (artificially limit the size of batches).
- [x] Improve performance of deduplication (utilize something like an [`indexmap`](https://docs.rs/indexmap/latest/indexmap/map/struct.IndexMap.html) for message history?).  And/or, avoid the need for deduplication.
- [x] Use `TARGETS` to open Query buffers for direct messages sent while disconnected.
- [x] Add get latest messages & load older messages to Query buffers.
- [x] Get message ids for user-sent messages.
- [x] Set up logic for the possibility of a `chathistory` request timeout.
