### PR TITLE
Input Error Overlay Size 

### DIFF
--- a/src/widget/input.rs
+++ b/src/widget/input.rs
@@ -266,7 +266,7 @@ where
 
 fn error<'a, 'b, Message: 'a>(error: &'b str) -> Element<'a, Message> {
     container(text(error.to_string()).style(theme::text::error))
-        .center_y(Length::Fill)
+        .center_y(Length::Shrink)
         .padding(8)
         .style(theme::container::context)
         .into()


### PR DESCRIPTION
In my testing the error overlay for user input fills the full height of the pane.  E.g. typing then attempting to submit `/msg BouncerServer` (without a message argument) results in a full height overlay that looks like:
![Screenshot from 2024-06-09 14-43-36](https://github.com/squidowl/halloy/assets/5768180/e6c3ffc9-675a-4572-888a-71e656b3f3de)
This minor tweak is to instead shrink the size of the container to the text (not worthy of a changelog entry, I think).