### PR TITLE
ZNC Nickname Support for Outgoing Messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+Fixed:
+
+- Regression where messages sent to ZNC virtual users were routed to the wrong buffer (e.g. `*status` routed to `status`).
+
 # 2024.11 (2024-09-04)
 
 Added:

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -65,9 +65,10 @@ impl<'a> TryFrom<&'a str> for User {
             return Err("nickname can't be empty");
         }
 
-        let Some(index) = value.find(|c: char| c.is_alphabetic() || "[\\]^_`{|}".find(c).is_some())
+        let Some(index) =
+            value.find(|c: char| c.is_alphabetic() || "[\\]^_`{|}*".find(c).is_some())
         else {
-            return Err("nickname must start with alphabetic or [ \\ ] ^ _ ` { | }");
+            return Err("nickname must start with alphabetic or [ \\ ] ^ _ ` { | } *");
         };
 
         let (access_levels, rest) = (&value[..index], &value[index..]);

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -523,6 +523,17 @@ mod tests {
                     away: false,
                 },
             ),
+            (
+                "*status",
+                User {
+                    nickname: "*status".into(),
+                    username: None,
+                    hostname: None,
+                    accountname: None,
+                    access_levels: HashSet::<AccessLevel>::new(),
+                    away: false,
+                },
+            ),
         ];
 
         for (test, expected) in tests {


### PR DESCRIPTION
This allows nicknames to start with `*` in `User::try_from`, which addresses #528 in my testing.