### PR TITLE
User Context Menu Status Icon Tweak

### DIFF
--- a/src/buffer/user_context.rs
+++ b/src/buffer/user_context.rs
@@ -3,8 +3,8 @@ use data::{Buffer, User};
 use iced::widget::{button, container, horizontal_rule, row, text, Space};
 use iced::Length;
 
-use crate::theme;
 use crate::widget::{context_menu, double_pass, Element};
+use crate::{icon, theme};
 
 #[derive(Debug, Clone, Copy)]
 enum Entry {
@@ -153,21 +153,25 @@ fn user_info(current_user: Option<&User>, length: Length) -> Element<'_, Message
             row![]
                 .push(text("Away").style(theme::text::transparent).width(length))
                 .push(
-                    text("⬤")
+                    icon::dot()
+                        .size(6)
                         .style(theme::text::info)
                         .shaping(text::Shaping::Advanced),
                 )
                 .padding(right_justified_padding())
+                .align_items(iced::Alignment::Center)
                 .into()
         } else {
             row![]
                 .push(text("Online").style(theme::text::transparent).width(length))
                 .push(
-                    text("⬤")
+                    icon::dot()
+                        .size(6)
                         .style(theme::text::success)
                         .shaping(text::Shaping::Advanced),
                 )
                 .padding(right_justified_padding())
+                .align_items(iced::Alignment::Center)
                 .into()
         }
     } else {
@@ -178,11 +182,13 @@ fn user_info(current_user: Option<&User>, length: Length) -> Element<'_, Message
                     .width(length),
             )
             .push(
-                text("⬤")
+                icon::dot()
+                    .size(6)
                     .style(theme::text::error)
                     .shaping(text::Shaping::Advanced),
             )
             .padding(right_justified_padding())
+            .align_items(iced::Alignment::Center)
             .into()
     }
 }


### PR DESCRIPTION
The original idea for the user context menu status icon was to use a unicode character so that it would line up precisely with the last character.  However, playing around with font settings recently I've found that most fonts do not have that character, and depending on the font the fallback font the circle ends up being way too big/small.  So I switched it to use the same method as the sidebar's unread messages icon.  Looks about the same to me when using default font settings.