### PR TITLE
Support for CTCP queries `CLIENTINFO`, `PING`, `SOURCE`, and `VERSION`

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -501,10 +501,10 @@ impl Client {
                     } else {
                         // Handle CTCP queries except ACTION and DCC
                         if user.nickname() != self.nickname()
-                            && ctcp::is_ctcp_query(text)
+                            && ctcp::is_query(text)
                             && !message::is_action(text)
                         {
-                            if let Ok(query) = ctcp::parse_ctcp_query(text) {
+                            if let Some(query) = ctcp::parse_query(text) {
                                 match query.command {
                                     "CLIENTINFO" => {
                                         let _ = self.handle.try_send(command!(

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -506,24 +506,37 @@ impl Client {
                                     "CLIENTINFO" => {
                                         let _ = self.handle.try_send(command!(
                                             "NOTICE",
-                                            user.nickname().as_ref().to_string(),
-                                            "\u{1}CLIENTINFO ACTION CLIENTINFO DCC PING VERSION\u{1}"
+                                            user,
+                                            "\u{1}CLIENTINFO ACTION CLIENTINFO DCC PING SOURCE VERSION\u{1}"
                                         ));
                                     }
                                     "PING" => {
+                                        let reply = if text.ends_with('\u{1}') {
+                                            text.clone()
+                                        } else {
+                                            format!("{text}\u{1}")
+                                        };
+
+                                        let _ =
+                                            self.handle.try_send(command!("NOTICE", user, reply));
+                                    }
+                                    "SOURCE" => {
                                         let _ = self.handle.try_send(command!(
                                             "NOTICE",
-                                            user.nickname().as_ref().to_string(),
-                                            text
+                                            user,
+                                            format!(
+                                                "\u{1}{}\u{1}",
+                                                crate::environment::SOURCE_WEBSITE
+                                            )
                                         ));
                                     }
                                     "VERSION" => {
                                         let _ = self.handle.try_send(command!(
                                             "NOTICE",
-                                            user.nickname().as_ref().to_string(),
+                                            user,
                                             format!(
                                                 "\u{1}Halloy {}\u{1}",
-                                                include_str!("../../VERSION")
+                                                crate::environment::VERSION
                                             )
                                         ));
                                     }

--- a/data/src/ctcp.rs
+++ b/data/src/ctcp.rs
@@ -4,21 +4,20 @@ pub struct Query<'a> {
     pub params: &'a str,
 }
 
-pub fn is_ctcp_query(text: &str) -> bool {
+pub fn is_query(text: &str) -> bool {
     text.starts_with('\u{1}')
 }
 
-pub fn parse_ctcp_query(text: &str) -> Result<Query, &'static str> {
+pub fn parse_query(text: &str) -> Option<Query> {
     let query = text
         .strip_suffix('\u{1}')
         .unwrap_or(text)
-        .strip_prefix('\u{1}')
-        .ok_or("text is not a CTCP query")?;
+        .strip_prefix('\u{1}')?;
 
     if let Some((command, params)) = query.split_once(char::is_whitespace) {
-        Ok(Query { command, params })
+        Some(Query { command, params })
     } else {
-        Ok(Query {
+        Some(Query {
             command: query,
             params: "",
         })

--- a/data/src/ctcp.rs
+++ b/data/src/ctcp.rs
@@ -1,0 +1,26 @@
+#[derive(Debug)]
+pub struct Query<'a> {
+    pub command: &'a str,
+    pub params: &'a str,
+}
+
+pub fn is_ctcp_query(text: &str) -> bool {
+    text.starts_with('\u{1}')
+}
+
+pub fn parse_ctcp_query(text: &str) -> Result<Query, &'static str> {
+    let query = text
+        .strip_suffix('\u{1}')
+        .unwrap_or(text)
+        .strip_prefix('\u{1}')
+        .ok_or("text is not a CTCP query")?;
+
+    if let Some((command, params)) = query.split_once(char::is_whitespace) {
+        Ok(Query { command, params })
+    } else {
+        Ok(Query {
+            command: query,
+            params: "",
+        })
+    }
+}

--- a/data/src/dcc.rs
+++ b/data/src/dcc.rs
@@ -7,7 +7,7 @@ use crate::ctcp;
 use irc::proto::{self, command};
 
 pub fn decode(content: &str) -> Option<Command> {
-    let query = ctcp::parse_ctcp_query(content).ok()?;
+    let query = ctcp::parse_query(content)?;
 
     if query.command != "DCC" {
         return None;

--- a/data/src/environment.rs
+++ b/data/src/environment.rs
@@ -8,6 +8,7 @@ pub const APPLICATION_ID: &str = "org.squidowl.halloy";
 pub const WIKI_WEBSITE: &str = "https://halloy.squidowl.org";
 pub const MIGRATION_WEBSITE: &str = "https://halloy.squidowl.org/guides/migrating-from-yaml.html";
 pub const RELEASE_WEBSITE: &str = "https://github.com/squidowl/halloy/releases/latest";
+pub const SOURCE_WEBSITE: &str = "https://github.com/squidowl/halloy/";
 
 pub fn formatted_version() -> String {
     let hash = GIT_HASH

--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -21,6 +21,7 @@ pub mod client;
 pub mod command;
 mod compression;
 pub mod config;
+pub mod ctcp;
 pub mod dashboard;
 pub mod dcc;
 pub mod environment;

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -544,12 +544,24 @@ impl Limit {
     }
 }
 
-fn is_action(text: &str) -> bool {
-    text.starts_with("\u{1}ACTION ") && text.ends_with('\u{1}')
+pub fn ctcp_command(text: &str) -> Option<&str> {
+    let command = text
+        .strip_suffix('\u{1}')
+        .unwrap_or(text)
+        .strip_prefix('\u{1}')?;
+
+    command.split_whitespace().next()
+}
+
+pub fn is_action(text: &str) -> bool {
+    text.starts_with("\u{1}ACTION ")
 }
 
 pub fn parse_action(nick: NickRef, text: &str) -> Option<String> {
-    let action = text.strip_prefix("\u{1}ACTION ")?.strip_suffix('\u{1}')?;
+    let action = text
+        .strip_suffix('\u{1}')
+        .unwrap_or(text)
+        .strip_prefix("\u{1}ACTION ")?;
     Some(action_text(nick, action))
 }
 

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -545,17 +545,17 @@ impl Limit {
 }
 
 pub fn is_action(text: &str) -> bool {
-    if let Ok(ctcp_query) = ctcp::parse_ctcp_query(text) {
-        ctcp_query.command == "ACTION"
+    if let Some(query) = ctcp::parse_query(text) {
+        query.command == "ACTION"
     } else {
         false
     }
 }
 
 pub fn parse_action(nick: NickRef, text: &str) -> Option<String> {
-    let ctcp_query = ctcp::parse_ctcp_query(text).ok()?;
+    let query = ctcp::parse_query(text)?;
 
-    Some(action_text(nick, ctcp_query.params))
+    Some(action_text(nick, query.params))
 }
 
 pub fn action_text(nick: NickRef, action: &str) -> String {


### PR DESCRIPTION
Using <https://raw.githubusercontent.com/DanielOaks/irc-rfcs/master/dist/draft-oakley-irc-ctcp-latest.txt> as reference for CTCP, this PR implements three changes:
1.  Responds to `CLIENTINFO`, `PING`, `SOURCE`, and `VERSION` queries.  These queries seem benign to reply to.  `FINGER`, `TIME`, and `USERINFO`, on the other hand, give information about the user that I don't think should be provided automatically.
2.  Does not pass any CTCP queries on to the user (whether responded to or not).
3.  Permits incoming CTCP queries to not be properly terminated by `\u{1}` (as prescribed by the reference document).

Primarily creating this to stop having `\u{1}VERSION\u{1}` messages from OFTC's `CTCPServ` show up in the GUI.

Didn't add anything to the changelog since there is little to no user-facing functionality provided as far as I can tell.