### PR TITLE
Add users to userlist on PRIVMSG event

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -675,6 +675,13 @@ impl Client {
                             }
                         }
 
+                        // add user to user list if we somehow missed the join
+                        if let Some(channel) = self.chanmap.get_mut(channel) {
+                            if channel.users.take(&user).is_none() {
+                                channel.users.insert(user.clone());
+                            }
+                        }
+
                         // Highlight notification
                         if message::references_user_text(user.nickname(), self.nickname(), text) {
                             return Ok(vec![Event::Notification(


### PR DESCRIPTION
A certain irc server doesn't respond to WHO properly, and we might have missed the join. This means that we might never actually know that that user is in the channel even if they are sending messages.

The best fix I could come up with client-side for this is to just add the user to the channel's userlist on a PRIVMSG event.