### PR TITLE
persistant window position and size

### DIFF
--- a/data/src/window/size.rs
+++ b/data/src/window/size.rs
@@ -7,8 +7,8 @@ pub struct Size {
 }
 
 impl Size {
-    pub const MIN_WIDTH: f32 = 320.0;
-    pub const MIN_HEIGHT: f32 = 200.0;
+    pub const MIN_WIDTH: f32 = 426.0;
+    pub const MIN_HEIGHT: f32 = 240.0;
 
     pub fn new(width: f32, height: f32) -> Self {
         Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,11 @@ pub fn main() -> iced::Result {
         }
     }
 
-    let window_load = Window::load().unwrap_or_default();
+    // TODO: Renable persistant window position and size:
+    // Winit currently has a bug with resize and move events.
+    // Until it have been fixed, the persistant position and size has been disabled.
+    //
+    // let window_load = Window::load().unwrap_or_default();
 
     if let Err(error) = iced::application("Halloy", Halloy::update, Halloy::view)
         .theme(Halloy::theme)
@@ -85,8 +89,12 @@ pub fn main() -> iced::Result {
         .subscription(Halloy::subscription)
         .settings(settings(&config_load))
         .window(window::Settings {
-            size: window_load.size.into(),
-            position: window_load.position.map(From::from).unwrap_or_default(),
+            size: data::window::Size::default().into(),
+            position: iced::window::Position::Default,
+            min_size: (Some(iced::Size::new(
+                data::window::Size::MIN_WIDTH,
+                data::window::Size::MIN_HEIGHT,
+            ))),
             exit_on_close_request: false,
             ..window::settings()
         })


### PR DESCRIPTION
This disabled persistant position and size due to a bug in winit.
Related to https://github.com/squidowl/halloy/issues/411.