### PR TITLE
Theme Configuration Parsing Tweak

### DIFF
--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -210,7 +210,9 @@ impl Config {
 
             if file_name.ends_with(".toml") {
                 if let Ok(theme) = read_entry(entry) {
-                    if file_name.strip_suffix(".toml").unwrap_or_default() == default_key {
+                    if file_name.strip_suffix(".toml").unwrap_or_default() == default_key
+                        || file_name == default_key
+                    {
                         default = theme.clone();
                     }
                     if file_name == DEFAULT_THEME_FILE_NAME {


### PR DESCRIPTION
A minor tweak to accept `"<theme_name>.toml"` as well as `"<theme_name>"` in the configuration `.toml`.  The documentation specifies it should be the name of the file, but does not say whether or not to include the extension;  we could make the documentation more specific/restricted, but since it's fairly simple to allow both formats that seems like the more user-friendly option to me.