### PR TITLE
`CASEMAPPING` Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Added:
 - Enable support for IRCv3 `chathistory`
 - Highlight notifications for `/me` actions
 - Timeout delay for notifications
+- Case mapping support via `ISUPPORT`
 
 # 2024.14 (2024-10-29)
 

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -6,7 +6,8 @@ pub use self::away::Away;
 
 pub mod away;
 
-use crate::{channel, config, message, target, Server};
+use crate::target::{self, Target};
+use crate::{channel, config, message, Server};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -62,10 +63,10 @@ impl Upstream {
         }
     }
 
-    pub fn target(&self) -> Option<target::Target> {
+    pub fn target(&self) -> Option<Target> {
         match self {
-            Self::Channel(_, channel) => Some(target::Target::Channel(channel.clone())),
-            Self::Query(_, query) => Some(target::Target::Query(query.clone())),
+            Self::Channel(_, channel) => Some(Target::Channel(channel.clone())),
+            Self::Query(_, query) => Some(Target::Query(query.clone())),
             Self::Server(_) => None,
         }
     }

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -6,8 +6,7 @@ pub use self::away::Away;
 
 pub mod away;
 
-use crate::user::Nick;
-use crate::{channel, config, message, Server};
+use crate::{channel, config, message, target, Server};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -19,8 +18,8 @@ pub enum Buffer {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Upstream {
     Server(Server),
-    Channel(Server, String),
-    Query(Server, Nick),
+    Channel(Server, target::Channel),
+    Query(Server, target::Query),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, strum::Display)]
@@ -56,17 +55,17 @@ impl Upstream {
         }
     }
 
-    pub fn channel(&self) -> Option<&str> {
+    pub fn channel(&self) -> Option<&target::Channel> {
         match self {
             Self::Channel(_, channel) => Some(channel),
             Self::Server(_) | Self::Query(_, _) => None,
         }
     }
 
-    pub fn target(&self) -> Option<String> {
+    pub fn target(&self) -> Option<target::Target> {
         match self {
-            Self::Channel(_, channel) => Some(channel.clone()),
-            Self::Query(_, nick) => Some(nick.to_string()),
+            Self::Channel(_, channel) => Some(target::Target::Channel(channel.clone())),
+            Self::Query(_, query) => Some(target::Target::Query(query.clone())),
             Self::Server(_) => None,
         }
     }
@@ -79,10 +78,9 @@ impl Upstream {
             Self::Channel(_, channel) => message::Target::Channel {
                 channel,
                 source: message::Source::Server(source),
-                prefixes: Default::default(),
             },
-            Self::Query(_, nick) => message::Target::Query {
-                nick,
+            Self::Query(_, query) => message::Target::Query {
+                query,
                 source: message::Source::Server(source),
             },
         }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -55,7 +55,7 @@ pub enum Notification {
     Highlight {
         enabled: bool,
         user: User,
-        channel: target::Channel,
+        target: target::Target,
     },
     FileTransferRequest(Nick),
     MonitoredOnline(Vec<User>),
@@ -929,7 +929,7 @@ impl Client {
                     });
                 }
             }
-            Command::PRIVMSG(channel, text) | Command::NOTICE(channel, text) => {
+            Command::PRIVMSG(target, text) | Command::NOTICE(target, text) => {
                 if let Some(user) = message.user() {
                     if let Some(command) = dcc::decode(text) {
                         match command {
@@ -1010,12 +1010,12 @@ impl Client {
                                 Notification::Highlight {
                                     enabled: self.highlight_blackout.allow_highlights(),
                                     user,
-                                    channel: target::Channel::parse(
-                                        channel,
+                                    target: target::Target::parse(
+                                        target,
                                         self.chantypes(),
                                         self.statusmsg(),
                                         self.casemapping(),
-                                    )?,
+                                    ),
                                 },
                             )]);
                         } else if user.nickname() == self.nickname()
@@ -1028,8 +1028,8 @@ impl Client {
                             return Ok(vec![]);
                         }
 
-                        // use `channel` to confirm the direct message, then send notification
-                        if channel == &self.nickname().to_string() {
+                        // use `target` to confirm the direct message, then send notification
+                        if target == &self.nickname().to_string() {
                             return Ok(vec![Event::Notification(
                                 message.clone(),
                                 self.nickname().to_owned(),

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -20,7 +20,7 @@ use crate::user::{Nick, NickRef};
 use crate::{
     buffer, compression, config, ctcp, dcc, environment, isupport, message, mode, Server, User,
 };
-use crate::{file_transfer, server};
+use crate::{file_transfer, server, target};
 
 const HIGHLIGHT_BLACKOUT_INTERVAL: Duration = Duration::from_secs(5);
 
@@ -67,20 +67,20 @@ pub enum Broadcast {
     Quit {
         user: User,
         comment: Option<String>,
-        channels: Vec<String>,
+        channels: Vec<target::Channel>,
         sent_time: DateTime<Utc>,
     },
     Nickname {
         old_user: User,
         new_nick: Nick,
         ourself: bool,
-        channels: Vec<String>,
+        channels: Vec<target::Channel>,
         sent_time: DateTime<Utc>,
     },
     Invite {
         inviter: User,
-        channel: String,
-        user_channels: Vec<String>,
+        channel: target::Channel,
+        user_channels: Vec<target::Channel>,
         sent_time: DateTime<Utc>,
     },
     ChangeHost {
@@ -88,7 +88,7 @@ pub enum Broadcast {
         new_username: String,
         new_hostname: String,
         ourself: bool,
-        channels: Vec<String>,
+        channels: Vec<target::Channel>,
         sent_time: DateTime<Utc>,
     },
 }
@@ -109,7 +109,7 @@ pub enum Event {
     Notification(message::Encoded, Nick, Notification),
     FileTransferRequest(file_transfer::ReceiveRequest),
     UpdateReadMarker(String, ReadMarker),
-    JoinedChannel(String, DateTime<Utc>),
+    JoinedChannel(target::Channel, DateTime<Utc>),
     ChatHistoryAcknowledged(DateTime<Utc>),
     ChatHistoryTargetReceived(String, DateTime<Utc>),
     ChatHistoryTargetsReceived(DateTime<Utc>),
@@ -126,11 +126,11 @@ pub struct Client {
     handle: server::Handle,
     alt_nick: Option<usize>,
     resolved_nick: Option<String>,
-    chanmap: BTreeMap<String, Channel>,
-    channels: Vec<String>,
-    users: HashMap<String, Vec<User>>,
+    chanmap: BTreeMap<target::Channel, Channel>,
+    channels: Vec<target::Channel>,
+    users: HashMap<target::Channel, Vec<User>>,
     labels: HashMap<String, Context>,
-    batches: HashMap<String, Batch>,
+    batches: HashMap<target::Target, Batch>,
     reroute_responses_to: Option<buffer::Upstream>,
     registration_step: RegistrationStep,
     listed_caps: Vec<String>,
@@ -140,11 +140,11 @@ pub struct Client {
     supports_extended_join: bool,
     supports_read_marker: bool,
     supports_chathistory: bool,
-    chathistory_requests: HashMap<String, ChatHistoryRequest>,
-    chathistory_exhausted: HashMap<String, bool>,
+    chathistory_requests: HashMap<target::Target, ChatHistoryRequest>,
+    chathistory_exhausted: HashMap<target::Target, bool>,
     chathistory_targets_request: Option<ChatHistoryRequest>,
     highlight_blackout: HighlightBlackout,
-    registration_required_channels: Vec<String>,
+    registration_required_channels: Vec<target::Channel>,
     isupport: HashMap<isupport::Kind, isupport::Parameter>,
 }
 
@@ -217,7 +217,7 @@ impl Client {
         }
     }
 
-    fn join(&mut self, channels: &[String]) {
+    fn join(&mut self, channels: &[target::Channel]) {
         let keys = HashMap::new();
 
         let messages = group_joins(channels, &keys);
@@ -294,7 +294,12 @@ impl Client {
                 .or_else(|| {
                     batch_tag.as_ref().and_then(|batch| {
                         self.batches
-                            .get(batch)
+                            .get(&target::Target::parse(
+                                batch,
+                                self.chantypes(),
+                                self.statusmsg(),
+                                self.casemapping(),
+                            ))
                             .and_then(|batch| batch.context.clone())
                     })
                 })
@@ -317,22 +322,44 @@ impl Client {
                         let mut batch = Batch::new(context);
 
                         batch.chathistory = match params.first().map(|x| x.as_str()) {
-                            Some("chathistory") => params
-                                .get(1)
-                                .map(|target| ChatHistoryBatch::Target(target.clone())),
+                            Some("chathistory") => params.get(1).map(|target| {
+                                ChatHistoryBatch::Target(target::Target::parse(
+                                    target,
+                                    self.chantypes(),
+                                    self.statusmsg(),
+                                    self.casemapping(),
+                                ))
+                            }),
                             Some("draft/chathistory-targets") => Some(ChatHistoryBatch::Targets),
                             _ => None,
                         };
 
-                        self.batches.insert(reference, batch);
+                        self.batches.insert(
+                            target::Target::parse(
+                                &reference,
+                                self.chantypes(),
+                                self.statusmsg(),
+                                self.casemapping(),
+                            ),
+                            batch,
+                        );
                     }
                     '-' => {
-                        if let Some(mut finished) = self.batches.remove(&reference) {
+                        if let Some(mut finished) = self.batches.remove(&target::Target::parse(
+                            &reference,
+                            self.chantypes(),
+                            self.statusmsg(),
+                            self.casemapping(),
+                        )) {
                             // If nested, extend events into parent batch
-                            if let Some(parent) = batch_tag
-                                .as_ref()
-                                .and_then(|batch| self.batches.get_mut(batch))
-                            {
+                            if let Some(parent) = batch_tag.as_ref().and_then(|batch| {
+                                self.batches.get_mut(&target::Target::parse(
+                                    batch,
+                                    self.chantypes(),
+                                    self.statusmsg(),
+                                    self.casemapping(),
+                                ))
+                            }) {
                                 parent.events.extend(finished.events);
                             } else {
                                 match &finished.chathistory {
@@ -346,7 +373,7 @@ impl Client {
                                                 subcommand
                                             {
                                                 self.chathistory_exhausted.insert(
-                                                    batch_target.to_string(),
+                                                    batch_target.clone(),
                                                     finished.events.len() < *limit as usize,
                                                 );
                                             }
@@ -488,7 +515,14 @@ impl Client {
             _ if batch_tag.is_some() => {
                 let events = if let Some(target) = batch_tag
                     .as_ref()
-                    .and_then(|batch| self.batches.get(batch))
+                    .and_then(|batch| {
+                        self.batches.get(&target::Target::parse(
+                            batch,
+                            self.chantypes(),
+                            self.statusmsg(),
+                            self.casemapping(),
+                        ))
+                    })
                     .and_then(|batch| {
                         batch
                             .chathistory
@@ -510,37 +544,41 @@ impl Client {
                         vec![]
                     } else {
                         match &message.command {
-                            Command::NICK(_) => {
-                                let target = message::Target::Channel {
-                                    channel: target,
-                                    source: source::Source::Server(None),
-                                    prefixes: Default::default(),
-                                };
+                            Command::NICK(_) => target
+                                .as_channel()
+                                .map(|channel| {
+                                    let target = message::Target::Channel {
+                                        channel: channel.clone(),
+                                        source: source::Source::Server(None),
+                                    };
 
-                                vec![Event::WithTarget(
-                                    message,
-                                    self.nickname().to_owned(),
-                                    target,
-                                )]
-                            }
-                            Command::QUIT(_) => {
-                                let target = message::Target::Channel {
-                                    channel: target,
-                                    source: source::Source::Server(Some(source::Server::new(
-                                        source::server::Kind::Quit,
-                                        message
-                                            .user()
-                                            .map(|user| Nick::from(user.nickname().as_ref())),
-                                    ))),
-                                    prefixes: Default::default(),
-                                };
+                                    vec![Event::WithTarget(
+                                        message,
+                                        self.nickname().to_owned(),
+                                        target,
+                                    )]
+                                })
+                                .unwrap_or_default(),
+                            Command::QUIT(_) => target
+                                .as_channel()
+                                .map(|channel| {
+                                    let target = message::Target::Channel {
+                                        channel: channel.clone(),
+                                        source: source::Source::Server(Some(source::Server::new(
+                                            source::server::Kind::Quit,
+                                            message
+                                                .user()
+                                                .map(|user| Nick::from(user.nickname().as_ref())),
+                                        ))),
+                                    };
 
-                                vec![Event::WithTarget(
-                                    message,
-                                    self.nickname().to_owned(),
-                                    target,
-                                )]
-                            }
+                                    vec![Event::WithTarget(
+                                        message,
+                                        self.nickname().to_owned(),
+                                        target,
+                                    )]
+                                })
+                                .unwrap_or_default(),
                             Command::PRIVMSG(_, text) | Command::NOTICE(_, text) => {
                                 if ctcp::is_query(text) && !message::is_action(text) {
                                     // Ignore historical CTCP queries/responses except for ACTIONs
@@ -556,7 +594,12 @@ impl Client {
                     self.handle(message, context)?
                 };
 
-                if let Some(batch) = self.batches.get_mut(&batch_tag.unwrap()) {
+                if let Some(batch) = self.batches.get_mut(&target::Target::parse(
+                    &batch_tag.unwrap(),
+                    self.chantypes(),
+                    self.statusmsg(),
+                    self.casemapping(),
+                )) {
                     batch.events.extend(events);
                     return Ok(vec![]);
                 } else {
@@ -993,12 +1036,18 @@ impl Client {
             }
             Command::INVITE(user, channel) => {
                 let user = User::from(Nick::from(user.as_str()));
+                let channel = target::Channel::parse(
+                    channel,
+                    self.chantypes(),
+                    self.statusmsg(),
+                    self.casemapping(),
+                )?;
                 let inviter = ok!(message.user());
                 let user_channels = self.user_channels(user.nickname());
 
                 return Ok(vec![Event::Broadcast(Broadcast::Invite {
                     inviter,
-                    channel: channel.clone(),
+                    channel,
                     user_channels,
                     sent_time: server_time(&message),
                 })]);
@@ -1116,8 +1165,23 @@ impl Client {
                     };
                 }
 
+                let channels = self
+                    .config
+                    .channels
+                    .iter()
+                    .filter_map(|channel| {
+                        target::Channel::parse(
+                            channel,
+                            self.chantypes(),
+                            self.statusmsg(),
+                            self.casemapping(),
+                        )
+                        .ok()
+                    })
+                    .collect::<Vec<_>>();
+
                 // Send JOIN
-                for message in group_joins(&self.config.channels, &self.config.channel_keys) {
+                for message in group_joins(&channels, &self.config.channel_keys) {
                     self.handle.try_send(message)?;
                 }
             }
@@ -1142,20 +1206,37 @@ impl Client {
                 let user = ok!(message.user());
 
                 if user.nickname() == self.nickname() {
-                    self.chanmap.remove(channel);
-                } else if let Some(channel) = self.chanmap.get_mut(channel) {
+                    self.chanmap.remove(&target::Channel::parse(
+                        channel,
+                        self.chantypes(),
+                        self.statusmsg(),
+                        self.casemapping(),
+                    )?);
+                } else if let Some(channel) = self.chanmap.get_mut(&target::Channel::parse(
+                    channel,
+                    self.chantypes(),
+                    self.statusmsg(),
+                    self.casemapping(),
+                )?) {
                     channel.users.remove(&user);
                 }
             }
             Command::JOIN(channel, accountname) => {
                 let user = ok!(message.user());
 
+                let target = target::Channel::parse(
+                    channel,
+                    self.chantypes(),
+                    self.statusmsg(),
+                    self.casemapping(),
+                )?;
+
                 if user.nickname() == self.nickname() {
-                    self.chanmap.insert(channel.clone(), Channel::default());
+                    self.chanmap.insert(target.clone(), Channel::default());
 
                     // Sends WHO to get away state on users if WHO poll is enabled.
                     if self.config.who_poll_enabled {
-                        if let Some(state) = self.chanmap.get_mut(channel) {
+                        if let Some(state) = self.chanmap.get_mut(&target) {
                             if self.isupport.contains_key(&isupport::Kind::WHOX) {
                                 let fields = if self.supports_account_notify {
                                     "tcnfa"
@@ -1182,11 +1263,8 @@ impl Client {
                         }
                     }
 
-                    return Ok(vec![Event::JoinedChannel(
-                        channel.clone(),
-                        server_time(&message),
-                    )]);
-                } else if let Some(channel) = self.chanmap.get_mut(channel) {
+                    return Ok(vec![Event::JoinedChannel(target, server_time(&message))]);
+                } else if let Some(channel) = self.chanmap.get_mut(&target) {
                     let user = if self.supports_extended_join {
                         accountname.as_ref().map_or(user.clone(), |accountname| {
                             user.with_accountname(accountname)
@@ -1200,8 +1278,18 @@ impl Client {
             }
             Command::KICK(channel, victim, _) => {
                 if victim == self.nickname().as_ref() {
-                    self.chanmap.remove(channel);
-                } else if let Some(channel) = self.chanmap.get_mut(channel) {
+                    self.chanmap.remove(&target::Channel::parse(
+                        channel,
+                        self.chantypes(),
+                        self.statusmsg(),
+                        self.casemapping(),
+                    )?);
+                } else if let Some(channel) = self.chanmap.get_mut(&target::Channel::parse(
+                    channel,
+                    self.chantypes(),
+                    self.statusmsg(),
+                    self.casemapping(),
+                )?) {
                     channel
                         .users
                         .remove(&User::from(Nick::from(victim.as_str())));
@@ -1210,64 +1298,71 @@ impl Client {
             Command::Numeric(RPL_WHOREPLY, args) => {
                 let target = ok!(args.get(1));
 
-                if self.is_channel(target) {
-                    if let Some(channel) = self.chanmap.get_mut(target) {
-                        channel.update_user_away(ok!(args.get(5)), ok!(args.get(6)));
+                if let Some(channel) = self.chanmap.get_mut(&target::Channel::parse(
+                    target,
+                    self.chantypes(),
+                    self.statusmsg(),
+                    self.casemapping(),
+                )?) {
+                    channel.update_user_away(ok!(args.get(5)), ok!(args.get(6)));
 
-                        if matches!(channel.last_who, Some(WhoStatus::Requested(_, None)) | None) {
-                            channel.last_who = Some(WhoStatus::Receiving(None));
-                            log::debug!("[{}] {target} - WHO receiving...", self.server);
-                        }
+                    if matches!(channel.last_who, Some(WhoStatus::Requested(_, None)) | None) {
+                        channel.last_who = Some(WhoStatus::Receiving(None));
+                        log::debug!("[{}] {target} - WHO receiving...", self.server);
+                    }
 
-                        if matches!(channel.last_who, Some(WhoStatus::Receiving(_))) {
-                            // We requested, don't save to history
-                            return Ok(vec![]);
-                        }
+                    if matches!(channel.last_who, Some(WhoStatus::Receiving(_))) {
+                        // We requested, don't save to history
+                        return Ok(vec![]);
                     }
                 }
             }
             Command::Numeric(RPL_WHOSPCRPL, args) => {
                 let target = ok!(args.get(2));
 
-                if self.is_channel(target) {
-                    if let Some(channel) = self.chanmap.get_mut(target) {
-                        channel.update_user_away(ok!(args.get(3)), ok!(args.get(4)));
+                if let Some(channel) = self.chanmap.get_mut(&target::Channel::parse(
+                    target,
+                    self.chantypes(),
+                    self.statusmsg(),
+                    self.casemapping(),
+                )?) {
+                    channel.update_user_away(ok!(args.get(3)), ok!(args.get(4)));
 
-                        if self.supports_account_notify {
-                            if let (Some(user), Some(accountname)) = (args.get(3), args.get(5)) {
-                                channel.update_user_accountname(user, accountname);
+                    if self.supports_account_notify {
+                        if let (Some(user), Some(accountname)) = (args.get(3), args.get(5)) {
+                            channel.update_user_accountname(user, accountname);
+                        }
+                    }
+
+                    if let Ok(token) = ok!(args.get(1)).parse::<isupport::WhoToken>() {
+                        if let Some(WhoStatus::Requested(_, Some(request_token))) = channel.last_who
+                        {
+                            if request_token == token {
+                                channel.last_who = Some(WhoStatus::Receiving(Some(request_token)));
+                                log::debug!("[{}] {target} - WHO receiving...", self.server);
                             }
                         }
+                    }
 
-                        if let Ok(token) = ok!(args.get(1)).parse::<isupport::WhoToken>() {
-                            if let Some(WhoStatus::Requested(_, Some(request_token))) =
-                                channel.last_who
-                            {
-                                if request_token == token {
-                                    channel.last_who =
-                                        Some(WhoStatus::Receiving(Some(request_token)));
-                                    log::debug!("[{}] {target} - WHO receiving...", self.server);
-                                }
-                            }
-                        }
-
-                        if matches!(channel.last_who, Some(WhoStatus::Receiving(_))) {
-                            // We requested, don't save to history
-                            return Ok(vec![]);
-                        }
+                    if matches!(channel.last_who, Some(WhoStatus::Receiving(_))) {
+                        // We requested, don't save to history
+                        return Ok(vec![]);
                     }
                 }
             }
             Command::Numeric(RPL_ENDOFWHO, args) => {
                 let target = ok!(args.get(1));
 
-                if self.is_channel(target) {
-                    if let Some(channel) = self.chanmap.get_mut(target) {
-                        if matches!(channel.last_who, Some(WhoStatus::Receiving(_))) {
-                            channel.last_who = Some(WhoStatus::Done(Instant::now()));
-                            log::debug!("[{}] {target} - WHO done", self.server);
-                            return Ok(vec![]);
-                        }
+                if let Some(channel) = self.chanmap.get_mut(&target::Channel::parse(
+                    target,
+                    self.chantypes(),
+                    self.statusmsg(),
+                    self.casemapping(),
+                )?) {
+                    if matches!(channel.last_who, Some(WhoStatus::Receiving(_))) {
+                        channel.last_who = Some(WhoStatus::Done(Instant::now()));
+                        log::debug!("[{}] {target} - WHO done", self.server);
+                        return Ok(vec![]);
                     }
                 }
             }
@@ -1309,19 +1404,22 @@ impl Client {
                 }
             }
             Command::MODE(target, Some(modes), Some(args)) => {
-                if self.is_channel(target) {
+                if let Some(channel) = self.chanmap.get_mut(&target::Channel::parse(
+                    target,
+                    self.chantypes(),
+                    self.statusmsg(),
+                    self.casemapping(),
+                )?) {
                     let modes = mode::parse::<mode::Channel>(modes, args);
 
-                    if let Some(channel) = self.chanmap.get_mut(target) {
-                        for mode in modes {
-                            if let Some((op, lookup)) = mode
-                                .operation()
-                                .zip(mode.arg().map(|nick| User::from(Nick::from(nick))))
-                            {
-                                if let Some(mut user) = channel.users.take(&lookup) {
-                                    user.update_access_level(op, *mode.value());
-                                    channel.users.insert(user);
-                                }
+                    for mode in modes {
+                        if let Some((op, lookup)) = mode
+                            .operation()
+                            .zip(mode.arg().map(|nick| User::from(Nick::from(nick))))
+                        {
+                            if let Some(mut user) = channel.users.take(&lookup) {
+                                user.update_access_level(op, *mode.value());
+                                channel.users.insert(user);
                             }
                         }
                     }
@@ -1351,7 +1449,14 @@ impl Client {
                 }
             }
             Command::Numeric(RPL_NAMREPLY, args) if args.len() > 3 => {
-                if let Some(channel) = self.chanmap.get_mut(&args[2]) {
+                let channel = ok!(args.get(2));
+
+                if let Some(channel) = self.chanmap.get_mut(&target::Channel::parse(
+                    channel,
+                    self.chantypes(),
+                    self.statusmsg(),
+                    self.casemapping(),
+                )?) {
                     for user in args[3].split(' ') {
                         if let Ok(user) = User::try_from(user) {
                             channel.users.insert(user);
@@ -1367,18 +1472,26 @@ impl Client {
             Command::Numeric(RPL_ENDOFNAMES, args) => {
                 let target = ok!(args.get(1));
 
-                if self.is_channel(target) {
-                    if let Some(channel) = self.chanmap.get_mut(target) {
-                        if !channel.names_init {
-                            channel.names_init = true;
+                if let Some(channel) = self.chanmap.get_mut(&target::Channel::parse(
+                    target,
+                    self.chantypes(),
+                    self.statusmsg(),
+                    self.casemapping(),
+                )?) {
+                    if !channel.names_init {
+                        channel.names_init = true;
 
-                            return Ok(vec![]);
-                        }
+                        return Ok(vec![]);
                     }
                 }
             }
             Command::TOPIC(channel, topic) => {
-                if let Some(channel) = self.chanmap.get_mut(channel) {
+                if let Some(channel) = self.chanmap.get_mut(&target::Channel::parse(
+                    channel,
+                    self.chantypes(),
+                    self.statusmsg(),
+                    self.casemapping(),
+                )?) {
                     if let Some(text) = topic {
                         channel.topic.content = Some(message::parse_fragments(text.clone(), &[]));
                     }
@@ -1388,7 +1501,14 @@ impl Client {
                 }
             }
             Command::Numeric(RPL_TOPIC, args) => {
-                if let Some(channel) = self.chanmap.get_mut(&args[1]) {
+                let channel = ok!(args.get(1));
+
+                if let Some(channel) = self.chanmap.get_mut(&target::Channel::parse(
+                    channel,
+                    self.chantypes(),
+                    self.statusmsg(),
+                    self.casemapping(),
+                )?) {
                     channel.topic.content =
                         Some(message::parse_fragments(ok!(args.get(2)).to_owned(), &[]));
                 }
@@ -1397,7 +1517,14 @@ impl Client {
                 return Ok(vec![]);
             }
             Command::Numeric(RPL_TOPICWHOTIME, args) => {
-                if let Some(channel) = self.chanmap.get_mut(&args[1]) {
+                let channel = ok!(args.get(1));
+
+                if let Some(channel) = self.chanmap.get_mut(&target::Channel::parse(
+                    channel,
+                    self.chantypes(),
+                    self.statusmsg(),
+                    self.casemapping(),
+                )?) {
                     channel.topic.who = Some(ok!(args.get(2)).to_string());
                     let timestamp = Posix::from_seconds(ok!(args.get(3)).parse::<u64>()?);
                     channel.topic.time =
@@ -1410,17 +1537,22 @@ impl Client {
                 return Ok(vec![]);
             }
             Command::Numeric(ERR_NOCHANMODES, args) => {
-                let channel = ok!(args.get(1));
+                let channel = target::Channel::parse(
+                    ok!(args.get(1)),
+                    self.chantypes(),
+                    self.statusmsg(),
+                    self.casemapping(),
+                )?;
 
                 // If the channel has not been joined but is in the configured channels,
                 // then interpret this numeric as ERR_NEEDREGGEDNICK (which has the
                 // same number as ERR_NOCHANMODES)
-                if !self.chanmap.contains_key(channel)
+                if !self.chanmap.contains_key(&channel)
                     && self
                         .config
                         .channels
                         .iter()
-                        .any(|config_channel| config_channel == channel)
+                        .any(|config_channel| config_channel == channel.as_str())
                 {
                     self.registration_required_channels.push(channel.clone());
                 }
@@ -1578,29 +1710,32 @@ impl Client {
                 let mut events = vec![];
 
                 if sub == "TARGETS" {
-                    if let Some(target) = args.first() {
-                        if let Some((prefixes, channel)) = proto::parse_channel_from_target(
-                            target,
-                            self.chantypes(),
-                            self.statusmsg(),
-                        ) {
-                            if !prefixes.is_empty() && self.chanmap.contains_key(&channel) {
+                    match target::Target::parse(
+                        ok!(args.first()),
+                        self.chantypes(),
+                        self.statusmsg(),
+                        self.casemapping(),
+                    ) {
+                        target::Target::Channel(channel) => {
+                            if !channel.prefixes().is_empty() && self.chanmap.contains_key(&channel)
+                            {
                                 events.push(Event::ChatHistoryTargetReceived(
-                                    target.clone(),
+                                    channel.to_string(),
                                     server_time(&message),
                                 ));
                             }
-                        } else {
+                        }
+                        target::Target::Query(query) => {
                             events.push(Event::ChatHistoryTargetReceived(
-                                target.clone(),
+                                query.to_string(),
                                 server_time(&message),
                             ));
                         }
+                    }
 
-                        if self.chathistory_targets_request.is_none() {
-                            // User requested, save to history
-                            events.push(Event::Single(message.clone(), self.nickname().to_owned()));
-                        }
+                    if self.chathistory_targets_request.is_none() {
+                        // User requested, save to history
+                        events.push(Event::Single(message.clone(), self.nickname().to_owned()));
                     }
                 }
 
@@ -1669,25 +1804,31 @@ impl Client {
         }
     }
 
-    pub fn chathistory_request(&self, target: &str) -> Option<ChatHistorySubcommand> {
+    pub fn chathistory_request(&self, target: &target::Target) -> Option<ChatHistorySubcommand> {
         self.chathistory_requests
             .get(target)
             .map(|request| request.subcommand.clone())
     }
 
     pub fn send_chathistory_request(&mut self, subcommand: ChatHistorySubcommand) {
+        use std::collections::hash_map;
+
         if self.supports_chathistory {
             if let Some(target) = subcommand.target() {
-                if self.chathistory_requests.contains_key(target) {
-                    return;
+                if let hash_map::Entry::Vacant(entry) =
+                    self.chathistory_requests.entry(target::Target::parse(
+                        target,
+                        self.chantypes(),
+                        self.statusmsg(),
+                        self.casemapping(),
+                    ))
+                {
+                    entry.insert(ChatHistoryRequest {
+                        subcommand: subcommand.clone(),
+                        requested_at: Instant::now(),
+                    });
                 } else {
-                    self.chathistory_requests.insert(
-                        target.to_string(),
-                        ChatHistoryRequest {
-                            subcommand: subcommand.clone(),
-                            requested_at: Instant::now(),
-                        },
-                    );
+                    return;
                 }
             } else if self.chathistory_targets_request.is_some() {
                 return;
@@ -1803,7 +1944,7 @@ impl Client {
         }
     }
 
-    pub fn clear_chathistory_request(&mut self, target: Option<&str>) {
+    pub fn clear_chathistory_request(&mut self, target: Option<&target::Target>) {
         if let Some(target) = target {
             self.chathistory_requests.remove(target);
         } else {
@@ -1811,7 +1952,7 @@ impl Client {
         }
     }
 
-    pub fn chathistory_exhausted(&self, target: &str) -> bool {
+    pub fn chathistory_exhausted(&self, target: &target::Target) -> bool {
         self.chathistory_exhausted
             .get(target)
             .cloned()
@@ -1869,7 +2010,7 @@ impl Client {
             .chanmap
             .keys()
             .cloned()
-            .sorted_by(|a, b| self.compare_channels(a, b))
+            .sorted_by(|a, b| self.compare_channels(a.as_str(), b.as_str()))
             .collect();
         self.users = self
             .chanmap
@@ -1883,28 +2024,32 @@ impl Client {
             .collect();
     }
 
-    pub fn channels(&self) -> &[String] {
+    pub fn channels(&self) -> &[target::Channel] {
         &self.channels
     }
 
-    fn topic<'a>(&'a self, channel: &str) -> Option<&'a Topic> {
+    fn topic<'a>(&'a self, channel: &target::Channel) -> Option<&'a Topic> {
         self.chanmap.get(channel).map(|channel| &channel.topic)
     }
 
-    fn resolve_user_attributes<'a>(&'a self, channel: &str, user: &User) -> Option<&'a User> {
+    fn resolve_user_attributes<'a>(
+        &'a self,
+        channel: &target::Channel,
+        user: &User,
+    ) -> Option<&'a User> {
         self.chanmap
             .get(channel)
             .and_then(|channel| channel.users.get(user))
     }
 
-    pub fn users<'a>(&'a self, channel: &str) -> &'a [User] {
+    pub fn users<'a>(&'a self, channel: &target::Channel) -> &'a [User] {
         self.users
             .get(channel)
             .map(Vec::as_slice)
             .unwrap_or_default()
     }
 
-    fn user_channels(&self, nick: NickRef) -> Vec<String> {
+    fn user_channels(&self, nick: NickRef) -> Vec<target::Channel> {
         self.channels()
             .iter()
             .filter(|channel| {
@@ -1964,7 +2109,7 @@ impl Client {
 
                     self.handle.try_send(command!(
                         "WHO",
-                        channel,
+                        channel.to_string(),
                         fields,
                         isupport::WHO_POLL_TOKEN.to_owned()
                     ))?;
@@ -1974,7 +2119,7 @@ impl Client {
                         Some(isupport::WHO_POLL_TOKEN),
                     ));
                 } else {
-                    self.handle.try_send(command!("WHO", channel))?;
+                    self.handle.try_send(command!("WHO", channel.to_string()))?;
                     state.last_who = Some(WhoStatus::Requested(Instant::now(), None));
                 }
                 log::debug!(
@@ -1993,6 +2138,16 @@ impl Client {
         });
 
         Ok(())
+    }
+
+    pub fn casemapping(&self) -> isupport::CaseMap {
+        if let Some(isupport::Parameter::CASEMAPPING(casemapping)) =
+            self.isupport.get(&isupport::Kind::CASEMAPPING)
+        {
+            return *casemapping;
+        }
+
+        isupport::CaseMap::default()
     }
 
     pub fn chantypes(&self) -> &[char] {
@@ -2185,7 +2340,7 @@ impl Map {
         Ok(())
     }
 
-    pub fn join(&mut self, server: &Server, channels: &[String]) {
+    pub fn join(&mut self, server: &Server, channels: &[target::Channel]) {
         if let Some(client) = self.client_mut(server) {
             client.join(channels);
         }
@@ -2214,32 +2369,40 @@ impl Map {
     pub fn resolve_user_attributes<'a>(
         &'a self,
         server: &Server,
-        channel: &str,
+        channel: &target::Channel,
         user: &User,
     ) -> Option<&'a User> {
         self.client(server)
             .and_then(|client| client.resolve_user_attributes(channel, user))
     }
 
-    pub fn get_channel_users<'a>(&'a self, server: &Server, channel: &str) -> &'a [User] {
+    pub fn get_channel_users<'a>(
+        &'a self,
+        server: &Server,
+        channel: &target::Channel,
+    ) -> &'a [User] {
         self.client(server)
             .map(|client| client.users(channel))
             .unwrap_or_default()
     }
 
-    pub fn get_user_channels(&self, server: &Server, nick: NickRef) -> Vec<String> {
+    pub fn get_user_channels(&self, server: &Server, nick: NickRef) -> Vec<target::Channel> {
         self.client(server)
             .map(|client| client.user_channels(nick))
             .unwrap_or_default()
     }
 
-    pub fn get_channel_topic<'a>(&'a self, server: &Server, channel: &str) -> Option<&'a Topic> {
+    pub fn get_channel_topic<'a>(
+        &'a self,
+        server: &Server,
+        channel: &target::Channel,
+    ) -> Option<&'a Topic> {
         self.client(server)
             .map(|client| client.topic(channel))
             .unwrap_or_default()
     }
 
-    pub fn get_channels<'a>(&'a self, server: &Server) -> &'a [String] {
+    pub fn get_channels<'a>(&'a self, server: &Server) -> &'a [target::Channel] {
         self.client(server)
             .map(|client| client.channels())
             .unwrap_or_default()
@@ -2248,6 +2411,12 @@ impl Map {
     pub fn get_isupport(&self, server: &Server) -> HashMap<isupport::Kind, isupport::Parameter> {
         self.client(server)
             .map(|client| client.isupport.clone())
+            .unwrap_or_default()
+    }
+
+    pub fn get_casemapping(&self, server: &Server) -> isupport::CaseMap {
+        self.client(server)
+            .map(|client| client.casemapping())
             .unwrap_or_default()
     }
 
@@ -2287,7 +2456,7 @@ impl Map {
     pub fn get_chathistory_request(
         &self,
         server: &Server,
-        target: &str,
+        target: &target::Target,
     ) -> Option<ChatHistorySubcommand> {
         self.client(server)
             .and_then(|client| client.chathistory_request(target))
@@ -2299,19 +2468,23 @@ impl Map {
         }
     }
 
-    pub fn clear_chathistory_request(&mut self, server: &Server, target: Option<&str>) {
+    pub fn clear_chathistory_request(&mut self, server: &Server, target: Option<&target::Target>) {
         if let Some(client) = self.client_mut(server) {
             client.clear_chathistory_request(target);
         }
     }
 
-    pub fn get_chathistory_exhausted(&self, server: &Server, target: &str) -> bool {
+    pub fn get_chathistory_exhausted(&self, server: &Server, target: &target::Target) -> bool {
         self.client(server)
             .map(|client| client.chathistory_exhausted(target))
             .unwrap_or_default()
     }
 
-    pub fn get_chathistory_state(&self, server: &Server, target: &str) -> Option<ChatHistoryState> {
+    pub fn get_chathistory_state(
+        &self,
+        server: &Server,
+        target: &target::Target,
+    ) -> Option<ChatHistoryState> {
         self.client(server).and_then(|client| {
             if client.supports_chathistory {
                 if client.chathistory_request(target).is_some() {
@@ -2412,12 +2585,12 @@ impl Context {
 
 #[derive(Debug)]
 pub enum ChatHistoryBatch {
-    Target(String),
+    Target(target::Target),
     Targets,
 }
 
 impl ChatHistoryBatch {
-    pub fn target(&self) -> Option<String> {
+    pub fn target(&self) -> Option<target::Target> {
         match self {
             ChatHistoryBatch::Target(batch_target) => Some(batch_target.clone()),
             ChatHistoryBatch::Targets => None,
@@ -2554,13 +2727,13 @@ fn group_capability_requests<'a>(
 
 /// Group channels together into as few JOIN messages as possible
 fn group_joins<'a>(
-    channels: &'a [String],
+    channels: &'a [target::Channel],
     keys: &'a HashMap<String, String>,
 ) -> impl Iterator<Item = proto::Message> + 'a {
     const MAX_LEN: usize = proto::format::BYTE_LIMIT - b"JOIN \r\n".len();
 
     let (without_keys, with_keys): (Vec<_>, Vec<_>) = channels.iter().partition_map(|channel| {
-        keys.get(channel)
+        keys.get(channel.as_str())
             .map(|key| Either::Right((channel, key)))
             .unwrap_or(Either::Left(channel))
     });
@@ -2569,7 +2742,7 @@ fn group_joins<'a>(
         .into_iter()
         .scan(0, |count, channel| {
             // Channel + a comma
-            *count += channel.len() + 1;
+            *count += channel.as_str().len() + 1;
 
             let chunk = *count / MAX_LEN;
 
@@ -2583,7 +2756,7 @@ fn group_joins<'a>(
         .into_iter()
         .scan(0, |count, (channel, key)| {
             // Channel + key + a comma for each
-            *count += channel.len() + key.len() + 2;
+            *count += channel.as_str().len() + key.len() + 2;
 
             let chunk = *count / MAX_LEN;
 
@@ -2635,4 +2808,6 @@ pub enum Error {
     Io(#[from] io::Error),
     #[error(transparent)]
     SerdeJson(#[from] serde_json::Error),
+    #[error(transparent)]
+    Target(#[from] target::ParseError),
 }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -97,7 +97,7 @@ pub enum Broadcast {
 pub enum Message {
     ChatHistoryRequest(Server, ChatHistorySubcommand),
     ChatHistoryTargetsTimestampUpdated(Server, DateTime<Utc>, Result<(), Error>),
-    RequestNewerChatHistory(Server, String, DateTime<Utc>),
+    RequestNewerChatHistory(Server, target::Target, DateTime<Utc>),
     RequestChatHistoryTargets(Server, Option<DateTime<Utc>>, DateTime<Utc>),
 }
 
@@ -108,10 +108,10 @@ pub enum Event {
     Broadcast(Broadcast),
     Notification(message::Encoded, Nick, Notification),
     FileTransferRequest(file_transfer::ReceiveRequest),
-    UpdateReadMarker(String, ReadMarker),
+    UpdateReadMarker(target::Target, ReadMarker),
     JoinedChannel(target::Channel, DateTime<Utc>),
     ChatHistoryAcknowledged(DateTime<Utc>),
-    ChatHistoryTargetReceived(String, DateTime<Utc>),
+    ChatHistoryTargetReceived(target::Target, DateTime<Utc>),
     ChatHistoryTargetsReceived(DateTime<Utc>),
 }
 
@@ -1703,31 +1703,41 @@ impl Client {
                     .strip_prefix("timestamp=")
                     .and_then(|timestamp| timestamp.parse::<ReadMarker>().ok())
                 {
-                    return Ok(vec![Event::UpdateReadMarker(target.clone(), read_marker)]);
+                    return Ok(vec![Event::UpdateReadMarker(
+                        target::Target::parse(
+                            target,
+                            self.chantypes(),
+                            self.statusmsg(),
+                            self.casemapping(),
+                        ),
+                        read_marker,
+                    )]);
                 }
             }
             Command::CHATHISTORY(sub, args) => {
                 let mut events = vec![];
 
                 if sub == "TARGETS" {
-                    match target::Target::parse(
+                    let target = target::Target::parse(
                         ok!(args.first()),
                         self.chantypes(),
                         self.statusmsg(),
                         self.casemapping(),
-                    ) {
-                        target::Target::Channel(channel) => {
-                            if !channel.prefixes().is_empty() && self.chanmap.contains_key(&channel)
+                    );
+
+                    match target {
+                        target::Target::Channel(ref channel) => {
+                            if !channel.prefixes().is_empty() && self.chanmap.contains_key(channel)
                             {
                                 events.push(Event::ChatHistoryTargetReceived(
-                                    channel.to_string(),
+                                    target,
                                     server_time(&message),
                                 ));
                             }
                         }
                         target::Target::Query(query) => {
                             events.push(Event::ChatHistoryTargetReceived(
-                                query.to_string(),
+                                target,
                                 server_time(&message),
                             ));
                         }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -55,7 +55,7 @@ pub enum Notification {
     Highlight {
         enabled: bool,
         user: User,
-        channel: String,
+        channel: target::Channel,
     },
     FileTransferRequest(Nick),
     MonitoredOnline(Vec<User>),
@@ -1010,7 +1010,12 @@ impl Client {
                                 Notification::Highlight {
                                     enabled: self.highlight_blackout.allow_highlights(),
                                     user,
-                                    channel: channel.clone(),
+                                    channel: target::Channel::parse(
+                                        channel,
+                                        self.chantypes(),
+                                        self.statusmsg(),
+                                        self.casemapping(),
+                                    )?,
                                 },
                             )]);
                         } else if user.nickname() == self.nickname()

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1863,7 +1863,7 @@ impl Client {
                     let _ = self.handle.try_send(command!(
                         "CHATHISTORY",
                         "LATEST",
-                        target,
+                        target.to_string(),
                         command_message_reference.to_string(),
                         limit.to_string(),
                     ));
@@ -1881,7 +1881,7 @@ impl Client {
                     let _ = self.handle.try_send(command!(
                         "CHATHISTORY",
                         "BEFORE",
-                        target,
+                        target.to_string(),
                         command_message_reference.to_string(),
                         limit.to_string(),
                     ));
@@ -1908,7 +1908,7 @@ impl Client {
                     let _ = self.handle.try_send(command!(
                         "CHATHISTORY",
                         "BETWEEN",
-                        target,
+                        target.to_string(),
                         command_start_message_reference.to_string(),
                         command_end_message_reference.to_string(),
                         limit.to_string(),
@@ -2190,7 +2190,7 @@ impl Client {
 }
 
 fn continue_chathistory_between(
-    target: &str,
+    target: &target::Target,
     events: &[Event],
     end_message_reference: &MessageReference,
     limit: u16,
@@ -2209,7 +2209,7 @@ fn continue_chathistory_between(
 
     start_message_reference.map(|start_message_reference| {
         ChatHistorySubcommand::Between(
-            target.to_string(),
+            target.clone(),
             start_message_reference,
             end_message_reference.clone(),
             limit,

--- a/data/src/command.rs
+++ b/data/src/command.rs
@@ -104,7 +104,7 @@ pub fn parse(s: &str, buffer: Option<&buffer::Upstream>) -> Result<Command, Erro
             }
             Kind::Me => {
                 if let Some(target) = buffer.and_then(|b| b.target()) {
-                    validated::<1, 0, true>(args, |[text], _| Command::Me(target, text))
+                    validated::<1, 0, true>(args, |[text], _| Command::Me(target.to_string(), text))
                 } else {
                     Ok(unknown())
                 }
@@ -148,7 +148,10 @@ pub fn parse(s: &str, buffer: Option<&buffer::Upstream>) -> Result<Command, Erro
             Kind::Raw => Ok(Command::Raw(raw.to_string())),
             Kind::Format => {
                 if let Some(target) = buffer.and_then(|b| b.target()) {
-                    Ok(Command::Msg(target, formatting::encode(raw, false)))
+                    Ok(Command::Msg(
+                        target.to_string(),
+                        formatting::encode(raw, false),
+                    ))
                 } else {
                     Ok(unknown())
                 }

--- a/data/src/command.rs
+++ b/data/src/command.rs
@@ -251,6 +251,6 @@ fn fmt_incorrect_arg_count(min: usize, max: usize, actual: usize) -> String {
 
         format!("expected {min} argument{s}, received {actual}")
     } else {
-        format!("expected {min} to {max} arguments, recevied {actual}")
+        format!("expected {min} to {max} arguments, received {actual}")
     }
 }

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -190,8 +190,8 @@ async fn path(kind: &Kind) -> Result<PathBuf, Error> {
 
     let name = match kind {
         Kind::Server(server) => format!("{server}"),
-        Kind::Channel(server, channel) => format!("{server}channel{channel}"),
-        Kind::Query(server, nick) => format!("{server}nickname{}", nick),
+        Kind::Channel(server, channel) => format!("{server}channel{}", channel.as_normalized_str()),
+        Kind::Query(server, query) => format!("{server}nickname{}", query.as_normalized_str()),
         Kind::Logs => "logs".to_string(),
         Kind::Highlights => "highlights".to_string(),
     };

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -35,17 +35,24 @@ pub enum Kind {
 }
 
 impl Kind {
-    pub fn from_target(
+    pub fn from_target(server: Server, target: target::Target) -> Self {
+        match target {
+            target::Target::Channel(channel) => Self::Channel(server, channel),
+            target::Target::Query(query) => Self::Query(server, query),
+        }
+    }
+
+    pub fn from_str(
         server: Server,
         chantypes: &[char],
         statusmsg: &[char],
         casemapping: isupport::CaseMap,
-        target: String,
+        target: &str,
     ) -> Self {
-        match target::Target::parse(&target, chantypes, statusmsg, casemapping) {
-            target::Target::Channel(channel) => Self::Channel(server, channel),
-            target::Target::Query(query) => Self::Query(server, query),
-        }
+        Self::from_target(
+            server,
+            target::Target::parse(target, chantypes, statusmsg, casemapping),
+        )
     }
 
     pub fn from_input_buffer(buffer: buffer::Upstream) -> Self {

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -9,7 +9,8 @@ use tokio::fs;
 use tokio::time::Instant;
 
 use crate::message::{self, MessageReferences};
-use crate::{buffer, compression, environment, isupport, target, Buffer, Message, Server};
+use crate::target::{self, Target};
+use crate::{buffer, compression, environment, isupport, Buffer, Message, Server};
 
 pub use self::manager::{Manager, Resource};
 pub use self::metadata::{Metadata, ReadMarker};
@@ -35,10 +36,10 @@ pub enum Kind {
 }
 
 impl Kind {
-    pub fn from_target(server: Server, target: target::Target) -> Self {
+    pub fn from_target(server: Server, target: Target) -> Self {
         match target {
-            target::Target::Channel(channel) => Self::Channel(server, channel),
-            target::Target::Query(query) => Self::Query(server, query),
+            Target::Channel(channel) => Self::Channel(server, channel),
+            Target::Query(query) => Self::Query(server, query),
         }
     }
 
@@ -51,7 +52,7 @@ impl Kind {
     ) -> Self {
         Self::from_target(
             server,
-            target::Target::parse(target, chantypes, statusmsg, casemapping),
+            Target::parse(target, chantypes, statusmsg, casemapping),
         )
     }
 

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -7,9 +7,10 @@ use tokio::time::Instant;
 
 use crate::history::{self, History, MessageReferences};
 use crate::message::{self, Limit};
+use crate::target::{self, Target};
 use crate::user::Nick;
 use crate::{buffer, config, input, isupport};
-use crate::{server, target, Config, Input, Server, User};
+use crate::{server, Config, Input, Server, User};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Resource {
@@ -244,23 +245,19 @@ impl Manager {
     pub fn load_metadata(
         &mut self,
         server: Server,
-        target: target::Target,
+        target: Target,
     ) -> Option<impl Future<Output = Message>> {
         self.data.load_metadata(server, target)
     }
 
-    pub fn first_can_reference(
-        &self,
-        server: Server,
-        target: target::Target,
-    ) -> Option<&crate::Message> {
+    pub fn first_can_reference(&self, server: Server, target: Target) -> Option<&crate::Message> {
         self.data.first_can_reference(server, target)
     }
 
     pub fn last_can_reference_before(
         &self,
         server: Server,
-        target: target::Target,
+        target: Target,
         server_time: DateTime<Utc>,
     ) -> Option<MessageReferences> {
         self.data
@@ -745,7 +742,7 @@ impl Data {
     fn load_metadata(
         &mut self,
         server: server::Server,
-        target: target::Target,
+        target: Target,
     ) -> Option<impl Future<Output = Message>> {
         use std::collections::hash_map;
 
@@ -771,7 +768,7 @@ impl Data {
     fn first_can_reference(
         &self,
         server: server::Server,
-        target: target::Target,
+        target: Target,
     ) -> Option<&crate::Message> {
         let kind = history::Kind::from_target(server, target);
 
@@ -783,7 +780,7 @@ impl Data {
     fn last_can_reference_before(
         &self,
         server: Server,
-        target: target::Target,
+        target: Target,
         server_time: DateTime<Utc>,
     ) -> Option<MessageReferences> {
         let kind = history::Kind::from_target(server, target);

--- a/data/src/history/metadata.rs
+++ b/data/src/history/metadata.rs
@@ -130,8 +130,12 @@ async fn path(kind: &Kind) -> Result<PathBuf, Error> {
 
     let name = match kind {
         Kind::Server(server) => format!("{server}-metadata"),
-        Kind::Channel(server, channel) => format!("{server}channel{channel}-metadata"),
-        Kind::Query(server, nick) => format!("{server}nickname{}-metadata", nick),
+        Kind::Channel(server, channel) => {
+            format!("{server}channel{}-metadata", channel.as_normalized_str())
+        }
+        Kind::Query(server, query) => {
+            format!("{server}nickname{}-metadata", query.as_normalized_str())
+        }
         Kind::Logs => "logs-metadata".to_string(),
         Kind::Highlights => "highlights-metadata".to_string(),
     };

--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -93,7 +93,7 @@ impl Input {
                     .collect(),
             ),
             Command::Me(target, action) => Some(vec![Message::sent(
-                to_target(&target, message::Source::Action(Some(user.clone())))?,
+                to_target(&target, message::Source::Action(Some(user.clone()))),
                 message::action_text(user.nickname(), Some(&action)),
             )]),
             _ => None,

--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -5,7 +5,8 @@ use irc::proto::format;
 
 use crate::buffer::{self, AutoFormat};
 use crate::message::formatting;
-use crate::{command, isupport, message, target, Command, Message, Server, User};
+use crate::target::Target;
+use crate::{command, isupport, message, Command, Message, Server, User};
 
 const INPUT_HISTORY_LENGTH: usize = 100;
 
@@ -71,15 +72,11 @@ impl Input {
         statusmsg: &[char],
         casemapping: isupport::CaseMap,
     ) -> Option<Vec<Message>> {
-        let to_target = |target: &str, source| match target::Target::parse(
-            target,
-            chantypes,
-            statusmsg,
-            casemapping,
-        ) {
-            target::Target::Channel(channel) => message::Target::Channel { channel, source },
-            target::Target::Query(query) => message::Target::Query { query, source },
-        };
+        let to_target =
+            |target: &str, source| match Target::parse(target, chantypes, statusmsg, casemapping) {
+                Target::Channel(channel) => message::Target::Channel { channel, source },
+                Target::Query(query) => message::Target::Query { query, source },
+            };
 
         let command = self.content.command(&self.buffer)?;
 

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use chrono::{format::SecondsFormat, DateTime, Utc};
 
-use crate::Message;
+use crate::{target, Message};
 
 // Utilized ISUPPORT parameters should have an associated Kind enum variant
 // returned by Operation::kind() and Parameter::kind()
@@ -708,9 +708,9 @@ pub struct ChannelMode {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum ChatHistorySubcommand {
-    Latest(String, MessageReference, u16),
-    Before(String, MessageReference, u16),
-    Between(String, MessageReference, MessageReference, u16),
+    Latest(target::Target, MessageReference, u16),
+    Before(target::Target, MessageReference, u16),
+    Between(target::Target, MessageReference, MessageReference, u16),
     Targets(MessageReference, MessageReference, u16),
 }
 
@@ -719,7 +719,7 @@ impl ChatHistorySubcommand {
         match self {
             ChatHistorySubcommand::Latest(target, _, _)
             | ChatHistorySubcommand::Before(target, _, _)
-            | ChatHistorySubcommand::Between(target, _, _, _) => Some(target),
+            | ChatHistorySubcommand::Between(target, _, _, _) => Some(target.as_str()),
             ChatHistorySubcommand::Targets(_, _, _) => None,
         }
     }

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -11,6 +11,7 @@ use crate::Message;
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Kind {
     AWAYLEN,
+    CASEMAPPING,
     CHANLIMIT,
     CHANNELLEN,
     CHANTYPES,
@@ -477,6 +478,7 @@ impl Operation {
             Operation::Add(parameter) => parameter.kind(),
             Operation::Remove(parameter) => match parameter.as_ref() {
                 "AWAYLEN" => Some(Kind::AWAYLEN),
+                "CASEMAPPING" => Some(Kind::CASEMAPPING),
                 "CHANLIMIT" => Some(Kind::CHANLIMIT),
                 "CHANNELLEN" => Some(Kind::CHANNELLEN),
                 "CHANTYPES" => Some(Kind::CHANTYPES),
@@ -576,6 +578,7 @@ impl Parameter {
     pub fn kind(&self) -> Option<Kind> {
         match self {
             Parameter::AWAYLEN(_) => Some(Kind::AWAYLEN),
+            Parameter::CASEMAPPING(_) => Some(Kind::CASEMAPPING),
             Parameter::CHANLIMIT(_) => Some(Kind::CHANLIMIT),
             Parameter::CHANNELLEN(_) => Some(Kind::CHANNELLEN),
             Parameter::CHANTYPES(_) => Some(Kind::CHANTYPES),
@@ -602,12 +605,93 @@ impl Parameter {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub enum CaseMap {
     ASCII,
     RFC1459,
     RFC1459_STRICT,
+    #[default]
     RFC7613,
+}
+
+impl CaseMap {
+    pub fn normalize(&self, from_str: &str) -> String {
+        match self {
+            CaseMap::ASCII => from_str.to_ascii_lowercase(),
+            CaseMap::RFC1459 => from_str
+                .chars()
+                .map(|c| match c {
+                    'A' => 'a',
+                    'B' => 'b',
+                    'C' => 'c',
+                    'D' => 'd',
+                    'E' => 'e',
+                    'F' => 'f',
+                    'G' => 'g',
+                    'H' => 'h',
+                    'I' => 'i',
+                    'J' => 'j',
+                    'K' => 'k',
+                    'L' => 'l',
+                    'M' => 'm',
+                    'N' => 'n',
+                    'O' => 'o',
+                    'P' => 'p',
+                    'Q' => 'q',
+                    'R' => 'r',
+                    'S' => 's',
+                    'T' => 't',
+                    'U' => 'u',
+                    'V' => 'v',
+                    'W' => 'w',
+                    'X' => 'x',
+                    'Y' => 'y',
+                    'Z' => 'z',
+                    '[' => '{',
+                    ']' => '}',
+                    '\\' => '|',
+                    '~' => '^',
+                    _ => c,
+                })
+                .collect(),
+            CaseMap::RFC1459_STRICT => from_str
+                .chars()
+                .map(|c| match c {
+                    'A' => 'a',
+                    'B' => 'b',
+                    'C' => 'c',
+                    'D' => 'd',
+                    'E' => 'e',
+                    'F' => 'f',
+                    'G' => 'g',
+                    'H' => 'h',
+                    'I' => 'i',
+                    'J' => 'j',
+                    'K' => 'k',
+                    'L' => 'l',
+                    'M' => 'm',
+                    'N' => 'n',
+                    'O' => 'o',
+                    'P' => 'p',
+                    'Q' => 'q',
+                    'R' => 'r',
+                    'S' => 's',
+                    'T' => 't',
+                    'U' => 'u',
+                    'V' => 'v',
+                    'W' => 'w',
+                    'X' => 'x',
+                    'Y' => 'y',
+                    'Z' => 'z',
+                    '[' => '{',
+                    ']' => '}',
+                    '\\' => '|',
+                    _ => c,
+                })
+                .collect(),
+            CaseMap::RFC7613 => from_str.to_lowercase(),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use chrono::{format::SecondsFormat, DateTime, Utc};
 
-use crate::{target, Message};
+use crate::{target::Target, Message};
 
 // Utilized ISUPPORT parameters should have an associated Kind enum variant
 // returned by Operation::kind() and Parameter::kind()
@@ -708,9 +708,9 @@ pub struct ChannelMode {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum ChatHistorySubcommand {
-    Latest(target::Target, MessageReference, u16),
-    Before(target::Target, MessageReference, u16),
-    Between(target::Target, MessageReference, MessageReference, u16),
+    Latest(Target, MessageReference, u16),
+    Before(Target, MessageReference, u16),
+    Between(Target, MessageReference, MessageReference, u16),
     Targets(MessageReference, MessageReference, u16),
 }
 

--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::large_enum_variant, clippy::too_many_arguments)]
 
+pub use self::appearance::Theme;
 pub use self::buffer::Buffer;
 pub use self::command::Command;
 pub use self::config::Config;
@@ -10,7 +11,6 @@ pub use self::mode::Mode;
 pub use self::pane::Pane;
 pub use self::server::Server;
 pub use self::shortcut::Shortcut;
-pub use self::appearance::Theme;
 pub use self::url::Url;
 pub use self::user::User;
 pub use self::version::Version;
@@ -39,6 +39,7 @@ pub mod pane;
 pub mod server;
 pub mod shortcut;
 pub mod stream;
+pub mod target;
 pub mod time;
 pub mod url;
 pub mod user;

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -689,7 +689,7 @@ fn target(
 
     match message.0.command {
         // Channel
-        Command::MODE(target, ..) if proto::is_channel(&target, chantypes) => {
+        Command::MODE(target, ..) => {
             let channel =
                 target::Channel::parse(&target, chantypes, statusmsg, casemapping).ok()?;
 
@@ -889,7 +889,6 @@ fn target(
         | Command::TAGMSG(_)
         | Command::USERIP(_)
         | Command::HELP(_)
-        | Command::MODE(_, _, _)
         | Command::Numeric(_, _)
         | Command::Unknown(_, _)
         | Command::Raw(_) => Some(Target::Server {

--- a/data/src/target.rs
+++ b/data/src/target.rs
@@ -1,0 +1,293 @@
+use std::hash::Hash;
+use std::{cmp, fmt};
+
+use irc::proto;
+use serde::{Deserialize, Serialize};
+
+use crate::isupport;
+use crate::user::User;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum Target {
+    Channel(Channel),
+    Query(Query),
+}
+
+impl Target {
+    pub fn as_channel(&self) -> Option<&Channel> {
+        match self {
+            Target::Channel(channel) => Some(channel),
+            Target::Query(_) => None,
+        }
+    }
+
+    pub fn as_normalized_str(&self) -> &str {
+        match self {
+            Target::Channel(channel) => channel.as_normalized_str(),
+            Target::Query(query) => query.as_normalized_str(),
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            Target::Channel(channel) => channel.as_str(),
+            Target::Query(query) => query.as_str(),
+        }
+    }
+
+    pub fn parse(
+        target: &str,
+        chantypes: &[char],
+        statusmsg: &[char],
+        casemapping: isupport::CaseMap,
+    ) -> Self {
+        if let Some((prefixes, channel)) =
+            proto::parse_channel_from_target(target, chantypes, statusmsg)
+        {
+            Target::Channel(Channel {
+                prefixes,
+                normalized: casemapping.normalize(&channel),
+                raw: target.to_string(),
+            })
+        } else {
+            Target::Query(Query {
+                normalized: casemapping.normalize(target),
+                raw: target.to_string(),
+            })
+        }
+    }
+}
+
+impl PartialEq for Target {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Target::Channel(channel), Target::Channel(other_channel)) => {
+                channel.normalized.eq(&other_channel.normalized)
+            }
+            (Target::Query(query), Target::Query(other_query)) => {
+                query.normalized.eq(&other_query.normalized)
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Eq for Target {}
+
+impl Hash for Target {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            Target::Channel(channel) => channel.hash(state),
+            Target::Query(query) => query.hash(state),
+        }
+    }
+}
+
+impl Ord for Target {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        match (self, other) {
+            (Target::Channel(channel), Target::Channel(other_channel)) => {
+                channel.normalized.cmp(&other_channel.normalized)
+            }
+            (Target::Channel(_), Target::Query(_)) => cmp::Ordering::Less,
+            (Target::Query(query), Target::Query(other_query)) => {
+                query.normalized.cmp(&other_query.normalized)
+            }
+            (Target::Query(_), Target::Channel(_)) => cmp::Ordering::Greater,
+        }
+    }
+}
+
+impl PartialOrd for Target {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl fmt::Display for Target {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Target::Channel(channel) => channel.fmt(f),
+            Target::Query(query) => query.fmt(f),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Channel {
+    prefixes: Vec<char>,
+    normalized: String,
+    raw: String,
+}
+
+impl Channel {
+    pub fn as_normalized_str(&self) -> &str {
+        self.normalized.as_ref()
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.raw.as_ref()
+    }
+
+    pub fn from_str(target: &str, casemapping: isupport::CaseMap) -> Self {
+        if let Some(index) = target.find(proto::DEFAULT_CHANNEL_PREFIXES) {
+            // This will not panic, since `find` always returns a valid codepoint index.
+            // We call `find` -> `split_at` because it is an _inclusive_ split, which includes the match.
+            let (prefixes, channel) = target.split_at(index);
+
+            return Channel {
+                prefixes: prefixes.chars().collect(),
+                normalized: casemapping.normalize(channel),
+                raw: target.to_string(),
+            };
+        }
+
+        Channel {
+            prefixes: vec![],
+            normalized: casemapping.normalize(target),
+            raw: target.to_string(),
+        }
+    }
+
+    pub fn parse(
+        target: &str,
+        chantypes: &[char],
+        statusmsg: &[char],
+        casemapping: isupport::CaseMap,
+    ) -> Result<Self, ParseError> {
+        if let Some((prefixes, channel)) =
+            proto::parse_channel_from_target(target, chantypes, statusmsg)
+        {
+            Ok(Channel {
+                prefixes,
+                normalized: casemapping.normalize(&channel),
+                raw: target.to_string(),
+            })
+        } else {
+            Err(ParseError::InvalidChannel(target.to_string()))
+        }
+    }
+
+    pub fn prefixes(&self) -> &[char] {
+        &self.prefixes
+    }
+
+    pub fn to_target(&self) -> Target {
+        Target::Channel(self.clone())
+    }
+}
+
+impl PartialEq for Channel {
+    fn eq(&self, other: &Self) -> bool {
+        self.normalized.eq(&other.normalized)
+    }
+}
+
+impl Eq for Channel {}
+
+impl Hash for Channel {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.normalized.hash(state);
+    }
+}
+
+impl Ord for Channel {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.normalized.cmp(&other.normalized)
+    }
+}
+
+impl PartialOrd for Channel {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl fmt::Display for Channel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.raw.fmt(f)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Query {
+    normalized: String,
+    raw: String,
+}
+
+impl Query {
+    pub fn as_normalized_str(&self) -> &str {
+        self.normalized.as_ref()
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.raw.as_ref()
+    }
+
+    pub fn from_user(user: &User, casemapping: isupport::CaseMap) -> Self {
+        Query {
+            normalized: casemapping.normalize(user.as_str()),
+            raw: user.as_str().to_string(),
+        }
+    }
+
+    pub fn parse(
+        target: &str,
+        chantypes: &[char],
+        statusmsg: &[char],
+        casemapping: isupport::CaseMap,
+    ) -> Result<Self, ParseError> {
+        if let Some((_, _)) = proto::parse_channel_from_target(target, chantypes, statusmsg) {
+            Err(ParseError::InvalidQuery(target.to_string()))
+        } else {
+            Ok(Query {
+                normalized: casemapping.normalize(target),
+                raw: target.to_string(),
+            })
+        }
+    }
+
+    pub fn to_target(&self) -> Target {
+        Target::Query(self.clone())
+    }
+}
+
+impl PartialEq for Query {
+    fn eq(&self, other: &Self) -> bool {
+        self.normalized.eq(&other.normalized)
+    }
+}
+
+impl Eq for Query {}
+
+impl Hash for Query {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.normalized.hash(state);
+    }
+}
+
+impl Ord for Query {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.normalized.cmp(&other.normalized)
+    }
+}
+
+impl PartialOrd for Query {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl fmt::Display for Query {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.raw.fmt(f)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+    #[error("unable to parse channel from {0}")]
+    InvalidChannel(String),
+    #[error("unable to parse query from {0}")]
+    InvalidQuery(String),
+}

--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use data::user::Nick;
-use data::{message, Config, Server, User};
+use data::{isupport, message, target, Config, Server, User};
 use iced::widget::{column, container, horizontal_rule, row, scrollable, Scrollable};
 use iced::Length;
 
@@ -11,7 +11,7 @@ use crate::{theme, Theme};
 #[derive(Debug, Clone)]
 pub enum Event {
     UserContext(user_context::Event),
-    OpenChannel(String),
+    OpenChannel(target::Channel),
 }
 
 #[derive(Debug, Clone)]
@@ -37,7 +37,8 @@ pub fn update(message: Message) -> Option<Event> {
 
 pub fn view<'a>(
     server: &'a Server,
-    channel: &'a str,
+    casemapping: isupport::CaseMap,
+    channel: &'a target::Channel,
     content: &'a message::Content,
     who: Option<&'a str>,
     time: Option<&'a DateTime<Utc>>,
@@ -55,6 +56,7 @@ pub fn view<'a>(
                 selectable_text(user.display(config.buffer.channel.nicklist.show_access_levels))
                     .style(|theme| theme::selectable_text::topic_nickname(theme, config, user)),
                 server,
+                casemapping,
                 Some(channel),
                 user,
                 Some(user),
@@ -79,6 +81,7 @@ pub fn view<'a>(
 
     let content = column![message_content(
         content,
+        casemapping,
         theme,
         Message::Link,
         theme::selectable_text::topic,

--- a/src/buffer/highlights.rs
+++ b/src/buffer/highlights.rs
@@ -1,4 +1,4 @@
-use data::{history, message, Config, Server};
+use data::{history, message, target, Config, Server};
 use iced::widget::{container, row, span};
 use iced::{Length, Task};
 
@@ -13,8 +13,8 @@ pub enum Message {
 
 pub enum Event {
     UserContext(user_context::Event),
-    OpenChannel(String),
-    GoToMessage(Server, String, message::Hash),
+    OpenChannel(target::Channel),
+    GoToMessage(Server, target::Channel, message::Hash),
     History(Task<history::manager::Message>),
 }
 
@@ -49,13 +49,13 @@ pub fn view<'a>(
                             });
 
                     let channel_text = selectable_rich_text::<_, _, (), _, _>(vec![
-                        span(channel).color(theme.colors().buffer.url).link(
-                            message::Link::GoToMessage(
+                        span(channel.as_str())
+                            .color(theme.colors().buffer.url)
+                            .link(message::Link::GoToMessage(
                                 server.clone(),
-                                channel.to_string(),
+                                channel.clone(),
                                 message.hash,
-                            ),
-                        ),
+                            )),
                         span(" "),
                     ])
                     .on_link(scroll_view::Message::Link);
@@ -73,12 +73,22 @@ pub fn view<'a>(
                     )
                     .style(|theme| theme::selectable_text::nickname(theme, config, user));
 
-                    let nick =
-                        user_context::view(text, server, Some(channel), user, current_user, None)
-                            .map(scroll_view::Message::UserContext);
+                    let casemapping = clients.get_casemapping(server);
+
+                    let nick = user_context::view(
+                        text,
+                        server,
+                        casemapping,
+                        Some(channel),
+                        user,
+                        current_user,
+                        None,
+                    )
+                    .map(scroll_view::Message::UserContext);
 
                     let text = message_content::with_context(
                         &message.content,
+                        casemapping,
                         theme,
                         scroll_view::Message::Link,
                         theme::selectable_text::default,
@@ -88,7 +98,14 @@ pub fn view<'a>(
                         },
                         move |link, entry, length| match link {
                             message::Link::User(user) => entry
-                                .view(server, Some(channel), user, current_user, length)
+                                .view(
+                                    server,
+                                    clients.get_casemapping(server),
+                                    Some(channel),
+                                    user,
+                                    current_user,
+                                    length,
+                                )
                                 .map(scroll_view::Message::UserContext),
                             _ => row![].into(),
                         },

--- a/src/buffer/highlights.rs
+++ b/src/buffer/highlights.rs
@@ -149,8 +149,11 @@ pub fn view<'a>(
                     ])
                     .on_link(scroll_view::Message::Link);
 
+                    let casemapping = clients.get_casemapping(server);
+
                     let text = message_content(
                         &message.content,
+                        casemapping,
                         theme,
                         scroll_view::Message::Link,
                         theme::selectable_text::action,

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -156,7 +156,8 @@ impl State {
                 self.selected_history = None;
 
                 if let Some(entry) = self.completion.select() {
-                    let new_input = entry.complete_input(input);
+                    let chantypes = clients.get_chantypes(buffer.server());
+                    let new_input = entry.complete_input(input, chantypes);
 
                     self.on_completion(buffer, history, new_input)
                 } else if !input.is_empty() {
@@ -223,7 +224,8 @@ impl State {
                 let input = history.input(buffer).draft;
 
                 if let Some(entry) = self.completion.tab(reverse) {
-                    let new_input = entry.complete_input(input);
+                    let chantypes = clients.get_chantypes(buffer.server());
+                    let new_input = entry.complete_input(input, chantypes);
 
                     self.on_completion(buffer, history, new_input)
                 } else {

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -186,6 +186,7 @@ impl State {
                         let mut channel_users = &[][..];
                         let chantypes = clients.get_chantypes(buffer.server());
                         let statusmsg = clients.get_statusmsg(buffer.server());
+                        let casemapping = clients.get_casemapping(buffer.server());
 
                         // Resolve our attributes if sending this message in a channel
                         if let buffer::Upstream::Channel(server, channel) = &buffer {
@@ -200,7 +201,14 @@ impl State {
 
                         history_task = Task::batch(
                             history
-                                .record_input(input, user, channel_users, chantypes, statusmsg)
+                                .record_input(
+                                    input,
+                                    user,
+                                    channel_users,
+                                    chantypes,
+                                    statusmsg,
+                                    casemapping,
+                                )
                                 .into_iter()
                                 .map(Task::future),
                         );

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -80,11 +80,11 @@ pub enum Entry {
 }
 
 impl Entry {
-    pub fn complete_input(&self, input: &str) -> String {
+    pub fn complete_input(&self, input: &str, chantypes: &[char]) -> String {
         match self {
             Entry::Command(command) => format!("/{}", command.title.to_lowercase()),
             Entry::Text(next) => {
-                let is_channel = next.starts_with('#');
+                let is_channel = next.starts_with(chantypes);
                 let colon_space = ": ";
 
                 let trimmed_input = input.trim_end_matches(colon_space);

--- a/src/buffer/logs.rs
+++ b/src/buffer/logs.rs
@@ -1,4 +1,4 @@
-use data::{history, message, Config};
+use data::{history, isupport, message, target, Config};
 use iced::widget::container;
 use iced::{Length, Task};
 
@@ -13,7 +13,7 @@ pub enum Message {
 
 pub enum Event {
     UserContext(user_context::Event),
-    OpenChannel(String),
+    OpenChannel(target::Channel),
     History(Task<history::manager::Message>),
 }
 
@@ -34,6 +34,7 @@ pub fn view<'a>(
                 message::Source::Internal(message::source::Internal::Logs) => Some(
                     container(message_content(
                         &message.content,
+                        isupport::CaseMap::default(),
                         theme,
                         scroll_view::Message::Link,
                         theme::selectable_text::default,

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -2,8 +2,7 @@ use chrono::{DateTime, Utc};
 use data::isupport::ChatHistoryState;
 use data::message::{self, Limit};
 use data::server::Server;
-use data::user::Nick;
-use data::{history, Config};
+use data::{history, target, Config};
 use iced::widget::{
     button, column, container, horizontal_rule, horizontal_space, row, scrollable, text, Scrollable,
 };
@@ -32,16 +31,16 @@ pub enum Message {
 #[derive(Debug, Clone)]
 pub enum Event {
     UserContext(user_context::Event),
-    OpenChannel(String),
-    GoToMessage(Server, String, message::Hash),
+    OpenChannel(target::Channel),
+    GoToMessage(Server, target::Channel, message::Hash),
     RequestOlderChatHistory,
 }
 
 #[derive(Debug, Clone, Copy)]
 pub enum Kind<'a> {
     Server(&'a Server),
-    Channel(&'a Server, &'a str),
-    Query(&'a Server, &'a Nick),
+    Channel(&'a Server, &'a target::Channel),
+    Query(&'a Server, &'a target::Query),
     Logs,
     Highlights,
 }
@@ -51,7 +50,7 @@ impl From<Kind<'_>> for history::Kind {
         match value {
             Kind::Server(server) => history::Kind::Server(server.clone()),
             Kind::Channel(server, channel) => {
-                history::Kind::Channel(server.clone(), channel.to_string())
+                history::Kind::Channel(server.clone(), channel.clone())
             }
             Kind::Query(server, nick) => history::Kind::Query(server.clone(), nick.clone()),
             Kind::Logs => history::Kind::Logs,

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -1,4 +1,4 @@
-use data::{buffer, history, message, Config};
+use data::{buffer, history, message, target, Config};
 use iced::widget::{column, container, row, vertical_space};
 use iced::{Length, Task};
 
@@ -14,7 +14,7 @@ pub enum Message {
 
 pub enum Event {
     UserContext(user_context::Event),
-    OpenChannel(String),
+    OpenChannel(target::Channel),
     History(Task<history::manager::Message>),
 }
 
@@ -27,6 +27,7 @@ pub fn view<'a>(
     is_focused: bool,
 ) -> Element<'a, Message> {
     let status = clients.status(&state.server);
+    let casemapping = clients.get_casemapping(&state.server);
     let buffer = &state.buffer;
     let input = history.input(buffer);
 
@@ -50,6 +51,7 @@ pub fn view<'a>(
                     message::Source::Server(server) => {
                         let message = message_content(
                             &message.content,
+                            casemapping,
                             theme,
                             scroll_view::Message::Link,
                             move |theme| theme::selectable_text::server(theme, server.as_ref()),
@@ -61,6 +63,7 @@ pub fn view<'a>(
                     message::Source::Internal(message::source::Internal::Status(status)) => {
                         let message = message_content(
                             &message.content,
+                            casemapping,
                             theme,
                             scroll_view::Message::Link,
                             move |theme| theme::selectable_text::status(theme, *status),

--- a/src/main.rs
+++ b/src/main.rs
@@ -721,7 +721,7 @@ impl Halloy {
                                                     if dashboard.history().has_unread(
                                                         &history::Kind::Query(
                                                             server.clone(),
-                                                            user.nickname().to_owned(),
+                                                            query,
                                                         ),
                                                     ) || !self.main_window.focused
                                                     {
@@ -736,7 +736,7 @@ impl Halloy {
                                             data::client::Notification::Highlight {
                                                 enabled: _,
                                                 user: _,
-                                                channel: _,
+                                                target: _,
                                             }
                                             | data::client::Notification::MonitoredOnline(_)
                                             | data::client::Notification::MonitoredOffline(_) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,9 @@ use appearance::{theme, Theme};
 use chrono::Utc;
 use data::config::{self, Config};
 use data::history::{self, manager::Broadcast};
+use data::target::{self, Target};
 use data::version::Version;
-use data::{client::Notification, environment, server, target, version, Server, Url, User};
+use data::{client::Notification, environment, server, version, Server, Url, User};
 use iced::widget::{column, container};
 use iced::{padding, Length, Subscription, Task};
 use screen::{dashboard, help, migration, welcome};
@@ -778,7 +779,7 @@ impl Halloy {
                                             .load_metadata(
                                                 &self.clients,
                                                 server.clone(),
-                                                target::Target::Channel(channel),
+                                                Target::Channel(channel),
                                                 server_time,
                                             )
                                             .map(Message::Dashboard);

--- a/src/main.rs
+++ b/src/main.rs
@@ -766,9 +766,6 @@ impl Halloy {
                                                 .update_read_marker(
                                                     history::Kind::from_target(
                                                         server.clone(),
-                                                        chantypes,
-                                                        statusmsg,
-                                                        casemapping,
                                                         target,
                                                     ),
                                                     read_marker,
@@ -781,7 +778,7 @@ impl Halloy {
                                             .load_metadata(
                                                 &self.clients,
                                                 server.clone(),
-                                                channel.clone(),
+                                                target::Target::Channel(channel),
                                                 server_time,
                                             )
                                             .map(Message::Dashboard);
@@ -804,23 +801,16 @@ impl Halloy {
                                         target,
                                         server_time,
                                     ) => {
-                                        if let Ok(channel) = target::Channel::parse(
-                                            &target,
-                                            chantypes,
-                                            statusmsg,
-                                            casemapping,
-                                        ) {
-                                            let command = dashboard
-                                                .load_metadata(
-                                                    &self.clients,
-                                                    server.clone(),
-                                                    channel,
-                                                    server_time,
-                                                )
-                                                .map(Message::Dashboard);
+                                        let command = dashboard
+                                            .load_metadata(
+                                                &self.clients,
+                                                server.clone(),
+                                                target,
+                                                server_time,
+                                            )
+                                            .map(Message::Dashboard);
 
-                                            commands.push(command);
-                                        }
+                                        commands.push(command);
                                     }
                                     data::client::Event::ChatHistoryTargetsReceived(
                                         server_time,

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -108,14 +108,14 @@ impl Notifications {
             Notification::Highlight {
                 enabled,
                 user,
-                channel,
+                target,
             } => {
                 if *enabled {
                     self.execute(
                         &config.highlight,
                         notification,
                         "Highlight",
-                        format!("{} highlighted you in {}", user.nickname(), channel),
+                        format!("{} highlighted you in {}", user.nickname(), target),
                     );
                 }
             }
@@ -146,6 +146,7 @@ impl Notifications {
             audio::play(sound.clone());
         }
 
-        self.recent_notifications.insert(notification.clone(), Utc::now());
+        self.recent_notifications
+            .insert(notification.clone(), Utc::now());
     }
 }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1003,7 +1003,7 @@ impl Dashboard {
 
                     clients.send_chathistory_request(
                         &server,
-                        ChatHistorySubcommand::Latest(target.to_string(), message_reference, limit),
+                        ChatHistorySubcommand::Latest(target, message_reference, limit),
                     );
                 }
                 client::Message::RequestChatHistoryTargets(server, timestamp, server_time) => {
@@ -1497,13 +1497,13 @@ impl Dashboard {
 
                 let subcommand = if matches!(first_can_reference, MessageReference::None) {
                     ChatHistorySubcommand::Latest(
-                        target.to_string(),
+                        target,
                         first_can_reference,
                         clients.get_server_chathistory_limit(server),
                     )
                 } else {
                     ChatHistorySubcommand::Before(
-                        target.to_string(),
+                        target,
                         first_can_reference,
                         clients.get_server_chathistory_limit(server),
                     )

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -11,8 +11,9 @@ use data::config;
 use data::file_transfer;
 use data::history::manager::Broadcast;
 use data::isupport::{self, ChatHistorySubcommand, MessageReference};
+use data::target::{self, Target};
 use data::user::Nick;
-use data::{client, environment, history, target, Config, Server, Version};
+use data::{client, environment, history, Config, Server, Version};
 use iced::widget::pane_grid::{self, PaneGrid};
 use iced::widget::{column, container, row, Space};
 use iced::{clipboard, Length, Task, Vector};
@@ -1444,7 +1445,7 @@ impl Dashboard {
     pub fn get_oldest_message_reference(
         &self,
         server: &Server,
-        target: target::Target,
+        target: Target,
         message_reference_types: &[isupport::MessageReferenceType],
     ) -> MessageReference {
         if let Some(first_can_reference) = self
@@ -1545,7 +1546,7 @@ impl Dashboard {
         &mut self,
         clients: &data::client::Map,
         server: Server,
-        target: target::Target,
+        target: Target,
         server_time: DateTime<Utc>,
     ) -> Task<Message> {
         let command = self

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -67,17 +67,17 @@ impl Pane {
         let title_bar_text = match &self.buffer {
             Buffer::Empty => "".to_string(),
             Buffer::Channel(state) => {
-                let channel = &state.channel;
+                let channel = state.target.as_str();
                 let server = &state.server;
                 let users = clients
-                    .get_channel_users(&state.server, &state.channel)
+                    .get_channel_users(&state.server, &state.target)
                     .len();
 
                 format!("{channel} @ {server} - {users} users")
             }
             Buffer::Server(state) => state.server.to_string(),
             Buffer::Query(state) => {
-                let nick = &state.nick;
+                let nick = state.target.as_str();
                 let server = &state.server;
 
                 format!("{nick} @ {server}")
@@ -123,13 +123,13 @@ impl Pane {
         match &self.buffer {
             Buffer::Empty => None,
             Buffer::Channel(state) => Some(history::Resource {
-                kind: history::Kind::Channel(state.server.clone(), state.channel.clone()),
+                kind: history::Kind::Channel(state.server.clone(), state.target.clone()),
             }),
             Buffer::Server(state) => Some(history::Resource {
                 kind: history::Kind::Server(state.server.clone()),
             }),
             Buffer::Query(state) => Some(history::Resource {
-                kind: history::Kind::Query(state.server.clone(), state.nick.clone()),
+                kind: history::Kind::Query(state.server.clone(), state.target.clone()),
             }),
             Buffer::FileTransfers(_) => None,
             Buffer::Logs(_) => Some(history::Resource::logs()),
@@ -179,7 +179,7 @@ impl TitleBar {
             }
 
             // Show topic button only if there is a topic to show
-            if let Some(topic) = clients.get_channel_topic(&state.server, &state.channel) {
+            if let Some(topic) = clients.get_channel_topic(&state.server, &state.target) {
                 if topic.content.is_some() {
                     let topic_button = button(center(icon::topic()))
                         .padding(5)
@@ -319,11 +319,11 @@ impl From<Pane> for data::Pane {
         let buffer = match pane.buffer {
             Buffer::Empty => return data::Pane::Empty,
             Buffer::Channel(state) => {
-                data::Buffer::Upstream(buffer::Upstream::Channel(state.server, state.channel))
+                data::Buffer::Upstream(buffer::Upstream::Channel(state.server, state.target))
             }
             Buffer::Server(state) => data::Buffer::Upstream(buffer::Upstream::Server(state.server)),
             Buffer::Query(state) => {
-                data::Buffer::Upstream(buffer::Upstream::Query(state.server, state.nick))
+                data::Buffer::Upstream(buffer::Upstream::Query(state.server, state.target))
             }
             Buffer::FileTransfers(_) => data::Buffer::Internal(buffer::Internal::FileTransfers),
             Buffer::Logs(_) => data::Buffer::Internal(buffer::Internal::Logs),

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -307,6 +307,8 @@ impl Sidebar {
 
                     let queries = history.get_unique_queries(server);
                     for query in queries {
+                        let query = clients.resolve_query(server, query).unwrap_or(query);
+
                         buffers.push(upstream_buffer_button(
                             main_window,
                             panes,

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -540,13 +540,13 @@ fn upstream_buffer_button(
             )
             .push(unread_dot_indicator_spacing)
             .push(
-                text(channel.clone())
+                text(channel.to_string())
                     .style(buffer_title_style)
                     .shaping(text::Shaping::Advanced),
             )
             .push(horizontal_space().width(3))
             .align_y(iced::Alignment::Center),
-        buffer::Upstream::Query(_, nick) => row![]
+        buffer::Upstream::Query(_, query) => row![]
             .push(horizontal_space().width(3))
             .push_maybe(
                 show_unread_indicator
@@ -554,7 +554,7 @@ fn upstream_buffer_button(
             )
             .push(unread_dot_indicator_spacing)
             .push(
-                text(nick.to_string())
+                text(query.to_string())
                     .style(buffer_title_style)
                     .shaping(text::Shaping::Advanced),
             )

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -306,18 +306,19 @@ impl Sidebar {
                     }
 
                     let queries = history.get_unique_queries(server);
-                    for user in queries {
+                    for query in queries {
                         buffers.push(upstream_buffer_button(
                             main_window,
                             panes,
                             focus,
-                            buffer::Upstream::Query(server.clone(), user.clone()),
+                            buffer::Upstream::Query(server.clone(), query.clone()),
                             true,
                             config.buffer_action,
                             config.buffer_focused_action,
                             config.position,
                             config.unread_indicator,
-                            history.has_unread(&history::Kind::Query(server.clone(), user.clone())),
+                            history
+                                .has_unread(&history::Kind::Query(server.clone(), query.clone())),
                         ));
                     }
 

--- a/src/widget/message_content.rs
+++ b/src/widget/message_content.rs
@@ -1,5 +1,5 @@
 use data::appearance::theme::randomize_color;
-use data::{message, Config};
+use data::{isupport, message, target, Config};
 use iced::widget::span;
 use iced::widget::text::Span;
 use iced::{border, Length};
@@ -10,6 +10,7 @@ use super::{selectable_rich_text, selectable_text, Element, Renderer};
 
 pub fn message_content<'a, M: 'a>(
     content: &'a message::Content,
+    casemapping: isupport::CaseMap,
     theme: &'a Theme,
     on_link: impl Fn(message::Link) -> M + 'a,
     style: impl Fn(&Theme) -> selectable_text::Style + 'a,
@@ -17,6 +18,7 @@ pub fn message_content<'a, M: 'a>(
 ) -> Element<'a, M> {
     message_content_impl::<(), M>(
         content,
+        casemapping,
         theme,
         on_link,
         style,
@@ -27,6 +29,7 @@ pub fn message_content<'a, M: 'a>(
 
 pub fn with_context<'a, T: Copy + 'a, M: 'a>(
     content: &'a message::Content,
+    casemapping: isupport::CaseMap,
     theme: &'a Theme,
     on_link: impl Fn(message::Link) -> M + 'a,
     style: impl Fn(&Theme) -> selectable_text::Style + 'a,
@@ -36,6 +39,7 @@ pub fn with_context<'a, T: Copy + 'a, M: 'a>(
 ) -> Element<'a, M> {
     message_content_impl(
         content,
+        casemapping,
         theme,
         on_link,
         style,
@@ -47,6 +51,7 @@ pub fn with_context<'a, T: Copy + 'a, M: 'a>(
 #[allow(clippy::type_complexity)]
 fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
     content: &'a message::Content,
+    casemapping: isupport::CaseMap,
     theme: &'a Theme,
     on_link: impl Fn(message::Link) -> M + 'a,
     style: impl Fn(&Theme) -> selectable_text::Style + 'a,
@@ -66,7 +71,10 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
                         data::message::Fragment::Text(s) => span(s),
                         data::message::Fragment::Channel(s) => span(s.as_str())
                             .color(theme.colors().buffer.url)
-                            .link(message::Link::Channel(s.as_str().to_string())),
+                            .link(message::Link::Channel(target::Channel::from_str(
+                                s.as_str(),
+                                casemapping,
+                            ))),
                         data::message::Fragment::User(user, text) => {
                             let color = theme.colors().buffer.nickname;
                             let seed = match &config.buffer.channel.message.nickname_color {


### PR DESCRIPTION
Uses the `CASEMAPPING` `RPL_ISUPPORT` parameter to normalize targets (user/channel) names, then uses normalized targets for routing.  Still undergoing testing and open to be refactored.

Known issue(s):
- [x] First version of target name seen (sent by the server/bouncer) is used in the sidebar.  If that is one that has been pre-normalized, then the normalized version of the target will appear in the sidebar.  E.g.  if a message has been sent by `Guest59` then it may appear in the sidebar as `guest59`.