### PR TITLE
Mention Flathub and Snap Store in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Join **#halloy** on libera.chat if you have questions or looking for help.
     <img src="https://repology.org/badge/vertical-allrepos/halloy.svg" alt="Packaging status">
 </a>
 
+Halloy is also available from [Flathub](https://flathub.org/apps/org.squidowl.halloy) and [Snap Store](https://snapcraft.io/halloy).
+
 ## Features
 
 * IRCv3.2 capabilities


### PR DESCRIPTION
The Repology image does not list Flathub and Snap entries. The developers of Repology have stated that they never will support listing Flathub or Snap entries.

I think many users would be interested to know that Flathub or Snap packages are available, without having to navigate to further documentation, so I added one sentence to the README.md file.