### PR TITLE
Allow Zero-Arguments Commands without Trailing Space

### DIFF
--- a/data/src/command.rs
+++ b/data/src/command.rs
@@ -77,12 +77,12 @@ pub fn parse(s: &str, buffer: Option<&Buffer>) -> Result<Command, Error> {
 
     let cmd = split.next().ok_or(Error::MissingCommand)?;
 
-    if rest.len() == cmd.len() {
-        return Err(Error::MissingArgs);
-    }
-
     let args = split.collect::<Vec<_>>();
-    let raw = &rest[cmd.len() + 1..];
+    let raw = if rest.len() == cmd.len() {
+        ""
+    } else {
+        &rest[cmd.len() + 1..]
+    };
 
     let unknown = || {
         Command::Unknown(


### PR DESCRIPTION
When attempting to submit a command that does not require any arguments (e.g. `/list`), if the user attempts to submit the command without a trailing space then it is rejected with the error message "missing args".  The command submits as expected if a space is added after the command name (e.g. `/list `).  This PR is just to remove the need for a trailing space after the command.