### PR TITLE
Issue #498 Fix

### DIFF
--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -93,7 +93,7 @@ impl<'a> TryFrom<&'a str> for User {
                         Some(rest[j + 1..].to_string()),
                     )
                 } else {
-                    return Err("found username delimiter @ before nickname delimiter !");
+                    (&rest[..i], Some(rest[i + 1..].to_string()), None)
                 }
             }
         };
@@ -392,5 +392,57 @@ impl TryFrom<mode::Channel> for AccessLevel {
             mode::Channel::Voice => Self::Voice,
             _ => return Err(()),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_try_from() {
+        let tests = [
+            (
+                "dan!d@localhost",
+                User {
+                    nickname: "dan".into(),
+                    username: Some("d".into()),
+                    hostname: Some("localhost".into()),
+                    accountname: None,
+                    access_levels: HashSet::<AccessLevel>::new(),
+                    away: false,
+                },
+            ),
+            (
+                "$@H1N5!the.flu@in.you",
+                User {
+                    nickname: "H1N5".into(),
+                    username: Some("the.flu".into()),
+                    hostname: Some("in.you".into()),
+                    accountname: None,
+                    access_levels: HashSet::<AccessLevel>::from([AccessLevel::Oper]),
+                    away: false,
+                },
+            ),
+        ];
+
+        for (test, expected) in tests {
+            let user = super::User::try_from(test).unwrap();
+
+            assert_eq!(
+                (
+                    user.nickname,
+                    user.username,
+                    user.hostname,
+                    user.access_levels
+                ),
+                (
+                    expected.nickname,
+                    expected.username,
+                    expected.hostname,
+                    expected.access_levels
+                )
+            );
+        }
     }
 }

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -92,6 +92,12 @@ impl<'a> TryFrom<&'a str> for User {
                         Some(rest[i + 1..j].to_string()),
                         Some(rest[j + 1..].to_string()),
                     )
+                } else if let Some(k) = rest[i + 1..].find('@') {
+                    (
+                        &rest[..i],
+                        Some(rest[i + 1..i + k + 1].to_string()),
+                        Some(rest[i + k + 2..].to_string()),
+                    )
                 } else {
                     (&rest[..i], Some(rest[i + 1..].to_string()), None)
                 }
@@ -421,6 +427,28 @@ mod tests {
                     hostname: Some("in.you".into()),
                     accountname: None,
                     access_levels: HashSet::<AccessLevel>::from([AccessLevel::Oper]),
+                    away: false,
+                },
+            ),
+            (
+                "d@n!d@localhost",
+                User {
+                    nickname: "d@n".into(),
+                    username: Some("d".into()),
+                    hostname: Some("localhost".into()),
+                    accountname: None,
+                    access_levels: HashSet::<AccessLevel>::new(),
+                    away: false,
+                },
+            ),
+            (
+                "d@n!d",
+                User {
+                    nickname: "d@n".into(),
+                    username: Some("d".into()),
+                    hostname: None,
+                    accountname: None,
+                    access_levels: HashSet::<AccessLevel>::new(),
                     away: false,
                 },
             ),


### PR DESCRIPTION
When a server has an unrecognized access level character (in the case of #498, `$`) then access level parsing could end prematurely (leaving unparsed access levels at the beginning of the rest of the string).  Since `@` is a valid access level, it could then be found in the remaining string before `!` leading to a panic from `rest[i + 1..j].to_string()`.  This switches to looking for a valid first nickname character, then parsing everything before it as an access level and everything after as rest.  As a fallback, if `i` is ever found to be greater than or equal to `j` then an error is produced instead of evaluating `rest[i + 1..j].to_string()`.

Edit: criteria for valid first character was taken from [RFC 2812](https://www.rfc-editor.org/rfc/rfc2812.txt).