### PR TITLE
Add support for Windows binary meta information and fix WiX installer…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,6 +1745,7 @@ dependencies = [
  "tokio",
  "unicode-segmentation",
  "uuid",
+ "windows_exe_info",
 ]
 
 [[package]]
@@ -5462,6 +5463,15 @@ name = "windows_aarch64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
+name = "windows_exe_info"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e7bfd02caf5cd98a197cec15c852685c8c42605f91d7be3083541a0b40a7ff"
+dependencies = [
+ "embed-resource",
+]
 
 [[package]]
 name = "windows_i686_gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ image = "0.24.6"
 [build-dependencies]
 embed-resource = "2.1.1"
 windows_exe_info = "0.4"
-cargo-edit = "0.12"
 
 [workspace]
 members = ["data", "ipc", "irc", "irc/proto"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "halloy"
-authors = ["Casper Rogild Storm", "Cory Forsstrom"]
 version = "0.1.0"
+authors = ["Casper Rogild Storm", "Cory Forsstrom"]
+description = "Halloy is an open-source IRC client written in Rust, with the Iced GUI library. It aims to provide a simple and fast client for Mac, Windows, and Linux platforms."
+documentation = "https://halloy.squidowl.org/"
+license = "LICENSE"
 edition = "2021"
 
 [features]
@@ -49,6 +52,8 @@ image = "0.24.6"
 
 [build-dependencies]
 embed-resource = "2.1.1"
+windows_exe_info = "0.4"
+cargo-edit = "0.12"
 
 [workspace]
 members = ["data", "ipc", "irc", "irc/proto"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ features = ["xdg-portal", "tokio"]
 [target.'cfg(windows)'.dependencies]
 image = "0.24.6"
 
-[build-dependencies]
+[target.'cfg(windows)'.build-dependencies]
 embed-resource = "2.1.1"
 windows_exe_info = "0.4"
 

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,7 @@ extern crate windows_exe_info;
 
 fn main() {
     #[cfg(windows)]
+
     embed_resource::compile("assets/windows/halloy.rc", embed_resource::NONE);
     windows_exe_info::versioninfo::link_cargo_env();
 }

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,8 @@
 extern crate embed_resource;
+extern crate windows_exe_info;
 
 fn main() {
     #[cfg(windows)]
     embed_resource::compile("assets/windows/halloy.rc", embed_resource::NONE);
+    windows_exe_info::versioninfo::link_cargo_env();
 }

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,7 @@
-extern crate embed_resource;
-extern crate windows_exe_info;
-
 fn main() {
     #[cfg(windows)]
-
-    embed_resource::compile("assets/windows/halloy.rc", embed_resource::NONE);
-    windows_exe_info::versioninfo::link_cargo_env();
+    {
+        embed_resource::compile("assets/windows/halloy.rc", embed_resource::NONE);
+        windows_exe_info::versioninfo::link_cargo_env();
+    }
 }

--- a/scripts/build-windows-installer.sh
+++ b/scripts/build-windows-installer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 WXS_FILE="wix/main.wxs"
-VERSION=$(cat VERSION)
+HALLOY_VERSION=$(cat VERSION)
 
 # build the binary
 scripts/build-windows.sh
@@ -12,4 +12,4 @@ dotnet tool install --global wix
 wix extension add WixToolset.UI.wixext
 
 # build the installer
-wix build -pdbtype none -arch x64 -d PackageVersion=$VERSION $WXS_FILE -o target/release/halloy-installer.msi -ext WixToolset.UI.wixext
+wix build -pdbtype none -arch x64 -d PackageVersion=$HALLOY_VERSION $WXS_FILE -o target/release/halloy-installer.msi -ext WixToolset.UI.wixext

--- a/scripts/build-windows-installer.sh
+++ b/scripts/build-windows-installer.sh
@@ -6,7 +6,7 @@ VERSION=$(cat VERSION)
 dotnet tool install --global wix
 
 # add required wix extension
-wix extension add WixToolset.Ui.wixex
+wix extension add WixToolset.UI.wixext
 
 # build the installer
-wix build -pdbtype none -arch x64 -d PackageVersion=$VERSION main.wxs -o halloy-installer.msi -ext ./.wix/extensions/WixToolset.Ui.wixext/5.0.1/wixext5/WixToolset.UI.wixext.dll
+wix build -pdbtype none -arch x64 -d PackageVersion=$VERSION $WXS_FILE -o halloy-installer.msi -ext WixToolset.UI.wixext

--- a/scripts/build-windows-installer.sh
+++ b/scripts/build-windows-installer.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 WXS_FILE="wix/main.wxs"
-TARGET="x86_64-pc-windows-msvc"
 VERSION=$(cat VERSION)
 
 # install latest wix
@@ -10,4 +9,4 @@ dotnet tool install --global wix
 wix extension add WixToolset.UI.wixext
 
 # build the installer
-wix build -pdbtype none -arch x64 -d PackageVersion=$VERSION $WXS_FILE -d Target=$TARGET -o halloy-installer.msi -ext WixToolset.UI.wixext
+wix build -pdbtype none -arch x64 -d PackageVersion=$VERSION $WXS_FILE -o halloy-installer.msi -ext WixToolset.UI.wixext

--- a/scripts/build-windows-installer.sh
+++ b/scripts/build-windows-installer.sh
@@ -9,4 +9,4 @@ dotnet tool install --global wix
 wix extension add WixToolset.Ui.wixex
 
 # build the installer
-wix build -pdbtype none -arch x64 -d PackageVersion=$VERSION main.wxs -o halloy-installer.msi -ext .\.wix\extensions\WixToolset.Ui.wixext\5.0.1\wixext5\WixToolset.UI.wixext.dll
+wix build -pdbtype none -arch x64 -d PackageVersion=$VERSION main.wxs -o halloy-installer.msi -ext ./.wix/extensions/WixToolset.Ui.wixext/5.0.1/wixext5/WixToolset.UI.wixext.dll

--- a/scripts/build-windows-installer.sh
+++ b/scripts/build-windows-installer.sh
@@ -2,6 +2,9 @@
 WXS_FILE="wix/main.wxs"
 VERSION=$(cat VERSION)
 
+# build the binary
+scripts/build-windows.sh
+
 # install latest wix
 dotnet tool install --global wix
 

--- a/scripts/build-windows-installer.sh
+++ b/scripts/build-windows-installer.sh
@@ -2,13 +2,11 @@
 WXS_FILE="wix/main.wxs"
 VERSION=$(cat VERSION)
 
-# update version and build
-sed -i '' -e "s/{{ VERSION }}/$VERSION/g" "$WXS_FILE"
+# install latest wix
+dotnet tool install --global wix
 
-# install wix tools, and ensure paths are set
-choco install wixtoolset -y --force --version=3.11.2
-$env:Path += ';C:\Program Files (x86)\Wix Toolset v3.11\bin'
+# add required wix extension
+wix extension add WixToolset.Ui.wixex
 
-# build msi installer
-cargo install cargo-wix
-cargo wix --nocapture --package halloy -o target/release/halloy-installer.msi
+# build the installer
+wix build -pdbtype none -arch x64 -d PackageVersion=$VERSION main.wxs -o halloy-installer.msi -ext .\.wix\extensions\WixToolset.Ui.wixext\5.0.1\wixext5\WixToolset.UI.wixext.dll

--- a/scripts/build-windows-installer.sh
+++ b/scripts/build-windows-installer.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 WXS_FILE="wix/main.wxs"
+TARGET="x86_64-pc-windows-msvc"
 VERSION=$(cat VERSION)
 
 # install latest wix
@@ -9,4 +10,4 @@ dotnet tool install --global wix
 wix extension add WixToolset.UI.wixext
 
 # build the installer
-wix build -pdbtype none -arch x64 -d PackageVersion=$VERSION $WXS_FILE -o halloy-installer.msi -ext WixToolset.UI.wixext
+wix build -pdbtype none -arch x64 -d PackageVersion=$VERSION $WXS_FILE -d Target=$TARGET -o halloy-installer.msi -ext WixToolset.UI.wixext

--- a/scripts/build-windows-installer.sh
+++ b/scripts/build-windows-installer.sh
@@ -12,4 +12,4 @@ dotnet tool install --global wix
 wix extension add WixToolset.UI.wixext
 
 # build the installer
-wix build -pdbtype none -arch x64 -d PackageVersion=$VERSION $WXS_FILE -o halloy-installer.msi -ext WixToolset.UI.wixext
+wix build -pdbtype none -arch x64 -d PackageVersion=$VERSION $WXS_FILE -o target/release/halloy-installer.msi -ext WixToolset.UI.wixext

--- a/scripts/build-windows.sh
+++ b/scripts/build-windows.sh
@@ -4,10 +4,13 @@
 #!/bin/bash
 EXE_NAME="halloy.exe"
 TARGET="x86_64-pc-windows-msvc"
-VERSION=$(cat VERSION).0
+HALLOY_VERSION=$(cat VERSION).0
+
+# update package version on Cargo.toml
+cargo install cargo-edit
+cargo set-version $HALLOY_VERSION
 
 # build binary
 rustup target add $TARGET
-cargo-set-version set-version $VERSION
 cargo build --release --target=$TARGET
 cp -fp target/$TARGET/release/$EXE_NAME target/release

--- a/scripts/build-windows.sh
+++ b/scripts/build-windows.sh
@@ -4,8 +4,10 @@
 #!/bin/bash
 EXE_NAME="halloy.exe"
 TARGET="x86_64-pc-windows-msvc"
+VERSION=$(cat VERSION).0
 
 # build binary
 rustup target add $TARGET
+cargo-set-version set-version $VERSION
 cargo build --release --target=$TARGET
 cp -fp target/$TARGET/release/$EXE_NAME target/release

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -21,7 +21,7 @@
         <StandardDirectory Id="ProgramFiles6432Folder">
             <Directory
                 Id="INSTALLFOLDER"
-                Name="!(bind.Property.Manufacturer)\!(bind.Property.ProductName)"
+                Name="!(bind.Property.ProductName)"
             />
         </StandardDirectory>
 

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -16,7 +16,7 @@
         Manufacturer='Squidowl'
         Language='1033'
         Codepage='1252'
-        Version='{{ VERSION }}.0.0'>
+        Version='0.0.{{ VERSION }}'>
 
         <Package 
             Id='*'

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -28,7 +28,7 @@
         <ComponentGroup Id="MainComponents" Directory="INSTALLFOLDER">
 
             <Component>
-                <File Id="Application" DiskId="1" Source="target/release/halloy.exe" KeyPath="yes">
+                <File Id="Application" DiskId="1" Source="target/$(Target)/release/halloy.exe" KeyPath="yes">
                     <Shortcut
                         Id="ApplicationStartMenuShortcutInFile"
                         Name="halloy.exe"
@@ -47,7 +47,7 @@
                 <RegistryValue Root="HKCR" Key="Halloy" Name="EditFlags" Value="2" Type="integer" />
                 <RegistryValue Root="HKCR" Key="Halloy" Name="FriendlyTypeName" Value="Web URL" Type="string" />
                 <RegistryValue Root="HKCR" Key="Halloy" Name="URL Protocol" Value="" Type="string" />
-                <RegistryValue Root="HKCR" Key="Halloy\DefaultIcon" Value="[INSTALLFOLDER]Halloy.exe,1" Type="string" />
+                <RegistryValue Root="HKCR" Key="Halloy\DefaultIcon" Value="[INSTALLFOLDER]halloy.exe,1" Type="string" />
                 <RegistryValue Root="HKCR" Key="Halloy\shell" Type="string" Value="open" />
                 <RegistryValue Root="HKCR" Key="Halloy\shell\open\command" Type="string" Value="&quot;[INSTALLFOLDER]Halloy.exe&quot; &quot;%1&quot;" />
 

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -28,7 +28,7 @@
         <ComponentGroup Id="MainComponents" Directory="INSTALLFOLDER">
 
             <Component>
-                <File Id="Application" DiskId="1" Source="target/$(Target)/release/halloy.exe" KeyPath="yes">
+                <File Id="Application" DiskId="1" Source="target/release/halloy.exe" KeyPath="yes">
                     <Shortcut
                         Id="ApplicationStartMenuShortcutInFile"
                         Name="halloy.exe"

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -1,172 +1,85 @@
-<?xml version='1.0' encoding='windows-1252'?>
+<?xml version="1.0" encoding="UTF-8" ?>
 
-<?if $(var.Platform) = x64 ?>
-    <?define Win64 = "yes" ?>
-    <?define PlatformProgramFilesFolder = "ProgramFiles64Folder" ?>
-<?else ?>
-  <?define Win64 = "no" ?>
-  <?define PlatformProgramFilesFolder = "ProgramFilesFolder" ?>
-<?endif ?>
+<Wix
+    xmlns="http://wixtoolset.org/schemas/v4/wxs"
+    xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
 
-<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
-    <Product
-        Id='*'
-        Name='Halloy'
-        UpgradeCode='3ed18662-fb43-4803-a4f9-89bbbc0b6d01'
-        Manufacturer='Squidowl'
-        Language='1033'
-        Codepage='1252'
-        Version='0.0.{{ VERSION }}'>
+    <Package
+        Name="Halloy"
+        Version="$(PackageVersion)"
+        Manufacturer="Squidowl"
+        Language="1033"
+        UpgradeCode="3ed18662-fb43-4803-a4f9-89bbbc0b6d01"
+        UpgradeStrategy="majorUpgrade"
+        Scope="perMachine">
 
-        <Package 
-            Id='*'
-            Keywords='Installer'
-            Description='IRC application written in Rust'
-            Manufacturer='Squidowl'
-            InstallerVersion='450'
-            Languages='1033'
-            Compressed='yes'
-            InstallScope='perMachine'
-            SummaryCodepage='1252'
-            Platform='$(var.Platform)'/>
+        <MajorUpgrade Schedule="afterInstallInitialize"
+            DowngradeErrorMessage="A newer version of [ProductName] is already installed. Setup will now exit."/>
 
-        <MajorUpgrade
-            Schedule='afterInstallInitialize'
-            DowngradeErrorMessage='A newer version of [ProductName] is already installed. Setup will now exit.'/>
+        <Media Id="1" Cabinet="media1.cab" EmbedCab="yes"/>
 
-        <Media Id='1' Cabinet='media1.cab' EmbedCab='yes' />
-        <Property Id='DiskPrompt' Value='Halloy Installation'/>
+        <StandardDirectory Id="ProgramFiles6432Folder">
+            <Directory
+                Id="INSTALLFOLDER"
+                Name="!(bind.Property.Manufacturer)\!(bind.Property.ProductName)"
+            />
+        </StandardDirectory>
 
-        <Directory Id='TARGETDIR' Name='SourceDir'>
-            <Directory Id='$(var.PlatformProgramFilesFolder)' Name='PFiles'>
-                <Directory Id='APPLICATIONFOLDER' Name='Halloy'>
-                    <!-- Component for setting PATH environment variable -->
-                    <Component Id='Path' Guid='6112ca47-e424-4454-b780-081463624eee' Win64='$(var.Win64)' KeyPath='yes'>
-                        <Environment
-                            Id='PATH'
-                            Name='PATH'
-                            Value='[APPLICATIONFOLDER]'
-                            Permanent='no'
-                            Part='last'
-                            Action='set'
-                            System='yes'/>
-                    </Component>
+        <ComponentGroup Id="MainComponents" Directory="INSTALLFOLDER">
 
-                    <!-- Component for executable -->
-                    <Component Id='binary0' Guid='*' Win64='$(var.Win64)'>
-                        <File
-                            Id='exe0'
-                            Name='Halloy.exe'
-                            DiskId='1'
-                            Source='target\$(var.Profile)\halloy.exe'
-                            KeyPath='yes'>
-                            <Shortcut
-                                Id="ApplicationStartMenuShortcutInFile"
-                                Name="Halloy"
-                                Icon="HalloyIcon.exe"
-                                Directory="ApplicationProgramsFolder"
-                                Description="IRC application written in Rust"
-                                Advertise="yes"
-                                WorkingDirectory="APPLICATIONFOLDER">
-                                <ShortcutProperty Key="System.AppUserModel.ID" Value="org.squidowl.halloy" />
-                            </Shortcut>
-                        </File>
-                    </Component>
-
-                    <!-- Component for default program registration -->
-                    <Component Id='RegistryComponentDefaultPrograms' Guid='*'>
-                        <RegistryValue Root="HKCR" Key="Halloy" Value="Halloy" Type="string" />
-                        <RegistryValue Root="HKCR" Key="Halloy" Name="EditFlags" Value="2" Type="integer" />
-                        <RegistryValue Root="HKCR" Key="Halloy" Name="FriendlyTypeName" Value="Web URL" Type="string" />
-                        <RegistryValue Root="HKCR" Key="Halloy" Name="URL Protocol" Value="" Type="string" />
-                        <RegistryValue Root="HKCR" Key="Halloy\DefaultIcon" Value="[APPLICATIONFOLDER]Halloy.exe,1" Type="string" />
-                        <RegistryValue Root="HKCR" Key="Halloy\shell" Type="string" Value="open" />
-                        <RegistryValue Root="HKCR" Key="Halloy\shell\open\command" Type="string" Value="&quot;[APPLICATIONFOLDER]Halloy.exe&quot; &quot;%1&quot;" />
-
-                        <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities" Name="ApplicationDescription" Value="IRC client" Type="string" />
-                        <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities" Name="ApplicationIcon" Value="[APPLICATIONFOLDER]Halloy.exe,0" Type="string" />
-                        <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities" Name="ApplicationName" Value="IRC Picker" Type="string" />
-                        <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities\DefaultIcon" Value="[INSTALLFOLDER]Halloy.exe,1" Type="string" />
-                        <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities\URLAssociations" Name="irc" Value="Halloy" Type="string" />
-                        <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities\URLAssociations" Name="ircs" Value="Halloy" Type="string" />
-                        <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities\URLAssociations" Name="halloy" Value="Halloy" Type="string" />
-                        <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities\shell" Value="open" Type="string" />
-                        <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities\shell\open\command" Value="&quot;[APPLICATIONFOLDER]Halloy.exe&quot; &quot;%1&quot;" Type="string" />
-                        <RegistryValue Root="HKLM" Key="SOFTWARE\RegisteredApplications" Name="Halloy" Value="SOFTWARE\Halloy\Capabilities" Type="string" />
-                    </Component>
-                </Directory>
-            </Directory>
-
-            <Directory Id="ProgramMenuFolder">
-                <Directory Id="ApplicationProgramsFolder" Name="Halloy"/>
-            </Directory>
-        </Directory>
-
-        <DirectoryRef Id="ApplicationProgramsFolder">
-            <Component Id="ApplicationShortcut" Guid="c28a5892-ccdf-4870-af36-f87a440b3415">
-                <Shortcut
-                    Id="ApplicationStartMenuShortcut"
-                    Name="Halloy"
-                    Description="IRC application written in Rust"
-                    Target="[binary0]"
-                    WorkingDirectory="APPLICATIONFOLDER"/>
-
-                <RemoveFolder
-                    Id="CleanUpShortCut"
-                    Directory="ApplicationProgramsFolder"
-                    On="uninstall"/>
-
-                <RegistryValue Root="HKCU" Key="Software\Halloy" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
+            <Component>
+                <File Id="Application" DiskId="1" Source="target/release/halloy.exe" KeyPath="yes">
+                    <Shortcut
+                        Id="ApplicationStartMenuShortcutInFile"
+                        Name="halloy.exe"
+                        Icon="HalloyIcon.exe"
+                        Directory="ProgramMenuFolder"
+                        Description="IRC application written in Rust"
+                        Advertise="yes"
+                        WorkingDirectory="INSTALLFOLDER">
+                        <ShortcutProperty Key="System.AppUserModel.ID" Value="org.squidowl.halloy" />
+                    </Shortcut>
+                </File>
             </Component>
-        </DirectoryRef>
-
-        <!-- Features -->
-        <Feature
-            Id='Binaries'
-            Title='Application'
-            Level='1'
-            Description='Install binaries.'
-            ConfigurableDirectory='APPLICATIONFOLDER'
-            AllowAdvertise='no'
-            Display='expand'
-            Absent='disallow'>
-
-            <ComponentRef Id='binary0'/>
-            <ComponentRef Id='Path'/>
-            <ComponentRef Id='RegistryComponentDefaultPrograms' />
             
-            <Feature
-                Id='Shortcut'
-                Title='Start Menu Shortcut'
-                Level='1'
-                Absent='allow'>
-                <ComponentRef Id="ApplicationShortcut" />
-            </Feature>
-        </Feature>
+            <Component Id='RegistryComponentDefaultPrograms' Guid='*'>
+                <RegistryValue Root="HKCR" Key="Halloy" Value="Halloy" Type="string" />
+                <RegistryValue Root="HKCR" Key="Halloy" Name="EditFlags" Value="2" Type="integer" />
+                <RegistryValue Root="HKCR" Key="Halloy" Name="FriendlyTypeName" Value="Web URL" Type="string" />
+                <RegistryValue Root="HKCR" Key="Halloy" Name="URL Protocol" Value="" Type="string" />
+                <RegistryValue Root="HKCR" Key="Halloy\DefaultIcon" Value="[INSTALLFOLDER]Halloy.exe,1" Type="string" />
+                <RegistryValue Root="HKCR" Key="Halloy\shell" Type="string" Value="open" />
+                <RegistryValue Root="HKCR" Key="Halloy\shell\open\command" Type="string" Value="&quot;[INSTALLFOLDER]Halloy.exe&quot; &quot;%1&quot;" />
 
-        <Property Id="WIXUI_INSTALLDIR" Value="APPLICATIONFOLDER" />
+                <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities" Name="ApplicationDescription" Value="IRC client" Type="string" />
+                <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities" Name="ApplicationIcon" Value="[INSTALLFOLDER]Halloy.exe,0" Type="string" />
+                <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities" Name="ApplicationName" Value="IRC Picker" Type="string" />
+                <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities\DefaultIcon" Value="[INSTALLFOLDER]Halloy.exe,1" Type="string" />
+                <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities\URLAssociations" Name="irc" Value="Halloy" Type="string" />
+                <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities\URLAssociations" Name="ircs" Value="Halloy" Type="string" />
+                <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities\URLAssociations" Name="halloy" Value="Halloy" Type="string" />
+                <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities\shell" Value="open" Type="string" />
+                <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities\shell\open\command" Value="&quot;[INSTALLFOLDER]Halloy.exe&quot; &quot;%1&quot;" Type="string" />
+                <RegistryValue Root="HKLM" Key="SOFTWARE\RegisteredApplications" Name="Halloy" Value="SOFTWARE\Halloy\Capabilities" Type="string" />
+            </Component>
+
+        </ComponentGroup>
 
         <Icon Id="HalloyIcon.exe" SourceFile="assets/windows/halloy.ico" />
-        <Property Id='ARPPRODUCTICON' Value='HalloyIcon.exe' />
-        <Property Id='ARPHELPLINK' Value='https://squidowl.org/'/>
 
-        <UIRef Id='WixUI_InstallDir'/>
+        <Property Id="ARPPRODUCTICON" Value="HalloyIcon.exe"/>
+        <Property Id="APPHELPLINK" Value="https://halloy.squidowl.org/"/>
 
-        <CustomAction
-          Id="LaunchApp"
-          Impersonate="yes"
-          Execute="deferred"
-          FileKey="exe0"
-          ExeCommand=""
-          Return="asyncNoWait"
-        />
+        <CustomAction Id="LaunchApp" Impersonate="yes" Execute="deferred" FileRef="Application" ExeCommand="" Return="asyncNoWait" />
 
         <InstallExecuteSequence>
-          <Custom Action="LaunchApp" Before="InstallFinalize">NOT REMOVE</Custom>
+          <Custom Action="LaunchApp" Before="InstallFinalize"/>
         </InstallExecuteSequence>
 
-        <WixVariable Id="WixUILicenseRtf" Value="wix/license.rtf" />
-        <WixVariable Id='WixUIDialogBmp' Value='wix/dialog.png' />
-        <WixVariable Id='WixUIBannerBmp' Value='wix/banner.png' />
-    </Product>
+        <WixVariable Id="WixUILicenseRtf" Value="license.rtf"/>
+        <WixVariable Id="WixUIDialogBmp" Value="dialog.png"/>
+        <WixVariable Id="WixUIBannerBmp" Value="banner.png"/>
+
+        <ui:WixUI Id="WixUI_InstallDir" InstallDirectory="INSTALLFOLDER" />
+    </Package>
 </Wix>

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -41,26 +41,62 @@
                     </Shortcut>
                 </File>
             </Component>
-            
-            <Component Id='RegistryComponentDefaultPrograms' Guid='*'>
-                <RegistryValue Root="HKCR" Key="Halloy" Value="Halloy" Type="string" />
-                <RegistryValue Root="HKCR" Key="Halloy" Name="EditFlags" Value="2" Type="integer" />
-                <RegistryValue Root="HKCR" Key="Halloy" Name="FriendlyTypeName" Value="Web URL" Type="string" />
-                <RegistryValue Root="HKCR" Key="Halloy" Name="URL Protocol" Value="" Type="string" />
-                <RegistryValue Root="HKCR" Key="Halloy\DefaultIcon" Value="[INSTALLFOLDER]halloy.exe,1" Type="string" />
-                <RegistryValue Root="HKCR" Key="Halloy\shell" Type="string" Value="open" />
-                <RegistryValue Root="HKCR" Key="Halloy\shell\open\command" Type="string" Value="&quot;[INSTALLFOLDER]Halloy.exe&quot; &quot;%1&quot;" />
 
-                <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities" Name="ApplicationDescription" Value="IRC client" Type="string" />
+            <Component>
+                <RegistryKey Root="HKLM" Key="SOFTWARE\Halloy" ForceDeleteOnUninstall="yes" />
+                <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities" Name="ApplicationDescription" Value="Halloy is an open-source IRC client written in Rust, with the Iced GUI library. It aims to provide a simple and fast client for Mac, Windows, and Linux platforms." Type="string" />
                 <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities" Name="ApplicationIcon" Value="[INSTALLFOLDER]Halloy.exe,0" Type="string" />
-                <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities" Name="ApplicationName" Value="IRC Picker" Type="string" />
+                <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities" Name="ApplicationName" Value="Halloy" Type="string" />
+
                 <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities\DefaultIcon" Value="[INSTALLFOLDER]Halloy.exe,1" Type="string" />
-                <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities\URLAssociations" Name="irc" Value="Halloy" Type="string" />
-                <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities\URLAssociations" Name="ircs" Value="Halloy" Type="string" />
-                <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities\URLAssociations" Name="halloy" Value="Halloy" Type="string" />
+
+                <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities\URLAssociations" Name="halloy" Value="halloy" Type="string" />
+                <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities\URLAssociations" Name="irc" Value="halloy" Type="string" />
+                <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities\URLAssociations" Name="ircs" Value="halloy" Type="string" />
+
                 <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities\shell" Value="open" Type="string" />
                 <RegistryValue Root="HKLM" Key="SOFTWARE\Halloy\Capabilities\shell\open\command" Value="&quot;[INSTALLFOLDER]Halloy.exe&quot; &quot;%1&quot;" Type="string" />
+
                 <RegistryValue Root="HKLM" Key="SOFTWARE\RegisteredApplications" Name="Halloy" Value="SOFTWARE\Halloy\Capabilities" Type="string" />
+            </Component>
+
+            <Component>
+                <RegistryKey Root="HKCR" Key="halloy" ForceDeleteOnUninstall="yes" />
+                <RegistryValue Root="HKCR" Key="halloy" Value="URL:Halloy" Type="string"  />
+                <RegistryValue Root="HKCR" Key="halloy" Name="FriendlyTypeName" Value="Halloy URL" Type="string" />
+                <RegistryValue Root="HKCR" Key="halloy" Name="EditFlags" Value="2" Type="integer" />
+                <RegistryValue Root="HKCR" Key="halloy" Name="URL Protocol" Value="halloy" Type="string" />
+
+                <RegistryValue Root="HKCR" Key="halloy\DefaultIcon" Value="[INSTALLFOLDER]halloy.exe,1" Type="string" />
+
+                <RegistryValue Root="HKCR" Key="halloy\shell" Type="string" Value="open" />
+                <RegistryValue Root="HKCR" Key="halloy\shell\open\command" Type="string" Value="&quot;[INSTALLFOLDER]Halloy.exe&quot; &quot;%1&quot;" />
+            </Component>
+
+            <Component>
+                <RegistryKey Root="HKCR" Key="irc" ForceDeleteOnUninstall="yes" />
+                <RegistryValue Root="HKCR" Key="irc" Value="URL:Internet Relay Chat" Type="string" />
+                <RegistryValue Root="HKCR" Key="irc" Name="FriendlyTypeName" Value="Internet Relay Chat URL" Type="string" />
+                <RegistryValue Root="HKCR" Key="irc" Name="EditFlags" Value="2" Type="integer" />
+                <RegistryValue Root="HKCR" Key="irc" Name="URL Protocol" Value="irc" Type="string" />
+
+                <RegistryValue Root="HKCR" Key="irc\DefaultIcon" Value="[INSTALLFOLDER]halloy.exe,1" Type="string" />
+
+                <RegistryValue Root="HKCR" Key="irc\shell" Type="string" Value="open" />
+                <RegistryValue Root="HKCR" Key="irc\shell\open\command" Type="string" Value="&quot;[INSTALLFOLDER]Halloy.exe&quot; &quot;%1&quot;" />
+            </Component>
+
+            <Component>
+                <RegistryKey Root="HKCR" Key="ircs" ForceDeleteOnUninstall="yes" />
+                <RegistryValue Root="HKCR" Key="ircs" Value="URL:Internet Relay Chat with Privacy" Type="string" />
+                <RegistryValue Root="HKCR" Key="ircs" Name="FriendlyTypeName" Value="Internet Relay Chat with Privacy URL" Type="string" />
+                <RegistryValue Root="HKCR" Key="ircs" Name="EditFlags" Value="2" Type="integer" />
+                <RegistryValue Root="HKCR" Key="ircs" Name="URL Protocol" Value="ircs" Type="string" />
+                
+                <RegistryValue Root="HKCR" Key="ircs\DefaultIcon" Value="[INSTALLFOLDER]halloy.exe,1" Type="string" />
+
+                <RegistryValue Root="HKCR" Key="ircs\shell" Type="string" Value="open" />
+                <RegistryValue Root="HKCR" Key="ircs\shell\open\command" Type="string" Value="&quot;[INSTALLFOLDER]Halloy.exe&quot; &quot;%1&quot;" />
             </Component>
 
         </ComponentGroup>

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -16,7 +16,7 @@
         Manufacturer='Squidowl'
         Language='1033'
         Codepage='1252'
-        Version='0.0.{{ VERSION }}'>
+        Version='{{ VERSION }}.0.0'>
 
         <Package 
             Id='*'

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -76,9 +76,9 @@
           <Custom Action="LaunchApp" Before="InstallFinalize"/>
         </InstallExecuteSequence>
 
-        <WixVariable Id="WixUILicenseRtf" Value="license.rtf"/>
-        <WixVariable Id="WixUIDialogBmp" Value="dialog.png"/>
-        <WixVariable Id="WixUIBannerBmp" Value="banner.png"/>
+        <WixVariable Id="WixUILicenseRtf" Value="wix/license.rtf"/>
+        <WixVariable Id="WixUIDialogBmp" Value="wix/dialog.png"/>
+        <WixVariable Id="WixUIBannerBmp" Value="wix/banner.png"/>
 
         <ui:WixUI Id="WixUI_InstallDir" InstallDirectory="INSTALLFOLDER" />
     </Package>


### PR DESCRIPTION
This PR add support for getting the Windows binary meta information in line with the release version and some other information. Also it updates the WiX installer description to have to correct release version also.

To achieve this i added two build dependencies:
- windows_exe_info = "0.4"
- cargo-edit = "0.12"

Tell me what you think.

![image](https://github.com/squidowl/halloy/assets/107122965/5398fd63-48ef-4565-af9c-7097039155e6)
