### PR TITLE
Add password_command for sasl and `nick_password`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 - New configuration options
-  - Ability to define a shell command for loading a NICKSERV password. See [configuration](https://halloy.squidowl.org/configuration/servers/index.html#password_command)
+  - Ability to define a shell command for loading a NICKSERV password. See [configuration](https://halloy.squidowl.org/configuration/servers/index.html#nick_password_command)
   - Ability to define a shell command for loading a SASL password. See [configuration](https://halloy.squidowl.org/configuration/servers/sasl/plain.html)
 
 Fixed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Unreleased
+- New configuration options
+  - Ability to define a shell command for loading a NICKSERV password. See [configuration](https://halloy.squidowl.org/configuration/servers/index.html#password_command)
+  - Ability to define a shell command for loading a SASL password. See [configuration](https://halloy.squidowl.org/configuration/servers/sasl/plain.html)
+
+Fixed:
+
+- Errors from password commands are now caught and displayed to the user.
 
 # 2024.12 (2024-09-17)
 

--- a/book/src/configuration/servers/README.md
+++ b/book/src/configuration/servers/README.md
@@ -40,6 +40,14 @@ Read nick_password from the file at the given path.[^1]
 - **values**: any string
 - **default**: not set
 
+## `nick_password_command`
+
+Executes the command with `sh` (or equivalent) and reads `nickname_password` as the output.
+
+- **type**: string
+- **values**: any string
+- **default**: not set
+
 ## `nick_identify_syntax`
 
 The server's NICKSERV IDENTIFY syntax.

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -161,7 +161,7 @@ impl Config {
         let path = Self::path();
         let content = fs::read_to_string(path)
             .await
-            .map_err(|e| Error::Read(e.to_string()))?;
+            .map_err(|e| Error::LoadConfigFile(e.to_string()))?;
 
         let Configuration {
             theme,
@@ -305,9 +305,9 @@ fn default_tooltip() -> bool {
 #[derive(Debug, Error, Clone)]
 pub enum Error {
     #[error("config could not be read: {0}")]
-    Read(String),
+    LoadConfigFile(String),
     #[error("command could not be run: {0}")]
-    Execute(String),
+    ExecutePasswordCommand(String),
     #[error("{0}")]
     Io(String),
     #[error("{0}")]
@@ -321,10 +321,10 @@ pub enum Error {
 }
 
 impl Error {
-    pub fn is_expected(&self) -> bool {
+    pub fn is_expected_on_first_load(&self) -> bool {
         match self {
             // If a user doesn't have a config when we start up, then we end up with a read error
-            Error::Read(_) => true,
+            Error::LoadConfigFile(_) => true,
             _ => false,
         }
     }

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -15,6 +15,8 @@ pub struct Server {
     pub nick_password: Option<String>,
     /// The client's NICKSERV password file.
     pub nick_password_file: Option<String>,
+    /// The client's NICKSERV password command.
+    pub nick_password_command: Option<String>,
     /// The server's NICKSERV IDENTIFY syntax.
     pub nick_identify_syntax: Option<IdentifySyntax>,
     /// Alternative nicknames for the client, if the default is taken.
@@ -143,6 +145,7 @@ impl Default for Server {
             nickname: Default::default(),
             nick_password: Default::default(),
             nick_password_file: Default::default(),
+            nick_password_command: Default::default(),
             nick_identify_syntax: Default::default(),
             alt_nicks: Default::default(),
             username: Default::default(),
@@ -189,6 +192,8 @@ pub enum Sasl {
         password: Option<String>,
         /// Account password file
         password_file: Option<String>,
+        /// Account password command
+        password_command: Option<String>,
     },
     External {
         /// The path to PEM encoded X509 user certificate for external auth

--- a/data/src/server.rs
+++ b/data/src/server.rs
@@ -74,7 +74,7 @@ async fn read_from_command(pass_command: &str) -> Result<String, Error> {
         // trailing newline
         Ok(str::from_utf8(&output.stdout)?.trim_end().to_string())
     } else {
-        Err(Error::Execute(String::from_utf8(output.stderr)?))
+        Err(Error::ExecutePasswordCommand(String::from_utf8(output.stderr)?))
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,30 +151,28 @@ impl Halloy {
                     command.map(Message::Dashboard),
                 )
             }
-            Err(error) => {
-                if config::has_yaml_config() {
-                    // If we have a YAML file, but end up in this arm
-                    // it means the user tried to load Halloy with a YAML configuration, but it expected TOML.
-                    (
-                        Screen::Migration(screen::Migration::new()),
-                        Config::default(),
-                        Task::none(),
-                    )
-                } else if error.is_expected_on_first_load() {
-                    // Show regular welcome screen for new users.
-                    (
-                        Screen::Welcome(screen::Welcome::new()),
-                        Config::default(),
-                        Task::none(),
-                    )
-                } else {
-                    (
-                        Screen::Help(screen::Help::new(error)),
-                        Config::default(),
-                        Task::none(),
-                    )
-                }
-            },
+            // If we have a YAML file, but end up in this arm
+            // it means the user tried to load Halloy with a YAML configuration, but it expected TOML.
+            Err(config::Error::ConfigMissing {
+                has_yaml_config: true,
+            }) => (
+                Screen::Migration(screen::Migration::new()),
+                Config::default(),
+                Task::none(),
+            ),
+            // Show regular welcome screen for new users.
+            Err(config::Error::ConfigMissing {
+                has_yaml_config: false,
+            }) => (
+                Screen::Welcome(screen::Welcome::new()),
+                Config::default(),
+                Task::none(),
+            ),
+            Err(error) => (
+                Screen::Help(screen::Help::new(error)),
+                Config::default(),
+                Task::none(),
+            ),
         };
 
         (

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,7 +160,7 @@ impl Halloy {
                         Config::default(),
                         Task::none(),
                     )
-                } else if error.is_expected() {
+                } else if error.is_expected_on_first_load() {
                     // Show regular welcome screen for new users.
                     (
                         Screen::Welcome(screen::Welcome::new()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,29 +151,28 @@ impl Halloy {
                     command.map(Message::Dashboard),
                 )
             }
-            Err(error) => match &error {
-                config::Error::Parse(_) | config::Error::LoadSounds(_) => (
-                    Screen::Help(screen::Help::new(error)),
-                    Config::default(),
-                    Task::none(),
-                ),
-                _ => {
+            Err(error) => {
+                if config::has_yaml_config() {
                     // If we have a YAML file, but end up in this arm
                     // it means the user tried to load Halloy with a YAML configuration, but it expected TOML.
-                    if config::has_yaml_config() {
-                        (
-                            Screen::Migration(screen::Migration::new()),
-                            Config::default(),
-                            Task::none(),
-                        )
-                    } else {
-                        // Otherwise, show regular welcome screen for new users.
-                        (
-                            Screen::Welcome(screen::Welcome::new()),
-                            Config::default(),
-                            Task::none(),
-                        )
-                    }
+                    (
+                        Screen::Migration(screen::Migration::new()),
+                        Config::default(),
+                        Task::none(),
+                    )
+                } else if error.is_expected() {
+                    // Show regular welcome screen for new users.
+                    (
+                        Screen::Welcome(screen::Welcome::new()),
+                        Config::default(),
+                        Task::none(),
+                    )
+                } else {
+                    (
+                        Screen::Help(screen::Help::new(error)),
+                        Config::default(),
+                        Task::none(),
+                    )
                 }
             },
         };


### PR DESCRIPTION
This commit builds off of #552 and allows the user to supply a command instead of a password file anywhere that a password file is used. If the password command ends unsuccessfully, then an error is displayed.

Trailing whitespace is now trimmed from password commands, as it is commonplace for commands to leave a trailing newline after the password they output.

Resolves #580