### PR TITLE
Add `IRC` to linux desktop file keywords

### DIFF
--- a/assets/linux/org.squidowl.halloy.desktop
+++ b/assets/linux/org.squidowl.halloy.desktop
@@ -2,7 +2,7 @@
 Name=Halloy
 Comment=IRC client written in Rust
 Type=Application
-Keywords=IM;Chat;
+Keywords=IRC;IM;Chat;
 Categories=Network;IRCClient;
 Exec=halloy %U
 Icon=org.squidowl.halloy


### PR DESCRIPTION
This makes it show up when searching "irc" on GNOME.