### PR TITLE
Expand Echo Search

### DIFF
--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -491,7 +491,11 @@ impl History {
 /// of the incoming message. Either message IDs match, or server times
 /// have an exact match + target & content.
 pub fn insert_message(messages: &mut Vec<Message>, message: Message) {
-    const FUZZ_SECONDS: chrono::Duration = chrono::Duration::seconds(1);
+    let fuzz_seconds = if matches!(message.direction, message::Direction::Received(true)) {
+        chrono::Duration::seconds(120)
+    } else {
+        chrono::Duration::seconds(1)
+    };
 
     if messages.is_empty() {
         messages.push(message);
@@ -499,8 +503,8 @@ pub fn insert_message(messages: &mut Vec<Message>, message: Message) {
         return;
     }
 
-    let start = message.server_time - FUZZ_SECONDS;
-    let end = message.server_time + FUZZ_SECONDS;
+    let start = message.server_time - fuzz_seconds;
+    let end = message.server_time + fuzz_seconds;
 
     let start_index = match messages.binary_search_by(|stored| stored.server_time.cmp(&start)) {
         Ok(match_index) => match_index,
@@ -519,7 +523,7 @@ pub fn insert_message(messages: &mut Vec<Message>, message: Message) {
         if (message.id.is_some() && stored.id == message.id)
             || ((stored.server_time == message.server_time
                 || (matches!(stored.direction, message::Direction::Sent)
-                    && matches!(message.direction, message::Direction::Received)))
+                    && matches!(message.direction, message::Direction::Received(true))))
                 && has_matching_content(stored, &message))
         {
             replace_at = Some(current_index);

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -27,7 +27,7 @@ fn expand(
         Message {
             received_at,
             server_time: sent_time,
-            direction: Direction::Received,
+            direction: Direction::Received(false),
             target,
             content,
             id: None,


### PR DESCRIPTION
Increases the search time interval when inserting an echo (message sent by the user received from the server) into message history.  This is to help address the duplicate messages issue discussed in #709.