### PR TITLE
Fix memory leak in rust-dark-light crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,14 +1165,16 @@ dependencies = [
 [[package]]
 name = "dark-light"
 version = "1.1.1"
-source = "git+https://github.com/frewsxcv/rust-dark-light?rev=77ae4349f11a556cef9c683803a832f171253479#77ae4349f11a556cef9c683803a832f171253479"
+source = "git+https://github.com/casperstorm/rust-dark-light?rev=10176d160bc3922ed0511ab0e3949b4b6eaf4d50#10176d160bc3922ed0511ab0e3949b4b6eaf4d50"
 dependencies = [
  "anyhow",
  "ashpd 0.7.0",
  "dconf_rs",
  "detect-desktop-environment 1.1.0",
  "futures",
- "objc",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
  "rust-ini 0.20.0",
  "web-sys",
  "winreg 0.52.0",
@@ -2055,7 +2057,7 @@ version = "0.1.0"
 dependencies = [
  "bytesize",
  "chrono",
- "dark-light 1.1.1 (git+https://github.com/frewsxcv/rust-dark-light?rev=77ae4349f11a556cef9c683803a832f171253479)",
+ "dark-light 1.1.1 (git+https://github.com/casperstorm/rust-dark-light?rev=10176d160bc3922ed0511ab0e3949b4b6eaf4d50)",
  "data",
  "embed-resource",
  "fern",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,8 @@ rodio = "0.19.0"
 strum = { version = "0.26.3", features = ["derive"] }
 tokio-stream = {version = "0.1.16", features = ["fs"] }
 
-# Using commit hash for dark-light as latest release didn't have async notify.
-dark-light = { git = "https://github.com/frewsxcv/rust-dark-light", rev = "77ae4349f11a556cef9c683803a832f171253479" }
+# Using a fork from @madsmtm since he has a outstanding PR to the original repo which fixes a memory leak on macOS.
+dark-light = { git = "https://github.com/casperstorm/rust-dark-light", rev = "10176d160bc3922ed0511ab0e3949b4b6eaf4d50" }
 
 [dependencies.uuid]
 version = "1.0"


### PR DESCRIPTION
The original crate (https://github.com/frewsxcv/rust-dark-light) has a memory leak which causes macOS to eventually crash. This has been fixed by @madsmtm in a [PR ](https://github.com/frewsxcv/rust-dark-light/pull/37) where he updates to `objc2` - however this hasn't been merged yet and have been sitting since may.

I've forked the fork and will keep an eye on when it merges.
Thanks for the fix, @madsmtm and thanks for spotting it @englut.