### PR TITLE
Fix various performance issues

### DIFF
--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -17,7 +17,7 @@ flate2 = "1.0"
 futures = "0.3.21"
 hex = "0.4.3"
 iced_core = "0.14.0-dev"
-log = "0.4.16"
+log = { version = "0.4.16", features = ['std'] }
 palette = "0.7.4"
 rand = "0.8.4"
 rand_chacha = "0.3.0"
@@ -27,8 +27,8 @@ sha2 = "0.10.8"
 toml = "0.8.11"
 thiserror = "1.0.30"
 reqwest = { version = "0.12", features = ["json"] }
-tokio = { version = "1.0", features = ["io-util"] }
-tokio-stream = { version = "0.1", features = ["time"] }
+tokio = { version = "1.0", features = ["io-util", "fs"] }
+tokio-stream = { version = "0.1", features = ["time", "fs"] }
 itertools = "0.12.1"
 timeago = "0.4.2"
 url = { version = "2.5.0", features = ["serde"] }
@@ -46,4 +46,4 @@ path = "../irc"
 
 [dependencies.serde]
 version = "1.0"
-features = ["derive"]
+features = ["derive", "rc"]

--- a/data/src/server.rs
+++ b/data/src/server.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::{fmt, str};
 use tokio::fs;
 use tokio::process::Command;
@@ -14,23 +15,35 @@ use crate::config::Error;
 pub type Handle = Sender<proto::Message>;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct Server(String);
+#[serde(transparent)]
+pub struct Server {
+    name: Arc<str>,
+}
+
+impl Server {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+}
 
 impl From<&str> for Server {
     fn from(value: &str) -> Self {
-        Server(value.to_string())
+        Server {
+            name: Arc::from(value),
+        }
     }
 }
 
 impl fmt::Display for Server {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
+        self.name.fmt(f)
     }
 }
 
 impl AsRef<str> for Server {
     fn as_ref(&self) -> &str {
-        &self.0
+        self.name()
     }
 }
 

--- a/irc/proto/src/command.rs
+++ b/irc/proto/src/command.rs
@@ -149,6 +149,9 @@ impl Command {
                 params.next()
             };
         }
+        macro_rules! remaining {
+            () => { params.collect() };
+        }
 
         match tag.as_str() {
             "CAP" if len > 0 => {
@@ -183,7 +186,7 @@ impl Command {
             "STATS" if len > 0 => STATS(req!(), opt!()),
             "HELP" => HELP(opt!()),
             "INFO" => INFO,
-            "MODE" if len > 0 => MODE(req!(), opt!(), Some(params.collect())),
+            "MODE" if len > 0 => MODE(req!(), opt!(), Some(remaining!())),
             "PRIVMSG" if len > 1 => PRIVMSG(req!(), req!()),
             "NOTICE" if len > 1 => NOTICE(req!(), req!()),
             "WHO" if len > 0 => WHO(req!(), opt!(), opt!()),
@@ -201,11 +204,11 @@ impl Command {
             "SQUIT" if len > 1 => SQUIT(req!(), req!()),
             "AWAY" => AWAY(opt!()),
             "LINKS" => LINKS,
-            "USERHOST" => USERHOST(params.collect()),
+            "USERHOST" => USERHOST(remaining!()),
             "WALLOPS" if len > 0 => WALLOPS(req!()),
             "ACCOUNT" if len > 0 => ACCOUNT(req!()),
-            "BATCH" if len > 0 => BATCH(req!(), params.collect()),
-            "CHATHISTORY" if len > 0 => CHATHISTORY(req!(), params.collect()),
+            "BATCH" if len > 0 => BATCH(req!(), remaining!()),
+            "CHATHISTORY" if len > 0 => CHATHISTORY(req!(), remaining!()),
             "CHGHOST" if len > 1 => CHGHOST(req!(), req!()),
             "CNOTICE" if len > 2 => CNOTICE(req!(), req!(), req!()),
             "CPRIVMSG" if len > 2 => CPRIVMSG(req!(), req!(), req!()),
@@ -214,7 +217,7 @@ impl Command {
             "MONITOR" if len > 0 => MONITOR(req!(), opt!()),
             "TAGMSG" if len > 0 => TAGMSG(req!()),
             "USERIP" if len > 0 => USERIP(req!()),
-            _ => Self::Unknown(tag, params.collect()),
+            _ => Self::Unknown(tag, remaining!()),
         }
     }
 


### PR DESCRIPTION
This commit includes various fixes that I have found working on bouncer-networks. It includes several performance benefits—such as changing `Server` to be an `Arc<str>` which removes much of the copying overhead. I have also made sure that there is only one copy of the server config in the `Halloy` struct, which was previously duplicated for seemingly no reason.
Still, several performance issues go un-addressed. such as the duplication of server configs between threads (should this also be an `Arc<config>`?) and the copying of `client` structs.

I have also made some changes to the client. The capability negotiation process has been streamlined, and I've eliminated some branching with preference toward pattern matching. I've also fixed a slight error with halloy, making sure that it detects the end of registration correctly (matching other clients).

I have also made changes to the `Cargo.toml` in the `data` crate. This is to fix some compilation issues when building that crate in isolation. I would like this fixed so that it'd be easier to run `data` crate tests in isolation.
Ideally I think that each of the sub-crates should be tested individually in CI—but that's out of scope for this PR.

In my opinion, this resolves #640