### PR TITLE
No Sent Messages as `chathistory` Reference

### DIFF
--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -189,7 +189,9 @@ impl Message {
     }
 
     pub fn can_reference(&self) -> bool {
-        if matches!(self.target.source(), Source::Internal(_)) {
+        if matches!(self.direction, Direction::Sent)
+            || matches!(self.target.source(), Source::Internal(_))
+        {
             return false;
         } else if let Source::Server(Some(source)) = self.target.source() {
             if matches!(

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -316,37 +316,37 @@ impl<'a> From<&'a str> for NickRef<'a> {
     }
 }
 
-impl<'a> NickRef<'a> {
+impl NickRef<'_> {
     pub fn to_owned(self) -> Nick {
         Nick(self.0.to_string())
     }
 }
 
-impl<'a> fmt::Display for NickRef<'a> {
+impl fmt::Display for NickRef<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
 }
 
-impl<'a> AsRef<str> for NickRef<'a> {
+impl AsRef<str> for NickRef<'_> {
     fn as_ref(&self) -> &str {
         self.0
     }
 }
 
-impl<'a> PartialOrd for NickRef<'a> {
+impl PartialOrd for NickRef<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.0.to_lowercase().cmp(&other.0.to_lowercase()))
     }
 }
 
-impl<'a> Ord for NickRef<'a> {
+impl Ord for NickRef<'_> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.0.to_lowercase().cmp(&other.0.to_lowercase())
     }
 }
 
-impl<'a> PartialEq<Nick> for NickRef<'a> {
+impl PartialEq<Nick> for NickRef<'_> {
     fn eq(&self, other: &Nick) -> bool {
         self.0.eq(other.0.as_str())
     }

--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -37,7 +37,7 @@ pub fn update(message: Message) -> Option<Event> {
 
 pub fn view<'a>(
     server: &'a Server,
-    channel: &'a String,
+    channel: &'a str,
     content: &'a message::Content,
     who: Option<&'a str>,
     time: Option<&'a DateTime<Utc>>,

--- a/src/widget/anchored_overlay.rs
+++ b/src/widget/anchored_overlay.rs
@@ -32,7 +32,7 @@ struct AnchoredOverlay<'a, Message> {
     offset: f32,
 }
 
-impl<'a, Message> Widget<Message, Theme, Renderer> for AnchoredOverlay<'a, Message> {
+impl<Message> Widget<Message, Theme, Renderer> for AnchoredOverlay<'_, Message> {
     fn size(&self) -> Size<Length> {
         self.base.as_widget().size()
     }
@@ -184,7 +184,7 @@ struct Overlay<'a, 'b, Message> {
     position: Point,
 }
 
-impl<'a, 'b, Message> overlay::Overlay<Message, Theme, Renderer> for Overlay<'a, 'b, Message> {
+impl<Message> overlay::Overlay<Message, Theme, Renderer> for Overlay<'_, '_, Message> {
     fn layout(&mut self, renderer: &Renderer, bounds: Size) -> layout::Node {
         let height = match self.anchor {
             // From top of base to top of viewport

--- a/src/widget/context_menu.rs
+++ b/src/widget/context_menu.rs
@@ -379,8 +379,8 @@ struct Overlay<'a, 'b, Message, Theme, Renderer> {
     position: Point,
 }
 
-impl<'a, 'b, Message, Theme, Renderer> overlay::Overlay<Message, Theme, Renderer>
-    for Overlay<'a, 'b, Message, Theme, Renderer>
+impl<Message, Theme, Renderer> overlay::Overlay<Message, Theme, Renderer>
+    for Overlay<'_, '_, Message, Theme, Renderer>
 where
     Renderer: advanced::Renderer,
 {

--- a/src/widget/modal.rs
+++ b/src/widget/modal.rs
@@ -44,8 +44,8 @@ impl<'a, Message, Theme, Renderer> Modal<'a, Message, Theme, Renderer> {
     }
 }
 
-impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
-    for Modal<'a, Message, Theme, Renderer>
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Modal<'_, Message, Theme, Renderer>
 where
     Renderer: advanced::Renderer,
 {
@@ -173,8 +173,8 @@ struct Overlay<'a, 'b, Message, Theme, Renderer> {
     on_blur: &'b dyn Fn() -> Message,
 }
 
-impl<'a, 'b, Message, Theme, Renderer> overlay::Overlay<Message, Theme, Renderer>
-    for Overlay<'a, 'b, Message, Theme, Renderer>
+impl<Message, Theme, Renderer> overlay::Overlay<Message, Theme, Renderer>
+    for Overlay<'_, '_, Message, Theme, Renderer>
 where
     Renderer: advanced::Renderer,
 {

--- a/src/widget/selectable_rich_text.rs
+++ b/src/widget/selectable_rich_text.rs
@@ -199,8 +199,8 @@ where
     }
 }
 
-impl<'a, Message, Link, Entry, Theme, Renderer> Default
-    for Rich<'a, Message, Link, Entry, Theme, Renderer>
+impl<Message, Link, Entry, Theme, Renderer> Default
+    for Rich<'_, Message, Link, Entry, Theme, Renderer>
 where
     Link: self::Link + 'static,
     Theme: Catalog,

--- a/src/widget/selectable_text.rs
+++ b/src/widget/selectable_text.rs
@@ -120,7 +120,7 @@ where
     }
 }
 
-impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer> for Text<'a, Theme, Renderer>
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer> for Text<'_, Theme, Renderer>
 where
     Renderer: text::Renderer,
     Theme: Catalog,


### PR DESCRIPTION
Sent messages may not be have been registered by the server yet.  This prevents the following bug:
1.  User is disconnected.
2.  Chat continues in the channel(s) the user is in while they're disconnected.
3.  User sends a message while disconnected.
4.  User reconnects.  Message sent in 3 is used as the reference for requesting chat history, but it was sent (locally) after all the messages in 2 were sent.  As a result, messages sent in 2 are never received.

At some point this could be refined to verify that the message has been received by the server, but for now skipping all sent messages will likely only result in a few extra messages being transmitted and avoids any potential for a false positive.