### PR TITLE
Show Errors from Loading Sounds

### DIFF
--- a/data/src/audio.rs
+++ b/data/src/audio.rs
@@ -21,7 +21,7 @@ impl Sound {
             internal.bytes()
         } else {
             let Some(sound_path) = find_external_sound(name) else {
-                return Err(LoadError::NoSoundFound);
+                return Err(LoadError::NoSoundFound(name.to_string()));
             };
 
             read(sound_path)?
@@ -93,8 +93,8 @@ fn find_external_sound(sound: &str) -> Option<PathBuf> {
 pub enum LoadError {
     #[error(transparent)]
     File(Arc<std::io::Error>),
-    #[error("sound was not found")]
-    NoSoundFound,
+    #[error("sound \"{0}\" was not found")]
+    NoSoundFound(String),
 }
 
 impl From<std::io::Error> for LoadError {

--- a/data/src/audio.rs
+++ b/data/src/audio.rs
@@ -20,9 +20,7 @@ impl Sound {
         let source = if let Ok(internal) = Internal::try_from(name) {
             internal.bytes()
         } else {
-            let Some(sound_path) = find_external_sound(name) else {
-                return Err(LoadError::NoSoundFound(name.to_string()));
-            };
+            let sound_path = find_external_sound(name)?;
 
             read(sound_path)?
         };
@@ -74,27 +72,33 @@ impl TryFrom<&str> for Internal {
     }
 }
 
-fn find_external_sound(sound: &str) -> Option<PathBuf> {
+fn find_external_sound(sound: &str) -> Result<PathBuf, LoadError> {
     let sounds_dir = Config::sounds_dir();
 
-    for e in walkdir::WalkDir::new(sounds_dir)
+    for e in walkdir::WalkDir::new(sounds_dir.clone())
         .into_iter()
         .filter_map(|e| e.ok())
     {
         if e.metadata().map(|data| data.is_file()).unwrap_or_default() && e.file_name() == sound {
-            return Some(e.path().to_path_buf());
+            return Ok(e.path().to_path_buf());
         }
     }
 
-    None
+    let sounds_dir = if let Ok(sounds_dir) = sounds_dir.into_os_string().into_string() {
+        format!(" in {sounds_dir}")
+    } else {
+        "".to_string()
+    };
+
+    Err(LoadError::NoSoundFound(sound.to_string(), sounds_dir))
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum LoadError {
     #[error(transparent)]
     File(Arc<std::io::Error>),
-    #[error("sound \"{0}\" was not found")]
-    NoSoundFound(String),
+    #[error("sound \"{0}\" was not found{1}")]
+    NoSoundFound(String, String),
 }
 
 impl From<std::io::Error> for LoadError {

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -305,7 +305,7 @@ pub enum Error {
     Io(String),
     #[error("{0}")]
     Parse(String),
-    #[error("error loading sound: {0}")]
+    #[error(transparent)]
     LoadSounds(#[from] audio::LoadError),
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,7 +157,7 @@ impl Halloy {
                 )
             }
             Err(error) => match &error {
-                config::Error::Parse(_) => (
+                config::Error::Parse(_) | config::Error::LoadSounds(_) => (
                     Screen::Help(screen::Help::new(error)),
                     Config::default(),
                     Task::none(),


### PR DESCRIPTION
When configuring the `sound` setting for a notification to a non-existent sound, 

```toml
[notifications.highlight]
show_toast = true
sound = "no-such-sound-file"
```
no error message is shown to the user.  Instead the welcome screen is shown.  These changes aim to show the error screen, and to make the error actionable.