### PR TITLE
`draft/read-marker` Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Added:
   - Ability to include or exclude channels for server messages (join, part, etc.). See [configuration](https://halloy.squidowl.org/configuration/buffer/server_messages/index.html).
   - Ability to color nicknames within channel messages. See [configuration](https://halloy.squidowl.org/configuration/buffer/channel/message.html#nickname_color)
   - Ability to define a shell command for loading a server password. See [configuration](https://halloy.squidowl.org/configuration/servers/index.html#password_command)
-- Enable support for IRCv3 `msgid`
+- Enable support for IRCv3 `msgid` and `read-marker`
 
 Fixed:
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Halloy is also available from [Flathub](https://flathub.org/apps/org.squidowl.ha
     * [Monitor](https://ircv3.net/specs/extensions/monitor)
     * [msgid](https://ircv3.net/specs/extensions/message-ids)
     * [multi-prefix](https://ircv3.net/specs/extensions/multi-prefix)
+    * [read-marker](https://ircv3.net/specs/extensions/read-marker)
     * [sasl-3.1](https://ircv3.net/specs/extensions/sasl-3.1)
     * [server-time](https://ircv3.net/specs/extensions/server-time)
     * [userhost-in-names](https://ircv3.net/specs/extensions/userhost-in-names)

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -20,6 +20,7 @@
     * [Monitor](https://ircv3.net/specs/extensions/monitor)
     * [msgid](https://ircv3.net/specs/extensions/message-ids)
     * [multi-prefix](https://ircv3.net/specs/extensions/multi-prefix)
+    * [read-marker](https://ircv3.net/specs/extensions/read-marker)
     * [sasl-3.1](https://ircv3.net/specs/extensions/sasl-3.1)
     * [server-time](https://ircv3.net/specs/extensions/server-time)
     * [userhost-in-names](https://ircv3.net/specs/extensions/userhost-in-names)

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -81,6 +81,7 @@ pub enum Event {
     Notification(message::Encoded, Nick, Notification),
     FileTransferRequest(file_transfer::ReceiveRequest),
     UpdateReadMarker(String, ReadMarker),
+    JoinedChannel(String),
 }
 
 pub struct Client {
@@ -872,6 +873,11 @@ impl Client {
 
                     channel.users.insert(user);
                 }
+
+                return Some(vec![
+                    Event::JoinedChannel(channel.clone()),
+                    Event::Single(message, self.nickname().to_owned()),
+                ]);
             }
             Command::KICK(channel, victim, _) => {
                 if victim == self.nickname().as_ref() {

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1485,6 +1485,20 @@ impl Map {
         }
     }
 
+    pub fn exit(&mut self) -> HashSet<Server> {
+        self.0
+            .iter_mut()
+            .filter_map(|(server, state)| {
+                if let State::Ready(client) = state {
+                    client.quit(None);
+                    Some(server.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
     pub fn resolve_user_attributes<'a>(
         &'a self,
         server: &Server,
@@ -1559,10 +1573,6 @@ impl Map {
                 client.tick(now);
             }
         })
-    }
-
-    pub fn take(&mut self) -> Self {
-        Self(std::mem::take(&mut self.0))
     }
 }
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1557,6 +1557,10 @@ impl Map {
             }
         })
     }
+
+    pub fn take(&mut self) -> Self {
+        Self(std::mem::take(&mut self.0))
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -862,6 +862,8 @@ impl Client {
                         }
                         log::debug!("[{}] {channel} - WHO requested", self.server);
                     }
+
+                    return Some(vec![Event::JoinedChannel(channel.clone())]);
                 } else if let Some(channel) = self.chanmap.get_mut(channel) {
                     let user = if self.supports_extended_join {
                         accountname.as_ref().map_or(user.clone(), |accountname| {
@@ -873,11 +875,6 @@ impl Client {
 
                     channel.users.insert(user);
                 }
-
-                return Some(vec![
-                    Event::JoinedChannel(channel.clone()),
-                    Event::Single(message, self.nickname().to_owned()),
-                ]);
             }
             Command::KICK(channel, victim, _) => {
                 if victim == self.nickname().as_ref() {

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -221,10 +221,9 @@ impl History {
             } => {
                 // Read marker is prior to last message on disk
                 // or prior to unflushed messages in memory
-                metadata.read_marker.is_none()
-                    || last_on_disk
-                        .zip(metadata.read_marker)
-                        .map_or(false, |(a, b)| a > b.date_time())
+                last_on_disk
+                    .zip(metadata.read_marker)
+                    .map_or(false, |(a, b)| a > b.date_time())
                     || metadata.unread_count(messages) > 0
             }
             History::Full { .. } => false,

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -362,7 +362,7 @@ impl History {
         }
     }
 
-    async fn close(self) -> Result<(), Error> {
+    async fn close(self) -> Result<Option<ReadMarker>, Error> {
         match self {
             History::Partial {
                 server,
@@ -372,7 +372,10 @@ impl History {
                 ..
             } => {
                 let metadata = metadata.updated(&messages);
-                append(&server, &kind, messages, &metadata).await
+
+                append(&server, &kind, messages, &metadata).await?;
+
+                Ok(metadata.read_marker)
             }
             History::Full {
                 server,
@@ -382,7 +385,10 @@ impl History {
                 ..
             } => {
                 let metadata = metadata.updated(&messages);
-                overwrite(&server, &kind, &messages, &metadata).await
+
+                overwrite(&server, &kind, &messages, &metadata).await?;
+
+                Ok(metadata.read_marker)
             }
         }
     }

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -336,7 +336,7 @@ impl History {
                 let messages = std::mem::take(messages);
 
                 let read_marker = ReadMarker::latest(&messages).max(*read_marker);
-                let max_triggers_unread = metadata::find_latest_triggers(&messages);
+                let max_triggers_unread = metadata::latest_triggers_unread(&messages);
 
                 *self = Self::Partial {
                     server: server.clone(),

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -367,7 +367,7 @@ impl History {
             } => {
                 append(&server, &kind, messages, read_marker).await?;
 
-                Ok(read_marker)
+                Ok(None)
             }
             History::Full {
                 server,

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -224,10 +224,17 @@ impl History {
             } => {
                 // Read marker is prior to last message on disk
                 // or prior to unflushed messages in memory
-                last_on_disk.zip(metadata.read_marker).map_or(
-                    last_on_disk.is_some() && metadata.read_marker.is_none(),
-                    |(a, b)| a > b.date_time(),
-                ) || metadata.unread_count(messages) > 0
+                if let Some(read_marker) = metadata.read_marker {
+                    last_on_disk.is_some_and(|last| read_marker.date_time() < last)
+                        || messages.iter().any(|message| {
+                            read_marker.date_time() < message.server_time
+                                && message.triggers_unread()
+                        })
+                }
+                // Default state == unread
+                else {
+                    true
+                }
             }
             History::Full { .. } => false,
         }

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -379,13 +379,6 @@ impl History {
         }
     }
 
-    pub fn get_read_marker(&self) -> Option<ReadMarker> {
-        match self {
-            History::Partial { metadata, .. } => metadata.read_marker,
-            History::Full { metadata, .. } => metadata.read_marker,
-        }
-    }
-
     pub fn update_read_marker(&mut self, read_marker: ReadMarker) {
         let metadata = match self {
             History::Partial { metadata, .. } => metadata,

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -221,10 +221,10 @@ impl History {
             } => {
                 // Read marker is prior to last message on disk
                 // or prior to unflushed messages in memory
-                last_on_disk
-                    .zip(metadata.read_marker)
-                    .map_or(false, |(a, b)| a > b.date_time())
-                    || metadata.unread_count(messages) > 0
+                last_on_disk.zip(metadata.read_marker).map_or(
+                    last_on_disk.is_some() && metadata.read_marker.is_none(),
+                    |(a, b)| a > b.date_time(),
+                ) || metadata.unread_count(messages) > 0
             }
             History::Full { .. } => false,
         }

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -362,14 +362,20 @@ impl History {
                 messages,
                 metadata,
                 ..
-            } => append(&server, &kind, messages, &metadata).await,
+            } => {
+                let metadata = metadata.updated(&messages);
+                append(&server, &kind, messages, &metadata).await
+            }
             History::Full {
                 server,
                 kind,
                 messages,
                 metadata,
                 ..
-            } => overwrite(&server, &kind, &messages, &metadata).await,
+            } => {
+                let metadata = metadata.updated(&messages);
+                overwrite(&server, &kind, &messages, &metadata).await
+            }
         }
     }
 

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -225,9 +225,9 @@ impl History {
                 if let Some(read_marker) = metadata.read_marker {
                     max_triggers_unread.is_some_and(|max| read_marker.date_time() < max)
                 }
-                // Default state == unread
+                // Default state == unread if theres messages that trigger indicator
                 else {
-                    true
+                    max_triggers_unread.is_some()
                 }
             }
             History::Full { .. } => false,

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -371,8 +371,6 @@ impl History {
                 metadata,
                 ..
             } => {
-                let metadata = metadata.updated(&messages);
-
                 append(&server, &kind, messages, &metadata).await?;
 
                 Ok(metadata.read_marker)

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -121,10 +121,6 @@ pub async fn append(
     messages: Vec<Message>,
     read_marker: Option<ReadMarker>,
 ) -> Result<(), Error> {
-    if messages.is_empty() {
-        return metadata::save(server, kind, &messages, read_marker).await;
-    }
-
     let loaded = load(server.clone(), kind.clone()).await?;
 
     let mut all_messages = loaded.messages;

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -9,10 +9,11 @@ use irc::proto;
 use tokio::fs;
 use tokio::time::Instant;
 
-pub use self::manager::{Manager, Resource};
-pub use self::metadata::{Metadata, ReadMarker};
 use crate::user::Nick;
 use crate::{compression, environment, message, server, Message};
+
+pub use self::manager::{Manager, Resource};
+pub use self::metadata::{Metadata, ReadMarker};
 
 pub mod manager;
 pub mod metadata;

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -292,7 +292,7 @@ impl Manager {
         broadcast: Broadcast,
         config: &Config,
         sent_time: DateTime<Utc>,
-    ) {
+    ) -> Vec<impl Future<Output = Message>> {
         let map = self.data.map.entry(server.clone()).or_default();
 
         let channels = map
@@ -410,9 +410,10 @@ impl Manager {
             }
         };
 
-        messages.into_iter().for_each(|message| {
-            self.record_message(server, message);
-        });
+        messages
+            .into_iter()
+            .filter_map(|message| self.record_message(server, message))
+            .collect()
     }
 
     pub fn input<'a>(&'a self, buffer: &Buffer) -> input::Cache<'a> {

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -480,9 +480,7 @@ impl Data {
                     metadata: partial_metadata,
                     ..
                 } => {
-                    // In-memory metadata will always be more up-to-date than disk
-                    // since we might not have flushed this yet
-                    let metadata = *partial_metadata;
+                    let metadata = partial_metadata.merge(metadata);
 
                     let last_updated_at = *last_updated_at;
                     messages.extend(std::mem::take(new_messages));

--- a/data/src/history/metadata.rs
+++ b/data/src/history/metadata.rs
@@ -1,0 +1,64 @@
+use chrono::{format::SecondsFormat, DateTime, Utc};
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use tokio::fs;
+
+use crate::history::{dir_path, Error, Kind};
+use crate::{server, Message};
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct Metadata {
+    pub read_marker: Option<DateTime<Utc>>,
+}
+
+pub async fn load(server: server::Server, kind: Kind) -> Result<Metadata, Error> {
+    let path = path(&server, &kind).await?;
+
+    if let Ok(bytes) = fs::read(path).await {
+        Ok(serde_json::from_slice(&bytes).unwrap_or_default())
+    } else {
+        Ok(Metadata::default())
+    }
+}
+
+pub async fn overwrite(
+    server: &server::Server,
+    kind: &Kind,
+    metadata: &Metadata,
+) -> Result<(), Error> {
+    let bytes = serde_json::to_vec(metadata)?;
+
+    let path = path(server, kind).await?;
+
+    fs::write(path, &bytes).await?;
+
+    Ok(())
+}
+
+async fn path(server: &server::Server, kind: &Kind) -> Result<PathBuf, Error> {
+    let dir = dir_path().await?;
+
+    let name = match kind {
+        Kind::Server => format!("{server}-metadata"),
+        Kind::Channel(channel) => format!("{server}channel{channel}-metadata"),
+        Kind::Query(nick) => format!("{server}nickname{}-metadata", nick),
+    };
+
+    let hashed_name = seahash::hash(name.as_bytes());
+
+    Ok(dir.join(format!("{hashed_name}.json")))
+}
+
+pub fn after_read_marker(message: &Message, read_marker: &Option<DateTime<Utc>>) -> bool {
+    read_marker.is_none()
+        || read_marker.is_some_and(|read_marker| message.server_time > read_marker)
+}
+
+pub fn read_marker_to_string(read_marker: &Option<DateTime<Utc>>) -> String {
+    if let Some(read_marker) = read_marker {
+        read_marker.to_rfc3339_opts(SecondsFormat::Millis, true)
+    } else {
+        "*".to_string()
+    }
+}

--- a/data/src/history/metadata.rs
+++ b/data/src/history/metadata.rs
@@ -1,8 +1,8 @@
-use chrono::{format::SecondsFormat, DateTime, Utc};
 use std::fmt;
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use chrono::{format::SecondsFormat, DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tokio::fs;
 

--- a/data/src/history/metadata.rs
+++ b/data/src/history/metadata.rs
@@ -38,24 +38,6 @@ impl Metadata {
             read_marker: ReadMarker::latest(messages).or(self.read_marker),
         }
     }
-
-    pub fn unread_count(&self, messages: &[Message]) -> usize {
-        messages
-            .iter()
-            .filter(|message| self.triggers_unread(message))
-            .count()
-    }
-
-    pub fn triggers_unread(&self, message: &Message) -> bool {
-        message.triggers_unread() && self.after_read_marker(message)
-    }
-
-    pub fn after_read_marker(&self, message: &Message) -> bool {
-        self.read_marker.is_none()
-            || self
-                .read_marker
-                .is_some_and(|read_marker| message.server_time > read_marker.0)
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Deserialize, Serialize)]

--- a/data/src/history/metadata.rs
+++ b/data/src/history/metadata.rs
@@ -17,20 +17,12 @@ pub struct Metadata {
 impl Metadata {
     pub fn merge(self, other: Self) -> Self {
         Self {
-            read_marker: self
-                .read_marker
-                .zip(other.read_marker)
-                .map(|(a, b)| a.max(b))
-                .or(self.read_marker)
-                .or(other.read_marker),
+            read_marker: self.read_marker.max(other.read_marker),
         }
     }
 
     pub fn update_read_marker(&mut self, read_marker: ReadMarker) {
-        self.read_marker = Some(
-            self.read_marker
-                .map_or(read_marker, |marker| marker.max(read_marker)),
-        );
+        self.read_marker = self.read_marker.max(Some(read_marker));
     }
 
     pub fn updated(self, messages: &[Message]) -> Self {

--- a/data/src/history/metadata.rs
+++ b/data/src/history/metadata.rs
@@ -22,11 +22,7 @@ pub async fn load(server: server::Server, kind: Kind) -> Result<Metadata, Error>
     }
 }
 
-pub async fn overwrite(
-    server: &server::Server,
-    kind: &Kind,
-    metadata: &Metadata,
-) -> Result<(), Error> {
+pub async fn save(server: &server::Server, kind: &Kind, metadata: &Metadata) -> Result<(), Error> {
     let bytes = serde_json::to_vec(metadata)?;
 
     let path = path(server, kind).await?;

--- a/data/src/history/metadata.rs
+++ b/data/src/history/metadata.rs
@@ -1,15 +1,95 @@
 use chrono::{format::SecondsFormat, DateTime, Utc};
+use std::fmt;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 use tokio::fs;
 
 use crate::history::{dir_path, Error, Kind};
-use crate::{server, Message};
+use crate::{message, server, Message};
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
 pub struct Metadata {
-    pub read_marker: Option<DateTime<Utc>>,
+    pub read_marker: Option<ReadMarker>,
+}
+
+impl Metadata {
+    pub fn merge(self, other: Self) -> Self {
+        Self {
+            read_marker: self
+                .read_marker
+                .zip(other.read_marker)
+                .map(|(a, b)| a.max(b))
+                .or(self.read_marker)
+                .or(other.read_marker),
+        }
+    }
+
+    pub fn update_read_marker(&mut self, read_marker: ReadMarker) {
+        self.read_marker = Some(
+            self.read_marker
+                .map_or(read_marker, |marker| marker.max(read_marker)),
+        );
+    }
+
+    pub fn updated(self, messages: &[Message]) -> Self {
+        Self {
+            read_marker: ReadMarker::latest(messages).or(self.read_marker),
+        }
+    }
+
+    pub fn unread_count(&self, messages: &[Message]) -> usize {
+        messages
+            .iter()
+            .filter(|message| self.triggers_unread(message))
+            .count()
+    }
+
+    pub fn triggers_unread(&self, message: &Message) -> bool {
+        message.triggers_unread() && self.after_read_marker(message)
+    }
+
+    pub fn after_read_marker(&self, message: &Message) -> bool {
+        self.read_marker.is_none()
+            || self
+                .read_marker
+                .is_some_and(|read_marker| message.server_time > read_marker.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Deserialize, Serialize)]
+pub struct ReadMarker(DateTime<Utc>);
+
+impl ReadMarker {
+    pub fn latest(messages: &[Message]) -> Option<Self> {
+        messages
+            .iter()
+            .rev()
+            .find(|message| !matches!(message.target.source(), message::Source::Internal(_)))
+            .map(|message| message.server_time)
+            .map(Self)
+    }
+
+    pub fn date_time(&self) -> DateTime<Utc> {
+        self.0
+    }
+}
+
+impl FromStr for ReadMarker {
+    type Err = chrono::ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        DateTime::parse_from_rfc3339(s)
+            .map(|dt| dt.with_timezone(&Utc))
+            .map(Self)
+    }
+}
+
+impl fmt::Display for ReadMarker {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.to_rfc3339_opts(SecondsFormat::Millis, true).fmt(f)
+    }
 }
 
 pub async fn load(server: server::Server, kind: Kind) -> Result<Metadata, Error> {
@@ -44,17 +124,4 @@ async fn path(server: &server::Server, kind: &Kind) -> Result<PathBuf, Error> {
     let hashed_name = seahash::hash(name.as_bytes());
 
     Ok(dir.join(format!("{hashed_name}.json")))
-}
-
-pub fn after_read_marker(message: &Message, read_marker: &Option<DateTime<Utc>>) -> bool {
-    read_marker.is_none()
-        || read_marker.is_some_and(|read_marker| message.server_time > read_marker)
-}
-
-pub fn read_marker_to_string(read_marker: &Option<DateTime<Utc>>) -> String {
-    if let Some(read_marker) = read_marker {
-        read_marker.to_rfc3339_opts(SecondsFormat::Millis, true)
-    } else {
-        "*".to_string()
-    }
 }

--- a/data/src/history/metadata.rs
+++ b/data/src/history/metadata.rs
@@ -20,7 +20,7 @@ pub struct ReadMarker(DateTime<Utc>);
 
 impl ReadMarker {
     pub fn latest(messages: &[Message]) -> Option<Self> {
-        find_latest_triggers(messages).map(Self)
+        latest_triggers_unread(messages).map(Self)
     }
 
     pub fn date_time(self) -> DateTime<Utc> {
@@ -44,7 +44,7 @@ impl fmt::Display for ReadMarker {
     }
 }
 
-pub fn find_latest_triggers(messages: &[Message]) -> Option<DateTime<Utc>> {
+pub fn latest_triggers_unread(messages: &[Message]) -> Option<DateTime<Utc>> {
     messages
         .iter()
         .rev()
@@ -70,7 +70,7 @@ pub async fn save(
 ) -> Result<(), Error> {
     let bytes = serde_json::to_vec(&Metadata {
         read_marker,
-        last_triggers_unread: find_latest_triggers(messages),
+        last_triggers_unread: latest_triggers_unread(messages),
     })?;
 
     let path = path(server, kind).await?;

--- a/data/src/history/metadata.rs
+++ b/data/src/history/metadata.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use tokio::fs;
 
 use crate::history::{dir_path, Error, Kind};
-use crate::{server, Message};
+use crate::{message, server, Message};
 
 #[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
 pub struct Metadata {
@@ -20,7 +20,12 @@ pub struct ReadMarker(DateTime<Utc>);
 
 impl ReadMarker {
     pub fn latest(messages: &[Message]) -> Option<Self> {
-        latest_triggers_unread(messages).map(Self)
+        messages
+            .iter()
+            .rev()
+            .find(|message| !matches!(message.target.source(), message::Source::Internal(_)))
+            .map(|message| message.server_time)
+            .map(Self)
     }
 
     pub fn date_time(self) -> DateTime<Utc> {

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -14,6 +14,7 @@ pub use self::formatting::Formatting;
 pub use self::source::Source;
 
 use crate::config::buffer::UsernameFormat;
+use crate::history::after_read_marker;
 use crate::time::{self, Posix};
 use crate::user::{Nick, NickRef};
 use crate::{ctcp, Config, User};
@@ -152,7 +153,7 @@ pub struct Message {
 }
 
 impl Message {
-    pub fn triggers_unread(&self) -> bool {
+    pub fn triggers_unread(&self, read_marker: &Option<DateTime<Utc>>) -> bool {
         matches!(self.direction, Direction::Received)
             && match self.target.source() {
                 Source::User(_) => true,
@@ -166,6 +167,7 @@ impl Message {
                 }
                 _ => false,
             }
+            && after_read_marker(self, read_marker)
     }
 
     pub fn received<'a>(
@@ -687,6 +689,7 @@ fn target(
         | Command::CNOTICE(_, _, _)
         | Command::CPRIVMSG(_, _, _)
         | Command::KNOCK(_, _)
+        | Command::MARKREAD(_, _)
         | Command::MONITOR(_, _)
         | Command::TAGMSG(_)
         | Command::USERIP(_)

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -14,7 +14,6 @@ pub use self::formatting::Formatting;
 pub use self::source::Source;
 
 use crate::config::buffer::UsernameFormat;
-use crate::history::after_read_marker;
 use crate::time::{self, Posix};
 use crate::user::{Nick, NickRef};
 use crate::{ctcp, Config, User};
@@ -153,7 +152,7 @@ pub struct Message {
 }
 
 impl Message {
-    pub fn triggers_unread(&self, read_marker: &Option<DateTime<Utc>>) -> bool {
+    pub fn triggers_unread(&self) -> bool {
         matches!(self.direction, Direction::Received)
             && match self.target.source() {
                 Source::User(_) => true,
@@ -167,7 +166,6 @@ impl Message {
                 }
                 _ => false,
             }
-            && after_read_marker(self, read_marker)
     }
 
     pub fn received<'a>(

--- a/irc/proto/src/command.rs
+++ b/irc/proto/src/command.rs
@@ -107,6 +107,8 @@ pub enum Command {
     CPRIVMSG(String, String, String),
     /// <channel> [<message>]
     KNOCK(String, Option<String>),
+    /// <target> [<timestamp>]
+    MARKREAD(String, Option<String>),
     /// <subcommand> [<targets>]
     MONITOR(String, Option<String>),
     /// <msgtarget>
@@ -205,6 +207,7 @@ impl Command {
             "CNOTICE" if len > 2 => CNOTICE(req!(), req!(), req!()),
             "CPRIVMSG" if len > 2 => CPRIVMSG(req!(), req!(), req!()),
             "KNOCK" if len > 0 => KNOCK(req!(), opt!()),
+            "MARKREAD" if len > 0 => MARKREAD(req!(), opt!()),
             "MONITOR" if len > 0 => MONITOR(req!(), opt!()),
             "TAGMSG" if len > 0 => TAGMSG(req!()),
             "USERIP" if len > 0 => USERIP(req!()),
@@ -265,6 +268,7 @@ impl Command {
             Command::CNOTICE(a, b, c) => vec![a, b, c],
             Command::CPRIVMSG(a, b, c) => vec![a, b, c],
             Command::KNOCK(a, b) => std::iter::once(a).chain(b).collect(),
+            Command::MARKREAD(a, b) => std::iter::once(a).chain(b).collect(),
             Command::MONITOR(a, b) => std::iter::once(a).chain(b).collect(),
             Command::TAGMSG(a) => vec![a],
             Command::USERIP(a) => vec![a],
@@ -324,6 +328,7 @@ impl Command {
             CNOTICE(_, _, _) => "CNOTICE".to_string(),
             CPRIVMSG(_, _, _) => "CPRIVMSG".to_string(),
             KNOCK(_, _) => "KNOCK".to_string(),
+            MARKREAD(_, _) => "MARKREAD".to_string(),
             MONITOR(_, _) => "MONITOR".to_string(),
             TAGMSG(_) => "TAGMSG".to_string(),
             USERIP(_) => "USERIP".to_string(),

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -37,10 +37,10 @@ pub enum Message {
     FileTransfers(file_transfers::Message),
 }
 
-#[derive(Debug, Clone)]
 pub enum Event {
     UserContext(user_context::Event),
     OpenChannel(String),
+    History(Task<history::manager::Message>),
 }
 
 impl Buffer {
@@ -73,6 +73,7 @@ impl Buffer {
                 let event = event.map(|event| match event {
                     channel::Event::UserContext(event) => Event::UserContext(event),
                     channel::Event::OpenChannel(channel) => Event::OpenChannel(channel),
+                    channel::Event::History(task) => Event::History(task),
                 });
 
                 (command.map(Message::Channel), event)
@@ -83,6 +84,7 @@ impl Buffer {
                 let event = event.map(|event| match event {
                     server::Event::UserContext(event) => Event::UserContext(event),
                     server::Event::OpenChannel(channel) => Event::OpenChannel(channel),
+                    server::Event::History(task) => Event::History(task),
                 });
 
                 (command.map(Message::Server), event)
@@ -93,6 +95,7 @@ impl Buffer {
                 let event = event.map(|event| match event {
                     query::Event::UserContext(event) => Event::UserContext(event),
                     query::Event::OpenChannel(channel) => Event::OpenChannel(channel),
+                    query::Event::History(task) => Event::History(task),
                 });
 
                 (command.map(Message::Query), event)

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -19,10 +19,10 @@ pub enum Message {
     Topic(topic::Message),
 }
 
-#[derive(Debug, Clone)]
 pub enum Event {
     UserContext(user_context::Event),
     OpenChannel(String),
+    History(Task<history::manager::Message>),
 }
 
 pub fn view<'a>(
@@ -341,13 +341,13 @@ impl Channel {
                 let command = command.map(Message::InputView);
 
                 match event {
-                    Some(input_view::Event::InputSent) => {
+                    Some(input_view::Event::InputSent { history_task }) => {
                         let command = Task::batch(vec![
                             command,
                             self.scroll_view.scroll_to_end().map(Message::ScrollView),
                         ]);
 
-                        (command, None)
+                        (command, Some(Event::History(history_task)))
                     }
                     None => (command, None),
                 }

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -13,10 +13,10 @@ pub enum Message {
     InputView(input_view::Message),
 }
 
-#[derive(Debug, Clone)]
 pub enum Event {
     UserContext(user_context::Event),
     OpenChannel(String),
+    History(Task<history::manager::Message>),
 }
 
 pub fn view<'a>(
@@ -255,13 +255,13 @@ impl Query {
                 let command = command.map(Message::InputView);
 
                 match event {
-                    Some(input_view::Event::InputSent) => {
+                    Some(input_view::Event::InputSent { history_task }) => {
                         let command = Task::batch(vec![
                             command,
                             self.scroll_view.scroll_to_end().map(Message::ScrollView),
                         ]);
 
-                        (command, None)
+                        (command, Some(Event::History(history_task)))
                     }
                     None => (command, None),
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -778,7 +778,7 @@ impl Halloy {
                         }
                         window::Event::CloseRequested => {
                             if let Screen::Dashboard(dashboard) = &mut self.screen {
-                                return dashboard.exit().then(|_| iced::exit());
+                                return dashboard.exit(self.clients.take()).then(|_| iced::exit());
                             } else {
                                 return iced::exit();
                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -707,6 +707,13 @@ impl Halloy {
                                                 .map(Message::Dashboard),
                                         );
                                     }
+                                    data::client::Event::JoinedChannel(channel) => {
+                                        commands.push(
+                                            dashboard
+                                                .channel_joined(server.clone(), channel)
+                                                .map(Message::Dashboard),
+                                        );
+                                    }
                                 }
                             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,10 +19,11 @@ mod window;
 use std::env;
 use std::time::{Duration, Instant};
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use data::config::{self, Config};
+use data::history::{self, read_marker_to_string};
 use data::version::Version;
-use data::{environment, history, server, version, Url, User};
+use data::{environment, server, version, Url, User};
 use iced::widget::{column, container};
 use iced::{padding, Length, Subscription, Task};
 use screen::{dashboard, help, migration, welcome};
@@ -217,6 +218,7 @@ pub enum Message {
     RouteReceived(String),
     Window(window::Id, window::Event),
     WindowSettingsSaved(Result<(), window::Error>),
+    UpdateReadMarker(server::Server, history::Kind, Option<DateTime<Utc>>),
 }
 
 impl Halloy {
@@ -644,6 +646,57 @@ impl Halloy {
                                             commands.push(command.map(Message::Dashboard));
                                         }
                                     }
+                                    data::client::Event::LoadReadMarker(target) => {
+                                        let server = server.clone();
+                                        let kind = history::Kind::from(target);
+
+                                        commands.push(Task::perform(
+                                            history::load_read_marker(server.clone(), kind.clone()),
+                                            move |read_marker| {
+                                                Message::UpdateReadMarker(
+                                                    server.clone(),
+                                                    kind.clone(),
+                                                    read_marker.ok().flatten(),
+                                                )
+                                            },
+                                        ));
+                                    }
+                                    data::client::Event::UpdateReadMarker(target, read_marker) => {
+                                        let server = server.clone();
+                                        let kind = history::Kind::from(target);
+
+                                        if dashboard.update_read_marker(&server, &kind, read_marker)
+                                        {
+                                            log::debug!(
+                                                "[{server}] updated read-marker for {kind} to {}",
+                                                read_marker_to_string(&read_marker),
+                                            );
+
+                                            if dashboard.stored_messages_may_be_unread(
+                                                &server,
+                                                &kind,
+                                                read_marker,
+                                            ) {
+                                                commands.push(Task::perform(
+                                                    history::num_stored_unread_messages(
+                                                        server.clone(),
+                                                        kind.clone(),
+                                                        read_marker,
+                                                    ),
+                                                    move |num_stored_unread_messages| {
+                                                        Message::Dashboard(
+                                                            dashboard::Message::IncrementUnread(
+                                                                server.clone(),
+                                                                kind.clone(),
+                                                                read_marker,
+                                                                num_stored_unread_messages,
+                                                            ),
+                                                        )
+                                                    },
+                                                ));
+                                            }
+                                        }
+                                    }
                                 }
                             }
 
@@ -786,6 +839,47 @@ impl Halloy {
             Message::WindowSettingsSaved(result) => {
                 if let Err(err) = result {
                     log::error!("window settings failed to save: {:?}", err)
+                }
+
+                Task::none()
+            }
+            Message::UpdateReadMarker(server, kind, read_marker) => {
+                if let Screen::Dashboard(dashboard) = &mut self.screen {
+                    if dashboard.update_read_marker(&server, &kind, read_marker) {
+                        log::debug!(
+                            "[{server}] updated read-marker for {kind} to {}",
+                            read_marker_to_string(&read_marker),
+                        );
+
+                        match kind.clone() {
+                            history::Kind::Server => (),
+                            history::Kind::Channel(channel) => {
+                                self.clients.send_markread(&server, &channel, read_marker)
+                            }
+                            history::Kind::Query(nick) => {
+                                self.clients
+                                    .send_markread(&server, nick.as_ref(), read_marker)
+                            }
+                        }
+
+                        if dashboard.stored_messages_may_be_unread(&server, &kind, read_marker) {
+                            return Task::perform(
+                                history::num_stored_unread_messages(
+                                    server.clone(),
+                                    kind.clone(),
+                                    read_marker,
+                                ),
+                                move |num_stored_unread_messages| {
+                                    Message::Dashboard(dashboard::Message::IncrementUnread(
+                                        server.clone(),
+                                        kind.clone(),
+                                        read_marker,
+                                        num_stored_unread_messages,
+                                    ))
+                                },
+                            );
+                        }
+                    }
                 }
 
                 Task::none()

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1247,6 +1247,14 @@ impl Dashboard {
         }
     }
 
+    pub fn channel_joined(&mut self, server: Server, channel: String) -> Task<Message> {
+        if let Some(task) = self.history.channel_joined(server, channel) {
+            Task::perform(task, Message::History)
+        } else {
+            Task::none()
+        }
+    }
+
     fn get_focused_mut(
         &mut self,
         main_window: &Window,

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -499,16 +499,16 @@ impl Dashboard {
                 if let history::manager::Message::Closed(ref server, ref kind, Ok(_)) = message {
                     match kind {
                         history::Kind::Server => (),
-                        history::Kind::Channel(channel) => clients.send_markread(
-                            server,
-                            channel,
-                            self.get_read_marker(server, kind),
-                        ),
-                        history::Kind::Query(nick) => clients.send_markread(
-                            server,
-                            nick.as_ref(),
-                            self.get_read_marker(server, kind),
-                        ),
+                        history::Kind::Channel(channel) => {
+                            if let Some(read_marker) = self.get_read_marker(server, kind) {
+                                clients.send_markread(server, channel, read_marker)
+                            }
+                        }
+                        history::Kind::Query(nick) => {
+                            if let Some(read_marker) = self.get_read_marker(server, kind) {
+                                clients.send_markread(server, nick.as_ref(), read_marker)
+                            }
+                        }
                     }
                 }
 


### PR DESCRIPTION
An initial implementation for [`read-marker`](https://ircv3.net/specs/extensions/read-marker) support.  To facilitate the support, a new file is stored with the local read marker information (last read non-internal message).  It's a separate from the message history file since I wanted it to be quick/simple to access without loading the channel's message history.

As a side benefit, this allows unread message state for channels to persist across application close→open.

Second step in cutting up PR #370 into more digestible pieces.