### PR TITLE
Add `password_command` config option

### DIFF
--- a/book/src/configuration/servers/README.md
+++ b/book/src/configuration/servers/README.md
@@ -105,6 +105,14 @@ Read password from the file at the given path.[^1]
 - **values**: any string
 - **default**: not set
 
+## `password_command`
+
+Executes the command with `sh` (or equivalent) and reads `password` as the output.
+
+- **type**: string
+- **values**: any string
+- **default**: not set
+
 ## `channels`
 
 A list of channels to join on connection.

--- a/book/src/configuration/servers/sasl/plain.md
+++ b/book/src/configuration/servers/sasl/plain.md
@@ -32,4 +32,12 @@ Read `password` from the file at the given path.[^1]
 - **values**: any string
 - **default**: not set
 
+## `password_command`
+
+Executes the command with `sh` (or equivalent) and reads `password` as the output.
+
+- **type**: string
+- **values**: any string
+- **default**: not set
+
 [^1]: Shell expansions (e.g. `"~/"` → `"/home/user/"`) are not supported in path strings.

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::string;
 
 use tokio_stream::wrappers::ReadDirStream;
 use tokio_stream::StreamExt;
@@ -176,7 +177,7 @@ impl Config {
             tooltips,
         } = toml::from_str(content.as_ref()).map_err(|e| Error::Parse(e.to_string()))?;
 
-        servers.read_password_files().await?;
+        servers.read_passwords().await?;
 
         let loaded_notifications = notifications.load_sounds()?;
 
@@ -309,6 +310,8 @@ pub enum Error {
     Io(String),
     #[error("{0}")]
     Parse(String),
+    #[error("UTF8 parsing error: {0}")]
+    UI(#[from] string::FromUtf8Error),
     #[error(transparent)]
     LoadSounds(#[from] audio::LoadError),
 }

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -33,6 +33,8 @@ pub struct Server {
     pub password: Option<String>,
     /// The file with the password to connect to the server.
     pub password_file: Option<String>,
+    /// The command which outputs a password to connect to the server.
+    pub password_command: Option<String>,
     /// A list of channels to join on connection.
     #[serde(default)]
     pub channels: Vec<String>,
@@ -149,6 +151,7 @@ impl Default for Server {
             port: default_tls_port(),
             password: Default::default(),
             password_file: Default::default(),
+            password_command: Default::default(),
             channels: Default::default(),
             channel_keys: Default::default(),
             ping_time: default_ping_time(),

--- a/data/src/server.rs
+++ b/data/src/server.rs
@@ -78,7 +78,8 @@ impl Map {
             if let Some(pass_file) = &config.password_file {
                 if config.password.is_some() || config.password_command.is_some() {
                     return Err(Error::Parse(
-                        "Only one of password, password_file and password_command can be set.".to_string(),
+                        "Only one of password, password_file and password_command can be set."
+                            .to_string(),
                     ));
                 }
                 let pass = fs::read_to_string(pass_file).await?;
@@ -87,22 +88,21 @@ impl Map {
             if let Some(pass_command) = &config.password_command {
                 if config.password.is_some() {
                     return Err(Error::Parse(
-                        "Only one of password, password_file and password_command can be set.".to_string(),
+                        "Only one of password, password_file and password_command can be set."
+                            .to_string(),
                     ));
                 }
                 let output = if cfg!(target_os = "windows") {
                     Command::new("cmd")
                         .args(["/C", pass_command])
                         .output()
-                        .await
-                        .expect("failed to execute process")
+                        .await?
                 } else {
                     Command::new("sh")
                         .arg("-c")
                         .arg(pass_command)
                         .output()
-                        .await
-                        .expect("failed to execute process")
+                        .await?
                 };
                 config.password = Some(String::from_utf8(output.stdout)?);
             }

--- a/data/src/server.rs
+++ b/data/src/server.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::fmt;
-
 use tokio::fs;
+use tokio::process::Command;
 
 use futures::channel::mpsc::Sender;
 use irc::proto;
@@ -73,16 +73,38 @@ impl Map {
         self.0.iter().map(Entry::from)
     }
 
-    pub async fn read_password_files(&mut self) -> Result<(), Error> {
+    pub async fn read_passwords(&mut self) -> Result<(), Error> {
         for (_, config) in self.0.iter_mut() {
             if let Some(pass_file) = &config.password_file {
-                if config.password.is_some() {
+                if config.password.is_some() || config.password_command.is_some() {
                     return Err(Error::Parse(
-                        "Only one of password and password_file can be set.".to_string(),
+                        "Only one of password, password_file and password_command can be set.".to_string(),
                     ));
                 }
                 let pass = fs::read_to_string(pass_file).await?;
                 config.password = Some(pass);
+            }
+            if let Some(pass_command) = &config.password_command {
+                if config.password.is_some() {
+                    return Err(Error::Parse(
+                        "Only one of password, password_file and password_command can be set.".to_string(),
+                    ));
+                }
+                let output = if cfg!(target_os = "windows") {
+                    Command::new("cmd")
+                        .args(["/C", pass_command])
+                        .output()
+                        .await
+                        .expect("failed to execute process")
+                } else {
+                    Command::new("sh")
+                        .arg("-c")
+                        .arg(pass_command)
+                        .output()
+                        .await
+                        .expect("failed to execute process")
+                };
+                config.password = Some(String::from_utf8(output.stdout)?);
             }
             if let Some(nick_pass_file) = &config.nick_password_file {
                 if config.nick_password.is_some() {


### PR DESCRIPTION
closes #424

related to #551  but I don't think that fix should be done in this PR, since it the changes involved are largely orthogonal to this one.