### PR TITLE
Restore window position and size.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Added:
 - Highlight notifications for `/me` actions
 - Timeout delay for notifications
 - Case mapping support via `ISUPPORT`
+- Restore last known window position and size at launch
 
 Fixed:
 - Long username & password combinations could cause SASL authentication to fail

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3933,9 +3933,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.20"
+version = "0.23.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
+checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
 dependencies = [
  "once_cell",
  "ring",

--- a/data/src/window.rs
+++ b/data/src/window.rs
@@ -40,13 +40,10 @@ impl Window {
     pub async fn load() -> Result<Window, Error> {
         let path = path()?;
         let bytes = fs::read(path).await?;
-        let Window { position, size} = serde_json::from_slice(&bytes)?;
-    
+        let Window { position, size } = serde_json::from_slice(&bytes)?;
+
         let size = size.max(MIN_SIZE);
-        let position = position.map(|pos| Point {
-            x: pos.x.max(0.0),
-            y: pos.y.max(0.0),
-        });
+        let position = position.filter(|pos| pos.y.is_sign_positive() && pos.x.is_sign_positive());
 
         Ok(Window { position, size })
     }

--- a/data/src/window.rs
+++ b/data/src/window.rs
@@ -41,8 +41,14 @@ impl Window {
         let path = path()?;
 
         let bytes = std::fs::read(path)?;
+        let Window { position, size} = serde_json::from_slice(&bytes)?;
 
-        Ok(serde_json::from_slice(&bytes)?)
+        let size = size.max(MIN_SIZE);
+        let position = position.map(|Point { x, y}| {
+            Point { x: x.max(0.0), y: y.max(0.0)}
+        });
+
+        Ok(Window { size, position })
     }
 
     pub async fn save(self) -> Result<(), Error> {

--- a/data/src/window.rs
+++ b/data/src/window.rs
@@ -37,18 +37,18 @@ pub fn default_size() -> Size {
 }
 
 impl Window {
-    pub fn load() -> Result<Self, Error> {
+    pub async fn load() -> Result<Window, Error> {
         let path = path()?;
-
-        let bytes = std::fs::read(path)?;
+        let bytes = fs::read(path).await?;
         let Window { position, size} = serde_json::from_slice(&bytes)?;
-
+    
         let size = size.max(MIN_SIZE);
-        let position = position.map(|Point { x, y}| {
-            Point { x: x.max(0.0), y: y.max(0.0)}
+        let position = position.map(|pos| Point {
+            x: pos.x.max(0.0),
+            y: pos.y.max(0.0),
         });
 
-        Ok(Window { size, position })
+        return Ok(Window { position, size })
     }
 
     pub async fn save(self) -> Result<(), Error> {

--- a/data/src/window.rs
+++ b/data/src/window.rs
@@ -48,7 +48,7 @@ impl Window {
             y: pos.y.max(0.0),
         });
 
-        return Ok(Window { position, size })
+        Ok(Window { position, size })
     }
 
     pub async fn save(self) -> Result<(), Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,18 +85,12 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // TODO: Renable persistant window position and size:
-    // Winit currently has a bug with resize and move events.
-    // Until it have been fixed, the persistant position and size has been disabled.
-    //
-    let initial_window_data = data::Window::load().unwrap_or_default();
-
     iced::daemon("Halloy", Halloy::update, Halloy::view)
         .theme(Halloy::theme)
         .scale_factor(Halloy::scale_factor)
         .subscription(Halloy::subscription)
         .settings(settings(&config_load))
-        .run_with(move || Halloy::new(config_load, initial_window_data, destination, log_stream))
+        .run_with(move || Halloy::new(config_load, destination, log_stream))
         .inspect_err(|err| log::error!("{}", err))?;
 
     Ok(())
@@ -235,12 +229,11 @@ pub enum Message {
 impl Halloy {
     fn new(
         config_load: Result<Config, config::Error>,
-        initial_window_data: data::Window,
         url_received: Option<data::Url>,
         log_stream: ReceiverStream<Vec<logger::Record>>,
     ) -> (Halloy, Task<Message>) {
-        let data::Window { size, position} = initial_window_data;
-        println!("INITIAL SIZE IS: {:?}", size);
+        // Load stored window position and size, or use default.
+        let data::Window { size, position} = data::Window::load().unwrap_or_default();
         let position = position.map(|pos| window::Position::Specific(pos)).unwrap_or_default();
 
         let (main_window, open_main_window) = window::open(window::Settings {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ use data::{client::Notification, environment, server, version, Server, Url, User
 use iced::widget::{column, container};
 use iced::{padding, Length, Subscription, Task};
 use screen::{dashboard, help, migration, welcome};
-use tokio::{join, runtime};
+use tokio::runtime;
 use tokio_stream::wrappers::ReceiverStream;
 
 use self::event::{events, Event};
@@ -72,10 +72,10 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
             .build()?;
 
         rt.block_on(async { 
-            let config = Config::load();
-            let window = data::Window::load();
+            let config = Config::load().await;
+            let window = data::Window::load().await;
 
-            join!(config, window)
+            (config, window)
         })
     };
     // DANGER ZONE - font must be set using config

--- a/src/main.rs
+++ b/src/main.rs
@@ -234,7 +234,7 @@ impl Halloy {
     ) -> (Halloy, Task<Message>) {
         // Load stored window position and size, or use default.
         let data::Window { size, position} = data::Window::load().unwrap_or_default();
-        let position = position.map(|pos| window::Position::Specific(pos)).unwrap_or_default();
+        let position = position.map(window::Position::Specific).unwrap_or_default();
 
         let (main_window, open_main_window) = window::open(window::Settings {
             size,

--- a/src/window.rs
+++ b/src/window.rs
@@ -176,6 +176,10 @@ impl subscription::Recipe for Events {
         use futures::stream;
         const TIMEOUT: std::time::Duration = std::time::Duration::from_millis(500);
 
+        // This is a hack to skip n amount of certain events on Windows.
+        // This is a winit bug: https://github.com/rust-windowing/winit/issues/2094
+        //
+        // If we don't skip these events the window will become smaller and smaller on each launch.
         let mut move_events = {
             let threshold = if cfg!(target_os = "windows") { 1 } else { 0 };
             EventSkipper::new(threshold)

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,7 +1,7 @@
 use futures::{stream::BoxStream, Stream, StreamExt};
 use iced::{advanced::graphics::futures::subscription, Point, Size, Subscription};
 
-pub use data::window::{default_size, Error, MIN_SIZE};
+pub use data::window::{Error, MIN_SIZE};
 pub use iced::window::{close, gain_focus, open, Id, Position, Settings};
 
 #[derive(Debug, Clone, Copy)]
@@ -153,6 +153,7 @@ impl subscription::Recipe for Events {
         use futures::stream;
         const TIMEOUT: std::time::Duration = std::time::Duration::from_millis(500);
 
+
         let window_events = events.filter_map(|event| {
             futures::future::ready(match event {
                 subscription::Event::Interaction {
@@ -160,9 +161,14 @@ impl subscription::Recipe for Events {
                     event: iced::Event::Window(window_event),
                     status: _,
                 } => match window_event {
-                    iced::window::Event::Moved(point) => Some((id, Event::Moved(point))),
-                    iced::window::Event::Resized(Size { width, height }) => {
-                        Some((id, Event::Resized(Size::new(width, height))))
+                    iced::window::Event::Moved(point) => {
+                        let is_sign_positive = point.x.is_sign_positive() && point.y.is_sign_positive();
+                        is_sign_positive.then_some((id, Event::Moved(point)))
+                    },
+                    iced::window::Event::Resized(size) => {
+                        println!("RESIZED: {:?}", size);
+                        let is_above_zero = size.width > 0.0 && size.height > 0.0;
+                        is_above_zero.then_some((id, Event::Resized(size)))
                     }
                     iced::window::Event::Focused => Some((id, Event::Focused)),
                     iced::window::Event::Unfocused => Some((id, Event::Unfocused)),

--- a/src/window.rs
+++ b/src/window.rs
@@ -199,9 +199,10 @@ impl subscription::Recipe for Events {
                 } => match window_event {
                     iced::window::Event::Moved(point) => {
                         if move_events.should_process() {
-                            let is_sign_positive =
-                                point.x.is_sign_positive() && point.y.is_sign_positive();
-                            is_sign_positive.then_some((id, Event::Moved(point)))
+                            let clamped_x = point.x.max(0.0);
+                            let clamped_y = point.y.max(0.0);
+                        
+                            Some((id, Event::Moved(Point { x: clamped_x, y: clamped_y })))
                         } else {
                             move_events.skip();
                             None
@@ -209,8 +210,7 @@ impl subscription::Recipe for Events {
                     }
                     iced::window::Event::Resized(size) => {
                         if resize_events.should_process() {
-                            let is_above_zero = size.width > 0.0 && size.height > 0.0;
-                            is_above_zero.then_some((id, Event::Resized(size)))
+                             Some((id, Event::Resized(size.max(MIN_SIZE))))
                         } else {
                             resize_events.skip();
                             None


### PR DESCRIPTION
Fixes https://github.com/squidowl/halloy/issues/411.

I've introduced a hack to skip a few initial events which was causing problems on Windows due to a winit bug: https://github.com/rust-windowing/winit/issues/2094.

Tested on
- [X] Windows
- [X] macOS
- [x] Linux

Could you test on Linux @andymandias or @tarkah?