### PR TITLE
Adjust width, alignment and show_access_levels for nicklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 Added:
 
-- Configuration option for right aligning nicks in buffers, see [configuration](https://halloy.squidowl.org/configuration/buffer.html#buffernickname-section).
-- Configuration options for hiding/coloring `chghost` messages.
+- New configuration options
+  - Right aligning nicks in buffers. See [configuration](https://halloy.squidowl.org/configuration/buffer.html#buffernickname-section).
+  - Right aligning nicks in nicklist. See [configuration](https://halloy.squidowl.org/configuration/buffer).
+  - Hiding `chghost` messages. See [configuration](https://halloy.squidowl.org/configuration/buffer.html#bufferserver_messages-section).
+  - Overwrite nicklist `width` in channels. See [configuration](https://halloy.squidowl.org/configuration/buffer.html#bufferchannelnicklist-section).
+  - Show/hide user access levels in buffer and nicklist. See [configuration](https://halloy.squidowl.org/configuration/buffer.html#bufferchannelnicklist-section)
 
 Fixed:
 

--- a/book/src/configuration/buffer.md
+++ b/book/src/configuration/buffer.md
@@ -9,13 +9,15 @@
 alignment = "left" | "right" 
 color = "unique" | "solid"
 brackets = { left = "<string>", right = "<string>" }
+show_access_levels = true | false
 ```
 
-| Key         | Description                                                                                                                                                                                                         | Default                     |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
-| `alignment` | Alignment option for nicknames in buffer.                                                                                                                                                                           | `"left"`                    |
-| `color`     | Controls whether nickname color is `"solid"` or `"unique"`. `"unique"` generates colors by randomzing a hue which is used together with the saturation and lightness from the nickname color provided by the theme. | `"unique"`                  |
-| `brackets`  | Brackets for nicknames.                                                                                                                                                                                             | `{ left = "", right = "" }` |
+| Key                  | Description                                                                                                                                                                                                         | Default                     |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| `alignment`          | Alignment option for nicknames in buffer.                                                                                                                                                                           | `"left"`                    |
+| `color`              | Controls whether nickname color is `"solid"` or `"unique"`. `"unique"` generates colors by randomzing a hue which is used together with the saturation and lightness from the nickname color provided by the theme. | `"unique"`                  |
+| `brackets`           | Brackets for nicknames.                                                                                                                                                                                             | `{ left = "", right = "" }` |
+| `show_access_levels` | Show access levels (@, +, ~, etc.) on nicknames                                                                                                                                                                     | `true`                      |
 
 
 
@@ -62,14 +64,22 @@ auto_format = "disabled" | "markdown" | "all"
 [buffer.channel.nicklist]
 enabled = true | false
 position = "left" | "right"
+alignment = "left" | "right"
 color = "unique" | "solid"
+width = <number>
+show_access_levels = true | false
+
 ```
 
-| Key        | Description                                                                                                                                                                                                         | Default    |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| `enabled`  | Control if nicklist should be shown or not                                                                                                                                                                          | `true`     |
-| `position` | Nicklist position. Can be `"left"` or `"right"`.                                                                                                                                                                    | `"right"`  |
-| `color`    | Controls whether nickname color is `"solid"` or `"unique"`. `"unique"` generates colors by randomzing a hue which is used together with the saturation and lightness from the nickname color provided by the theme. | `"unique"` |
+| Key                  | Description                                                                                                                                                                                                         | Default    |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `enabled`            | Control if nicklist should be shown or not                                                                                                                                                                          | `true`     |
+| `position`           | Nicklist position. Can be `"left"` or `"right"`.                                                                                                                                                                    | `"right"`  |
+| `alignment`          | Horizontal nicknames alignment                                                                                                                                                                                      | `"left"`   |
+| `color`              | Controls whether nickname color is `"solid"` or `"unique"`. `"unique"` generates colors by randomzing a hue which is used together with the saturation and lightness from the nickname color provided by the theme. | `"unique"` |
+| `width`              | Overwrite nicklist width in pixels                                                                                                                                                                                  | `not set`  |
+| `show_access_levels` | Show access levels (@, +, ~, etc.) on nicknames                                                                                                                                                                     | `true`     |
+
 
 
 

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -118,6 +118,8 @@ pub struct Nickname {
     pub brackets: Brackets,
     #[serde(default)]
     pub alignment: Alignment,
+    #[serde(default = "default_bool_true")]
+    pub show_access_levels: bool,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -183,4 +185,8 @@ impl Resize {
 
 fn default_timestamp() -> String {
     "%R".to_string()
+}
+
+fn default_bool_true() -> bool {
+    true
 }

--- a/data/src/config/channel.rs
+++ b/data/src/config/channel.rs
@@ -19,6 +19,20 @@ pub struct Nicklist {
     pub position: Position,
     #[serde(default)]
     pub color: Color,
+    #[serde(default)]
+    pub width: Option<f32>,
+    #[serde(default)]
+    pub alignment: Alignment,
+    #[serde(default = "default_bool_true")]
+    pub show_access_levels: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Alignment {
+    #[default]
+    Left,
+    Right,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize)]

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -552,13 +552,21 @@ impl Data {
             .collect::<Vec<_>>();
 
         let total = filtered.len();
+        let with_access_levels = buffer_config.nickname.show_access_levels;
 
         let max_nick_chars = buffer_config.nickname.alignment.is_right().then(|| {
             filtered
                 .iter()
                 .filter_map(|message| {
                     if let message::Source::User(user) = message.target.source() {
-                        Some(buffer_config.nickname.brackets.format(user).chars().count())
+                        Some(
+                            buffer_config
+                                .nickname
+                                .brackets
+                                .format(user.display(with_access_levels))
+                                .chars()
+                                .count(),
+                        )
                     } else {
                         None
                     }

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -596,6 +596,8 @@ fn content(
             let user = resolve_attributes(&raw_user, target).unwrap_or(raw_user);
 
             let topic = topic.as_ref()?;
+            let with_access_levels = config.buffer.nickname.show_access_levels;
+            let user = user.display(with_access_levels);
 
             Some(parse_fragments(format!("{user} changed topic to {topic}")))
         }
@@ -627,7 +629,10 @@ fn content(
         }
         Command::KICK(channel, victim, comment) => {
             let raw_user = message.user()?;
-            let user = resolve_attributes(&raw_user, channel).unwrap_or(raw_user);
+            let with_access_levels = config.buffer.nickname.show_access_levels;
+            let user = resolve_attributes(&raw_user, channel)
+                .unwrap_or(raw_user)
+                .display(with_access_levels);
 
             let comment = comment
                 .as_ref()
@@ -645,7 +650,10 @@ fn content(
         }
         Command::MODE(target, modes, args) if proto::is_channel(target) => {
             let raw_user = message.user()?;
-            let user = resolve_attributes(&raw_user, target).unwrap_or(raw_user);
+            let with_access_levels = config.buffer.nickname.show_access_levels;
+            let user = resolve_attributes(&raw_user, target)
+                .unwrap_or(raw_user)
+                .display(with_access_levels);
 
             let modes = modes
                 .iter()

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -148,6 +148,13 @@ impl User {
         }
     }
 
+    pub fn display(&self, with_access_levels: bool) -> String {
+        match with_access_levels {
+            true => format!("{}{}", self.highest_access_level(), self.nickname()),
+            false => self.nickname().to_string(),
+        }
+    }
+
     pub fn is_away(&self) -> bool {
         self.away
     }
@@ -249,12 +256,6 @@ impl From<proto::User> for User {
             access_levels: HashSet::default(),
             away: false,
         }
-    }
-}
-
-impl fmt::Display for User {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}{}", self.highest_access_level(), self.nickname())
     }
 }
 

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -49,8 +49,13 @@ pub fn view<'a>(
 
                 match message.target.source() {
                     message::Source::User(user) => {
+                        let with_access_levels = config.buffer.nickname.show_access_levels;
                         let mut text = selectable_text(
-                            config.buffer.nickname.brackets.format(user),
+                            config
+                                .buffer
+                                .nickname
+                                .brackets
+                                .format(user.display(with_access_levels)),
                         )
                         .style(|theme| {
                             theme::selectable_text::nickname(


### PR DESCRIPTION
Fixes #505, #481.

This PR adds the ability to overwrite the width of nicklist, left/right align nicknames and hide/show access_levels.

<img width="261" alt="Screenshot 2024-08-30 at 11 04 56" src="https://github.com/user-attachments/assets/9968d78a-0a89-468c-bfde-305d54376631">
