### PR TITLE
`account-notify` and `extended-join` Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Added:
 
 - Small icon in sidemenu when a new release is available 
-- Enable support for IRCv3 `chghost`
+- Enable support for IRCv3 `chghost`, `account-notify`, and `extended-join`
 
 Removed:
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Halloy is also available from [Flathub](https://flathub.org/apps/org.squidowl.ha
     * [`WHOX`](https://ircv3.net/specs/extensions/whox)
     * [`UTF8ONLY`](https://ircv3.net/specs/extensions/utf8-only)
     * [chghost](https://ircv3.net/specs/extensions/chghost)
+    * [account-notify](https://ircv3.net/specs/extensions/account-notify)
+    * [extended-join](https://ircv3.net/specs/extensions/extended-join)
 * SASL support
 * DCC Send
 * Keyboard shortcuts

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -19,6 +19,8 @@
     * [`WHOX`](https://ircv3.net/specs/extensions/whox)
     * [`UTF8ONLY`](https://ircv3.net/specs/extensions/utf8-only)
     * [chghost](https://ircv3.net/specs/extensions/chghost)
+    * [account-notify](https://ircv3.net/specs/extensions/account-notify)
+    * [extended-join](https://ircv3.net/specs/extensions/extended-join)
 * SASL support
 * DCC Send
 * Keyboard shortcuts

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -94,6 +94,8 @@ pub struct Client {
     listed_caps: Vec<String>,
     supports_labels: bool,
     supports_away_notify: bool,
+    supports_account_notify: bool,
+    supports_extended_join: bool,
     highlight_blackout: HighlightBlackout,
     registration_required_channels: Vec<String>,
     isupport: HashMap<isupport::Kind, isupport::Parameter>,
@@ -144,6 +146,8 @@ impl Client {
             listed_caps: vec![],
             supports_labels: false,
             supports_away_notify: false,
+            supports_account_notify: false,
+            supports_extended_join: false,
             highlight_blackout: HighlightBlackout::Blackout(Instant::now()),
             registration_required_channels: vec![],
             isupport: HashMap::new(),
@@ -333,6 +337,13 @@ impl Client {
                     if contains("chghost") {
                         requested.push("chghost");
                     }
+                    if contains("account-notify") {
+                        requested.push("account-notify");
+
+                        if contains("extended-join") {
+                            requested.push("extended-join");
+                        }
+                    }
                     if contains("batch") {
                         requested.push("batch");
                     }
@@ -375,6 +386,12 @@ impl Client {
                 }
                 if caps.contains(&"away-notify") {
                     self.supports_away_notify = true;
+                }
+                if caps.contains(&"account-notify") {
+                    self.supports_account_notify = true;
+                }
+                if caps.contains(&"extended-join") {
+                    self.supports_extended_join = true;
                 }
 
                 let supports_sasl = caps.iter().any(|cap| cap.contains("sasl"));
@@ -428,6 +445,15 @@ impl Client {
                 if newly_contains("chghost") {
                     requested.push("chghost");
                 }
+                if contains("account-notify") || newly_contains("account-notify") {
+                    if newly_contains("account-notify") {
+                        requested.push("account-notify");
+                    }
+
+                    if newly_contains("extended-join") {
+                        requested.push("extended-join");
+                    }
+                }
                 if newly_contains("batch") {
                     requested.push("batch");
                 }
@@ -464,6 +490,12 @@ impl Client {
                 }
                 if del_caps.contains(&"away-notify") {
                     self.supports_away_notify = false;
+                }
+                if del_caps.contains(&"account-notify") {
+                    self.supports_account_notify = false;
+                }
+                if del_caps.contains(&"extended-join") {
+                    self.supports_extended_join = false;
                 }
 
                 self.listed_caps
@@ -738,7 +770,7 @@ impl Client {
                     channel.users.remove(&user);
                 }
             }
-            Command::JOIN(channel, _) => {
+            Command::JOIN(channel, accountname) => {
                 let user = message.user()?;
 
                 if user.nickname() == self.nickname() {
@@ -747,12 +779,19 @@ impl Client {
                     if let Some(state) = self.chanmap.get_mut(channel) {
                         // Sends WHO to get away state on users.
                         if self.isupport.contains_key(&isupport::Kind::WHOX) {
+                            let fields = if self.supports_account_notify {
+                                "tcnfa"
+                            } else {
+                                "tcnf"
+                            };
+
                             let _ = self.handle.try_send(command!(
                                 "WHO",
                                 channel,
-                                "tcnf",
+                                fields,
                                 isupport::WHO_POLL_TOKEN.to_owned()
                             ));
+
                             state.last_who = Some(WhoStatus::Requested(
                                 Instant::now(),
                                 Some(isupport::WHO_POLL_TOKEN),
@@ -764,6 +803,14 @@ impl Client {
                         log::debug!("[{}] {channel} - WHO requested", self.server);
                     }
                 } else if let Some(channel) = self.chanmap.get_mut(channel) {
+                    let user = if self.supports_extended_join {
+                        accountname.as_ref().map_or(user.clone(), |accountname| {
+                            user.with_accountname(accountname)
+                        })
+                    } else {
+                        user
+                    };
+
                     channel.users.insert(user);
                 }
             }
@@ -801,6 +848,12 @@ impl Client {
                 if proto::is_channel(target) {
                     if let Some(channel) = self.chanmap.get_mut(target) {
                         channel.update_user_away(args.get(3)?, args.get(4)?);
+
+                        if self.supports_account_notify {
+                            if let (Some(user), Some(accountname)) = (args.get(3), args.get(5)) {
+                                channel.update_user_accountname(user, accountname);
+                            }
+                        }
 
                         if let Ok(token) = args.get(1)?.parse::<isupport::WhoToken>() {
                             if let Some(WhoStatus::Requested(_, Some(request_token))) =
@@ -1020,6 +1073,29 @@ impl Client {
             Command::TAGMSG(_) => {
                 return None;
             }
+            Command::ACCOUNT(accountname) => {
+                let old_user = message.user()?;
+
+                self.chanmap.values_mut().for_each(|channel| {
+                    if let Some(user) = channel.users.take(&old_user) {
+                        channel.users.insert(user.with_accountname(accountname));
+                    }
+                });
+
+                if old_user.nickname() == self.nickname()
+                    && accountname != "*"
+                    && !self.registration_required_channels.is_empty()
+                {
+                    for message in group_joins(
+                        &self.registration_required_channels,
+                        &self.config.channel_keys,
+                    ) {
+                        let _ = self.handle.try_send(message);
+                    }
+
+                    self.registration_required_channels.clear();
+                }
+            }
             Command::CHGHOST(new_username, new_hostname) => {
                 let old_user = message.user()?;
 
@@ -1136,12 +1212,19 @@ impl Client {
 
             if let Some(request) = request {
                 if self.isupport.contains_key(&isupport::Kind::WHOX) {
+                    let fields = if self.supports_account_notify {
+                        "tcnfa"
+                    } else {
+                        "tcnf"
+                    };
+
                     let _ = self.handle.try_send(command!(
                         "WHO",
                         channel,
-                        "tcnf",
+                        fields,
                         isupport::WHO_POLL_TOKEN.to_owned()
                     ));
+
                     state.last_who = Some(WhoStatus::Requested(
                         Instant::now(),
                         Some(isupport::WHO_POLL_TOKEN),
@@ -1436,6 +1519,14 @@ impl Channel {
                 user.update_away(away);
                 self.users.insert(user);
             }
+        }
+    }
+
+    pub fn update_user_accountname(&mut self, user: &str, accountname: &str) {
+        let user = User::from(Nick::from(user));
+
+        if let Some(user) = self.users.take(&user) {
+            self.users.insert(user.with_accountname(accountname));
         }
     }
 }

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -498,6 +498,7 @@ fn target(
         | Command::USERHOST(_)
         | Command::CAP(_, _, _, _)
         | Command::AUTHENTICATE(_)
+        | Command::ACCOUNT(_)
         | Command::BATCH(_, _)
         | Command::CHGHOST(_, _)
         | Command::CNOTICE(_, _, _)

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -19,6 +19,7 @@ pub struct User {
     nickname: Nick,
     username: Option<String>,
     hostname: Option<String>,
+    accountname: Option<String>,
     access_levels: HashSet<AccessLevel>,
     away: bool,
 }
@@ -93,6 +94,7 @@ impl<'a> TryFrom<&'a str> for User {
             nickname: Nick::from(nickname),
             username,
             hostname,
+            accountname: None,
             access_levels,
             away: false,
         })
@@ -118,6 +120,7 @@ impl From<Nick> for User {
             nickname,
             username: None,
             hostname: None,
+            accountname: None,
             access_levels: HashSet::default(),
             away: false,
         }
@@ -157,6 +160,10 @@ impl User {
         self.hostname.as_deref()
     }
 
+    pub fn accountname(&self) -> Option<&str> {
+        self.accountname.as_deref()
+    }
+
     pub fn with_nickname(self, nickname: Nick) -> Self {
         Self { nickname, ..self }
     }
@@ -165,6 +172,19 @@ impl User {
         Self {
             username: Some(username),
             hostname: Some(hostname),
+            ..self
+        }
+    }
+
+    pub fn with_accountname(self, accountname: &str) -> Self {
+        let accountname = if accountname == "*" || accountname == "0" {
+            None
+        } else {
+            Some(accountname.to_string())
+        };
+
+        Self {
+            accountname,
             ..self
         }
     }
@@ -221,6 +241,7 @@ impl From<proto::User> for User {
             nickname: Nick::from(user.nickname),
             username: user.username,
             hostname: user.hostname,
+            accountname: None,
             access_levels: HashSet::default(),
             away: false,
         }

--- a/irc/proto/src/command.rs
+++ b/irc/proto/src/command.rs
@@ -24,7 +24,8 @@ pub enum Command {
     ERROR(String),
 
     /* Channel Operations */
-    /// <channel>{,<channel>} [<key>{,<key>}]
+    /// <channel>{,<channel>} [<key>{,<key>}] (send)
+    /// <channel>{,<channel>} [<accountname>] (receive [extended-join])
     JOIN(String, Option<String>),
     /// <channel>{,<channel>} [<reason>]
     PART(String, Option<String>),
@@ -94,6 +95,8 @@ pub enum Command {
     /// <text>
     WALLOPS(String),
 
+    /// <accountname>
+    ACCOUNT(String),
     /* IRC extensions */
     BATCH(String, Vec<String>),
     /// <new_username> <new_hostname>
@@ -194,6 +197,7 @@ impl Command {
             "LINKS" => LINKS,
             "USERHOST" => USERHOST(params.collect()),
             "WALLOPS" if len > 0 => WALLOPS(req!()),
+            "ACCOUNT" if len > 0 => ACCOUNT(req!()),
             "BATCH" if len > 0 => BATCH(req!(), params.collect()),
             "CHGHOST" if len > 1 => CHGHOST(req!(), req!()),
             "CNOTICE" if len > 2 => CNOTICE(req!(), req!(), req!()),
@@ -249,6 +253,7 @@ impl Command {
             Command::LINKS => vec![],
             Command::USERHOST(params) => params,
             Command::WALLOPS(a) => vec![a],
+            Command::ACCOUNT(a) => vec![a],
             Command::BATCH(a, rest) => std::iter::once(a).chain(rest).collect(),
             Command::CHGHOST(a, b) => vec![a, b],
             Command::CNOTICE(a, b, c) => vec![a, b, c],
@@ -306,6 +311,7 @@ impl Command {
             LINKS => "LINKS".to_string(),
             USERHOST(_) => "USERHOST".to_string(),
             WALLOPS(_) => "WALLOPS".to_string(),
+            ACCOUNT(_) => "ACCOUNT".to_string(),
             BATCH(_, _) => "BATCH".to_string(),
             CHGHOST(_, _) => "CHGHOST".to_string(),
             CNOTICE(_, _, _) => "CNOTICE".to_string(),


### PR DESCRIPTION
Adds support for IRCv3 [`account-notify`](https://ircv3.net/specs/extensions/account-notify) and [`extended-join`](https://ircv3.net/specs/extensions/extended-join) by adding an `accountname` to users.  Currently the `accountname` is only utilized to determine whether Halloy's user has been registered/logged-in.  Does not fix #465 by itself, since OFTC does not support `account-notify` (or `extended-join`), but I think we should check for these capabilities first before parsing user modes that are not standardized (which afaict is the only notice OFTC gives for that a user has logged in).