### PR TITLE
Make user fragment clickable

### DIFF
--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -1011,6 +1011,12 @@ pub fn reference_user_text(sender: NickRef, own_nick: NickRef, text: &str) -> bo
     sender != own_nick && text.contains(own_nick.as_ref())
 }
 
+#[derive(Debug, Clone)]
+pub enum Link {
+    Url(String),
+    User(User),
+}
+
 fn fail_as_none<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
 where
     T: Deserialize<'de>,

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -1,4 +1,4 @@
-use data::message::Limit;
+use data::message::{self, Limit};
 use data::server::Server;
 use data::user::Nick;
 use data::{history, time, Config};
@@ -19,7 +19,7 @@ pub enum Message {
         viewport: scrollable::Viewport,
     },
     UserContext(user_context::Message),
-    Link(String),
+    Link(message::Link),
 }
 
 #[derive(Debug, Clone)]
@@ -227,8 +227,16 @@ impl State {
                     user_context::update(message).map(Event::UserContext),
                 );
             }
-            Message::Link(link) => {
-                let _ = open::that_detached(link);
+            Message::Link(message::Link::Url(url)) => {
+                let _ = open::that_detached(url);
+            }
+            Message::Link(message::Link::User(user)) => {
+                return (
+                    Task::none(),
+                    Some(Event::UserContext(user_context::Event::SingleClick(
+                        user.nickname().to_owned(),
+                    ))),
+                )
             }
         }
 

--- a/src/buffer/user_context.rs
+++ b/src/buffer/user_context.rs
@@ -1,5 +1,5 @@
 use data::user::Nick;
-use data::{Buffer, User};
+use data::{message, Buffer, User};
 use iced::widget::{button, container, horizontal_rule, row, text, Space};
 use iced::{padding, Length, Padding};
 
@@ -53,7 +53,7 @@ pub enum Message {
     SingleClick(Nick),
     ToggleAccessLevel(Nick, String),
     SendFile(Nick),
-    Link(String),
+    Link(message::Link),
 }
 
 #[derive(Debug, Clone)]
@@ -72,9 +72,12 @@ pub fn update(message: Message) -> Option<Event> {
         Message::SingleClick(nick) => Some(Event::SingleClick(nick)),
         Message::ToggleAccessLevel(nick, mode) => Some(Event::ToggleAccessLevel(nick, mode)),
         Message::SendFile(nick) => Some(Event::SendFile(nick)),
-        Message::Link(link) => {
-            let _ = open::that_detached(link);
+        Message::Link(message::Link::Url(url)) => {
+            let _ = open::that_detached(url);
             None
+        }
+        Message::Link(message::Link::User(user)) => {
+            Some(Event::SingleClick(user.nickname().to_owned()))
         }
     }
 }

--- a/src/theme/selectable_text.rs
+++ b/src/theme/selectable_text.rs
@@ -1,6 +1,9 @@
 use data::{message, user::NickColor};
 
-use crate::widget::selectable_text::{Catalog, Style, StyleFn};
+use crate::widget::{
+    selectable_rich_text,
+    selectable_text::{Catalog, Style, StyleFn},
+};
 
 use super::{text, Theme};
 
@@ -97,5 +100,14 @@ pub fn status(theme: &Theme, status: message::source::Status) -> Style {
     Style {
         color,
         selection_color: theme.colors().buffer.selection,
+    }
+}
+
+impl selectable_rich_text::Link for message::Link {
+    fn underline(&self) -> bool {
+        match self {
+            data::message::Link::Url(_) => true,
+            data::message::Link::User(_) => false,
+        }
     }
 }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -49,7 +49,7 @@ pub type Button<'a, Message> = iced::widget::Button<'a, Message, Theme>;
 pub fn message_content<'a, M: 'a>(
     content: &'a message::Content,
     theme: &'a Theme,
-    on_link: impl Fn(String) -> M + 'a,
+    on_link: impl Fn(message::Link) -> M + 'a,
     style: impl Fn(&Theme) -> selectable_text::Style + 'a,
     config: &Config,
 ) -> Element<'a, M> {
@@ -71,11 +71,13 @@ pub fn message_content<'a, M: 'a>(
                             None => theme.colors().text.primary,
                         };
 
-                        span(user.nickname().to_string()).color(color)
+                        span(user.nickname().to_string())
+                            .color(color)
+                            .link(message::Link::User(user.clone()))
                     }
                     data::message::Fragment::Url(s) => span(s.as_str())
                         .color(theme.colors().buffer.url)
-                        .link(s.as_str().to_string()),
+                        .link(message::Link::Url(s.as_str().to_string())),
                     data::message::Fragment::Formatted { text, formatting } => {
                         let mut span = span(text)
                             .color_maybe(


### PR DESCRIPTION
Allows single left click functionality on user spans similar to the nicklist and nicknames in the buffer.

Adding right click / context menu to these is much more complex since it'll require some overlay approach, so that'll be a TODO item in the future.