### PR TITLE
Keep full user in history

### DIFF
--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -120,11 +120,11 @@ impl From<User> for String {
         let username = user
             .username()
             .map(|username| format!("!{username}"))
-            .unwrap_or(String::new());
+            .unwrap_or_default();
         let hostname = user
             .hostname()
             .map(|hostname| format!("@{hostname}"))
-            .unwrap_or(String::new());
+            .unwrap_or_default();
 
         format!("{access_levels}{nickname}{username}{hostname}")
     }


### PR DESCRIPTION
Serialize `access_flags` so when loading messages from history we see flags, if any.
Note this shoudn't break or nuke history, since we already support reading `access_level` off a `str` while converting to a `User`: https://github.com/squidowl/halloy/blob/main/data/src/user.rs#L59-L111

But please let me know if i broke something!