### PR TITLE
Configuration Options for `chghost` Messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+Added:
+
+- Configuration options for hiding/coloring `chghost` messages.
+
 Fixed:
 
 - Expanded recognized login notifications (used to join channels that report themselves as requiring registration after logging in)

--- a/book/src/configuration/buffer.md
+++ b/book/src/configuration/buffer.md
@@ -129,6 +129,13 @@ enabled = true | false
 hex = "<string>"
 ```
 
+```toml
+[buffer.server_messages.change_host]
+enabled = true | false
+smart = <integer>
+hex = "<string>"
+```
+
 | Key               | Description                                                                                                                                                      | Default   |
 | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
 | `enabled`         | Control if the server message should appear in buffers or not                                                                                                    | `true`    |

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -33,15 +33,18 @@ pub struct ServerMessages {
     pub part: ServerMessage,
     #[serde(default)]
     pub quit: ServerMessage,
+    #[serde(default)]
+    pub change_host: ServerMessage,
 }
 
 impl ServerMessages {
     pub fn get(&self, server: &source::Server) -> Option<&ServerMessage> {
         match server.kind() {
             source::server::Kind::ReplyTopic => Some(&self.topic),
+            source::server::Kind::Join => Some(&self.join),
             source::server::Kind::Part => Some(&self.part),
             source::server::Kind::Quit => Some(&self.quit),
-            source::server::Kind::Join => Some(&self.join),
+            source::server::Kind::ChangeHost => Some(&self.change_host),
         }
     }
 }

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -464,6 +464,12 @@ fn target(
                 }),
             }
         }
+        Command::CHGHOST(_, _) => Some(Target::Server {
+            source: source::Source::Server(Some(source::Server::new(
+                source::server::Kind::ChangeHost,
+                user.map(|user| user.nickname().to_owned()),
+            ))),
+        }),
 
         // Server
         Command::PASS(_)
@@ -500,7 +506,6 @@ fn target(
         | Command::AUTHENTICATE(_)
         | Command::ACCOUNT(_)
         | Command::BATCH(_, _)
-        | Command::CHGHOST(_, _)
         | Command::CNOTICE(_, _, _)
         | Command::CPRIVMSG(_, _, _)
         | Command::KNOCK(_, _)

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -226,7 +226,10 @@ pub fn change_host(
         channels,
         queries,
         false,
-        Cause::Server(None),
+        Cause::Server(Some(source::Server::new(
+            source::server::Kind::ChangeHost,
+            Some(old_user.nickname().to_owned()),
+        ))),
         content,
         sent_time,
     )

--- a/data/src/message/source.rs
+++ b/data/src/message/source.rs
@@ -64,6 +64,7 @@ pub mod server {
         Part,
         Quit,
         ReplyTopic,
+        ChangeHost,
     }
 
     #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/theme/selectable_text.rs
+++ b/src/theme/selectable_text.rs
@@ -69,6 +69,9 @@ pub fn server(
             message::source::server::Kind::ReplyTopic => {
                 config.topic.hex.as_deref().and_then(hex_to_color)
             }
+            message::source::server::Kind::ChangeHost => {
+                config.change_host.hex.as_deref().and_then(hex_to_color)
+            }
         })
         .or_else(|| text::info(theme).color);
 


### PR DESCRIPTION
Makes use of the existing `ServerMessage` infrastructure to add show/hide/color options for change host messages.