### PR TITLE
feat: overwrite nick color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+Added:
+
+- Ability to overwrite nickname colors by providing a hex string (see [buffer configuration](https://halloy.squidowl.org/configuration/buffer.html#buffernicknamecolor-section)).
+
 # 2024.7 (2024-05-05)
 
 Added:

--- a/book/src/configuration/buffer.md
+++ b/book/src/configuration/buffer.md
@@ -4,16 +4,31 @@
 
 ## `[buffer.nickname]` Section
 
+### `[buffer.nickname.color]` Section
+
 ```toml
-[buffer.nickname]
-color = "unique" | "solid"
-brackets = { left = "<string>", right = "<string>" }
+[buffer.nickname.color]
+kind = "unique" | "solid"
+hex = "<string>"
 ```
 
-| Key        | Description                                      | Default                     |
-| ---------- | ------------------------------------------------ | --------------------------- |
-| `color`    | Nickname colors. Can be `"unique"` or `"solid"`. | `"unique"`                  |
-| `brackets` | Brackets for nicknames.                          | `{ left = "", right = "" }` |
+| Key    | Description                                                                                                                                                                                                                                                 | Default           |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `kind` | Controls whether nickname color is `"solid"` or `"unique"`. `"unique"` generates colors by randomzing a hue which is used together with the saturation and lightness from the action color provided by the theme. This color can be overwritten with `hex`. | `kind = "unique"` |
+| `hex`  | Overwrite the default color. Optional.                                                                                                                                                                                                                      | `not set`         |
+
+### `[buffer.nickname.brackets]` Section
+
+```toml
+[buffer.nickname.brackets]
+left = "<string>"
+right = "<string>"
+```
+
+| Key     | Description                  | Default      |
+| ------- | ---------------------------- | ------------ |
+| `left`  | Left bracket for nicknames.  | `left = ""`  |
+| `right` | Right bracket for nicknames. | `right = ""` |
 
 ## `[buffer.timestamp]` Section
 
@@ -47,14 +62,25 @@ visibility = "always" | "focused"
 [buffer.channel.nicklist]
 enabled = true | false
 position = "left" | "right"
-color = "unique" | "solid"
 ```
 
 | Key        | Description                                      | Default    |
 | ---------- | ------------------------------------------------ | ---------- |
 | `enabled`  | Control if nicklist should be shown or not       | `true`     |
 | `position` | Nicklist position. Can be `"left"` or `"right"`. | `"right"`  |
-| `color`    | Nickname colors. Can be `"unique"` or `"solid"`. | `"unique"` |
+
+### `[buffer.channel.nicklist.color]` Section
+
+```toml
+[buffer.channel.nicklist.color]
+kind = "unique" | "solid"
+hex = "<string>"
+```
+
+| Key    | Description                                                                                                                                                                                                                                                 | Default           |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `kind` | Controls whether nickname color is `"solid"` or `"unique"`. `"unique"` generates colors by randomzing a hue which is used together with the saturation and lightness from the action color provided by the theme. This color can be overwritten with `hex`. | `kind = "unique"` |
+| `hex`  | Overwrite the default color. Optional.                                                                                                                                                                                                                      | `not set`         |
 
 ### `[buffer.channel.topic]` Section
 

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -118,16 +118,10 @@ pub enum ColorKind {
     Unique,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Color {
     pub kind: ColorKind,
     pub hex: Option<String>,
-}
-
-impl Default for Color {
-    fn default() -> Self {
-        Self { kind: ColorKind::default(), hex: None }
-    }
 }
 
 impl<'de> Deserialize<'de> for Color {

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -113,7 +113,7 @@ impl Default for Buffer {
         Buffer {
             timestamp: Timestamp::default(),
             nickname: Nickname {
-                color: Color::Unique,
+                color: Color::default(),
                 brackets: Default::default(),
             },
             text_input: Default::default(),

--- a/data/src/config/channel.rs
+++ b/data/src/config/channel.rs
@@ -11,7 +11,7 @@ pub struct Channel {
     pub topic: Topic,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Nicklist {
     #[serde(default = "default_bool_true")]
     pub enabled: bool,

--- a/data/src/theme.rs
+++ b/data/src/theme.rs
@@ -137,7 +137,7 @@ impl Default for Palette {
     }
 }
 
-fn hex_to_color(hex: &str) -> Option<Color> {
+pub fn hex_to_color(hex: &str) -> Option<Color> {
     if hex.len() == 7 {
         let hash = &hex[0..1];
         let r = u8::from_str_radix(&hex[1..3], 16);

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -63,7 +63,7 @@ pub fn view<'a>(
                                 |theme| {
                                     theme::selectable_text::nickname(
                                         theme,
-                                        user.color_seed(&config.buffer.nickname.color),
+                                        user.nick_color(theme.colors(), &config.buffer.nickname.color),
                                         user.is_away(),
                                     )
                                 },
@@ -304,7 +304,7 @@ mod nick_list {
             let content = text(user.to_string()).style(|theme| {
                 theme::text::nickname(
                     theme,
-                    user.color_seed(&config.buffer.channel.nicklist.color),
+                    user.nick_color(theme.colors(), &config.buffer.channel.nicklist.color),
                     user.is_away(),
                 )
             });

--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -26,7 +26,7 @@ pub fn view<'a>(
                 selectable_text(who).style(|theme| {
                     theme::selectable_text::nickname(
                         theme,
-                        user.color_seed(&config.buffer.nickname.color),
+                        user.nick_color(theme.colors(), &config.buffer.nickname.color),
                         false,
                     )
                 }),

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -51,7 +51,7 @@ pub fn view<'a>(
                                 |theme| {
                                     theme::selectable_text::nickname(
                                         theme,
-                                        user.color_seed(&config.buffer.nickname.color),
+                                        user.nick_color(theme.colors(), &config.buffer.nickname.color),
                                         false,
                                     )
                                 },

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -46,7 +46,7 @@ impl Theme {
         }
     }
 
-    fn colors(&self) -> &Colors {
+    pub fn colors(&self) -> &Colors {
         match self {
             Theme::Selected(selected) => &selected.colors,
             Theme::Preview { preview, .. } => &preview.colors,

--- a/src/theme/selectable_text.rs
+++ b/src/theme/selectable_text.rs
@@ -1,4 +1,4 @@
-use data::message;
+use data::{message, user::NickColor};
 
 use crate::widget::selectable_text::{Catalog, Style, StyleFn};
 
@@ -46,8 +46,8 @@ pub fn accent(theme: &Theme) -> Style {
     }
 }
 
-pub fn nickname(theme: &Theme, seed: Option<String>, transparent: bool) -> Style {
-    let color = text::nickname(theme, seed, transparent).color;
+pub fn nickname(theme: &Theme, nick_color: NickColor, transparent: bool) -> Style {
+    let color = text::nickname(theme, nick_color, transparent).color;
 
     Style {
         color,

--- a/src/theme/text.rs
+++ b/src/theme/text.rs
@@ -1,4 +1,4 @@
-use data::theme::{alpha, randomize_color};
+use data::{theme::{alpha, randomize_color}, user::NickColor};
 use iced::widget::text::{Catalog, Style, StyleFn};
 
 use super::Theme;
@@ -67,29 +67,26 @@ pub fn transparent_accent(theme: &Theme) -> Style {
     }
 }
 
-pub fn nickname(theme: &Theme, seed: Option<String>, transparent: bool) -> Style {
+pub fn nickname(theme: &Theme, nick_color: NickColor, transparent: bool) -> Style {
     let dark_theme = theme.colors().is_dark_theme();
+    let NickColor { color, seed } = nick_color;
 
-    if seed.is_none() {
-        let color = match transparent {
-            true => theme.colors().text.med_alpha,
-            false => theme.colors().text.base,
+    let Some(seed) = seed else {
+        let color = if transparent {
+            alpha(color, if dark_theme { 0.2 } else { 0.4 })
+        } else {
+            color
         };
 
         return Style { color: Some(color) };
-    }
+    };
 
-    let original_color = theme.colors().action.base;
-    let randomized_color = seed
-        .as_deref()
-        .map(|seed| randomize_color(original_color, seed))
-        .unwrap_or_else(|| original_color);
-
+    let randomized_color = randomize_color(color, &seed);
     let color = if transparent {
         alpha(randomized_color, if dark_theme { 0.2 } else { 0.4 })
     } else {
         randomized_color
     };
 
-    Style { color: Some(color) }
+Style { color: Some(color) }
 }


### PR DESCRIPTION
Ability to overwrite nickname colors by providing a hex string.
Note that I didn't add any breaking changes since we are still able to deserde from a string, instead of a map:

The new format looks like
```toml
[buffer.nickname.color]
kind = "unique"
hex = "#ff0000" # optional
```

But we still correctly parse
```toml
[buffer.nickname]
color = "unique"
```