### PR TITLE
Minor URL Parsing Tweaks

### DIFF
--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -16,7 +16,7 @@ use crate::{ctcp, Config, User};
 
 static URL_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r#"(?i)((https?|ircs?):\/\/|www\.)[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)"#,
+        r#"(?i)((https?|ircs?):\/\/|www\.)[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,63}\b([-a-zA-Z0-9()@:%_\+.~#?&\/=]*)"#,
     )
     .unwrap()
 });
@@ -806,6 +806,14 @@ mod test {
                     Fragment::Text("We have a wiki at ".into()),
                     Fragment::Url("https://halloy.squidowl.org".parse().unwrap()),
                 ],
+            ),
+            (
+                "https://catgirl.delivery/2024/07/25/sometimes-it-is-correct-to-blame-the-compiler/",
+                vec![Fragment::Url(
+                    "https://catgirl.delivery/2024/07/25/sometimes-it-is-correct-to-blame-the-compiler/"
+                    .parse()
+                    .unwrap()
+                )],
             ),
         ];
 


### PR DESCRIPTION
Two minor tweaks to the URL parsing regex:

1.  Allow TLDs to be up to 63 characters long (that's my reading from [Wikipedia's DNS article](https://en.wikipedia.org/wiki/Domain_Name_System#Domain_name_syntax,_internationalization) which refers to a TLD as the "right-most label" then later states "A label may contain zero to 63 characters").
2.  I *think* there was a typo near the end of the regex (`//` instead of `\/`).  At least, when I entered it into <https://regexr.com/> it gave me an error until I made the change.

Added the URL that didn't parse to the tests.