### PR TITLE
Fix bug - case-sensitive channel name handling

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -492,7 +492,7 @@ impl Client {
                             .and_then(|chathistory| chathistory.target())
                     })
                     .and_then(|target| {
-                        if self.chathistory_requests.contains_key(&target) {
+                        if self.chathistory_requests.contains_key(&target.to_lowercase()) {
                             Some(target)
                         } else {
                             None
@@ -1147,7 +1147,7 @@ impl Client {
                 let user = ok!(message.user());
 
                 if user.nickname() == self.nickname() {
-                    self.chanmap.insert(channel.clone(), Channel::default());
+                    self.chanmap.insert(channel.to_lowercase(), Channel::default());
 
                     // Sends WHO to get away state on users if WHO poll is enabled.
                     if self.config.who_poll_enabled {
@@ -1578,7 +1578,8 @@ impl Client {
                             self.chantypes(),
                             self.statusmsg(),
                         ) {
-                            if !prefixes.is_empty() && self.chanmap.contains_key(&channel) {
+                            let channel_lower = channel.to_lowercase();
+                            if !prefixes.is_empty() && self.chanmap.contains_key(&channel_lower) {
                                 return Ok(vec![Event::ChatHistoryTargetReceived(
                                     target.clone(),
                                     server_time(&message),
@@ -1592,6 +1593,7 @@ impl Client {
                         }
                     }
                 }
+            
 
                 return Ok(vec![]);
             }
@@ -1660,18 +1662,18 @@ impl Client {
 
     pub fn chathistory_request(&self, target: &str) -> Option<ChatHistorySubcommand> {
         self.chathistory_requests
-            .get(target)
+            .get(&target.to_string().to_lowercase())
             .map(|request| request.subcommand.clone())
     }
 
     pub fn send_chathistory_request(&mut self, subcommand: ChatHistorySubcommand) {
         if self.supports_chathistory {
             if let Some(target) = subcommand.target() {
-                if self.chathistory_requests.contains_key(target) {
+                if self.chathistory_requests.contains_key(&target.to_lowercase()) {
                     return;
                 } else {
                     self.chathistory_requests.insert(
-                        target.to_string(),
+                        target.to_string().to_lowercase(),
                         ChatHistoryRequest {
                             subcommand: subcommand.clone(),
                             requested_at: Instant::now(),

--- a/irc/proto/src/lib.rs
+++ b/irc/proto/src/lib.rs
@@ -82,7 +82,8 @@ pub fn parse_channel_from_target(
     // This will not panic, since `find` always returns a valid codepoint index.
     // We call `find` -> `split_at` because it is an _inclusive_ split, which includes the match.
     // We need to return this since the channel target includes its chantype.
-    let (prefix, chan) = target.split_at(chan_index);
+    let (prefix, chanoriginal) = target.split_at(chan_index);
+    let chan = chanoriginal.to_lowercase();
     if prefix.chars().all(|ref c| statusmsg_prefixes.contains(c)) {
         Some((prefix.chars().collect(), chan.to_owned()))
     } else {


### PR DESCRIPTION
This seems to fix the issue described in https://github.com/squidowl/halloy/issues/494 where unneeded case-sensitivity in handling channel names causes people's messages to not be displayed if those people joined a channel using different capitalisation than you (on servers that do not normalise case). 

IRC standard specifies case-insensitive channel names per [RFC 2812](https://www.rfc-editor.org/rfc/rfc2812.txt#:~:text=Channel%20names%20are%20case%20insensitive.). 

Apologies if the way I've changed it isn't great or introduces another bug that I did not find testing this, I am not fluent in rust.