### PR TITLE
STATUSMSG Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Fixed:
 
 - Expanded recognized login notifications (used to join channels that report themselves as requiring registration after logging in)
 - Messages with multiple targets are correctly recorded into multiple buffers (and/or multiple times into the same buffer) client-side.
+- Messages sent with a STATUSMSG prefix are recorded and indicated in the corresponding channel.
 
 # 2024.10 (2024-08-04)
 

--- a/book/src/configuration/buffer.md
+++ b/book/src/configuration/buffer.md
@@ -50,7 +50,16 @@ brackets = { left = "<string>", right = "<string>" }
 | Key        | Description                                                                                                                                  | Default                     |
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
 | `format`   | Format expected is [strftime](https://pubs.opengroup.org/onlinepubs/007908799/xsh/strftime.html). To disable, simply pass empty string `""`. | `"%R"`                      |
-| `brackets` | Brackets for nicknames                                                                                                                       | `{ left = "", right = "" }` |
+| `brackets` | Brackets for timestamps.                                                                                                                     | `{ left = "", right = "" }` |
+
+```toml
+[buffer.status_message_prefix]
+brackets = { left = "<string>", right = "<string>" }
+```
+
+| Key        | Description                                                                                                                                  | Default                     |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| `brackets` | Brackets for status message prefixes (uncommon).                                                                                             | `{ left = "", right = "" }` |
 
 ## `[buffer.text_input]` Section
 

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -45,6 +45,7 @@ impl Buffer {
             Self::Channel(_, channel) => message::Target::Channel {
                 channel,
                 source: message::Source::Server(source),
+                prefix: None,
             },
             Self::Query(_, nick) => message::Target::Query {
                 nick,

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -121,6 +121,12 @@ pub struct Nickname {
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
+pub struct StatusMessagePrefix {
+    #[serde(default)]
+    pub brackets: Brackets,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct Brackets {
     pub left: String,
     pub right: String,

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 
 use super::Channel;
 use crate::{
-    buffer::{Alignment, Color, Nickname, TextInput, Timestamp},
+    buffer::{Alignment, Color, Nickname, StatusMessagePrefix, TextInput, Timestamp},
     message::source,
 };
 
@@ -21,6 +21,8 @@ pub struct Buffer {
     pub server_messages: ServerMessages,
     #[serde(default)]
     pub internal_messages: InternalMessages,
+    #[serde(default)]
+    pub status_message_prefix: StatusMessagePrefix,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -130,6 +132,7 @@ impl Default for Buffer {
             channel: Channel::default(),
             server_messages: Default::default(),
             internal_messages: Default::default(),
+            status_message_prefix: Default::default(),
         }
     }
 }

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -271,6 +271,7 @@ pub struct View<'a> {
     pub old_messages: Vec<&'a Message>,
     pub new_messages: Vec<&'a Message>,
     pub max_nick_chars: Option<usize>,
+    pub max_prefix_chars: Option<usize>,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -567,6 +567,31 @@ impl Data {
                 .unwrap_or_default()
         });
 
+        let max_prefix_chars = buffer_config.nickname.alignment.is_right().then(|| {
+            if matches!(kind, history::Kind::Channel(_)) {
+                filtered
+                    .iter()
+                    .filter_map(|message| {
+                        message.target.prefix().map(|prefix| {
+                            Some(
+                                buffer_config
+                                    .status_message_prefix
+                                    .brackets
+                                    .format(prefix)
+                                    .chars()
+                                    .count()
+                                    + 1,
+                            )
+                        })
+                    })
+                    .flatten()
+                    .max()
+                    .unwrap_or_default()
+            } else {
+                0
+            }
+        });
+
         let limited = with_limit(limit, filtered.into_iter());
 
         let split_at = limited
@@ -581,6 +606,7 @@ impl Data {
             old_messages: old.to_vec(),
             new_messages: new.to_vec(),
             max_nick_chars,
+            max_prefix_chars,
         })
     }
 

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -573,18 +573,15 @@ impl Data {
                     .iter()
                     .filter_map(|message| {
                         message.target.prefix().map(|prefix| {
-                            Some(
-                                buffer_config
-                                    .status_message_prefix
-                                    .brackets
-                                    .format(prefix)
-                                    .chars()
-                                    .count()
-                                    + 1,
-                            )
+                            buffer_config
+                                .status_message_prefix
+                                .brackets
+                                .format(prefix)
+                                .chars()
+                                .count()
+                                + 1
                         })
                     })
-                    .flatten()
                     .max()
                     .unwrap_or_default()
             } else {

--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -67,10 +67,11 @@ impl Input {
 
     pub fn messages(&self, user: User) -> Option<Vec<Message>> {
         let to_target = |target: &str, source| {
-            if proto::is_channel(target) {
+            if let Some((prefix, channel)) = proto::parse_channel_from_target(target) {
                 Some(message::Target::Channel {
-                    channel: target.to_string(),
+                    channel,
                     source,
+                    prefix,
                 })
             } else if let Ok(user) = User::try_from(target) {
                 Some(message::Target::Query {

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -90,11 +90,11 @@ pub enum Target {
 }
 
 impl Target {
-    pub fn prefix(&self) -> &Option<char> {
+    pub fn prefix(&self) -> Option<&char> {
         match self {
-            Target::Server { .. } => &None,
-            Target::Channel { prefix, .. } => prefix,
-            Target::Query { .. } => &None,
+            Target::Server { .. } => None,
+            Target::Channel { prefix, .. } => prefix.as_ref(),
+            Target::Query { .. } => None,
         }
     }
 

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -435,7 +435,7 @@ fn target(
 
             match (proto::parse_channel_from_target(&target), user) {
                 (Some((prefix, channel)), Some(user)) => {
-                    let source = source(resolve_attributes(&user, &target).unwrap_or(user));
+                    let source = source(resolve_attributes(&user, &channel).unwrap_or(user));
                     Some(Target::Channel {
                         channel,
                         source,
@@ -469,7 +469,7 @@ fn target(
 
             match (proto::parse_channel_from_target(&target), user) {
                 (Some((prefix, channel)), Some(user)) => {
-                    let source = source(resolve_attributes(&user, &target).unwrap_or(user));
+                    let source = source(resolve_attributes(&user, &channel).unwrap_or(user));
                     Some(Target::Channel {
                         channel,
                         source,

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -90,6 +90,14 @@ pub enum Target {
 }
 
 impl Target {
+    pub fn prefix(&self) -> &Option<char> {
+        match self {
+            Target::Server { .. } => &None,
+            Target::Channel { prefix, .. } => prefix,
+            Target::Query { .. } => &None,
+        }
+    }
+
     pub fn source(&self) -> &Source {
         match self {
             Target::Server { source } => source,

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -42,6 +42,7 @@ fn expand(
                 Target::Channel {
                     channel,
                     source: source.clone(),
+                    prefix: None,
                 },
                 content.clone(),
             )

--- a/irc/proto/src/lib.rs
+++ b/irc/proto/src/lib.rs
@@ -58,6 +58,22 @@ pub fn is_channel(target: &str) -> bool {
 // Reference: https://defs.ircdocs.horse/defs/chanmembers
 pub const CHANNEL_MEMBERSHIP_PREFIXES: [char; 6] = ['~', '&', '!', '@', '%', '+'];
 
+pub fn parse_channel_from_target(target: &str) -> Option<(Option<char>, String)> {
+    if target.starts_with(CHANNEL_MEMBERSHIP_PREFIXES) {
+        let channel = target.strip_prefix(CHANNEL_MEMBERSHIP_PREFIXES)?;
+
+        if is_channel(channel) {
+            return Some((target.chars().next(), channel.to_string()));
+        }
+    }
+
+    if is_channel(target) {
+        Some((None, target.to_string()))
+    } else {
+        None
+    }
+}
+
 #[macro_export]
 macro_rules! command {
     ($c:expr) => (

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -48,7 +48,7 @@ pub fn view<'a>(
             scroll_view::Kind::Channel(&state.server, &state.channel),
             history,
             config,
-            move |message, max_nick_width| {
+            move |message, max_nick_width, max_prefix_width| {
                 let timestamp =
                     config
                         .buffer
@@ -57,13 +57,31 @@ pub fn view<'a>(
                             selectable_text(timestamp).style(theme::selectable_text::transparent)
                         });
 
-                let prefix = message.target.prefix().map(|prefix| {
-                    selectable_text(format!(
-                        "{} ",
-                        config.buffer.status_message_prefix.brackets.format(prefix)
-                    ))
-                    .style(theme::selectable_text::info)
-                });
+                let prefix = message.target.prefix().map_or(
+                    max_nick_width.and_then(|_| {
+                        max_prefix_width.map(|width| {
+                            selectable_text(" ")
+                                .width(width)
+                                .horizontal_alignment(alignment::Horizontal::Right)
+                        })
+                    }),
+                    |prefix| {
+                        let text = selectable_text(format!(
+                            "{} ",
+                            config.buffer.status_message_prefix.brackets.format(prefix)
+                        ))
+                        .style(theme::selectable_text::info);
+
+                        if let Some(width) = max_prefix_width {
+                            Some(
+                                text.width(width)
+                                    .horizontal_alignment(alignment::Horizontal::Right),
+                            )
+                        } else {
+                            Some(text)
+                        }
+                    },
+                );
 
                 match message.target.source() {
                     message::Source::User(user) => {

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -58,7 +58,11 @@ pub fn view<'a>(
                         });
 
                 let prefix = message.target.prefix().map(|prefix| {
-                    selectable_text(format!("({prefix}) ")).style(theme::selectable_text::info)
+                    selectable_text(format!(
+                        "{} ",
+                        config.buffer.status_message_prefix.brackets.format(prefix)
+                    ))
+                    .style(theme::selectable_text::info)
                 });
 
                 match message.target.source() {

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -57,6 +57,10 @@ pub fn view<'a>(
                             selectable_text(timestamp).style(theme::selectable_text::transparent)
                         });
 
+                let prefix = message.target.prefix().map(|prefix| {
+                    selectable_text(format!("({prefix}) ")).style(theme::selectable_text::info)
+                });
+
                 match message.target.source() {
                     message::Source::User(user) => {
                         let mut text = selectable_text(
@@ -97,6 +101,7 @@ pub fn view<'a>(
                             container(
                                 row![]
                                     .push_maybe(timestamp)
+                                    .push_maybe(prefix)
                                     .push(nick)
                                     .push(space)
                                     .push(text),
@@ -136,7 +141,15 @@ pub fn view<'a>(
                             theme::selectable_text::accent,
                         );
 
-                        Some(container(row![].push_maybe(timestamp).push(message)).into())
+                        Some(
+                            container(
+                                row![]
+                                    .push_maybe(timestamp)
+                                    .push_maybe(prefix)
+                                    .push(message),
+                            )
+                            .into(),
+                        )
                     }
                     message::Source::Internal(message::source::Internal::Status(status)) => {
                         let message = message_content(

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -36,7 +36,7 @@ pub fn view<'a>(
             scroll_view::Kind::Query(&state.server, &state.nick),
             history,
             config,
-            move |message, max_nick_width| {
+            move |message, max_nick_width, _| {
                 let timestamp =
                     config
                         .buffer

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -75,9 +75,9 @@ pub fn view<'a>(
         .unwrap_or_else(time::Posix::now);
     let status = state.status;
 
-    let max_nick_width = width_from_chars(max_nick_chars);
+    let max_nick_width = width_from_chars(max_nick_chars, config);
 
-    let max_prefix_width = width_from_chars(max_prefix_chars);
+    let max_prefix_width = width_from_chars(max_prefix_chars, config);
 
     let old = old_messages
         .into_iter()
@@ -130,12 +130,17 @@ pub fn view<'a>(
         .into()
 }
 
-fn width_from_chars(chars: Option<usize>) -> Option<f32> {
+fn width_from_chars(chars: Option<usize>, config: &Config) -> Option<f32> {
     chars.map(|len| {
         Paragraph::with_text(Text {
             content: &" ".repeat(len),
             bounds: Size::INFINITY,
-            size: theme::TEXT_SIZE.into(),
+            size: config
+                .font
+                .size
+                .map(f32::from)
+                .unwrap_or(theme::TEXT_SIZE)
+                .into(),
             line_height: Default::default(),
             font: font::MONO.clone().into(),
             horizontal_alignment: alignment::Horizontal::Right,

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -30,7 +30,7 @@ pub fn view<'a>(
             scroll_view::Kind::Server(&state.server),
             history,
             config,
-            move |message, _| {
+            move |message, _, _| {
                 let timestamp =
                     config
                         .buffer


### PR DESCRIPTION
Shows messages with a STATUSMSG prefix in the corresponding channel, and adds an indicator for those messages to the left of the nickname.  I put the indicator to the left of the nickname so that it couldn't be spoofed by message text.  I believe this addresses #438.