### PR TITLE
"Leave Buffer" and "Toggle Sidebar" Shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Added:
 - Ability to open `irc://` and `ircs://` URL schemes
 - Ability to overwrite nickname colors by providing a hex string (see [buffer configuration](https://halloy.squidowl.org/configuration/buffer.html#buffernicknamecolor-section)).
 - Ability to overwrite server & internal message colors by providing a hex string (see [buffer configuration](https://halloy.squidowl.org/configuration/buffer.html#bufferserver_messages-section)).
+- Configurable shortcuts for "Leave Buffer" and "Toggle Sidebar" actions (see [keyboard shortcuts configuration](https://github.com/squidowl/halloy/wiki/Keyboard-shortcuts)).
 
 # 2024.7 (2024-05-05)
 

--- a/book/src/configuration/keyboard.md
+++ b/book/src/configuration/keyboard.md
@@ -13,25 +13,29 @@ maximize_buffer = "<string>"
 restore_buffer = "<string>"
 cycle_next_buffer = "<string>"
 cycle_previous_buffer = "<string>"
+leave_buffer = "<string>"
 toggle_nick_list = "<string>"
+toggle_sidebar = "<string>"
 command_bar = "<string>"
 refresh_configuration = "<string>"
 ```
 
-| Key                     | Description              | Default MacOS                                       | Default Other                                       |
-| ----------------------- | ------------------------ | --------------------------------------------------- | --------------------------------------------------- |
-| `move_up`               | Moves focus up           | <kbd>⌥</kbd> + <kbd>↑</kbd>                         | <kbd>alt</kbd> + <kbd>↑</kbd>                       |
-| `move_down`             | Moves focus down         | <kbd>⌥</kbd> + <kbd>↓</kbd>                         | <kbd>alt</kbd> + <kbd>↓</kbd>                       |
-| `move_left`             | Moves focus left         | <kbd>⌥</kbd> + <kbd>←</kbd>                         | <kbd>alt</kbd> + <kbd>←</kbd>                       |
-| `move_right`            | Moves focus right        | <kbd>⌥</kbd> + <kbd>→</kbd>                         | <kbd>alt</kbd> + <kbd>→</kbd>                       |
-| `close_buffer`          | Close focused buffer     | <kbd>⌘</kbd> + <kbd>w</kbd>                         | <kbd>ctrl</kbd> + <kbd>w</kbd>                      |
-| `maximize_buffer`       | Maximize focused buffer  | <kbd>⌘</kbd> + <kbd>↑</kbd>                         | <kbd>ctrl</kbd> + <kbd>↑</kbd>                      |
-| `restore_buffer`        | Restore focused buffer   | <kbd>⌘</kbd> + <kbd>↓</kbd>                         | <kbd>ctrl</kbd> + <kbd>↓</kbd>                      |
-| `cycle_next_buffer`     | Cycle to next buffer     | <kbd>ctrl</kbd> + <kbd>tab</kbd>                    | <kbd>ctrl</kbd> + <kbd>tab</kbd>                    |
-| `cycle_previous_buffer` | Cycle to previous buffer | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>tab</kbd> | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>tab</kbd> |
-| `toggle_nick_list`      | Toggle nick list         | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>m</kbd>          | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>m</kbd>     |
-| `command_bar`           | Toggle command bar       | <kbd>⌘</kbd> + <kbd>k</kbd>                         | <kbd>ctrl</kbd> + <kbd>k</kbd>                      |
-| `reload_configuration`           | Refresh configuration file       | <kbd>⌘</kbd> + <kbd>r</kbd>                         | <kbd>ctrl</kbd> + <kbd>r</kbd>                      |
+| Key                     | Description                  | Default MacOS                                       | Default Other                                       |
+| ----------------------- | ---------------------------- | --------------------------------------------------- | --------------------------------------------------- |
+| `move_up`               | Moves focus up               | <kbd>⌥</kbd> + <kbd>↑</kbd>                         | <kbd>alt</kbd> + <kbd>↑</kbd>                       |
+| `move_down`             | Moves focus down             | <kbd>⌥</kbd> + <kbd>↓</kbd>                         | <kbd>alt</kbd> + <kbd>↓</kbd>                       |
+| `move_left`             | Moves focus left             | <kbd>⌥</kbd> + <kbd>←</kbd>                         | <kbd>alt</kbd> + <kbd>←</kbd>                       |
+| `move_right`            | Moves focus right            | <kbd>⌥</kbd> + <kbd>→</kbd>                         | <kbd>alt</kbd> + <kbd>→</kbd>                       |
+| `close_buffer`          | Close focused buffer         | <kbd>⌘</kbd> + <kbd>w</kbd>                         | <kbd>ctrl</kbd> + <kbd>w</kbd>                      |
+| `maximize_buffer`       | Maximize focused buffer      | <kbd>⌘</kbd> + <kbd>↑</kbd>                         | <kbd>ctrl</kbd> + <kbd>↑</kbd>                      |
+| `restore_buffer`        | Restore focused buffer       | <kbd>⌘</kbd> + <kbd>↓</kbd>                         | <kbd>ctrl</kbd> + <kbd>↓</kbd>                      |
+| `cycle_next_buffer`     | Cycle to next buffer         | <kbd>ctrl</kbd> + <kbd>tab</kbd>                    | <kbd>ctrl</kbd> + <kbd>tab</kbd>                    |
+| `cycle_previous_buffer` | Cycle to previous buffer     | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>tab</kbd> | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>tab</kbd> |
+| `leave_buffer`          | Leave channel or close query | <kbd>⌘</kbd> + <kbd>shift</kbd> + <kbd>w</kbd>      | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>w</kbd>   |
+| `toggle_nick_list`      | Toggle nick list             | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>m</kbd>          | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>m</kbd>     |
+| `toggle_sidebar`        | Toggle sidebar               | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>b</kbd>          | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>b</kbd>     |
+| `command_bar`           | Toggle command bar           | <kbd>⌘</kbd> + <kbd>k</kbd>                         | <kbd>ctrl</kbd> + <kbd>k</kbd>                      |
+| `reload_configuration`  | Refresh configuration file   | <kbd>⌘</kbd> + <kbd>r</kbd>                         | <kbd>ctrl</kbd> + <kbd>r</kbd>                      |
 
 Example for vim like movement
 

--- a/data/src/config/keys.rs
+++ b/data/src/config/keys.rs
@@ -22,8 +22,12 @@ pub struct Keyboard {
     pub cycle_next_buffer: KeyBind,
     #[serde(default = "KeyBind::cycle_previous_buffer")]
     pub cycle_previous_buffer: KeyBind,
+    #[serde(default = "KeyBind::leave_buffer")]
+    pub leave_buffer: KeyBind,
     #[serde(default = "KeyBind::toggle_nick_list")]
     pub toggle_nick_list: KeyBind,
+    #[serde(default = "KeyBind::toggle_sidebar")]
+    pub toggle_sidebar: KeyBind,
     #[serde(default = "KeyBind::command_bar")]
     pub command_bar: KeyBind,
     #[serde(default = "KeyBind::reload_configuration")]
@@ -42,7 +46,9 @@ impl Default for Keyboard {
             restore_buffer: KeyBind::restore_buffer(),
             cycle_next_buffer: KeyBind::cycle_next_buffer(),
             cycle_previous_buffer: KeyBind::cycle_previous_buffer(),
+            leave_buffer: KeyBind::leave_buffer(),
             toggle_nick_list: KeyBind::toggle_nick_list(),
+            toggle_sidebar: KeyBind::toggle_sidebar(),
             command_bar: KeyBind::command_bar(),
             reload_configuration: KeyBind::reload_configuration(),
         }
@@ -63,7 +69,9 @@ impl Keyboard {
             shortcut(self.restore_buffer.clone(), RestoreBuffer),
             shortcut(self.cycle_next_buffer.clone(), CycleNextBuffer),
             shortcut(self.cycle_previous_buffer.clone(), CyclePreviousBuffer),
+            shortcut(self.leave_buffer.clone(), LeaveBuffer),
             shortcut(self.toggle_nick_list.clone(), ToggleNicklist),
+            shortcut(self.toggle_sidebar.clone(), ToggleSidebar),
             shortcut(self.command_bar.clone(), CommandBar),
             shortcut(self.reload_configuration.clone(), ReloadConfiguration),
         ]

--- a/data/src/shortcut.rs
+++ b/data/src/shortcut.rs
@@ -32,7 +32,9 @@ pub enum Command {
     RestoreBuffer,
     CycleNextBuffer,
     CyclePreviousBuffer,
+    LeaveBuffer,
     ToggleNicklist,
+    ToggleSidebar,
     CommandBar,
     ReloadConfiguration,
 }
@@ -109,7 +111,9 @@ impl KeyBind {
     default!(restore_buffer, ArrowDown, COMMAND);
     default!(cycle_next_buffer, Tab, CTRL);
     default!(cycle_previous_buffer, Tab, CTRL | SHIFT);
+    default!(leave_buffer, "w", COMMAND | SHIFT);
     default!(toggle_nick_list, "m", COMMAND | ALT);
+    default!(toggle_sidebar, "b", COMMAND | ALT);
     default!(command_bar, "k", COMMAND);
     default!(reload_configuration, "r", COMMAND);
 


### PR DESCRIPTION
Added shortcuts for "leave buffer" (i.e. leave channel or close query as appropriate) and "toggle sidebar".  Picked "leave buffer" as a three-key shortcut by default to reduce the chance of accidental input, and "toggle sidebar" to use `b` in order to leave `s` open for other, future shortcuts.  But I'm not particularly attached to either.