### PR TITLE
Miscellaneous SASL Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Added:
 - Timeout delay for notifications
 - Case mapping support via `ISUPPORT`
 
+Fixed:
+- Long username & password combinations could cause SASL authentication to fail
+
 # 2024.14 (2024-10-29)
 
 Fixed:

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1880,7 +1880,7 @@ impl Dashboard {
             &client::Notification::FileTransferRequest(request.from.clone()),
             Some(server),
         );
-            
+
         let query =
             target::Query::parse(request.from.as_ref(), chantypes, statusmsg, casemapping).ok()?;
 


### PR DESCRIPTION
Various SASL fixes, including:
- Do not send `CAP END` before SASL has completed (success or failure received from server).
- Exclude authorization identity from `AUTHENTICATE` command (assumed to be the same as the authentication identity).
- Chunk SASL `AUTHENTICATE` command into 400 byte chunks.