### PR TITLE
Only highlight if user nick isn't part of another word

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Added:
 Fixed:
 
 - Inverted scrolling direction.
+- Only highlight if user nick isn't part of another word.
 
 # 2024.12 (2024-09-17)
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -650,7 +650,7 @@ impl Client {
                         }
 
                         // Highlight notification
-                        if message::reference_user_text(user.nickname(), self.nickname(), text)
+                        if message::references_user_text(user.nickname(), self.nickname(), text)
                             && self.highlight_blackout.allow_highlights()
                         {
                             return Some(vec![Event::Notification(

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -1061,11 +1061,16 @@ fn monitored_targets_text(targets: Vec<String>) -> Option<String> {
 }
 
 pub fn reference_user(sender: NickRef, own_nick: NickRef, message: &Message) -> bool {
+    let contains_nick = |text: &str, nick: &str| {
+        text.split(|c: char| !c.is_alphanumeric())
+            .any(|word| word == nick)
+    };
+
     let has_nick = match &message.content {
-        Content::Plain(text) => text.contains(own_nick.as_ref()),
+        Content::Plain(text) => contains_nick(text, own_nick.as_ref()),
         Content::Fragments(fragments) => fragments
             .iter()
-            .any(|f| f.as_str().contains(own_nick.as_ref())),
+            .any(|f| contains_nick(f.as_str(), own_nick.as_ref())),
     };
 
     sender != own_nick && has_nick

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -384,7 +384,7 @@ fn parse_url_fragments(text: String) -> Vec<Fragment> {
 }
 
 /// Checks if a given `text` contains or matches a user's nickname.
-fn text_reference_nickname(text: &str, nickname: NickRef) -> Option<bool> {
+fn text_references_nickname(text: &str, nickname: NickRef) -> Option<bool> {
     // TODO: Consider server case-mapping settings vs just ascii lowercase
     let nick = nickname.as_ref();
     let nick_lower = nick.to_ascii_lowercase();
@@ -412,7 +412,7 @@ fn parse_user_and_channel_fragments(text: &str, channel_users: &[User]) -> Vec<F
             let text = chars.collect::<String>();
             if !is_whitespace {
                 if let Some((is_trimmed, user)) = channel_users.iter().find_map(|user| {
-                    text_reference_nickname(text.as_str(), user.nickname())
+                    text_references_nickname(text.as_str(), user.nickname())
                         .map(|is_trimmed| (is_trimmed, user.clone()))
                 }) {
                     if is_trimmed {
@@ -1067,17 +1067,17 @@ fn monitored_targets_text(targets: Vec<String>) -> Option<String> {
     }
 }
 
-pub fn reference_user(sender: NickRef, own_nick: NickRef, message: &Message) -> bool {
+pub fn references_user(sender: NickRef, own_nick: NickRef, message: &Message) -> bool {
     match &message.content {
-        Content::Plain(text) => reference_user_text(sender, own_nick, text),
+        Content::Plain(text) => references_user_text(sender, own_nick, text),
         Content::Fragments(fragments) => fragments
             .iter()
-            .any(|f| reference_user_text(sender, own_nick, f.as_str())),
+            .any(|f| references_user_text(sender, own_nick, f.as_str())),
     }
 }
 
-pub fn reference_user_text(sender: NickRef, own_nick: NickRef, text: &str) -> bool {
-    sender != own_nick && text_reference_nickname(text, own_nick).is_some()
+pub fn references_user_text(sender: NickRef, own_nick: NickRef, text: &str) -> bool {
+    sender != own_nick && text_references_nickname(text, own_nick).is_some()
 }
 
 #[derive(Debug, Clone)]

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -147,7 +147,7 @@ pub fn view<'a>(
                                 ))
                                 .push(container(text).style(move |theme| match our_nick {
                                     Some(nick)
-                                        if message::reference_user(
+                                        if message::references_user(
                                             user.nickname(),
                                             nick,
                                             message,


### PR DESCRIPTION
Fixes #590.

This fixes so that we only highlight if nickname isn't part of another word.