### PR TITLE
Right Align Miscellaneous Messages

### DIFF
--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -181,7 +181,7 @@ impl Message {
                 nick: from.clone(),
                 source: Source::Action,
             },
-            content: plain(format!(" ∙ {from} wants to send you \"{filename}\"")),
+            content: plain(format!("{from} wants to send you \"{filename}\"")),
         }
     }
 
@@ -194,7 +194,7 @@ impl Message {
                 nick: to.clone(),
                 source: Source::Action,
             },
-            content: plain(format!(" ∙ offering to send {to} \"{filename}\"")),
+            content: plain(format!("offering to send {to} \"{filename}\"")),
         }
     }
 
@@ -597,9 +597,7 @@ fn content(
 
             let topic = topic.as_ref()?;
 
-            Some(parse_fragments(format!(
-                " ∙ {user} changed topic to {topic}"
-            )))
+            Some(parse_fragments(format!("{user} changed topic to {topic}")))
         }
         Command::PART(target, text) => {
             let raw_user = message.user()?;
@@ -661,9 +659,7 @@ fn content(
                 .collect::<Vec<_>>()
                 .join(" ");
 
-            Some(parse_fragments(format!(
-                " ∙ {user} sets mode {modes} {args}"
-            )))
+            Some(parse_fragments(format!("{user} sets mode {modes} {args}")))
         }
         Command::PRIVMSG(_, text) => {
             // Check if a synthetic action message
@@ -679,7 +675,7 @@ fn content(
         Command::Numeric(RPL_TOPIC, params) => {
             let topic = params.get(2)?;
 
-            Some(parse_fragments(format!(" ∙ topic is {topic}")))
+            Some(parse_fragments(format!("topic is {topic}")))
         }
         Command::Numeric(RPL_ENDOFWHOIS, _) => {
             // We skip the end message of a WHOIS.
@@ -701,7 +697,7 @@ fn content(
             let idle_readable = formatter.convert(duration);
 
             Some(parse_fragments(format!(
-                " ∙ {nick} signed on at {sign_on_datetime} and has been idle for {idle_readable}"
+                "{nick} signed on at {sign_on_datetime} and has been idle for {idle_readable}"
             )))
         }
         Command::Numeric(RPL_WHOISSERVER, params) => {
@@ -710,7 +706,7 @@ fn content(
             let region = params.get(3)?;
 
             Some(parse_fragments(format!(
-                " ∙ {nick} is connected on {server} ({region})"
+                "{nick} is connected on {server} ({region})"
             )))
         }
         Command::Numeric(RPL_WHOISUSER, params) => {
@@ -719,36 +715,34 @@ fn content(
             let real_name = params.get(5)?;
 
             Some(parse_fragments(format!(
-                " ∙ {nick} has userhost {userhost} and real name '{real_name}'"
+                "{nick} has userhost {userhost} and real name '{real_name}'"
             )))
         }
         Command::Numeric(RPL_WHOISCHANNELS, params) => {
             let nick = params.get(1)?;
             let channels = params.get(2)?;
 
-            Some(parse_fragments(format!(" ∙ {nick} is in {channels}")))
+            Some(parse_fragments(format!("{nick} is in {channels}")))
         }
         Command::Numeric(RPL_WHOISACTUALLY, params) => {
             let nick = params.get(1)?;
             let ip = params.get(2)?;
             let status_text = params.get(3)?;
 
-            Some(parse_fragments(format!(" ∙ {nick} {status_text} {ip}")))
+            Some(parse_fragments(format!("{nick} {status_text} {ip}")))
         }
         Command::Numeric(RPL_WHOISSECURE, params) => {
             let nick = params.get(1)?;
             let status_text = params.get(2)?;
 
-            Some(parse_fragments(format!(" ∙ {nick} {status_text}")))
+            Some(parse_fragments(format!("{nick} {status_text}")))
         }
         Command::Numeric(RPL_WHOISACCOUNT, params) => {
             let nick = params.get(1)?;
             let account = params.get(2)?;
             let status_text = params.get(3)?;
 
-            Some(parse_fragments(format!(
-                " ∙ {nick} {status_text} {account}"
-            )))
+            Some(parse_fragments(format!("{nick} {status_text} {account}")))
         }
         Command::Numeric(RPL_TOPICWHOTIME, params) => {
             let nick = params.get(2)?;
@@ -762,7 +756,7 @@ fn content(
                 .to_rfc2822();
 
             Some(parse_fragments(format!(
-                " ∙ topic set by {nick} at {datetime}"
+                "topic set by {nick} at {datetime}"
             )))
         }
         Command::Numeric(RPL_CHANNELMODEIS, params) => {
@@ -773,7 +767,7 @@ fn content(
                 .collect::<Vec<_>>()
                 .join(" ");
 
-            Some(parse_fragments(format!(" ∙ Channel mode is {mode}")))
+            Some(parse_fragments(format!("Channel mode is {mode}")))
         }
         Command::Numeric(RPL_AWAY, params) => {
             let user = params.get(1)?;
@@ -782,7 +776,7 @@ fn content(
                 .map(|away| format!(" ({away})"))
                 .unwrap_or_default();
 
-            Some(parse_fragments(format!(" ∙ {user} is away{away_message}")))
+            Some(parse_fragments(format!("{user} is away{away_message}")))
         }
         Command::Numeric(_, responses) | Command::Unknown(_, responses) => Some(parse_fragments(
             responses
@@ -832,9 +826,9 @@ fn parse_action(nick: NickRef, text: &str) -> Option<Content> {
 
 pub fn action_text(nick: NickRef, action: Option<&str>) -> Content {
     if let Some(action) = action {
-        parse_fragments(format!(" ∙ {nick} {action}"))
+        parse_fragments(format!("{nick} {action}"))
     } else {
-        plain(format!(" ∙ {nick}"))
+        plain(format!("{nick}"))
     }
 }
 

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -68,7 +68,7 @@ fn expand(
 }
 
 pub fn connecting(sent_time: DateTime<Utc>) -> Vec<Message> {
-    let content = plain(" ∙ connecting to server...".into());
+    let content = plain("connecting to server...".into());
     expand(
         [],
         [],
@@ -80,7 +80,7 @@ pub fn connecting(sent_time: DateTime<Utc>) -> Vec<Message> {
 }
 
 pub fn connected(sent_time: DateTime<Utc>) -> Vec<Message> {
-    let content = plain(" ∙ connected".into());
+    let content = plain("connected".into());
     expand(
         [],
         [],
@@ -92,7 +92,7 @@ pub fn connected(sent_time: DateTime<Utc>) -> Vec<Message> {
 }
 
 pub fn connection_failed(error: String, sent_time: DateTime<Utc>) -> Vec<Message> {
-    let content = plain(format!(" ∙ connection to server failed ({error})"));
+    let content = plain(format!("connection to server failed ({error})"));
     expand(
         [],
         [],
@@ -110,7 +110,7 @@ pub fn disconnected(
     sent_time: DateTime<Utc>,
 ) -> Vec<Message> {
     let error = error.map(|error| format!(" ({error})")).unwrap_or_default();
-    let content = plain(format!(" ∙ connection to server lost{error}"));
+    let content = plain(format!("connection to server lost{error}"));
     expand(
         channels,
         queries,
@@ -126,7 +126,7 @@ pub fn reconnected(
     queries: impl IntoIterator<Item = Nick>,
     sent_time: DateTime<Utc>,
 ) -> Vec<Message> {
-    let content = plain(" ∙ connection to server restored".into());
+    let content = plain("connection to server restored".into());
     expand(
         channels,
         queries,
@@ -177,9 +177,9 @@ pub fn nickname(
     sent_time: DateTime<Utc>,
 ) -> Vec<Message> {
     let content = if ourself {
-        plain(format!(" ∙ You're now known as {new_nick}"))
+        plain(format!("You're now known as {new_nick}"))
     } else {
-        plain(format!(" ∙ {old_nick} is now known as {new_nick}"))
+        plain(format!("{old_nick} is now known as {new_nick}"))
     };
 
     expand(
@@ -198,7 +198,7 @@ pub fn invite(
     channels: impl IntoIterator<Item = String>,
     sent_time: DateTime<Utc>,
 ) -> Vec<Message> {
-    let content = plain(format!(" ∙ {inviter} invited you to join {channel}"));
+    let content = plain(format!("{inviter} invited you to join {channel}"));
 
     expand(channels, [], false, Cause::Server(None), content, sent_time)
 }
@@ -214,11 +214,11 @@ pub fn change_host(
 ) -> Vec<Message> {
     let content = if ourself {
         plain(format!(
-            " ∙ You've changed host to {new_username}@{new_hostname}",
+            "You've changed host to {new_username}@{new_hostname}",
         ))
     } else {
         plain(format!(
-            " ∙ {} changed host to {new_username}@{new_hostname}",
+            "{} changed host to {new_username}@{new_hostname}",
             old_user.formatted(UsernameFormat::Full)
         ))
     };

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -9,7 +9,7 @@ use iced::widget::{column, container, horizontal_rule, row, scrollable, text, Sc
 use iced::{alignment, padding, Length, Size, Task};
 
 use super::user_context;
-use crate::widget::Element;
+use crate::widget::{Element, MESSAGE_MARKER_TEXT};
 use crate::{font, theme};
 
 #[derive(Debug, Clone)]
@@ -75,7 +75,10 @@ pub fn view<'a>(
         .unwrap_or_else(time::Posix::now);
     let status = state.status;
 
-    let max_nick_width = width_from_chars(max_nick_chars, config);
+    let max_nick_width = width_from_chars(
+        max_nick_chars.map(|len| usize::max(len, MESSAGE_MARKER_TEXT.chars().count())),
+        config,
+    );
 
     let max_prefix_width = width_from_chars(max_prefix_chars, config);
 

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -148,6 +148,7 @@ fn width_from_chars(chars: Option<usize>, config: &Config) -> Option<f32> {
             shaping: text::Shaping::Basic,
         })
         .min_bounds()
+        .expand(Size::new(1.0, 0.0))
         .width
     })
 }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -108,7 +108,7 @@ pub fn message_marker<'a, M: 'a>(
     width: Option<f32>,
     style: impl Fn(&Theme) -> selectable_text::Style + 'a,
 ) -> Element<'a, M> {
-    let marker = selectable_text(" ∙");
+    let marker = selectable_text(MESSAGE_MARKER_TEXT);
 
     if let Some(width) = width {
         marker
@@ -120,3 +120,5 @@ pub fn message_marker<'a, M: 'a>(
     .style(style)
     .into()
 }
+
+pub const MESSAGE_MARKER_TEXT: &str = " ∙";

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -108,7 +108,7 @@ pub fn message_marker<'a, M: 'a>(
     width: Option<f32>,
     style: impl Fn(&Theme) -> selectable_text::Style + 'a,
 ) -> Element<'a, M> {
-    let marker = selectable_text("∙");
+    let marker = selectable_text(" ∙");
 
     if let Some(width) = width {
         marker

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 use data::message;
-use iced::border;
 use iced::widget::span;
+use iced::{alignment, border};
 
 use crate::{font, Theme};
 
@@ -102,4 +102,21 @@ pub fn message_content<'a, M: 'a>(
         .style(style)
         .into(),
     }
+}
+
+pub fn message_marker<'a, M: 'a>(
+    width: Option<f32>,
+    style: impl Fn(&Theme) -> selectable_text::Style + 'a,
+) -> Element<'a, M> {
+    let marker = selectable_text("∙");
+
+    if let Some(width) = width {
+        marker
+            .width(width)
+            .horizontal_alignment(alignment::Horizontal::Right)
+    } else {
+        marker
+    }
+    .style(style)
+    .into()
 }


### PR DESCRIPTION
This tweaks how server messages, internal messages, and actions are displayed in order to line up with right-aligned nicknames.  

![screenshot](https://0x0.st/X430.png)

Messages already in history will get an extra `∙` as this is now.  History processing could be added to avoid this, but I'm not sure if that juice is worth the squeeze.