### PR TITLE
Exclude Trailing Punctuation from URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,6 +749,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,6 +985,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "chrono",
+ "const_format",
  "dirs-next",
  "flate2",
  "futures",

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -36,6 +36,7 @@ regex = "1.10.4"
 walkdir = "2.5.0"
 once_cell = "1.19.0"
 nom = "7.1"
+const_format = "0.2.32"
 
 [dependencies.irc]
 path = "../irc"

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
 use chrono::{DateTime, Utc};
+use const_format::concatcp;
 use irc::proto;
 use irc::proto::Command;
 use itertools::Itertools;
@@ -20,10 +21,34 @@ use crate::{ctcp, Config, User};
 // - https://datatracker.ietf.org/doc/html/rfc1738#section-5
 // - https://www.ietf.org/rfc/rfc2396.txt
 
+const URL_PATH_UNRESERVED: &str = r#"a-zA-Z0-9-_.!~*'()"#;
+
+const URL_PATH_RESERVED: &str = r#";?:@&=+$,"#;
+
+const URL_PATH: &str = concatcp!(r#"["#, URL_PATH_UNRESERVED, URL_PATH_RESERVED, r#"%\/#]"#);
+
+const URL_PATH_UNRESERVED_EXC_PUNC: &str = r#"a-zA-Z0-9-_~*'("#;
+
+const URL_PATH_RESERVED_EXC_PUNC: &str = r#"@&=+$"#;
+
+const URL_PATH_EXC_PUNC: &str = concatcp!(
+    r#"["#,
+    URL_PATH_UNRESERVED_EXC_PUNC,
+    URL_PATH_RESERVED_EXC_PUNC,
+    r#"%\/#]"#
+);
+
 static URL_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(
-        r#"(?i)((https?|ircs?):\/\/|www\.)[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,63}\b([a-zA-Z0-9-_.!~*'()%;?:@&=+$,\/#]*[a-zA-Z0-9-_~*(%:@&=+$\/#]|[a-zA-Z0-9-_~*(%:@&=+$\/#]?)"#,
-    )
+    Regex::new(concatcp!(
+        r#"(?i)((https?|ircs?):\/\/|www\.)[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,63}\b"#,
+        r#"("#,
+        URL_PATH,
+        r#"*"#,
+        URL_PATH_EXC_PUNC,
+        r#"|"#,
+        URL_PATH_EXC_PUNC,
+        r#"?)"#
+    ))
     .unwrap()
 });
 

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -22,7 +22,7 @@ use crate::{ctcp, Config, User};
 
 static URL_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r#"(?i)((https?|ircs?):\/\/|www\.)[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,63}\b([a-zA-Z0-9-_.!~*'()%;?:@&=+$,\/#]*)"#,
+        r#"(?i)((https?|ircs?):\/\/|www\.)[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,63}\b([a-zA-Z0-9-_.!~*'()%;?:@&=+$,\/#]*[a-zA-Z0-9-_~*(%:@&=+$\/#]|[a-zA-Z0-9-_~*(%:@&=+$\/#]?)"#,
     )
     .unwrap()
 });
@@ -877,6 +877,16 @@ mod test {
                     .parse()
                     .unwrap()
                 )],
+            ),
+            (
+                "(https://yt.drgnz.club/watch?v=s_VH36ChGXw and https://invidious.incogniweb.net/watch?v=H3v9unphfi0).",
+                vec![
+                    Fragment::Text("(".into()),
+                    Fragment::Url("https://yt.drgnz.club/watch?v=s_VH36ChGXw".parse().unwrap()),
+                    Fragment::Text(" and ".into()),
+                    Fragment::Url("https://invidious.incogniweb.net/watch?v=H3v9unphfi0".parse().unwrap()),
+                    Fragment::Text(").".into()),
+                ],
             ),
         ];
 


### PR DESCRIPTION
My understanding is that URLs technically can end in punctuation, but in my experience it is extremely rare.  So I think we should err on the side of assuming punctuation at the end of a URL is not part of the URL, which is what this PR does.

The regex got so long and unwieldy I broke it up into smaller components to make it more legible, but the only way I could find to do that involved adding the [`const_format`](https://docs.rs/const_format/latest/const_format/) crate.  The names `RESERVED` and `UNRESERVED` come from [RFC 2396](https://www.ietf.org/rfc/rfc2396.txt).