### PR TITLE
Minor Fixes

### DIFF
--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -569,6 +569,7 @@ impl Parameter {
             Parameter::AWAYLEN(_) => Some(Kind::AWAYLEN),
             Parameter::CHANLIMIT(_) => Some(Kind::CHANLIMIT),
             Parameter::CHANNELLEN(_) => Some(Kind::CHANNELLEN),
+            Parameter::CHANTYPES(_) => Some(Kind::CHANTYPES),
             Parameter::CNOTICE => Some(Kind::CNOTICE),
             Parameter::CPRIVMSG => Some(Kind::CPRIVMSG),
             Parameter::ELIST(_) => Some(Kind::ELIST),

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -129,7 +129,13 @@ impl Target {
     pub fn prefixes(&self) -> Option<&[char]> {
         match self {
             Target::Server { .. } => None,
-            Target::Channel { prefixes, .. } => Some(prefixes),
+            Target::Channel { prefixes, .. } => {
+                if prefixes.is_empty() {
+                    None
+                } else {
+                    Some(prefixes)
+                }
+            }
             Target::Query { .. } => None,
             Target::Logs => None,
             Target::Highlights { .. } => None,

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -38,7 +38,7 @@ pub fn setup(is_debug: bool) -> Result<ReceiverStream<Vec<Record>>, Error> {
         io_sink = io_sink.chain(log_file);
     }
 
-    let (channel_sink, reciever) = channel_logger();
+    let (channel_sink, receiver) = channel_logger();
 
     fern::Dispatch::new()
         .level(log::LevelFilter::Off)
@@ -50,7 +50,7 @@ pub fn setup(is_debug: bool) -> Result<ReceiverStream<Vec<Record>>, Error> {
         .chain(channel_sink)
         .apply()?;
 
-    Ok(reciever)
+    Ok(receiver)
 }
 
 fn channel_logger() -> (Box<dyn Log>, ReceiverStream<Vec<Record>>) {


### PR DESCRIPTION
A few minor things I found while working on `chathistory`.  A typo, a missed return value, and a tweak to the return value for `prefixes`.  If brackets are configured for status message prefixes, then brackets were being placed around the empty list of prefixes (e.g. with `(` and `)` configured as status message prefix brackets, `()` was being prepended to virtually every message in a channel).  I'm open to changing the prefix bracketing logic instead of the return value, but changing the return value for `prefixes` seemed cleaner to me.