### PR TITLE
Miscellaneous CASEMAPPING Fixes

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -2059,7 +2059,7 @@ impl Client {
             .chanmap
             .keys()
             .cloned()
-            .sorted_by(|a, b| self.compare_channels(a.as_str(), b.as_str()))
+            .sorted_by(|a, b| self.compare_channels(a.as_normalized_str(), b.as_normalized_str()))
             .collect();
         self.users = self
             .chanmap

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,7 @@ fn settings(config_load: &Result<Config, config::Error>) -> iced::Settings {
 }
 
 fn handle_irc_error(e: anyhow::Error) {
-    log::error!("IRC error: {:?}", e);
+    log::error!("{:#}", e);
 }
 
 struct Halloy {


### PR DESCRIPTION
A few fixes/improvements related to the previous CASEMAPPING PR.  Specifically:
1.  Bugfix in MODE parsing that would prevent the command from being parsed.
2.  Improved IRC error logging (additional context for reported errors).
3.  Use normalized channel names for sidebar sorting.