### PR TITLE
chghost Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Added:
 
 - Small icon in sidemenu when a new release is available 
+- Enable support for IRCv3 `chghost`
 
 # 2024.9 (2024-07-29)
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Halloy is also available from [Flathub](https://flathub.org/apps/org.squidowl.ha
     * [message-tags](https://ircv3.net/specs/extensions/message-tags)
     * [`WHOX`](https://ircv3.net/specs/extensions/whox)
     * [`UTF8ONLY`](https://ircv3.net/specs/extensions/utf8-only)
+    * [chghost](https://ircv3.net/specs/extensions/chghost)
 * SASL support
 * DCC Send
 * Keyboard shortcuts

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -18,6 +18,7 @@
     * [message-tags](https://ircv3.net/specs/extensions/message-tags)
     * [`WHOX`](https://ircv3.net/specs/extensions/whox)
     * [`UTF8ONLY`](https://ircv3.net/specs/extensions/utf8-only)
+    * [chghost](https://ircv3.net/specs/extensions/chghost)
 * SASL support
 * DCC Send
 * Keyboard shortcuts

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -352,6 +352,38 @@ impl Manager {
                 channel,
                 user_channels,
             } => message::broadcast::invite(inviter, channel, user_channels, sent_time),
+            Broadcast::ChangeHost {
+                old_user,
+                new_username,
+                new_hostname,
+                ourself,
+                user_channels,
+            } => {
+                if ourself {
+                    // If ourself, broadcast to all query channels (since we are in all of them)
+                    message::broadcast::change_host(
+                        user_channels,
+                        queries,
+                        &old_user,
+                        &new_username,
+                        &new_hostname,
+                        ourself,
+                        sent_time,
+                    )
+                } else {
+                    // Otherwise just the query channel of the user w/ host change
+                    let user_query = queries.find(|nick| old_user.nickname() == *nick);
+                    message::broadcast::change_host(
+                        user_channels,
+                        user_query,
+                        &old_user,
+                        &new_username,
+                        &new_hostname,
+                        ourself,
+                        sent_time,
+                    )
+                }
+            }
         };
 
         messages.into_iter().for_each(|message| {
@@ -628,6 +660,13 @@ pub enum Broadcast {
     Invite {
         inviter: Nick,
         channel: String,
+        user_channels: Vec<String>,
+    },
+    ChangeHost {
+        old_user: User,
+        new_username: String,
+        new_hostname: String,
+        ourself: bool,
         user_channels: Vec<String>,
     },
 }

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -495,6 +495,7 @@ fn target(
         | Command::CAP(_, _, _, _)
         | Command::AUTHENTICATE(_)
         | Command::BATCH(_, _)
+        | Command::CHGHOST(_, _)
         | Command::CNOTICE(_, _, _)
         | Command::CPRIVMSG(_, _, _)
         | Command::KNOCK(_, _)

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -161,6 +161,14 @@ impl User {
         Self { nickname, ..self }
     }
 
+    pub fn with_username_and_hostname(self, username: String, hostname: String) -> Self {
+        Self {
+            username: Some(username),
+            hostname: Some(hostname),
+            ..self
+        }
+    }
+
     pub fn highest_access_level(&self) -> AccessLevel {
         self.access_levels
             .iter()

--- a/irc/proto/src/command.rs
+++ b/irc/proto/src/command.rs
@@ -96,6 +96,8 @@ pub enum Command {
 
     /* IRC extensions */
     BATCH(String, Vec<String>),
+    /// <new_username> <new_hostname>
+    CHGHOST(String, String),
     /// <nickname> <channel> :<message>
     CNOTICE(String, String, String),
     /// <nickname> <channel> :<message>
@@ -193,6 +195,7 @@ impl Command {
             "USERHOST" => USERHOST(params.collect()),
             "WALLOPS" if len > 0 => WALLOPS(req!()),
             "BATCH" if len > 0 => BATCH(req!(), params.collect()),
+            "CHGHOST" if len > 1 => CHGHOST(req!(), req!()),
             "CNOTICE" if len > 2 => CNOTICE(req!(), req!(), req!()),
             "CPRIVMSG" if len > 2 => CPRIVMSG(req!(), req!(), req!()),
             "KNOCK" if len > 0 => KNOCK(req!(), opt!()),
@@ -247,6 +250,7 @@ impl Command {
             Command::USERHOST(params) => params,
             Command::WALLOPS(a) => vec![a],
             Command::BATCH(a, rest) => std::iter::once(a).chain(rest).collect(),
+            Command::CHGHOST(a, b) => vec![a, b],
             Command::CNOTICE(a, b, c) => vec![a, b, c],
             Command::CPRIVMSG(a, b, c) => vec![a, b, c],
             Command::KNOCK(a, b) => std::iter::once(a).chain(b).collect(),
@@ -303,6 +307,7 @@ impl Command {
             USERHOST(_) => "USERHOST".to_string(),
             WALLOPS(_) => "WALLOPS".to_string(),
             BATCH(_, _) => "BATCH".to_string(),
+            CHGHOST(_, _) => "CHGHOST".to_string(),
             CNOTICE(_, _, _) => "CNOTICE".to_string(),
             CPRIVMSG(_, _, _) => "CPRIVMSG".to_string(),
             KNOCK(_, _) => "KNOCK".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -507,6 +507,25 @@ impl Halloy {
                                                 sent_time,
                                             );
                                         }
+                                        data::client::Broadcast::ChangeHost {
+                                            old_user,
+                                            new_username,
+                                            new_hostname,
+                                            ourself,
+                                            channels,
+                                            sent_time,
+                                        } => {
+                                            dashboard.broadcast_change_host(
+                                                &server,
+                                                old_user,
+                                                new_username,
+                                                new_hostname,
+                                                ourself,
+                                                channels,
+                                                &self.config,
+                                                sent_time,
+                                            );
+                                        }
                                     },
                                     data::client::Event::Notification(
                                         encoded,

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -970,6 +970,31 @@ impl Dashboard {
         );
     }
 
+    pub fn broadcast_change_host(
+        &mut self,
+        server: &Server,
+        old_user: User,
+        new_username: String,
+        new_hostname: String,
+        ourself: bool,
+        user_channels: Vec<String>,
+        config: &Config,
+        sent_time: DateTime<Utc>,
+    ) {
+        self.history.broadcast(
+            server,
+            Broadcast::ChangeHost {
+                old_user,
+                new_username,
+                new_hostname,
+                ourself,
+                user_channels,
+            },
+            config,
+            sent_time,
+        );
+    }
+
     pub fn broadcast_connecting(
         &mut self,
         server: &Server,


### PR DESCRIPTION
Simple implementation for [chghost](https://ircv3.net/specs/extensions/chghost).  Appears to work in my testing, though it seems like Libera does not send `CHGHOST` messages when your own host changes (instead numeric 396 seems to be sent, which contains a notice that the cloak has been applied).

Would it make sense to add the a setting to mute change host messages? (And/or nickname change messages?)