### PR TITLE
Fix panic when MOTD set by user w/o username

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1044,7 +1044,7 @@ impl Client {
 
                     channel.topic.who = message
                         .user()
-                        .map(|user| user.username().unwrap().to_string());
+                        .map(|user| user.nickname().to_string());
                     channel.topic.time = Some(server_time(&message));
                 }
             }


### PR DESCRIPTION
Some servers use bots without a valid IRC username (but a nickname) for MOTD. This results in a panic:

	thread 'main' panicked at data/src/client.rs:1047:53:
	called `Option::unwrap()` on a `None` value
	note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
	thread 'main' panicked at /Users/janis.koenig/.cargo/git/checkouts/iced-f01cba4d5e61fd0a/9628dc2/winit/src/program.rs:467:43:
	Send event: SendError { kind: Disconnected }