### PR TITLE
UTF-8 Channel Name Rendering Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Added:
 - Ability to overwrite server & internal message colors by providing a hex string (see [buffer configuration](https://halloy.squidowl.org/configuration/buffer.html#bufferserver_messages-section)).
 - Configurable shortcuts for "Leave Buffer" and "Toggle Sidebar" actions (see [keyboard shortcuts configuration](https://github.com/squidowl/halloy/wiki/Keyboard-shortcuts)).
 
+Fixed:
+
+- UTF-8 channel name rendering in sidebar and in pane title bars.
+
 # 2024.7 (2024-05-05)
 
 Added:

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -236,10 +236,14 @@ impl TitleBar {
             controls = controls.push(close_button_with_tooltip);
         }
 
-        let title = container(text(value).style(theme::text::transparent))
-            .height(22)
-            .padding([0, 4])
-            .align_y(iced::alignment::Vertical::Center);
+        let title = container(
+            text(value)
+                .style(theme::text::transparent)
+                .shaping(text::Shaping::Advanced),
+        )
+        .height(22)
+        .padding([0, 4])
+        .align_y(iced::alignment::Vertical::Center);
 
         widget::TitleBar::new(title).controls(controls).padding(6)
     }

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -248,7 +248,9 @@ fn buffer_button<'a>(
             } else {
                 icon::wifi_off()
             },
-            text(server.to_string()).style(theme::text::primary)
+            text(server.to_string())
+                .style(theme::text::primary)
+                .shaping(text::Shaping::Advanced)
         ]
         .spacing(8)
         .align_items(iced::Alignment::Center),
@@ -256,13 +258,21 @@ fn buffer_button<'a>(
             .push(horizontal_space().width(3))
             .push_maybe(has_unread.then_some(icon::dot().size(6).style(theme::text::info)))
             .push(horizontal_space().width(if has_unread { 10 } else { 16 }))
-            .push(text(channel.clone()).style(theme::text::primary))
+            .push(
+                text(channel.clone())
+                    .style(theme::text::primary)
+                    .shaping(text::Shaping::Advanced),
+            )
             .align_items(iced::Alignment::Center),
         Buffer::Query(_, nick) => row![]
             .push(horizontal_space().width(3))
             .push_maybe(has_unread.then_some(icon::dot().size(6).style(theme::text::info)))
             .push(horizontal_space().width(if has_unread { 10 } else { 16 }))
-            .push(text(nick.to_string()).style(theme::text::primary))
+            .push(
+                text(nick.to_string())
+                    .style(theme::text::primary)
+                    .shaping(text::Shaping::Advanced),
+            )
             .align_items(iced::Alignment::Center),
     };
 


### PR DESCRIPTION
Channels with UTF-8 name can include glyphs that are not commonly covered by fonts (e.g. `#☃` on `irc.hackint.org`).  I've turned on advanced shaping for sidebar items and the pane title bar text to ensure that those channel names render properly via font fallback.