### PR TITLE
`chathistory` User Command Support

### DIFF
--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -1155,6 +1155,16 @@ fn content<'a>(
 
             Some(plain(format!("Monitored {targets} offline")))
         }
+        Command::CHATHISTORY(sub, args) => {
+            if sub == "TARGETS" {
+                let target = args.first()?;
+                let timestamp = args.get(1)?;
+
+                Some(plain(format!("Chat history for {target} at {timestamp}")))
+            } else {
+                None
+            }
+        }
         Command::Numeric(_, responses) | Command::Unknown(_, responses) => Some(parse_fragments(
             responses
                 .iter()

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -185,8 +185,7 @@ impl Commands {
                         }
                     }
                     "MSG" => {
-                        let channel_membership_prefixes = 
-                        if let Some(
+                        let channel_membership_prefixes = if let Some(
                             isupport::Parameter::STATUSMSG(channel_membership_prefixes),
                         ) =
                             isupport.get(&isupport::Kind::STATUSMSG)
@@ -978,7 +977,9 @@ fn chathistory_after_command(maximum_limit: &u16) -> Command {
             Arg {
                 text: "timestamp | msgid",
                 optional: false,
-                tooltip: Some(String::from("timestamp format: YYYY-MM-DDThh:mm:ss.sssZ")),
+                tooltip: Some(String::from(
+                    "timestamp format: timestamp=YYYY-MM-DDThh:mm:ss.sssZ",
+                )),
             },
             Arg {
                 text: "limit",
@@ -1008,7 +1009,9 @@ fn chathistory_around_command(maximum_limit: &u16) -> Command {
             Arg {
                 text: "timestamp | msgid",
                 optional: false,
-                tooltip: Some(String::from("timestamp format: YYYY-MM-DDThh:mm:ss.sssZ")),
+                tooltip: Some(String::from(
+                    "timestamp format: timestamp=YYYY-MM-DDThh:mm:ss.sssZ",
+                )),
             },
             Arg {
                 text: "limit",
@@ -1038,7 +1041,9 @@ fn chathistory_before_command(maximum_limit: &u16) -> Command {
             Arg {
                 text: "timestamp | msgid",
                 optional: false,
-                tooltip: Some(String::from("timestamp format: YYYY-MM-DDThh:mm:ss.sssZ")),
+                tooltip: Some(String::from(
+                    "timestamp format: timestamp=YYYY-MM-DDThh:mm:ss.sssZ",
+                )),
             },
             Arg {
                 text: "limit",
@@ -1068,12 +1073,16 @@ fn chathistory_between_command(maximum_limit: &u16) -> Command {
             Arg {
                 text: "timestamp | msgid",
                 optional: false,
-                tooltip: Some(String::from("timestamp format: YYYY-MM-DDThh:mm:ss.sssZ")),
+                tooltip: Some(String::from(
+                    "timestamp format: timestamp=YYYY-MM-DDThh:mm:ss.sssZ",
+                )),
             },
             Arg {
                 text: "timestamp | msgid",
                 optional: false,
-                tooltip: Some(String::from("timestamp format: YYYY-MM-DDThh:mm:ss.sssZ")),
+                tooltip: Some(String::from(
+                    "timestamp format: timestamp=YYYY-MM-DDThh:mm:ss.sssZ",
+                )),
             },
             Arg {
                 text: "limit",
@@ -1105,7 +1114,7 @@ fn chathistory_latest_command(maximum_limit: &u16) -> Command {
                 optional: false,
                 tooltip: Some(String::from(
                     "               *: no restriction on returned messages\
-                   \ntimestamp format: YYYY-MM-DDThh:mm:ss.sssZ",
+                   \ntimestamp format: timestamp=YYYY-MM-DDThh:mm:ss.sssZ",
                 )),
             },
             Arg {
@@ -1131,12 +1140,16 @@ fn chathistory_targets_command(maximum_limit: &u16) -> Command {
             Arg {
                 text: "timestamp",
                 optional: false,
-                tooltip: Some(String::from("timestamp format: YYYY-MM-DDThh:mm:ss.sssZ")),
+                tooltip: Some(String::from(
+                    "timestamp format: timestamp=YYYY-MM-DDThh:mm:ss.sssZ",
+                )),
             },
             Arg {
                 text: "timestamp",
                 optional: false,
-                tooltip: Some(String::from("timestamp format: YYYY-MM-DDThh:mm:ss.sssZ")),
+                tooltip: Some(String::from(
+                    "timestamp format: timestamp=YYYY-MM-DDThh:mm:ss.sssZ",
+                )),
             },
             Arg {
                 text: "limit",

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -247,6 +247,9 @@ impl Commands {
                 isupport
                     .iter()
                     .filter_map(|(_, isupport_parameter)| match isupport_parameter {
+                        isupport::Parameter::CHATHISTORY(maximum_limit) => {
+                            Some(chathistory_command(maximum_limit))
+                        }
                         isupport::Parameter::MONITOR(target_limit) => {
                             Some(monitor_command(target_limit))
                         }
@@ -918,6 +921,220 @@ fn away_command(max_len: &u16) -> Command {
             optional: true,
             tooltip: Some(format!("maximum length: {}", max_len)),
         }],
+        subcommands: None,
+    }
+}
+
+fn chathistory_command(maximum_limit: &u16) -> Command {
+    Command {
+        title: "CHATHISTORY",
+        args: vec![Arg {
+            text: "subcommand",
+            optional: false,
+            tooltip: Some(String::from(
+                " BEFORE: Request messages before a timestamp or msgid\
+               \n  AFTER: Request after before a timestamp or msgid\
+               \n LATEST: Request most recent messages that have been sent\
+               \n AROUND: Request messages before or after a timestamp or msgid\
+               \nBETWEEN: Request messages between a timestamp or msgid and another timestamp or msgid\
+               \nTARGETS: List channels with visible history and users that have sent direct messages",
+            )),
+        }],
+        subcommands: Some(vec![
+            chathistory_after_command(maximum_limit),
+            chathistory_around_command(maximum_limit),
+            chathistory_before_command(maximum_limit),
+            chathistory_between_command(maximum_limit),
+            chathistory_latest_command(maximum_limit),
+            chathistory_targets_command(maximum_limit),
+        ]),
+    }
+}
+
+fn chathistory_after_command(maximum_limit: &u16) -> Command {
+    let limit_tooltip = if *maximum_limit == 1 {
+        String::from("up to 1 message")
+    } else {
+        format!("up to {} messages", maximum_limit)
+    };
+
+    Command {
+        title: "CHATHISTORY AFTER",
+        args: vec![
+            Arg {
+                text: "target",
+                optional: false,
+                tooltip: None,
+            },
+            Arg {
+                text: "timestamp | msgid",
+                optional: false,
+                tooltip: Some(String::from("timestamp format: YYYY-MM-DDThh:mm:ss.sssZ")),
+            },
+            Arg {
+                text: "limit",
+                optional: false,
+                tooltip: Some(limit_tooltip),
+            },
+        ],
+        subcommands: None,
+    }
+}
+
+fn chathistory_around_command(maximum_limit: &u16) -> Command {
+    let limit_tooltip = if *maximum_limit == 1 {
+        String::from("up to 1 message")
+    } else {
+        format!("up to {} messages", maximum_limit)
+    };
+
+    Command {
+        title: "CHATHISTORY AROUND",
+        args: vec![
+            Arg {
+                text: "target",
+                optional: false,
+                tooltip: None,
+            },
+            Arg {
+                text: "timestamp | msgid",
+                optional: false,
+                tooltip: Some(String::from("timestamp format: YYYY-MM-DDThh:mm:ss.sssZ")),
+            },
+            Arg {
+                text: "limit",
+                optional: false,
+                tooltip: Some(limit_tooltip),
+            },
+        ],
+        subcommands: None,
+    }
+}
+
+fn chathistory_before_command(maximum_limit: &u16) -> Command {
+    let limit_tooltip = if *maximum_limit == 1 {
+        String::from("up to 1 message")
+    } else {
+        format!("up to {} messages", maximum_limit)
+    };
+
+    Command {
+        title: "CHATHISTORY BEFORE",
+        args: vec![
+            Arg {
+                text: "target",
+                optional: false,
+                tooltip: None,
+            },
+            Arg {
+                text: "timestamp | msgid",
+                optional: false,
+                tooltip: Some(String::from("timestamp format: YYYY-MM-DDThh:mm:ss.sssZ")),
+            },
+            Arg {
+                text: "limit",
+                optional: false,
+                tooltip: Some(limit_tooltip),
+            },
+        ],
+        subcommands: None,
+    }
+}
+
+fn chathistory_between_command(maximum_limit: &u16) -> Command {
+    let limit_tooltip = if *maximum_limit == 1 {
+        String::from("up to 1 message")
+    } else {
+        format!("up to {} messages", maximum_limit)
+    };
+
+    Command {
+        title: "CHATHISTORY BETWEEN",
+        args: vec![
+            Arg {
+                text: "target",
+                optional: false,
+                tooltip: None,
+            },
+            Arg {
+                text: "timestamp | msgid",
+                optional: false,
+                tooltip: Some(String::from("timestamp format: YYYY-MM-DDThh:mm:ss.sssZ")),
+            },
+            Arg {
+                text: "timestamp | msgid",
+                optional: false,
+                tooltip: Some(String::from("timestamp format: YYYY-MM-DDThh:mm:ss.sssZ")),
+            },
+            Arg {
+                text: "limit",
+                optional: false,
+                tooltip: Some(limit_tooltip),
+            },
+        ],
+        subcommands: None,
+    }
+}
+
+fn chathistory_latest_command(maximum_limit: &u16) -> Command {
+    let limit_tooltip = if *maximum_limit == 1 {
+        String::from("up to 1 message")
+    } else {
+        format!("up to {} messages", maximum_limit)
+    };
+
+    Command {
+        title: "CHATHISTORY LATEST",
+        args: vec![
+            Arg {
+                text: "target",
+                optional: false,
+                tooltip: None,
+            },
+            Arg {
+                text: "* | timestamp | msgid",
+                optional: false,
+                tooltip: Some(String::from(
+                    "               *: no restriction on returned messages\
+                   \ntimestamp format: YYYY-MM-DDThh:mm:ss.sssZ",
+                )),
+            },
+            Arg {
+                text: "limit",
+                optional: false,
+                tooltip: Some(limit_tooltip),
+            },
+        ],
+        subcommands: None,
+    }
+}
+
+fn chathistory_targets_command(maximum_limit: &u16) -> Command {
+    let limit_tooltip = if *maximum_limit == 1 {
+        String::from("up to 1 target")
+    } else {
+        format!("up to {} targets", maximum_limit)
+    };
+
+    Command {
+        title: "CHATHISTORY TARGETS",
+        args: vec![
+            Arg {
+                text: "timestamp",
+                optional: false,
+                tooltip: Some(String::from("timestamp format: YYYY-MM-DDThh:mm:ss.sssZ")),
+            },
+            Arg {
+                text: "timestamp",
+                optional: false,
+                tooltip: Some(String::from("timestamp format: YYYY-MM-DDThh:mm:ss.sssZ")),
+            },
+            Arg {
+                text: "limit",
+                optional: false,
+                tooltip: Some(limit_tooltip),
+            },
+        ],
         subcommands: None,
     }
 }

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -1281,7 +1281,7 @@ fn list_command(
     if let Some(target_limit) = target_limit {
         if let Some(limit) = target_limit.limit {
             channels_tooltip.push_str(format!("\nup to {} channel", limit).as_str());
-            if limit > 1 {
+            if limit != 1 {
                 channels_tooltip.push('s')
             }
         }
@@ -1362,7 +1362,7 @@ fn monitor_add_command(target_limit: &Option<u16>) -> Command {
 
     if let Some(target_limit) = target_limit {
         targets_tooltip.push_str(format!("\nup to {} target", target_limit).as_str());
-        if *target_limit > 1 {
+        if *target_limit != 1 {
             targets_tooltip.push('s')
         }
         targets_tooltip.push_str(" in total");
@@ -1430,7 +1430,7 @@ fn msg_command(
     if let Some(target_limit) = target_limit {
         if let Some(limit) = target_limit.limit {
             targets_tooltip.push_str(format!("\nup to {} target", limit).as_str());
-            if limit > 1 {
+            if limit != 1 {
                 targets_tooltip.push('s')
             }
         }
@@ -1459,7 +1459,7 @@ fn names_command(target_limit: &isupport::CommandTargetLimit) -> Command {
 
     if let Some(limit) = target_limit.limit {
         channels_tooltip.push_str(format!("\nup to {} channel", limit).as_str());
-        if limit > 1 {
+        if limit != 1 {
             channels_tooltip.push('s')
         }
     }
@@ -1579,7 +1579,7 @@ fn whois_command(target_limit: &isupport::CommandTargetLimit) -> Command {
 
     if let Some(limit) = target_limit.limit {
         nicks_tooltip.push_str(format!("\nup to {} nick", limit).as_str());
-        if limit > 1 {
+        if limit != 1 {
             nicks_tooltip.push('s')
         }
     }

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -506,12 +506,21 @@ impl Command {
     }
 
     fn view<'a, Message: 'a>(&self, input: &str) -> Element<'a, Message> {
-        let active_arg = [input, "_"]
-            .concat()
-            .split_ascii_whitespace()
-            .count()
-            .saturating_sub(2)
-            .min(self.args.len().saturating_sub(1));
+        let command_prefix = format!("/{}", self.title.to_lowercase());
+
+        let active_arg = [
+            "_",
+            input
+                .to_lowercase()
+                .strip_prefix(&command_prefix)
+                .unwrap_or(input),
+            "_",
+        ]
+        .concat()
+        .split_ascii_whitespace()
+        .count()
+        .saturating_sub(2)
+        .min(self.args.len().saturating_sub(1));
 
         let title = Some(Element::from(text(self.title)));
 


### PR DESCRIPTION
In the event that `chathistory` malfunctions, it would be nice to have some user remedy (beyond wiping their history clean).  So I've added some support for the user sending their own `chathistory` commands.  In particular:

1. Command completion for `chathistory` commands (and fix a minor issue in command completion for sub-commands)
2. Send the output of the `CHATHISTORY TARGETS` command to the server buffer (when it's user requested).