### PR TITLE
Remove iced `auto-detect-theme` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,17 +41,6 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
@@ -1149,35 +1138,19 @@ dependencies = [
 [[package]]
 name = "dark-light"
 version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a76fa97167fa740dcdbfe18e8895601e1bc36525f09b044e00916e717c03a3c"
-dependencies = [
- "dconf_rs",
- "detect-desktop-environment 0.2.0",
- "dirs",
- "objc",
- "rust-ini 0.18.0",
- "web-sys",
- "winreg 0.10.1",
- "zbus 4.4.0",
-]
-
-[[package]]
-name = "dark-light"
-version = "1.1.1"
 source = "git+https://github.com/casperstorm/rust-dark-light?rev=10176d160bc3922ed0511ab0e3949b4b6eaf4d50#10176d160bc3922ed0511ab0e3949b4b6eaf4d50"
 dependencies = [
  "anyhow",
  "ashpd 0.7.0",
  "dconf_rs",
- "detect-desktop-environment 1.1.0",
+ "detect-desktop-environment",
  "futures",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
- "rust-ini 0.20.0",
+ "rust-ini",
  "web-sys",
- "winreg 0.52.0",
+ "winreg",
  "xdg",
  "zbus 3.15.2",
 ]
@@ -1277,12 +1250,6 @@ dependencies = [
 
 [[package]]
 name = "detect-desktop-environment"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d8ad60dd5b13a4ee6bd8fa2d5d88965c597c67bce32b5fc49c94f55cb50810"
-
-[[package]]
-name = "detect-desktop-environment"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf27a1bbe31ac901a2350a6316b1f7056067118abe6bf1ff015d5950ac5e3eb3"
@@ -1298,15 +1265,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1314,17 +1272,6 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -1352,12 +1299,6 @@ checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
  "libloading",
 ]
-
-[[package]]
-name = "dlv-list"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
 name = "dlv-list"
@@ -1444,7 +1385,7 @@ dependencies = [
  "rustc_version",
  "toml",
  "vswhom",
- "winreg 0.52.0",
+ "winreg",
 ]
 
 [[package]]
@@ -2000,7 +1941,7 @@ checksum = "9c08c1f623a8d0b722b8b99f821eb0ba672a1618f0d3b16ddbee1cedd2dd8557"
 dependencies = [
  "bitflags 2.6.0",
  "gpu-descriptor-types",
- "hashbrown 0.14.5",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2057,7 +1998,7 @@ version = "0.1.0"
 dependencies = [
  "bytesize",
  "chrono",
- "dark-light 1.1.1 (git+https://github.com/casperstorm/rust-dark-light?rev=10176d160bc3922ed0511ab0e3949b4b6eaf4d50)",
+ "dark-light",
  "data",
  "embed-resource",
  "fern",
@@ -2085,20 +2026,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "allocator-api2",
 ]
 
@@ -2316,7 +2248,6 @@ source = "git+https://github.com/iced-rs/iced?rev=88a2fac1f9171f162ecfe2a033cba5
 dependencies = [
  "bitflags 2.6.0",
  "bytes",
- "dark-light 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "glam",
  "log",
  "num-traits",
@@ -2490,7 +2421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown",
 ]
 
 [[package]]
@@ -3504,22 +3435,12 @@ dependencies = [
 
 [[package]]
 name = "ordered-multimap"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
-dependencies = [
- "dlv-list 0.3.0",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
 dependencies = [
- "dlv-list 0.5.2",
- "hashbrown 0.14.5",
+ "dlv-list",
+ "hashbrown",
 ]
 
 [[package]]
@@ -4161,22 +4082,12 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rust-ini"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
-dependencies = [
- "cfg-if",
- "ordered-multimap 0.4.3",
-]
-
-[[package]]
-name = "rust-ini"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e0698206bcb8882bf2a9ecb4c1e7785db57ff052297085a6efd4fe42302068a"
 dependencies = [
  "cfg-if",
- "ordered-multimap 0.7.3",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -6167,7 +6078,7 @@ name = "winit"
 version = "0.30.1"
 source = "git+https://github.com/iced-rs/winit.git?rev=254d6b3420ce4e674f516f7a2bd440665e05484d#254d6b3420ce4e674f516f7a2bd440665e05484d"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "android-activity",
  "atomic-waker",
  "bitflags 2.6.0",
@@ -6229,15 +6140,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
-dependencies = [
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,10 @@ ipc = { version = "0.1.0", path = "ipc" }
 notify-rust = "4"
 chrono = { version = "0.4", features = ['serde'] }
 fern = "0.6.1"
-iced = { version = "0.14.0-dev", features = [
+iced = { version = "0.14.0-dev", default-features = false, features = [
+    "wgpu",
+    "tiny-skia",
+    "fira-sans",
     "tokio",
     "lazy",
     "advanced",
@@ -39,7 +42,7 @@ futures = "0.3.30"
 itertools = "0.13.0"
 rodio = "0.19.0"
 strum = { version = "0.26.3", features = ["derive"] }
-tokio-stream = {version = "0.1.16", features = ["fs"] }
+tokio-stream = { version = "0.1.16", features = ["fs"] }
 
 # Using a fork from @madsmtm since he has a outstanding PR to the original repo which fixes a memory leak on macOS.
 dark-light = { git = "https://github.com/casperstorm/rust-dark-light", rev = "10176d160bc3922ed0511ab0e3949b4b6eaf4d50" }


### PR DESCRIPTION
A different version of `dark-light` is depended on directly, meaning a bunch of unused dependencies were compiled and bundled. 
This is extra bad on linux because of `zbus`, see: https://github.com/iced-rs/iced/pull/2624#issuecomment-2389512677 (to entirely remove `zbus 3.x`, it's blocked on https://github.com/frewsxcv/rust-dark-light/pull/41 + upgrading `dark-light`, it now already includes the `objc2` patch)