### PR TITLE
`chathistory` Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Added:
 - New configuration options
   - Ability to disable dimming of away usernames. See [buffer configuartion](https://halloy.squidowl.org/configuration/buffer/away.html).
+- Enable support for IRCv3 `chathistory`
 
 # 2024.14 (2024-10-29)
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Halloy is also available from [Flathub](https://flathub.org/apps/org.squidowl.ha
     * [away-notify](https://ircv3.net/specs/extensions/away-notify)
     * [batch](https://ircv3.net/specs/extensions/batch)
     * [cap-notify](https://ircv3.net/specs/extensions/capability-negotiation.html#cap-notify)
+    * [chathistory](https://ircv3.net/specs/extensions/chathistory)
     * [chghost](https://ircv3.net/specs/extensions/chghost)
     * [echo-message](https://ircv3.net/specs/extensions/echo-message)
     * [extended-join](https://ircv3.net/specs/extensions/extended-join)

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -11,6 +11,7 @@
     * [away-notify](https://ircv3.net/specs/extensions/away-notify)
     * [batch](https://ircv3.net/specs/extensions/batch)
     * [cap-notify](https://ircv3.net/specs/extensions/capability-negotiation.html#cap-notify)
+    * [chathistory](https://ircv3.net/specs/extensions/chathistory)
     * [chghost](https://ircv3.net/specs/extensions/chghost)
     * [echo-message](https://ircv3.net/specs/extensions/echo-message)
     * [extended-join](https://ircv3.net/specs/extensions/extended-join)

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -25,6 +25,8 @@ pub struct Buffer {
     pub internal_messages: InternalMessages,
     #[serde(default)]
     pub status_message_prefix: StatusMessagePrefix,
+    #[serde(default)]
+    pub chathistory: ChatHistory,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -139,6 +141,12 @@ impl Default for InternalMessage {
             smart: Default::default(),
         }
     }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ChatHistory {
+    #[serde(default)]
+    pub infinite_scroll: bool,
 }
 
 #[derive(Debug, Copy, Clone, Default, Deserialize)]

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -96,6 +96,8 @@ pub struct Server {
     /// A list of nicknames to monitor (if MONITOR is supported by the server).
     #[serde(default)]
     pub monitor: Vec<String>,
+    #[serde(default = "default_chathistory")]
+    pub chathistory: bool,
 }
 
 impl Server {
@@ -175,6 +177,7 @@ impl Default for Server {
             who_poll_interval: default_who_poll_interval(),
             who_retry_interval: default_who_retry_interval(),
             monitor: Default::default(),
+            chathistory: default_chathistory(),
         }
     }
 }
@@ -296,4 +299,8 @@ fn default_who_poll_interval() -> Duration {
 
 fn default_who_retry_interval() -> Duration {
     Duration::from_secs(10)
+}
+
+fn default_chathistory() -> bool {
+    true
 }

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -9,11 +9,12 @@ use irc::proto;
 use tokio::fs;
 use tokio::time::Instant;
 
+use crate::message::{self, MessageReferences};
 use crate::user::Nick;
-use crate::{buffer, compression, environment, message, Buffer, Message, Server};
+use crate::{buffer, compression, environment, Buffer, Message, Server};
 
 pub use self::manager::{Manager, Resource};
-pub use self::metadata::{MessageReferences, Metadata, ReadMarker};
+pub use self::metadata::{Metadata, ReadMarker};
 
 pub mod manager;
 pub mod metadata;

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -479,14 +479,16 @@ impl History {
 /// of the incoming message. Either message IDs match, or server times
 /// have an exact match + target & content.
 pub fn insert_message(messages: &mut Vec<Message>, message: Message) {
+    const FUZZ_SECONDS: chrono::Duration = chrono::Duration::seconds(1);
+
     if messages.is_empty() {
         messages.push(message);
 
         return;
     }
 
-    let start = message::fuzz_start_server_time(message.server_time);
-    let end = message::fuzz_end_server_time(message.server_time);
+    let start = message.server_time - FUZZ_SECONDS;
+    let end = message.server_time + FUZZ_SECONDS;
 
     let start_index = match messages.binary_search_by(|stored| stored.server_time.cmp(&start)) {
         Ok(match_index) => match_index,

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -486,7 +486,11 @@ impl Data {
                     let read_marker = (*partial_read_marker).max(metadata.read_marker);
 
                     let last_updated_at = *last_updated_at;
-                    messages.extend(std::mem::take(new_messages));
+                    std::mem::take(new_messages)
+                        .into_iter()
+                        .for_each(|message| {
+                            history::insert_message(&mut messages, message);
+                        });
                     entry.insert(History::Full {
                         kind,
                         messages,

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -246,25 +246,18 @@ impl Manager {
         self.data.load_metadata(server, channel)
     }
 
-    pub fn first_can_reference(&self, server: &Server, target: &str) -> Option<&crate::Message> {
-        self.data
-            .map
-            .get(server)
-            .and_then(|map| map.get(&history::Kind::from(target)))
-            .map(|history| history.first_can_reference())?
+    pub fn first_can_reference(&self, server: Server, target: String) -> Option<&crate::Message> {
+        self.data.first_can_reference(server, target)
     }
 
     pub fn last_can_reference_before(
         &self,
-        server: &Server,
-        target: &str,
+        server: Server,
+        target: String,
         server_time: DateTime<Utc>,
     ) -> Option<MessageReferences> {
         self.data
-            .map
-            .get(server)
-            .and_then(|map| map.get(&history::Kind::from(target)))
-            .map(|history| history.last_can_reference_before(server_time))?
+            .last_can_reference_before(server, target, server_time)
     }
 
     pub fn get_messages(
@@ -762,6 +755,31 @@ impl Data {
                 )
             }
         }
+    }
+
+    fn first_can_reference(
+        &self,
+        server: server::Server,
+        target: String,
+    ) -> Option<&crate::Message> {
+        let kind = history::Kind::from_target(server, target);
+
+        self.map
+            .get(&kind)
+            .and_then(|history| history.first_can_reference())
+    }
+
+    fn last_can_reference_before(
+        &self,
+        server: Server,
+        target: String,
+        server_time: DateTime<Utc>,
+    ) -> Option<MessageReferences> {
+        let kind = history::Kind::from_target(server, target);
+
+        self.map
+            .get(&kind)
+            .and_then(|history| history.last_can_reference_before(server_time))
     }
 
     fn untrack(

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -246,18 +246,24 @@ impl Manager {
         self.data.load_metadata(server, channel)
     }
 
-    pub fn first_can_reference(&self, server: Server, target: String) -> Option<&crate::Message> {
-        self.data.first_can_reference(server, target)
+    pub fn first_can_reference(
+        &self,
+        server: Server,
+        chantypes: &[char],
+        target: String,
+    ) -> Option<&crate::Message> {
+        self.data.first_can_reference(server, chantypes, target)
     }
 
     pub fn last_can_reference_before(
         &self,
         server: Server,
+        chantypes: &[char],
         target: String,
         server_time: DateTime<Utc>,
     ) -> Option<MessageReferences> {
         self.data
-            .last_can_reference_before(server, target, server_time)
+            .last_can_reference_before(server, chantypes, target, server_time)
     }
 
     pub fn get_messages(
@@ -760,9 +766,10 @@ impl Data {
     fn first_can_reference(
         &self,
         server: server::Server,
+        chantypes: &[char],
         target: String,
     ) -> Option<&crate::Message> {
-        let kind = history::Kind::from_target(server, target);
+        let kind = history::Kind::from_target(server, target, chantypes);
 
         self.map
             .get(&kind)
@@ -772,10 +779,11 @@ impl Data {
     fn last_can_reference_before(
         &self,
         server: Server,
+        chantypes: &[char],
         target: String,
         server_time: DateTime<Utc>,
     ) -> Option<MessageReferences> {
-        let kind = history::Kind::from_target(server, target);
+        let kind = history::Kind::from_target(server, target, chantypes);
 
         self.map
             .get(&kind)

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -454,7 +454,7 @@ fn with_limit<'a>(
             collected[length.saturating_sub(n)..length].to_vec()
         }
         Some(Limit::Since(timestamp)) => messages
-            .skip_while(|message| message.received_at < timestamp)
+            .skip_while(|message| message.server_time < timestamp)
             .collect(),
         None => messages.collect(),
     }

--- a/data/src/history/metadata.rs
+++ b/data/src/history/metadata.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 use tokio::fs;
 
 use crate::history::{dir_path, Error, Kind};
-use crate::message::source;
-use crate::{isupport, Message};
+use crate::message::{source, MessageReferences};
+use crate::Message;
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct Metadata {
@@ -55,54 +55,6 @@ impl FromStr for ReadMarker {
 impl fmt::Display for ReadMarker {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.to_rfc3339_opts(SecondsFormat::Millis, true).fmt(f)
-    }
-}
-
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
-pub struct MessageReferences {
-    pub timestamp: DateTime<Utc>,
-    pub id: Option<String>,
-}
-
-impl MessageReferences {
-    pub fn message_reference(
-        &self,
-        message_reference_types: &[isupport::MessageReferenceType],
-    ) -> isupport::MessageReference {
-        for message_reference_type in message_reference_types {
-            match message_reference_type {
-                isupport::MessageReferenceType::MessageId => {
-                    if let Some(id) = &self.id {
-                        return isupport::MessageReference::MessageId(id.clone());
-                    }
-                }
-                isupport::MessageReferenceType::Timestamp => {
-                    return isupport::MessageReference::Timestamp(self.timestamp);
-                }
-            }
-        }
-
-        isupport::MessageReference::None
-    }
-}
-
-impl PartialEq for MessageReferences {
-    fn eq(&self, other: &Self) -> bool {
-        self.timestamp.eq(&other.timestamp)
-    }
-}
-
-impl Eq for MessageReferences {}
-
-impl Ord for MessageReferences {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.timestamp.cmp(&other.timestamp)
-    }
-}
-
-impl PartialOrd for MessageReferences {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
     }
 }
 

--- a/data/src/history/metadata.rs
+++ b/data/src/history/metadata.rs
@@ -7,7 +7,8 @@ use serde::{Deserialize, Serialize};
 use tokio::fs;
 
 use crate::history::{dir_path, Error, Kind};
-use crate::{isupport, message, server, Message};
+use crate::message::source;
+use crate::{isupport, Message};
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct Metadata {

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -1,7 +1,7 @@
-use chrono::{format::SecondsFormat, DateTime, Utc};
 use std::fmt;
 use std::str::FromStr;
 
+use chrono::{format::SecondsFormat, DateTime, Utc};
 use irc::proto;
 
 use crate::Message;

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 use irc::proto;
 
-use crate::{message, Message};
+use crate::Message;
 
 // Utilized ISUPPORT parameters should have an associated Kind enum variant
 // returned by Operation::kind() and Parameter::kind()
@@ -712,10 +712,12 @@ const DEFAULT_DEAF_LETTER: char = 'D';
 
 const DEFAULT_INVITE_EXCEPTION_LETTER: char = 'I';
 
+const FUZZ_SECONDS: chrono::Duration = chrono::Duration::seconds(5);
+
 pub fn fuzz_start_message_reference(message_reference: MessageReference) -> MessageReference {
     match message_reference {
         MessageReference::Timestamp(start_server_time) => {
-            MessageReference::Timestamp(message::fuzz_start_server_time(start_server_time))
+            MessageReference::Timestamp(start_server_time - FUZZ_SECONDS)
         }
         _ => message_reference,
     }
@@ -724,7 +726,7 @@ pub fn fuzz_start_message_reference(message_reference: MessageReference) -> Mess
 pub fn fuzz_end_message_reference(message_reference: MessageReference) -> MessageReference {
     match message_reference {
         MessageReference::Timestamp(end_server_time) => {
-            MessageReference::Timestamp(message::fuzz_end_server_time(end_server_time))
+            MessageReference::Timestamp(end_server_time + FUZZ_SECONDS)
         }
         _ => message_reference,
     }

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -2,7 +2,6 @@ use std::fmt;
 use std::str::FromStr;
 
 use chrono::{format::SecondsFormat, DateTime, Utc};
-use irc::proto;
 
 use crate::Message;
 

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -642,6 +642,13 @@ impl ChatHistorySubcommand {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ChatHistoryState {
+    Exhausted,
+    PendingRequest,
+    Ready,
+}
+
 #[derive(Clone, Debug)]
 pub enum ClientOnlyTags {
     Allowed(String),

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -231,7 +231,13 @@ impl Message {
             &channel_users,
             chantypes,
         )?;
-        let target = target(encoded, &our_nick, &resolve_attributes, chantypes, statusmsg)?;
+        let target = target(
+            encoded,
+            &our_nick,
+            &resolve_attributes,
+            chantypes,
+            statusmsg,
+        )?;
         let received_at = Posix::now();
         let hash = Hash::new(&received_at, &content);
 
@@ -664,11 +670,13 @@ fn target(
 
     match message.0.command {
         // Channel
-        Command::MODE(target, ..) if proto::is_channel(&target, chantypes) => Some(Target::Channel {
-            channel: target,
-            source: source::Source::Server(None),
-            prefixes: Default::default(),
-        }),
+        Command::MODE(target, ..) if proto::is_channel(&target, chantypes) => {
+            Some(Target::Channel {
+                channel: target,
+                source: source::Source::Server(None),
+                prefixes: Default::default(),
+            })
+        }
         Command::TOPIC(channel, _) | Command::KICK(channel, _, _) => Some(Target::Channel {
             channel,
             source: source::Source::Server(None),
@@ -728,7 +736,10 @@ fn target(
                 }
             };
 
-            match (proto::parse_channel_from_target(&target, chantypes, statusmsg), user) {
+            match (
+                proto::parse_channel_from_target(&target, chantypes, statusmsg),
+                user,
+            ) {
                 (Some((prefixes, channel)), Some(user)) => {
                     let source = source(resolve_attributes(&user, &channel).unwrap_or(user));
                     Some(Target::Channel {
@@ -762,7 +773,10 @@ fn target(
                 }
             };
 
-            match (proto::parse_channel_from_target(&target, chantypes, statusmsg), user) {
+            match (
+                proto::parse_channel_from_target(&target, chantypes, statusmsg),
+                user,
+            ) {
                 (Some((prefixes, channel)), Some(user)) => {
                     let source = source(resolve_attributes(&user, &channel).unwrap_or(user));
                     Some(Target::Channel {

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::hash::{DefaultHasher, Hash as _, Hasher};
 use std::iter;
 
-use chrono::{DateTime, TimeDelta, Utc};
+use chrono::{DateTime, Utc};
 use const_format::concatcp;
 use irc::proto;
 use irc::proto::Command;
@@ -862,20 +862,6 @@ pub fn server_time(message: &Encoded) -> DateTime<Utc> {
         .and_then(|rfc3339| DateTime::parse_from_rfc3339(&rfc3339).ok())
         .map(|dt| dt.with_timezone(&Utc))
         .unwrap_or_else(Utc::now)
-}
-
-pub const FUZZ_SECONDS: i64 = 1;
-
-pub fn fuzz_start_server_time(server_time: DateTime<Utc>) -> DateTime<Utc> {
-    TimeDelta::try_seconds(FUZZ_SECONDS)
-        .and_then(|time_delta| server_time.checked_sub_signed(time_delta))
-        .map_or(server_time, |fuzzed_server_time| fuzzed_server_time)
-}
-
-pub fn fuzz_end_server_time(server_time: DateTime<Utc>) -> DateTime<Utc> {
-    TimeDelta::try_seconds(FUZZ_SECONDS)
-        .and_then(|time_delta| server_time.checked_add_signed(time_delta))
-        .map_or(server_time, |fuzzed_server_time| fuzzed_server_time)
 }
 
 fn content<'a>(

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -588,7 +588,7 @@ fn parse_user_and_channel_fragments(text: &str, channel_users: &[User]) -> Vec<F
         })
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, Hash, Serialize, Deserialize)]
 pub enum Content {
     Plain(String),
     Fragments(Vec<Fragment>),
@@ -602,6 +602,12 @@ impl Content {
             Content::Fragments(fragments) => fragments.iter().map(Fragment::as_str).join("").into(),
             Content::Log(record) => (&record.message).into(),
         }
+    }
+}
+
+impl PartialEq for Content {
+    fn eq(&self, other: &Self) -> bool {
+        self.text() == other.text()
     }
 }
 

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -588,7 +588,7 @@ fn parse_user_and_channel_fragments(text: &str, channel_users: &[User]) -> Vec<F
         })
 }
 
-#[derive(Debug, Clone, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, Serialize, Deserialize)]
 pub enum Content {
     Plain(String),
     Fragments(Vec<Fragment>),
@@ -608,6 +608,12 @@ impl Content {
 impl PartialEq for Content {
     fn eq(&self, other: &Self) -> bool {
         self.text() == other.text()
+    }
+}
+
+impl std::hash::Hash for Content {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.text().hash(state);
     }
 }
 

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -1170,7 +1170,7 @@ fn content<'a>(
 pub enum Limit {
     Top(usize),
     Bottom(usize),
-    Since(time::Posix),
+    Since(DateTime<Utc>),
 }
 
 impl Limit {

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -16,10 +16,9 @@ pub use self::formatting::Formatting;
 pub use self::source::Source;
 
 use crate::config::buffer::UsernameFormat;
-use crate::history::MessageReferences;
 use crate::time::{self, Posix};
 use crate::user::{Nick, NickRef};
-use crate::{ctcp, Config, Server, User};
+use crate::{ctcp, isupport, Config, Server, User};
 
 // References:
 // - https://datatracker.ietf.org/doc/html/rfc1738#section-5
@@ -1256,6 +1255,54 @@ where
     let intermediate = serde_json::Value::deserialize(deserializer)?;
 
     Ok(Option::<T>::deserialize(intermediate).unwrap_or_default())
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct MessageReferences {
+    pub timestamp: DateTime<Utc>,
+    pub id: Option<String>,
+}
+
+impl MessageReferences {
+    pub fn message_reference(
+        &self,
+        message_reference_types: &[isupport::MessageReferenceType],
+    ) -> isupport::MessageReference {
+        for message_reference_type in message_reference_types {
+            match message_reference_type {
+                isupport::MessageReferenceType::MessageId => {
+                    if let Some(id) = &self.id {
+                        return isupport::MessageReference::MessageId(id.clone());
+                    }
+                }
+                isupport::MessageReferenceType::Timestamp => {
+                    return isupport::MessageReference::Timestamp(self.timestamp);
+                }
+            }
+        }
+
+        isupport::MessageReference::None
+    }
+}
+
+impl PartialEq for MessageReferences {
+    fn eq(&self, other: &Self) -> bool {
+        self.timestamp.eq(&other.timestamp)
+    }
+}
+
+impl Eq for MessageReferences {}
+
+impl Ord for MessageReferences {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.timestamp.cmp(&other.timestamp)
+    }
+}
+
+impl PartialOrd for MessageReferences {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 #[cfg(test)]

--- a/irc/proto/src/command.rs
+++ b/irc/proto/src/command.rs
@@ -99,6 +99,8 @@ pub enum Command {
     ACCOUNT(String),
     /* IRC extensions */
     BATCH(String, Vec<String>),
+    /// <subcommand> [<params>]
+    CHATHISTORY(String, Vec<String>),
     /// <new_username> <new_hostname>
     CHGHOST(String, String),
     /// <nickname> <channel> :<message>
@@ -203,6 +205,7 @@ impl Command {
             "WALLOPS" if len > 0 => WALLOPS(req!()),
             "ACCOUNT" if len > 0 => ACCOUNT(req!()),
             "BATCH" if len > 0 => BATCH(req!(), params.collect()),
+            "CHATHISTORY" if len > 0 => CHATHISTORY(req!(), params.collect()),
             "CHGHOST" if len > 1 => CHGHOST(req!(), req!()),
             "CNOTICE" if len > 2 => CNOTICE(req!(), req!(), req!()),
             "CPRIVMSG" if len > 2 => CPRIVMSG(req!(), req!(), req!()),
@@ -264,6 +267,7 @@ impl Command {
             Command::WALLOPS(a) => vec![a],
             Command::ACCOUNT(a) => vec![a],
             Command::BATCH(a, rest) => std::iter::once(a).chain(rest).collect(),
+            Command::CHATHISTORY(a, b) => std::iter::once(a).chain(b).collect(),
             Command::CHGHOST(a, b) => vec![a, b],
             Command::CNOTICE(a, b, c) => vec![a, b, c],
             Command::CPRIVMSG(a, b, c) => vec![a, b, c],
@@ -324,6 +328,7 @@ impl Command {
             WALLOPS(_) => "WALLOPS".to_string(),
             ACCOUNT(_) => "ACCOUNT".to_string(),
             BATCH(_, _) => "BATCH".to_string(),
+            CHATHISTORY(_, _) => "CHATHISTORY".to_string(),
             CHGHOST(_, _) => "CHGHOST".to_string(),
             CNOTICE(_, _, _) => "CNOTICE".to_string(),
             CPRIVMSG(_, _, _) => "CPRIVMSG".to_string(),

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,5 +1,4 @@
 pub use data::buffer::{Internal, Settings, Upstream};
-use data::isupport::ChatHistoryState;
 use data::user::Nick;
 use data::{buffer, file_transfer, history, message, Config};
 use iced::Task;
@@ -330,7 +329,6 @@ impl Buffer {
         message: message::Hash,
         history: &history::Manager,
         config: &Config,
-        chathistory_state: Option<ChatHistoryState>,
     ) -> Task<Message> {
         match self {
             Buffer::Empty | Buffer::FileTransfers(_) => Task::none(),
@@ -338,7 +336,7 @@ impl Buffer {
                 .scroll_view
                 .scroll_to_message(
                     message,
-                    scroll_view::Kind::Channel(&state.server, &state.channel, chathistory_state),
+                    scroll_view::Kind::Channel(&state.server, &state.channel),
                     history,
                     config,
                 )
@@ -356,7 +354,7 @@ impl Buffer {
                 .scroll_view
                 .scroll_to_message(
                     message,
-                    scroll_view::Kind::Query(&state.server, &state.nick, chathistory_state),
+                    scroll_view::Kind::Query(&state.server, &state.nick),
                     history,
                     config,
                 )
@@ -376,14 +374,13 @@ impl Buffer {
         &mut self,
         history: &history::Manager,
         config: &Config,
-        chathistory_state: Option<ChatHistoryState>,
     ) -> Task<Message> {
         match self {
             Buffer::Empty | Buffer::FileTransfers(_) => Task::none(),
             Buffer::Channel(state) => state
                 .scroll_view
                 .scroll_to_backlog(
-                    scroll_view::Kind::Channel(&state.server, &state.channel, chathistory_state),
+                    scroll_view::Kind::Channel(&state.server, &state.channel),
                     history,
                     config,
                 )
@@ -395,7 +392,7 @@ impl Buffer {
             Buffer::Query(state) => state
                 .scroll_view
                 .scroll_to_backlog(
-                    scroll_view::Kind::Query(&state.server, &state.nick, chathistory_state),
+                    scroll_view::Kind::Query(&state.server, &state.nick),
                     history,
                     config,
                 )

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,4 +1,5 @@
 pub use data::buffer::{Internal, Settings, Upstream};
+use data::isupport::ChatHistoryState;
 use data::user::Nick;
 use data::{buffer, file_transfer, history, message, Config};
 use iced::Task;
@@ -329,6 +330,7 @@ impl Buffer {
         message: message::Hash,
         history: &history::Manager,
         config: &Config,
+        chathistory_state: Option<ChatHistoryState>,
     ) -> Task<Message> {
         match self {
             Buffer::Empty | Buffer::FileTransfers(_) => Task::none(),
@@ -336,7 +338,7 @@ impl Buffer {
                 .scroll_view
                 .scroll_to_message(
                     message,
-                    scroll_view::Kind::Channel(&state.server, &state.channel),
+                    scroll_view::Kind::Channel(&state.server, &state.channel, chathistory_state),
                     history,
                     config,
                 )
@@ -354,7 +356,7 @@ impl Buffer {
                 .scroll_view
                 .scroll_to_message(
                     message,
-                    scroll_view::Kind::Query(&state.server, &state.nick),
+                    scroll_view::Kind::Query(&state.server, &state.nick, chathistory_state),
                     history,
                     config,
                 )
@@ -374,13 +376,14 @@ impl Buffer {
         &mut self,
         history: &history::Manager,
         config: &Config,
+        chathistory_state: Option<ChatHistoryState>,
     ) -> Task<Message> {
         match self {
             Buffer::Empty | Buffer::FileTransfers(_) => Task::none(),
             Buffer::Channel(state) => state
                 .scroll_view
                 .scroll_to_backlog(
-                    scroll_view::Kind::Channel(&state.server, &state.channel),
+                    scroll_view::Kind::Channel(&state.server, &state.channel, chathistory_state),
                     history,
                     config,
                 )
@@ -392,7 +395,7 @@ impl Buffer {
             Buffer::Query(state) => state
                 .scroll_view
                 .scroll_to_backlog(
-                    scroll_view::Kind::Query(&state.server, &state.nick),
+                    scroll_view::Kind::Query(&state.server, &state.nick, chathistory_state),
                     history,
                     config,
                 )

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -50,6 +50,7 @@ pub enum Event {
     OpenChannel(String),
     GoToMessage(data::Server, String, message::Hash),
     History(Task<history::manager::Message>),
+    RequestOlderChatHistory,
 }
 
 impl Buffer {
@@ -107,6 +108,7 @@ impl Buffer {
                     channel::Event::UserContext(event) => Event::UserContext(event),
                     channel::Event::OpenChannel(channel) => Event::OpenChannel(channel),
                     channel::Event::History(task) => Event::History(task),
+                    channel::Event::RequestOlderChatHistory => Event::RequestOlderChatHistory,
                 });
 
                 (command.map(Message::Channel), event)
@@ -129,6 +131,7 @@ impl Buffer {
                     query::Event::UserContext(event) => Event::UserContext(event),
                     query::Event::OpenChannel(channel) => Event::OpenChannel(channel),
                     query::Event::History(task) => Event::History(task),
+                    query::Event::RequestOlderChatHistory => Event::RequestOlderChatHistory,
                 });
 
                 (command.map(Message::Query), event)

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -47,21 +47,12 @@ pub fn view<'a>(
 
     let users = clients.get_channel_users(&state.server, &state.channel);
 
-    let chathistory_before_button = if clients.get_server_supports_chathistory(&state.server) {
-        Some((
-            clients
-                .get_chathistory_request(&state.server, &state.channel)
-                .is_some(),
-            clients.get_chathistory_exhausted(&state.server, &state.channel),
-        ))
-    } else {
-        None
-    };
+    let chathistory_state = clients.get_chathistory_state(server, channel);
 
     let messages = container(
         scroll_view::view(
             &state.scroll_view,
-            scroll_view::Kind::Channel(&state.server, &state.channel, chathistory_before_button),
+            scroll_view::Kind::Channel(&state.server, &state.channel, chathistory_state),
             history,
             config,
             move |message, max_nick_width, max_prefix_width| {
@@ -359,7 +350,9 @@ impl Channel {
                     scroll_view::Event::UserContext(event) => Some(Event::UserContext(event)),
                     scroll_view::Event::OpenChannel(channel) => Some(Event::OpenChannel(channel)),
                     scroll_view::Event::GoToMessage(..) => None,
-                    scroll_view::Event::RequestOlderChatHistory => Event::RequestOlderChatHistory,
+                    scroll_view::Event::RequestOlderChatHistory => {
+                        Some(Event::RequestOlderChatHistory)
+                    }
                 });
 
                 (command.map(Message::ScrollView), event)

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -52,8 +52,9 @@ pub fn view<'a>(
     let messages = container(
         scroll_view::view(
             &state.scroll_view,
-            scroll_view::Kind::Channel(&state.server, &state.channel, chathistory_state),
+            scroll_view::Kind::Channel(&state.server, &state.channel),
             history,
+            chathistory_state,
             config,
             move |message, max_nick_width, max_prefix_width| {
                 let timestamp =

--- a/src/buffer/highlights.rs
+++ b/src/buffer/highlights.rs
@@ -133,14 +133,15 @@ impl Highlights {
     pub fn update(&mut self, message: Message) -> (Task<Message>, Option<Event>) {
         match message {
             Message::ScrollView(message) => {
-                let (command, event) = self.scroll_view.update(message);
+                let (command, event) = self.scroll_view.update(message, false);
 
-                let event = event.map(|event| match event {
-                    scroll_view::Event::UserContext(event) => Event::UserContext(event),
-                    scroll_view::Event::OpenChannel(channel) => Event::OpenChannel(channel),
+                let event = event.and_then(|event| match event {
+                    scroll_view::Event::UserContext(event) => Some(Event::UserContext(event)),
+                    scroll_view::Event::OpenChannel(channel) => Some(Event::OpenChannel(channel)),
                     scroll_view::Event::GoToMessage(server, channel, message) => {
-                        Event::GoToMessage(server, channel, message)
+                        Some(Event::GoToMessage(server, channel, message))
                     }
+                    scroll_view::Event::RequestOlderChatHistory => None,
                 });
 
                 (command.map(Message::ScrollView), event)

--- a/src/buffer/highlights.rs
+++ b/src/buffer/highlights.rs
@@ -30,6 +30,7 @@ pub fn view<'a>(
             &state.scroll_view,
             scroll_view::Kind::Highlights,
             history,
+            None,
             config,
             move |message, _, _| match &message.target {
                 message::Target::Highlights {

--- a/src/buffer/logs.rs
+++ b/src/buffer/logs.rs
@@ -67,12 +67,13 @@ impl Logs {
     pub fn update(&mut self, message: Message) -> (Task<Message>, Option<Event>) {
         match message {
             Message::ScrollView(message) => {
-                let (command, event) = self.scroll_view.update(message);
+                let (command, event) = self.scroll_view.update(message, false);
 
                 let event = event.and_then(|event| match event {
                     scroll_view::Event::UserContext(event) => Some(Event::UserContext(event)),
                     scroll_view::Event::OpenChannel(channel) => Some(Event::OpenChannel(channel)),
                     scroll_view::Event::GoToMessage(_, _, _) => None,
+                    scroll_view::Event::RequestOlderChatHistory => None,
                 });
 
                 (command.map(Message::ScrollView), event)

--- a/src/buffer/logs.rs
+++ b/src/buffer/logs.rs
@@ -28,6 +28,7 @@ pub fn view<'a>(
             &state.scroll_view,
             scroll_view::Kind::Logs,
             history,
+            None,
             config,
             move |message, _, _| match message.target.source() {
                 message::Source::Internal(message::source::Internal::Logs) => Some(

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -33,21 +33,12 @@ pub fn view<'a>(
     let buffer = &state.buffer;
     let input = history.input(buffer);
 
-    let chathistory_before_button = if clients.get_server_supports_chathistory(&state.server) {
-        Some((
-            clients
-                .get_chathistory_request(&state.server, state.nick.as_ref())
-                .is_some(),
-            clients.get_chathistory_exhausted(&state.server, state.nick.as_ref()),
-        ))
-    } else {
-        None
-    };
+    let chathistory_state = clients.get_chathistory_state(server, state.nick.as_ref());
 
     let messages = container(
         scroll_view::view(
             &state.scroll_view,
-            scroll_view::Kind::Query(server, &state.nick, chathistory_before_button),
+            scroll_view::Kind::Query(server, &state.nick, chathistory_state),
             history,
             config,
             move |message, max_nick_width, _| {
@@ -256,7 +247,9 @@ impl Query {
                     scroll_view::Event::UserContext(event) => Some(Event::UserContext(event)),
                     scroll_view::Event::OpenChannel(channel) => Some(Event::OpenChannel(channel)),
                     scroll_view::Event::GoToMessage(_, _, _) => None,
-                    scroll_view::Event::RequestOlderChatHistory => Event::RequestOlderChatHistory,
+                    scroll_view::Event::RequestOlderChatHistory => {
+                        Some(Event::RequestOlderChatHistory)
+                    }
                 });
 
                 (command.map(Message::ScrollView), event)

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -38,8 +38,9 @@ pub fn view<'a>(
     let messages = container(
         scroll_view::view(
             &state.scroll_view,
-            scroll_view::Kind::Query(server, &state.nick, chathistory_state),
+            scroll_view::Kind::Query(server, &state.nick),
             history,
+            chathistory_state,
             config,
             move |message, max_nick_width, _| {
                 let timestamp =

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -1,8 +1,9 @@
+use chrono::{DateTime, Utc};
 use data::isupport::ChatHistoryState;
 use data::message::{self, Limit};
 use data::server::Server;
 use data::user::Nick;
-use data::{history, time, Config};
+use data::{history, Config};
 use iced::widget::{
     button, column, container, horizontal_rule, horizontal_space, row, scrollable, text, Scrollable,
 };
@@ -18,7 +19,7 @@ pub enum Message {
     Scrolled {
         count: usize,
         remaining: bool,
-        oldest: time::Posix,
+        oldest: DateTime<Utc>,
         status: Status,
         viewport: scrollable::Viewport,
     },
@@ -111,8 +112,8 @@ pub fn view<'a>(
         .iter()
         .chain(&new_messages)
         .next()
-        .map(|message| message.received_at)
-        .unwrap_or_else(time::Posix::now);
+        .map(|message| message.server_time)
+        .unwrap_or_else(Utc::now);
     let status = state.status;
 
     let max_nick_width = max_nick_chars.map(|len| {

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -35,6 +35,7 @@ pub fn view<'a>(
             &state.scroll_view,
             scroll_view::Kind::Server(&state.server),
             history,
+            None,
             config,
             move |message, _, _| {
                 let timestamp =

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -128,12 +128,13 @@ impl Server {
     ) -> (Task<Message>, Option<Event>) {
         match message {
             Message::ScrollView(message) => {
-                let (command, event) = self.scroll_view.update(message);
+                let (command, event) = self.scroll_view.update(message, false);
 
                 let event = event.and_then(|event| match event {
                     scroll_view::Event::UserContext(event) => Some(Event::UserContext(event)),
                     scroll_view::Event::OpenChannel(channel) => Some(Event::OpenChannel(channel)),
                     scroll_view::Event::GoToMessage(_, _, _) => None,
+                    scroll_view::Event::RequestOlderChatHistory => None,
                 });
 
                 (command.map(Message::ScrollView), event)

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,10 +21,9 @@ use std::time::{Duration, Instant};
 use std::{env, mem};
 
 use appearance::{theme, Theme};
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 use data::config::{self, Config};
 use data::history::{self, manager::Broadcast};
-use data::isupport::ChatHistorySubcommand;
 use data::version::Version;
 use data::{environment, server, version, Server, Url, User};
 use iced::widget::{column, container};
@@ -227,12 +226,6 @@ pub enum Message {
     Window(window::Id, window::Event),
     WindowSettingsSaved(Result<(), window::Error>),
     Logging(Vec<logger::Record>),
-    ChatHistoryRequest(server::Server, ChatHistorySubcommand),
-    UpdateChatHistoryTargetsTimestamp(
-        server::Server,
-        DateTime<Utc>,
-        Result<(), data::client::Error>,
-    ),
 }
 
 impl Halloy {
@@ -774,160 +767,59 @@ impl Halloy {
                                         );
                                     }
                                     data::client::Event::JoinedChannel(channel, server_time) => {
-                                        let command = dashboard
-                                            .load_metadata(server.clone(), channel.clone())
-                                            .map_or(Task::none(), |command| command.map(Message::Dashboard));
-
-                                        let command = if self.clients.get_server_supports_chathistory(&server) {
-                                            command.chain(Task::done(Message::Dashboard(
-                                                dashboard::Message::RequestNewerChatHistory(
-                                                    server.clone(),
-                                                    channel,
-                                                    server_time,
-                                                ),
-                                            )))
-                                        } else {
-                                            command
-                                        };
-
-                                        commands.push(command);
+                                        if let Some(command) = dashboard
+                                            .load_metadata(
+                                                &self.clients,
+                                                server.clone(),
+                                                channel.clone(),
+                                                server_time,
+                                            )
+                                            .map(|command| command.map(Message::Dashboard))
+                                        {
+                                            commands.push(command);
+                                        }
                                     }
                                     data::client::Event::ChatHistoryAcknowledged(server_time) => {
-                                        let server = server.clone();
-
-                                        commands.push(Task::perform(
-                                            async move {
-                                                (
-                                                    server.clone(),
-                                                    data::client::load_chathistory_targets_timestamp(server.clone())
-                                                        .await
-                                                        .ok()
-                                                        .flatten(),
-                                                )
-                                            },
-                                            move |(server, timestamp)| {
-                                                Message::Dashboard(dashboard::Message::RequestChatHistoryTargets(
-                                                    server,
-                                                    timestamp,
-                                                    server_time,
-                                                ))
-                                            },
-                                        ));
-                                    }
-                                    data::client::Event::ChatHistoryRequest(subcommand) => {
-                                        self.clients.send_chathistory_request(
-                                            &server,
-                                            subcommand,
-                                        );
-                                    }
-                                    data::client::Event::ChatHistoryRequestReceived(
-                                        subcommand,
-                                        batch_len,
-                                    ) => {
-                                        match &subcommand {
-                                            ChatHistorySubcommand::Latest(target, message_reference, _) => {
-                                                log::debug!(
-                                                    "[{}] received latest {} messages in {} since {}",
-                                                    server,
-                                                    batch_len,
-                                                    target,
-                                                    message_reference,
-                                                );
-                                            }
-                                            ChatHistorySubcommand::Before(target, message_reference, _) => {
-                                                log::debug!(
-                                                    "[{}] received {} messages in {} before {}",
-                                                    server,
-                                                    batch_len,
-                                                    target,
-                                                    message_reference,
-                                                );
-                                            }
-                                            ChatHistorySubcommand::Between(
-                                                target,
-                                                start_message_reference,
-                                                end_message_reference,
-                                                _,
-                                            ) => {
-                                                log::debug!(
-                                                    "[{}] received {} messages in {} between {} and {}",
-                                                    server,
-                                                    batch_len,
-                                                    target,
-                                                    start_message_reference,
-                                                    end_message_reference,
-                                                );
-                                            }
-                                            ChatHistorySubcommand::Targets(
-                                                start_message_reference,
-                                                end_message_reference,
-                                                _,
-                                            ) => {
-                                                log::debug!(
-                                                    "[{}] received {} targets between {} and {}",
-                                                    server,
-                                                    batch_len,
-                                                    start_message_reference,
-                                                    end_message_reference,
-                                                );
-                                            }
-                                        }
-
-                                        self.clients.clear_chathistory_request(&server, subcommand.target());
-                                    }
-                                    data::client::Event::ChatHistoryTarget(target, server_time) => {
-                                        let command = dashboard
-                                            .load_metadata(server.clone(), target.clone())
-                                            .map_or(Task::none(), |command| command.map(Message::Dashboard));
-
-                                        let command = command.chain(Task::done(Message::Dashboard(
-                                            dashboard::Message::RequestNewerChatHistory(
-                                                server.clone(),
-                                                target,
+                                        if let Some(command) = dashboard
+                                            .load_chathistory_targets_timestamp(
+                                                &self.clients,
+                                                &server,
                                                 server_time,
-                                            ),
-                                        )));
-
-                                        commands.push(command);
+                                            )
+                                            .map(|command| command.map(Message::Dashboard))
+                                        {
+                                            commands.push(command);
+                                        }
+                                    }
+                                    data::client::Event::ChatHistoryTargetReceived(
+                                        target,
+                                        server_time,
+                                    ) => {
+                                        if let Some(command) = dashboard
+                                            .load_metadata(
+                                                &self.clients,
+                                                server.clone(),
+                                                target.clone(),
+                                                server_time,
+                                            )
+                                            .map(|command| command.map(Message::Dashboard))
+                                        {
+                                            commands.push(command);
+                                        }
                                     }
                                     data::client::Event::ChatHistoryTargetsReceived(
-                                        subcommand,
-                                        batch_len,
-                                        server_time
+                                        server_time,
                                     ) => {
-                                        if let ChatHistorySubcommand::Targets(
-                                                start_message_reference,
-                                                end_message_reference,
-                                                _,
-                                        ) = subcommand {
-                                            log::debug!(
-                                                "[{}] received {} targets between {} and {}",
-                                                server.clone(),
-                                                batch_len,
-                                                start_message_reference,
-                                                end_message_reference,
-                                            );
+                                        if let Some(command) = dashboard
+                                            .overwrite_chathistory_targets_timestamp(
+                                                &self.clients,
+                                                &server,
+                                                server_time,
+                                            )
+                                            .map(|command| command.map(Message::Dashboard))
+                                        {
+                                            commands.push(command);
                                         }
-
-                                        let server = server.clone();
-
-                                        commands.push(
-                                            Task::perform(
-                                                async move {
-                                                    (
-                                                        server.clone(),
-                                                        data::client::overwrite_chathistory_targets_timestamp(
-                                                            server,
-                                                            server_time,
-                                                        )
-                                                        .await,
-                                                    )
-                                                },
-                                                move |(server, result)| {
-                                                    Message::UpdateChatHistoryTargetsTimestamp(server, server_time, result)
-                                                }
-                                            ),
-                                        );
                                     }
                                 }
                             }
@@ -1119,23 +1011,6 @@ impl Halloy {
                         .map(|record| dashboard.record_log(record)),
                 )
                 .map(Message::Dashboard)
-            }
-            Message::ChatHistoryRequest(server, subcommand) => {
-                self.clients.send_chathistory_request(&server, subcommand);
-
-                Task::none()
-            }
-            Message::UpdateChatHistoryTargetsTimestamp(server, timestamp, Ok(_)) => {
-                log::debug!("updated targets timestamp for {server} to {timestamp}");
-
-                Task::none()
-            }
-            Message::UpdateChatHistoryTargetsTimestamp(server, timestamp, Err(error)) => {
-                log::warn!(
-                    "failed to update targets timestamp for {server} to {timestamp}: {error}"
-                );
-
-                Task::none()
             }
         }
     }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -368,25 +368,10 @@ impl Dashboard {
                                     if let Some((window, pane, state)) =
                                         self.panes.get_mut_by_buffer(main_window.id, &buffer)
                                     {
-                                        let chathistory_state =
-                                            state.buffer.upstream().and_then(|upstream| {
-                                                upstream.target().as_ref().and_then(|target| {
-                                                    clients.get_chathistory_state(
-                                                        upstream.server(),
-                                                        target,
-                                                    )
-                                                })
-                                            });
-
                                         tasks.push(
                                             state
                                                 .buffer
-                                                .scroll_to_message(
-                                                    message,
-                                                    &self.history,
-                                                    config,
-                                                    chathistory_state,
-                                                )
+                                                .scroll_to_message(message, &self.history, config)
                                                 .map(move |message| {
                                                     Message::Pane(
                                                         window,
@@ -585,23 +570,15 @@ impl Dashboard {
                             if let Some((window, pane, state)) =
                                 self.panes.get_mut_by_buffer(main_window.id, &buffer)
                             {
-                                let chathistory_state =
-                                    state.buffer.upstream().and_then(|upstream| {
-                                        upstream.target().as_ref().and_then(|target| {
-                                            clients.get_chathistory_state(upstream.server(), target)
-                                        })
-                                    });
-
                                 return (
-                                    state
-                                        .buffer
-                                        .scroll_to_backlog(&self.history, config, chathistory_state)
-                                        .map(move |message| {
+                                    state.buffer.scroll_to_backlog(&self.history, config).map(
+                                        move |message| {
                                             Message::Pane(
                                                 window,
                                                 pane::Message::Buffer(pane, message),
                                             )
-                                        }),
+                                        },
+                                    ),
                                     None,
                                 );
                             }


### PR DESCRIPTION
A refactoring of the previous [`chathistory`](https://ircv3.net/specs/extensions/chathistory) PR.  It has all of the same features as before (plus a new configuration option), but the plumbing has been restructured to better match the paradigm set by the `draft/read-marker` PR.

Features (when `chathistory` is supported by the server):
- Uses `chathistory` to request new history for all joined channels from the server (limited to one request if no history for the channel that exists, 500 messages or the maximum number of messages allowed by the server).
- Adds button at the start of  channel/query buffers to request older history via `chathistory`.
- Uses `chathistory` to determine whether queries were received since last connection to the server, then request the new history for those queries from the server.
- Configuration option to automatically request older history when scrolling to the top of a channel/query buffer (`infinite_scroll`).
- Configuration option to disable `chathistory` for a server.

I haven't had much time to test it since refactoring, so I may make fixes in this PR as testing continues.  But so far it is working as intended for me, has the entirety of my intended functionality for initial support, and is ready for review.