### PR TITLE
WHO Polling Fixes/Improvements

### DIFF
--- a/book/src/configuration/servers/README.md
+++ b/book/src/configuration/servers/README.md
@@ -237,14 +237,6 @@ WHO poll interval (in seconds) for servers without away-notify.  Specifically, t
 - **values**: `1` .. `3600`
 - **default**: `2`
   
-## `who_retry_interval`
-
-WHO retry interval (in seconds) for servers without away-notify.
-
-- **type**: integer
-- **values**: `5` .. `3600`
-- **default**: `10`
-
 ## `monitor`
 
 A list of nicknames to [monitor](https://ircv3.net/specs/extensions/monitor) (if IRCv3 Monitor is supported by the server).

--- a/book/src/configuration/servers/README.md
+++ b/book/src/configuration/servers/README.md
@@ -231,11 +231,11 @@ Whether or not to WHO polling is enabled.
 
 ## `who_poll_interval`
 
-WHO poll interval (in seconds) for servers without away-notify.
+WHO poll interval (in seconds) for servers without away-notify.  Specifically, the time between individual WHO requests.  Will be increased automatically if the server sends a rate-limiting message.
 
 - **type**: integer
-- **values**: `5` .. `3600`
-- **default**: `180`
+- **values**: `1` .. `3600`
+- **default**: `2`
   
 ## `who_retry_interval`
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -963,7 +963,7 @@ impl Client {
                 }
 
                 if !self.supports_account_notify {
-                    let accountname = ok!(args.first());
+                    let accountname = ok!(args.get(2));
 
                     let old_user = User::from(self.nickname().to_owned());
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -2341,7 +2341,7 @@ impl Client {
                     if matches!(source, WhoSource::Poll) && !self.config.who_poll_enabled {
                         None
                     } else {
-                        (now.duration_since(*requested) >= self.config.who_retry_interval)
+                        (now.duration_since(*requested) >= 5 * self.who_poll_interval.duration)
                             .then_some(Request::Retry)
                     }
                 }

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -321,7 +321,7 @@ fn default_who_poll_enabled() -> bool {
 }
 
 fn default_who_poll_interval() -> Duration {
-    Duration::from_secs(60)
+    Duration::from_secs(2)
 }
 
 fn default_who_retry_interval() -> Duration {

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -285,7 +285,7 @@ where
     D: Deserializer<'de>,
 {
     let seconds: u64 = Deserialize::deserialize(deserializer)?;
-    Ok(Duration::from_secs(seconds.clamp(5, 3600)))
+    Ok(Duration::from_secs(seconds.clamp(1, 3600)))
 }
 
 fn default_use_tls() -> bool {

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -321,7 +321,7 @@ fn default_who_poll_enabled() -> bool {
 }
 
 fn default_who_poll_interval() -> Duration {
-    Duration::from_secs(180)
+    Duration::from_secs(60)
 }
 
 fn default_who_retry_interval() -> Duration {

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -87,12 +87,6 @@ pub struct Server {
         deserialize_with = "deserialize_duration_from_u64"
     )]
     pub who_poll_interval: Duration,
-    /// WHO retry interval for servers without away-notify.
-    #[serde(
-        default = "default_who_retry_interval",
-        deserialize_with = "deserialize_duration_from_u64"
-    )]
-    pub who_retry_interval: Duration,
     /// A list of nicknames to monitor (if MONITOR is supported by the server).
     #[serde(default)]
     pub monitor: Vec<String>,
@@ -175,7 +169,6 @@ impl Default for Server {
             on_connect: Default::default(),
             who_poll_enabled: default_who_poll_enabled(),
             who_poll_interval: default_who_poll_interval(),
-            who_retry_interval: default_who_retry_interval(),
             monitor: Default::default(),
             chathistory: default_chathistory(),
         }
@@ -322,10 +315,6 @@ fn default_who_poll_enabled() -> bool {
 
 fn default_who_poll_interval() -> Duration {
     Duration::from_secs(2)
-}
-
-fn default_who_retry_interval() -> Duration {
-    Duration::from_secs(10)
 }
 
 fn default_chathistory() -> bool {

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -879,9 +879,30 @@ impl FromStr for WhoToken {
     }
 }
 
-pub const WHO_POLL_TOKEN: WhoToken = WhoToken {
-    digits: ['9', '\0', '\0'],
-};
+pub enum WhoXPollParameters {
+    Default,
+    WithAccountName,
+}
+
+impl WhoXPollParameters {
+    pub fn fields(&self) -> &'static str {
+        match self {
+            WhoXPollParameters::Default => "tcnf",
+            WhoXPollParameters::WithAccountName => "tcnfa",
+        }
+    }
+
+    pub fn token(&self) -> WhoToken {
+        match self {
+            WhoXPollParameters::Default => WhoToken {
+                digits: ['9', '\0', '\0'],
+            },
+            WhoXPollParameters::WithAccountName => WhoToken {
+                digits: ['9', '9', '\0'],
+            },
+        }
+    }
+}
 
 fn parse_optional_letters(value: &str) -> Result<Option<String>, &'static str> {
     if value.is_empty() {

--- a/data/src/stream.rs
+++ b/data/src/stream.rs
@@ -226,6 +226,8 @@ async fn _run(
                             .unbounded_send(Update::MessagesReceived(server.clone(), messages));
                     }
                     Input::Send(message) => {
+                        log::trace!("[{server}] Sending message => {:?}", message);
+
                         if let Command::QUIT(reason) = &message.command {
                             let reason = reason.clone();
 


### PR DESCRIPTION
This contains a number of changes to WHO polling, primarily to address the behavior reported in #584.  Includes:

- Use WHO polling queue to perform WHO polls in serial, rather than in parallel.  Greatly reduces the effective rate of WHO polling for users in more than a few channels (the default rate has been increased a bit as a result, but should still be slower than before for most users).  And, ensures that the maximum WHO polling rate can be more-straightforwardly controlled by the user configuring `who_poll_interval` and `who_retry_interval`.
- Switches the WHO show/hide logic to hide all WHO replies unless a user initiated WHO request was sent.  Previously WHO replies would be shown unless a WHO poll was sent.  Ensures WHO replies sent by other clients are not shown, even if they are not routed to the requesting client (e.g. when using ZNC with multiple clients & without route_replies enabled).
- Fixes a bug where WHO polls that were sent before CAP negotiation completed could be parsed incorrectly (effectively throwing away the result of the first WHO poll request).

In testing this allows server WHO rate-limit to be better respected, but I do see some rate-limit notifications due to the initial WHO polling initiated by channel JOINs on Libera.  I expected those WHO polls to be valid since Solanum appears to give a "WHO credit" for each JOIN, so that remains to be sorted out.