### PR TITLE
Exclude and include channels on Server Messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Added:
 
 - In-app theme editor with ability to with share it via a halloy:// URL.
+- New configuration options
+  - Ability to include or exclude channels for server messages (join, part, etc.). See [configuration](https://halloy.squidowl.org/configuration/buffer/server_messages/index.html).
 
 Fixed:
 

--- a/book/src/configuration/buffer/server_messages/change_host.md
+++ b/book/src/configuration/buffer/server_messages/change_host.md
@@ -25,3 +25,21 @@ Only show server message if the user has sent a message in the given time interv
 - **type**: integer
 - **values**: any positive integer
 - **default**: not set
+
+## `exclude`
+
+Exclude channels from receiving the server messag.
+If you pass `["#halloy"]`, the channel `#halloy` will not receive the server message. You can also exclude all channels by using a wildcard: `["*"]`.
+
+- **type**: array of strings
+- **values**: array of any strings
+- **default**: `[]`
+
+## `include`
+
+Include channels to receive the server message.
+If you pass `["#halloy"]`, the channel `#halloy` will receive the server message. The include rule takes priority over exclude, so you can use both together. For example, you can exclude all channels with `["*"]` and then only include a few specific channels.
+
+- **type**: array of strings
+- **values**: array of any strings
+- **default**: `[]`

--- a/book/src/configuration/buffer/server_messages/join.md
+++ b/book/src/configuration/buffer/server_messages/join.md
@@ -34,3 +34,21 @@ Adjust the amount of information displayed for a username in server messages. If
 - **type**: string
 - **values**: `"full"`, `"short"`
 - **default**: `"full"`
+
+## `exclude`
+
+Exclude channels from receiving the server messag.
+If you pass `["#halloy"]`, the channel `#halloy` will not receive the server message. You can also exclude all channels by using a wildcard: `["*"]`.
+
+- **type**: array of strings
+- **values**: array of any strings
+- **default**: `[]`
+
+## `include`
+
+Include channels to receive the server message.
+If you pass `["#halloy"]`, the channel `#halloy` will receive the server message. The include rule takes priority over exclude, so you can use both together. For example, you can exclude all channels with `["*"]` and then only include a few specific channels.
+
+- **type**: array of strings
+- **values**: array of any strings
+- **default**: `[]`

--- a/book/src/configuration/buffer/server_messages/part.md
+++ b/book/src/configuration/buffer/server_messages/part.md
@@ -6,9 +6,7 @@ Server message is sent when a user leaves a channel.
 
 ```toml
 [buffer.server_messages.part]
-enabled = true
 smart = 180
-username_format = "full"
 ```
 
 ## `enabled`
@@ -34,3 +32,21 @@ Adjust the amount of information displayed for a username in server messages. If
 - **type**: string
 - **values**: `"full"`, `"short"`
 - **default**: `"full"`
+
+## `exclude`
+
+Exclude channels from receiving the server messag.
+If you pass `["#halloy"]`, the channel `#halloy` will not receive the server message. You can also exclude all channels by using a wildcard: `["*"]`.
+
+- **type**: array of strings
+- **values**: array of any strings
+- **default**: `[]`
+
+## `include`
+
+Include channels to receive the server message.
+If you pass `["#halloy"]`, the channel `#halloy` will receive the server message. The include rule takes priority over exclude, so you can use both together. For example, you can exclude all channels with `["*"]` and then only include a few specific channels.
+
+- **type**: array of strings
+- **values**: array of any strings
+- **default**: `[]`

--- a/book/src/configuration/buffer/server_messages/quit.md
+++ b/book/src/configuration/buffer/server_messages/quit.md
@@ -6,9 +6,8 @@ Server message is sent when a user closes the connection to a channel or server.
 
 ```toml
 [buffer.server_messages.quit]
-enabled = true
-smart = 180
-username_format = "full"
+exclude = ["*"]
+include = ["#halloy"]
 ```
 
 ## `enabled`
@@ -34,3 +33,21 @@ Adjust the amount of information displayed for a username in server messages. If
 - **type**: string
 - **values**: `"full"`, `"short"`
 - **default**: `"full"`
+
+## `exclude`
+
+Exclude channels from receiving the server messag.
+If you pass `["#halloy"]`, the channel `#halloy` will not receive the server message. You can also exclude all channels by using a wildcard: `["*"]`.
+
+- **type**: array of strings
+- **values**: array of any strings
+- **default**: `[]`
+
+## `include`
+
+Include channels to receive the server message.
+If you pass `["#halloy"]`, the channel `#halloy` will receive the server message. The include rule takes priority over exclude, so you can use both together. For example, you can exclude all channels with `["*"]` and then only include a few specific channels.
+
+- **type**: array of strings
+- **values**: array of any strings
+- **default**: `[]`

--- a/book/src/configuration/buffer/server_messages/topic.md
+++ b/book/src/configuration/buffer/server_messages/topic.md
@@ -16,3 +16,21 @@ Control if internal message type is enabled.
 - **type**: boolean
 - **values**: `true`, `false`
 - **default**: `true`
+
+## `exclude`
+
+Exclude channels from receiving the server messag.
+If you pass `["#halloy"]`, the channel `#halloy` will not receive the server message. You can also exclude all channels by using a wildcard: `["*"]`.
+
+- **type**: array of strings
+- **values**: array of any strings
+- **default**: `[]`
+
+## `include`
+
+Include channels to receive the server message.
+If you pass `["#halloy"]`, the channel `#halloy` will receive the server message. The include rule takes priority over exclude, so you can use both together. For example, you can exclude all channels with `["*"]` and then only include a few specific channels.
+
+- **type**: array of strings
+- **values**: array of any strings
+- **default**: `[]`

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -92,10 +92,9 @@ impl ServerMessage {
 
         let is_channel_filtered = |list: &Vec<String>, channel: &str| -> bool {
             let wildcards = ["*", "all"];
-            
-                list.iter()
-                    .any(|item| wildcards.contains(&item.as_str()) || item == channel)
-         
+
+            list.iter()
+                .any(|item| wildcards.contains(&item.as_str()) || item == channel)
         };
 
         let channel_included = is_channel_filtered(&self.include, channel);

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -66,9 +66,9 @@ pub struct ServerMessage {
     #[serde(default)]
     pub username_format: UsernameFormat,
     #[serde(default)]
-    pub excluded: Vec<String>,
+    pub exclude: Vec<String>,
     #[serde(default)]
-    pub included: Vec<String>,
+    pub include: Vec<String>,
 }
 
 impl Default for ServerMessage {
@@ -77,8 +77,8 @@ impl Default for ServerMessage {
             enabled: true,
             smart: Default::default(),
             username_format: UsernameFormat::default(),
-            excluded: Default::default(),
-            included: Default::default(),
+            exclude: Default::default(),
+            include: Default::default(),
         }
     }
 }
@@ -98,10 +98,10 @@ impl ServerMessage {
             })
         };
 
-        let channel_included = is_channel_filtered(&self.included, channel);
-        let channel_excluded = is_channel_filtered(&self.excluded, channel);
+        let channel_included = is_channel_filtered(&self.include, channel);
+        let channel_excluded = is_channel_filtered(&self.exclude, channel);
 
-        // If the channel is included, it has precedence over exclusion.
+        // If the channel is included, it has precedence over excluded.
         if channel_included || !channel_excluded {
             return true;
         }

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -84,29 +84,25 @@ impl Default for ServerMessage {
 }
 
 impl ServerMessage {
-    pub fn should_send_message(&self, channel: Option<&str>) -> bool {
+    pub fn should_send_message(&self, channel: &str) -> bool {
         // Server Message is not enabled.
         if !self.enabled {
             return false;
         }
 
-        let is_channel_filtered = |list: &Vec<String>, channel: Option<&str>| -> bool {
+        let is_channel_filtered = |list: &Vec<String>, channel: &str| -> bool {
             let wildcards = ["*", "all"];
-            channel.map_or(false, |channel| {
+            
                 list.iter()
                     .any(|item| wildcards.contains(&item.as_str()) || item == channel)
-            })
+         
         };
 
         let channel_included = is_channel_filtered(&self.include, channel);
         let channel_excluded = is_channel_filtered(&self.exclude, channel);
 
         // If the channel is included, it has precedence over excluded.
-        if channel_included || !channel_excluded {
-            return true;
-        }
-
-        false
+        channel_included || !channel_excluded
     }
 }
 

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -500,13 +500,11 @@ impl Data {
             .filter(|message| match message.target.source() {
                 message::Source::Server(Some(source)) => {
                     if let Some(server_message) = buffer_config.server_messages.get(source) {
-                        let channel = match &message.target {
-                            message::Target::Channel { channel, .. } => Some(channel.as_ref()),
-                            _ => None,
-                        };
-
-                        if !server_message.should_send_message(channel) {
-                            return false;
+                        // Check if target is a channel, and if included/excluded.
+                        if let message::Target::Channel { channel, .. } = &message.target {
+                            if !server_message.should_send_message(channel.as_ref()) {
+                                return false;
+                            }
                         }
 
                         if let Some(seconds) = server_message.smart {

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -500,7 +500,12 @@ impl Data {
             .filter(|message| match message.target.source() {
                 message::Source::Server(Some(source)) => {
                     if let Some(server_message) = buffer_config.server_messages.get(source) {
-                        if !server_message.enabled {
+                        let channel = match &message.target {
+                            message::Target::Channel { channel, .. } => Some(channel.as_ref()),
+                            _ => None,
+                        };
+
+                        if !server_message.should_send_message(channel) {
                             return false;
                         }
 


### PR DESCRIPTION
This PR solves the following problems:

1. You want to see `join` in all channels except `#linux` and `#halloy`.
2. You dont want to see `part` in any channels except `#linux` and `#halloy`.

This is now solved by `exclude` and `include`

```toml
# 1. see join messages in all channels except #linux and #halloy.
[buffer.server_messages.join]
exclude = ["#linux", "#halloy"]
```

```toml
# 2. don't see part messages in any channels except #linux and #halloy.
# The "*" (or "all") is a wildcard which means all channels.
[buffer.server_messages.join]
exclude = ["*"]
include = ["#linux", "#halloy"]
```

If the channel is `included`, it has precedence over `excluded` and `enabled` is above both so the following wont show any message at all:

```toml
# dont see any quit messages in any channel
[buffer.server_messages.quit]
enabled = false
include = ["*"]
```

- [x] Update CHANGELOG
- [x] Update book