### PR TITLE
Change default focus hotkeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Fixed:
 - Long username & password combinations could cause SASL authentication to fail
 - `nick_password_command` is now working as intended
 
+Changed:
+- Changed focus buffer shortcuts to include `Ctrl` (`⌘` on macOS) to avoid interfering with default text input shortcuts for word navigation (`⌥ + ←`, `⌥ + →`)
+
 # 2024.14 (2024-10-29)
 
 Fixed:

--- a/book/src/configuration/keyboard.md
+++ b/book/src/configuration/keyboard.md
@@ -14,10 +14,10 @@ move_right = "alt+l"
 
 | Key                     | Description                  | Default MacOS                                       | Default Other                                       |
 | ----------------------- | ---------------------------- | --------------------------------------------------- | --------------------------------------------------- |
-| `move_up`               | Moves focus up               | <kbd>⌥</kbd> + <kbd>↑</kbd>                         | <kbd>alt</kbd> + <kbd>↑</kbd>                       |
-| `move_down`             | Moves focus down             | <kbd>⌥</kbd> + <kbd>↓</kbd>                         | <kbd>alt</kbd> + <kbd>↓</kbd>                       |
-| `move_left`             | Moves focus left             | <kbd>⌥</kbd> + <kbd>←</kbd>                         | <kbd>alt</kbd> + <kbd>←</kbd>                       |
-| `move_right`            | Moves focus right            | <kbd>⌥</kbd> + <kbd>→</kbd>                         | <kbd>alt</kbd> + <kbd>→</kbd>                       |
+| `move_up`               | Moves focus up               | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>↑</kbd>          | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>↑</kbd>     |
+| `move_down`             | Moves focus down             | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>↓</kbd>          | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>↓</kbd>     |
+| `move_left`             | Moves focus left             | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>←</kbd>          | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>←</kbd>     |
+| `move_right`            | Moves focus right            | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>→</kbd>          | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>→</kbd>     |
 | `close_buffer`          | Close focused buffer         | <kbd>⌘</kbd> + <kbd>w</kbd>                         | <kbd>ctrl</kbd> + <kbd>w</kbd>                      |
 | `maximize_buffer`       | Maximize focused buffer      | <kbd>⌘</kbd> + <kbd>↑</kbd>                         | <kbd>ctrl</kbd> + <kbd>↑</kbd>                      |
 | `restore_buffer`        | Restore focused buffer       | <kbd>⌘</kbd> + <kbd>↓</kbd>                         | <kbd>ctrl</kbd> + <kbd>↓</kbd>                      |

--- a/data/src/shortcut.rs
+++ b/data/src/shortcut.rs
@@ -113,10 +113,10 @@ impl Hash for KeyBind {
 }
 
 impl KeyBind {
-    default!(move_up, ArrowUp, ALT);
-    default!(move_down, ArrowDown, ALT);
-    default!(move_left, ArrowLeft, ALT);
-    default!(move_right, ArrowRight, ALT);
+    default!(move_up, ArrowUp, COMMAND | ALT);
+    default!(move_down, ArrowDown, COMMAND | ALT);
+    default!(move_left, ArrowLeft, COMMAND | ALT);
+    default!(move_right, ArrowRight, COMMAND | ALT);
     default!(close_buffer, "w", COMMAND);
     default!(maximize_buffer, ArrowUp, COMMAND);
     default!(restore_buffer, ArrowDown, COMMAND);


### PR DESCRIPTION
Changed focus buffer shortcuts to include `Ctrl` (`⌘` on macOS) to avoid interfering with default text input shortcuts for word navigation (`⌥ + ←`, `⌥ + →`).

Fixes https://github.com/squidowl/halloy/issues/312