### PR TITLE
Timeout delay for notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Added:
   - Ability to disable dimming of away usernames. See [buffer configuartion](https://halloy.squidowl.org/configuration/buffer/away.html).
 - Enable support for IRCv3 `chathistory`
 - Highlight notifications for `/me` actions
+- Timeout delay for notifications
 
 # 2024.14 (2024-10-29)
 

--- a/book/src/configuration/notifications.md
+++ b/book/src/configuration/notifications.md
@@ -19,6 +19,8 @@ Following notifications are available:
 | `disconnected`          | Triggered when a server disconnects                |
 | `file_transfer_request` | Triggered when a file transfer request is received |
 | `highlight`             | Triggered when you were highlighted in a buffer    |
+| `monitored_online`      | Triggered when a user you're monitoring is online  |
+| `monitored_offline`     | Triggered when a user you're monitoring is offline |
 | `reconnected`           | Triggered when a server reconnects                 |
 
 
@@ -39,3 +41,11 @@ Notification should trigger a OS toast.
 - **type**: boolean
 - **values**: `true`, `false`
 - **default**: `false`
+
+## `delay`
+
+Delay in milliseconds before triggering the next notification.
+
+- **type**: integer
+- **values**: `0` or greater
+- **default**: `500`

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -46,14 +46,18 @@ pub enum State {
     Ready(Client),
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum Notification {
+    Connected,
+    Disconnected,
+    Reconnected,
     DirectMessage(User),
     Highlight {
         enabled: bool,
         user: User,
         channel: String,
     },
+    FileTransferRequest(Nick),
     MonitoredOnline(Vec<User>),
     MonitoredOffline(Vec<Nick>),
 }

--- a/data/src/config/notification.rs
+++ b/data/src/config/notification.rs
@@ -9,6 +9,7 @@ pub struct Notification<T = String> {
     #[serde(default)]
     pub show_toast: bool,
     pub sound: Option<T>,
+    pub delay: Option<u64>,
 }
 
 impl<T> Default for Notification<T> {
@@ -16,6 +17,7 @@ impl<T> Default for Notification<T> {
         Self {
             show_toast: false,
             sound: None,
+            delay: Some(500),
         }
     }
 }
@@ -61,6 +63,7 @@ impl Notifications {
             Ok(Notification {
                 show_toast: notification.show_toast,
                 sound: notification.sound.as_deref().map(Sound::load).transpose()?,
+                delay: notification.delay,
             })
         };
 

--- a/irc/proto/src/lib.rs
+++ b/irc/proto/src/lib.rs
@@ -104,7 +104,6 @@ macro_rules! command {
 mod tests {
     use super::*;
 
-
     // Reference: https://defs.ircdocs.horse/defs/chanmembers
     const CHANNEL_MEMBERSHIP_PREFIXES: &[char] = &['~', '&', '!', '@', '%', '+'];
 

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -44,6 +44,7 @@ pub struct Dashboard {
     command_bar: Option<CommandBar>,
     file_transfers: file_transfer::Manager,
     theme_editor: Option<ThemeEditor>,
+    notifications: notification::Notifications,
 }
 
 #[derive(Debug)]
@@ -88,6 +89,7 @@ impl Dashboard {
             command_bar: None,
             file_transfers: file_transfer::Manager::new(config.file_transfer.clone()),
             theme_editor: None,
+            notifications: notification::Notifications::new(),
         };
 
         let command = dashboard.track();
@@ -1864,7 +1866,11 @@ impl Dashboard {
             .file_transfers
             .receive(request.clone(), config.proxy.as_ref())
         {
-            notification::file_transfer_request(&config.notifications, request.from, server);
+            self.notifications.notify(
+                &config.notifications,
+                &client::Notification::FileTransferRequest(request.from.clone()),
+                Some(server),
+            );
 
             return Some(self.handle_file_transfer_event(server, event));
         }
@@ -1949,6 +1955,7 @@ impl Dashboard {
             command_bar: None,
             file_transfers: file_transfer::Manager::new(config.file_transfer.clone()),
             theme_editor: None,
+            notifications: notification::Notifications::new(),
         };
 
         let mut tasks = vec![];


### PR DESCRIPTION
Added timeout delay for ~~direct message~~ all notifications to prevent multiple simultaneous messages flooding with notification sounds.

Default is set to 500ms.
Addresses issue #600. 

EDIT: Refactored for all notifications.

EDIT 2: I had looked into maybe turning `Notifications` into a trait. But I don't think that's what traits are meant for. So I'll leave it for now. If anyone has any suggestions for refactors or improvements, I am open :pray: 