### PR TITLE
Windows Path String Documentation

### DIFF
--- a/book/src/configuration/README.md
+++ b/book/src/configuration/README.md
@@ -8,6 +8,8 @@ To edit configuration parameters, create a `config.toml` file located in your co
 
 > 💡 You can easily open the config file directory from command bar in Halloy
 
+The specification for the configuration file format ([TOML](https://toml.io/)) can be found at [https://toml.io/](https://toml.io/).
+
 Example config for connecting to [Libera](https://libera.chat/):
 
 ```toml

--- a/book/src/configuration/servers/README.md
+++ b/book/src/configuration/servers/README.md
@@ -34,7 +34,7 @@ The client's NICKSERV password.
  
 ## `nick_password_file`
 
-Read nick_password from the file at the given path.[^1]
+Read nick_password from the file at the given path.[^1] [^2]
 
 - **type**: string
 - **values**: any string
@@ -107,7 +107,7 @@ The password to connect to the server.
 
 ## `password_file`
 
-Read password from the file at the given path.[^1]
+Read password from the file at the given path.[^1] [^2]
 
 - **type**: string
 - **values**: any string
@@ -206,7 +206,7 @@ When `true`, all certificate validations are skipped.
 
 ## `root_cert_path`
 
-The path to the root TLS certificate for this server in PEM format.[^1]
+The path to the root TLS certificate for this server in PEM format.[^1] [^2]
 
 - **type**: string
 - **values**: any string
@@ -265,3 +265,4 @@ Whether or not to enable [IRCv3 Chat History](https://ircv3.net/specs/extensions
 - **default**: `true`
 
 [^1]: Shell expansions (e.g. `"~/"` → `"/home/user/"`) are not supported in path strings.
+[^2]: Windows path strings should usually be specified as literal strings (e.g. `'C:\Users\Default\'`), otherwise directory separators will need to be escaped (e.g. `"C:\\Users\\Default\\"`).

--- a/book/src/configuration/servers/sasl/external.md
+++ b/book/src/configuration/servers/sasl/external.md
@@ -12,7 +12,7 @@ key = "/path/to/your/private_key.pem"
 
 ## `cert`
 
-The path to PEM encoded X509 user certificate for external auth.[^1]
+The path to PEM encoded X509 user certificate for external auth.[^1] [^2]
 
 - **type**: string
 - **values**: any string
@@ -20,10 +20,11 @@ The path to PEM encoded X509 user certificate for external auth.[^1]
 
 ## `key`
 
-The path to PEM encoded PKCS#8 private key for external auth (optional).[^1]
+The path to PEM encoded PKCS#8 private key for external auth (optional).[^1] [^2]
 
 - **type**: string
 - **values**: any string
 - **default**: not set
 
 [^1]: Shell expansions (e.g. `"~/"` → `"/home/user/"`) are not supported in path strings.
+[^2]: Windows path strings should usually be specified as literal strings (e.g. `'C:\Users\Default\'`), otherwise directory separators will need to be escaped (e.g. `"C:\\Users\\Default\\"`).

--- a/book/src/configuration/servers/sasl/external.md
+++ b/book/src/configuration/servers/sasl/external.md
@@ -4,10 +4,18 @@ External SASL auth uses a PEM encoded X509 certificate. [Reference](https://libe
 
 **Example**
 
+Linux/Mac:
 ```toml
 [servers.liberachat.sasl.external]
 cert = "/path/to/your/certificate.pem"
 key = "/path/to/your/private_key.pem"
+```
+
+Windows:
+```toml
+[servers.liberachat.sasl.external]
+cert = 'C:\path\to\your\certificate.pem'
+key = 'C:\path\to\your\private_key.pem'
 ```
 
 ## `cert`

--- a/book/src/configuration/servers/sasl/plain.md
+++ b/book/src/configuration/servers/sasl/plain.md
@@ -26,7 +26,7 @@ The password associated with the account used for authentication.
 
 ## `password_file`
 
-Read `password` from the file at the given path.[^1]
+Read `password` from the file at the given path.[^1] [^2]
 
 - **type**: string
 - **values**: any string
@@ -41,3 +41,4 @@ Executes the command with `sh` (or equivalent) and reads `password` as the outpu
 - **default**: not set
 
 [^1]: Shell expansions (e.g. `"~/"` → `"/home/user/"`) are not supported in path strings.
+[^2]: Windows path strings should usually be specified as literal strings (e.g. `'C:\Users\Default\'`), otherwise directory separators will need to be escaped (e.g. `"C:\\Users\\Default\\"`).

--- a/book/src/guides/password-file.md
+++ b/book/src/guides/password-file.md
@@ -7,6 +7,8 @@ If you need to commit your configuration file to a public repository, you can ke
 
 > 💡 Shell expansions (e.g. `"~/"` → `"/home/user/"`) are not supported in path strings.
 
+> 💡 Windows path strings should usually be specified as literal strings (e.g. `'C:\Users\Default\'`), otherwise directory separators will need to be escaped (e.g. `"C:\\Users\\Default\\"`).
+
 ```toml
 [servers.liberachat]
 nickname = "foobar"


### PR DESCRIPTION
Further documentation attempting to help users with the Windows path string directory separator issue.  Specifically, that the directory separator `\` is also the TOML string escape character.