### PR TITLE
Miscellaneous Chat History Fixes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -767,17 +767,16 @@ impl Halloy {
                                         );
                                     }
                                     data::client::Event::JoinedChannel(channel, server_time) => {
-                                        if let Some(command) = dashboard
+                                        let command = dashboard
                                             .load_metadata(
                                                 &self.clients,
                                                 server.clone(),
                                                 channel.clone(),
                                                 server_time,
                                             )
-                                            .map(|command| command.map(Message::Dashboard))
-                                        {
-                                            commands.push(command);
-                                        }
+                                            .map(Message::Dashboard);
+
+                                        commands.push(command);
                                     }
                                     data::client::Event::ChatHistoryAcknowledged(server_time) => {
                                         if let Some(command) = dashboard
@@ -795,17 +794,16 @@ impl Halloy {
                                         target,
                                         server_time,
                                     ) => {
-                                        if let Some(command) = dashboard
+                                        let command = dashboard
                                             .load_metadata(
                                                 &self.clients,
                                                 server.clone(),
                                                 target.clone(),
                                                 server_time,
                                             )
-                                            .map(|command| command.map(Message::Dashboard))
-                                        {
-                                            commands.push(command);
-                                        }
+                                            .map(Message::Dashboard);
+
+                                        commands.push(command);
                                     }
                                     data::client::Event::ChatHistoryTargetsReceived(
                                         server_time,

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1488,14 +1488,25 @@ impl Dashboard {
                     &message_reference_types,
                 );
 
-                clients.send_chathistory_request(
-                    server,
-                    ChatHistorySubcommand::Before(
-                        target.clone(),
-                        first_can_reference,
-                        clients.get_server_chathistory_limit(server),
-                    ),
-                );
+                if matches!(first_can_reference, MessageReference::None) {
+                    clients.send_chathistory_request(
+                        server,
+                        ChatHistorySubcommand::Latest(
+                            target.clone(),
+                            first_can_reference,
+                            clients.get_server_chathistory_limit(server),
+                        ),
+                    );
+                } else {
+                    clients.send_chathistory_request(
+                        server,
+                        ChatHistorySubcommand::Before(
+                            target.clone(),
+                            first_can_reference,
+                            clients.get_server_chathistory_limit(server),
+                        ),
+                    );
+                }
             }
         }
     }
@@ -1533,21 +1544,19 @@ impl Dashboard {
         server: Server,
         channel: String,
         server_time: DateTime<Utc>,
-    ) -> Option<Task<Message>> {
+    ) -> Task<Message> {
         let command = self
             .history
             .load_metadata(server.clone(), channel.clone())
-            .map(|task| Task::perform(task, Message::History));
+            .map_or(Task::none(), |task| Task::perform(task, Message::History));
 
-        command.map(|command| {
-            if clients.get_server_supports_chathistory(&server) {
-                command.chain(Task::done(Message::Client(
-                    data::client::Message::RequestNewerChatHistory(server, channel, server_time),
-                )))
-            } else {
-                command
-            }
-        })
+        if clients.get_server_supports_chathistory(&server) {
+            command.chain(Task::done(Message::Client(
+                data::client::Message::RequestNewerChatHistory(server, channel, server_time),
+            )))
+        } else {
+            command
+        }
     }
 
     pub fn load_chathistory_targets_timestamp(

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1488,25 +1488,21 @@ impl Dashboard {
                     &message_reference_types,
                 );
 
-                if matches!(first_can_reference, MessageReference::None) {
-                    clients.send_chathistory_request(
-                        server,
-                        ChatHistorySubcommand::Latest(
-                            target.clone(),
-                            first_can_reference,
-                            clients.get_server_chathistory_limit(server),
-                        ),
-                    );
+                let subcommand = if matches!(first_can_reference, MessageReference::None) {
+                    ChatHistorySubcommand::Latest(
+                        target.clone(),
+                        first_can_reference,
+                        clients.get_server_chathistory_limit(server),
+                    )
                 } else {
-                    clients.send_chathistory_request(
-                        server,
-                        ChatHistorySubcommand::Before(
-                            target.clone(),
-                            first_can_reference,
-                            clients.get_server_chathistory_limit(server),
-                        ),
-                    );
-                }
+                    ChatHistorySubcommand::Before(
+                        target.clone(),
+                        first_can_reference,
+                        clients.get_server_chathistory_limit(server),
+                    )
+                };
+
+                clients.send_chathistory_request(server, subcommand);
             }
         }
     }


### PR DESCRIPTION
Two minor fixes.

1.  After one of the refactors history requests were no longer being made for the active buffer (due to metadata not being loaded, so there was no command to chain off of for the chathistory request).
2.  Requesting older chat history messages would fail for buffers with no messages in their history (because they produced an invalid chathistory request; `MessageReference::None` is not allowed for `BEFORE` chathistory requests).