### PR TITLE
Highlight notifications for `/me` actions.

### DIFF
--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -97,7 +97,7 @@ impl Input {
                     .collect(),
             ),
             Command::Me(target, action) => Some(vec![Message::sent(
-                to_target(&target, message::Source::Action)?,
+                to_target(&target, message::Source::Action(Some(user.clone())))?,
                 message::action_text(user.nickname(), Some(&action)),
             )]),
             _ => None,

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -175,7 +175,7 @@ impl Message {
         matches!(self.direction, Direction::Received)
             && match self.target.source() {
                 Source::User(_) => true,
-                Source::Action => true,
+                Source::Action(_) => true,
                 Source::Server(Some(server)) => {
                     matches!(
                         server.kind(),
@@ -280,7 +280,7 @@ impl Message {
             direction: Direction::Received,
             target: Target::Query {
                 nick: from.clone(),
-                source: Source::Action,
+                source: Source::Action(None),
             },
             content,
             id: None,
@@ -299,7 +299,7 @@ impl Message {
             direction: Direction::Sent,
             target: Target::Query {
                 nick: to.clone(),
-                source: Source::Action,
+                source: Source::Action(None),
             },
             content,
             id: None,
@@ -346,6 +346,15 @@ impl Message {
                 server,
                 channel,
                 source: Source::User(user),
+            },
+            Target::Channel {
+                channel,
+                source: Source::Action(user),
+                ..
+            } => Target::Highlights {
+                server,
+                channel,
+                source: Source::Action(user),
             },
             _ => return None,
         };
@@ -726,14 +735,14 @@ fn target(
 
             Some(Target::Query {
                 nick: target.nickname().to_owned(),
-                source: Source::Action,
+                source: Source::Action(None),
             })
         }
         Command::PRIVMSG(target, text) => {
             let is_action = is_action(&text);
             let source = |user| {
                 if is_action {
-                    Source::Action
+                    Source::Action(Some(user))
                 } else {
                     Source::User(user)
                 }
@@ -770,7 +779,7 @@ fn target(
             let is_action = is_action(&text);
             let source = |user| {
                 if is_action {
-                    Source::Action
+                    Source::Action(Some(user))
                 } else {
                     Source::User(user)
                 }

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -547,7 +547,6 @@ fn text_references_nickname(text: &str, nickname: NickRef) -> Option<bool> {
 
 fn parse_user_and_channel_fragments(text: &str, channel_users: &[User]) -> Vec<Fragment> {
     text.chars()
-        .filter(|&c| c != '\u{1}')
         .group_by(|c| c.is_whitespace())
         .into_iter()
         .flat_map(|(is_whitespace, chars)| {

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -538,6 +538,7 @@ fn text_references_nickname(text: &str, nickname: NickRef) -> Option<bool> {
 
 fn parse_user_and_channel_fragments(text: &str, channel_users: &[User]) -> Vec<Fragment> {
     text.chars()
+        .filter(|&c| c != '\u{1}')
         .group_by(|c| c.is_whitespace())
         .into_iter()
         .flat_map(|(is_whitespace, chars)| {
@@ -1239,6 +1240,7 @@ pub fn references_user_text(sender: NickRef, own_nick: NickRef, text: &str) -> b
     sender != own_nick
         && text
             .chars()
+            .filter(|&c| c != '\u{1}')
             .group_by(|c| c.is_whitespace())
             .into_iter()
             .any(|(is_whitespace, chars)| {

--- a/data/src/message/source.rs
+++ b/data/src/message/source.rs
@@ -8,7 +8,7 @@ pub use self::server::Server;
 pub enum Source {
     User(User),
     Server(Option<Server>),
-    Action,
+    Action(Option<User>),
     Internal(Internal),
 }
 

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -151,15 +151,14 @@ pub fn view<'a>(
                             .push(nick)
                             .push(space);
 
-                        let text_container =
-                            container(message_content).style(move |theme| match our_nick {
-                                Some(nick)
-                                    if message::references_user(user.nickname(), nick, message) =>
-                                {
-                                    theme::container::highlight(theme)
+                        let text_container = container(message_content).style(move |theme| {
+                            if let Some(nick) = our_nick {
+                                if message::references_user(user.nickname(), nick, message) {
+                                    return theme::container::highlight(theme);
                                 }
-                                _ => Default::default(),
-                            });
+                            }
+                            Default::default()
+                        });
 
                         match &config.buffer.nickname.alignment {
                             data::buffer::Alignment::Left | data::buffer::Alignment::Right => Some(

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -203,16 +203,33 @@ pub fn view<'a>(
                             .into(),
                         )
                     }
-                    message::Source::Action => {
+                    message::Source::Action(user) => {
                         let marker = message_marker(max_nick_width, theme::selectable_text::action);
 
-                        let message = message_content(
+                        let message_content = message_content(
                             &message.content,
                             theme,
                             scroll_view::Message::Link,
                             theme::selectable_text::action,
                             config,
                         );
+
+                        let text_container =
+                            container(message_content).style(move |theme| match user {
+                                Some(user) => match our_nick {
+                                    Some(nick)
+                                        if message::references_user(
+                                            user.nickname(),
+                                            nick,
+                                            message,
+                                        ) =>
+                                    {
+                                        theme::container::highlight(theme)
+                                    }
+                                    _ => Default::default(),
+                                },
+                                _ => Default::default(),
+                            });
 
                         Some(
                             container(
@@ -221,7 +238,7 @@ pub fn view<'a>(
                                     .push_maybe(prefixes)
                                     .push(marker)
                                     .push(space)
-                                    .push(message),
+                                    .push(text_container),
                             )
                             .into(),
                         )

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -214,22 +214,14 @@ pub fn view<'a>(
                             config,
                         );
 
-                        let text_container =
-                            container(message_content).style(move |theme| match user {
-                                Some(user) => match our_nick {
-                                    Some(nick)
-                                        if message::references_user(
-                                            user.nickname(),
-                                            nick,
-                                            message,
-                                        ) =>
-                                    {
-                                        theme::container::highlight(theme)
-                                    }
-                                    _ => Default::default(),
-                                },
-                                _ => Default::default(),
-                            });
+                        let text_container = container(message_content).style(move |theme| {
+                            if let (Some(user), Some(nick)) = (user, our_nick) {
+                                if message::references_user(user.nickname(), nick, message) {
+                                    return theme::container::highlight(theme);
+                                }
+                            }
+                            Default::default()
+                        });
 
                         Some(
                             container(

--- a/src/buffer/highlights.rs
+++ b/src/buffer/highlights.rs
@@ -106,7 +106,7 @@ pub fn view<'a>(
                         )
                         .into(),
                     )
-                },
+                }
                 message::Target::Highlights {
                     server,
                     channel,
@@ -141,15 +141,10 @@ pub fn view<'a>(
                     );
 
                     Some(
-                        container(
-                            row![]
-                                .push_maybe(timestamp)
-                                .push(channel_text)
-                                .push(text),
-                        )
-                        .into(),
+                        container(row![].push_maybe(timestamp).push(channel_text).push(text))
+                            .into(),
                     )
-                },
+                }
                 _ => None,
             },
         )

--- a/src/buffer/highlights.rs
+++ b/src/buffer/highlights.rs
@@ -106,7 +106,50 @@ pub fn view<'a>(
                         )
                         .into(),
                     )
-                }
+                },
+                message::Target::Highlights {
+                    server,
+                    channel,
+                    source: message::Source::Action(_),
+                } => {
+                    let timestamp =
+                        config
+                            .buffer
+                            .format_timestamp(&message.server_time)
+                            .map(|timestamp| {
+                                selectable_text(timestamp).style(theme::selectable_text::timestamp)
+                            });
+
+                    let channel_text = selectable_rich_text::<_, _, (), _, _>(vec![
+                        span(channel.as_str())
+                            .color(theme.colors().buffer.url)
+                            .link(message::Link::GoToMessage(
+                                server.clone(),
+                                channel.clone(),
+                                message.hash,
+                            )),
+                        span(" "),
+                    ])
+                    .on_link(scroll_view::Message::Link);
+
+                    let text = message_content(
+                        &message.content,
+                        theme,
+                        scroll_view::Message::Link,
+                        theme::selectable_text::action,
+                        config,
+                    );
+
+                    Some(
+                        container(
+                            row![]
+                                .push_maybe(timestamp)
+                                .push(channel_text)
+                                .push(text),
+                        )
+                        .into(),
+                    )
+                },
                 _ => None,
             },
         )

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -130,7 +130,7 @@ pub fn view<'a>(
                             .into(),
                         )
                     }
-                    message::Source::Action => {
+                    message::Source::Action(_) => {
                         let marker = message_marker(max_nick_width, theme::selectable_text::action);
 
                         let message = message_content(

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -32,6 +32,7 @@ pub fn view<'a>(
     let status = clients.status(server);
     let buffer = &state.buffer;
     let input = history.input(buffer);
+    let our_nick = clients.nickname(&state.server);
 
     let chathistory_state = clients.get_chathistory_state(server, state.nick.as_ref());
 
@@ -74,7 +75,7 @@ pub fn view<'a>(
                         let nick = user_context::view(text, server, None, user, None, None)
                             .map(scroll_view::Message::UserContext);
 
-                        let message = message_content::with_context(
+                        let message_content = message_content::with_context(
                             &message.content,
                             theme,
                             scroll_view::Message::Link,
@@ -95,12 +96,21 @@ pub fn view<'a>(
                         let timestamp_nickname_row =
                             row![].push_maybe(timestamp).push(nick).push(space);
 
+                        let text_container = container(message_content).style(move |theme| {
+                            if let Some(nick) = our_nick {
+                                if message::references_user(user.nickname(), nick, message) {
+                                    return theme::container::highlight(theme);
+                                }
+                            }
+                            Default::default()
+                        });
+
                         match &config.buffer.nickname.alignment {
                             data::buffer::Alignment::Left | data::buffer::Alignment::Right => {
-                                Some(row![].push(timestamp_nickname_row).push(message).into())
+                                Some(row![].push(timestamp_nickname_row).push(text_container).into())
                             }
                             data::buffer::Alignment::Top => {
-                                Some(column![].push(timestamp_nickname_row).push(message).into())
+                                Some(column![].push(timestamp_nickname_row).push(text_container).into())
                             }
                         }
                     }
@@ -130,10 +140,10 @@ pub fn view<'a>(
                             .into(),
                         )
                     }
-                    message::Source::Action(_) => {
+                    message::Source::Action(user) => {
                         let marker = message_marker(max_nick_width, theme::selectable_text::action);
 
-                        let message = message_content(
+                        let message_content = message_content(
                             &message.content,
                             theme,
                             scroll_view::Message::Link,
@@ -141,13 +151,22 @@ pub fn view<'a>(
                             config,
                         );
 
+                        let text_container = container(message_content).style(move |theme| {
+                            if let (Some(user), Some(nick)) = (user, our_nick) {
+                                if message::references_user(user.nickname(), nick, message) {
+                                    return theme::container::highlight(theme);
+                                }
+                            }
+                            Default::default()
+                        });
+
                         Some(
                             container(
                                 row![]
                                     .push_maybe(timestamp)
                                     .push(marker)
                                     .push(space)
-                                    .push(message),
+                                    .push(text_container),
                             )
                             .into(),
                         )


### PR DESCRIPTION
Found bugs with highlighting notifications when someone mentions you with a `/me` action.

There's three related issues: 
- Notification events for `/me` action highlights are not triggered.
- `/me` action is not visually highlighted.
- `/me` action highlights not showing in Highlights buffer.
- Highlights in the query buffer is missing.

Above issues should be addressed with this PR. 