### PR TITLE
Expand Echo Search (Take Two)

### DIFF
--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -299,7 +299,7 @@ impl Message {
 
         Message {
             received_at,
-            server_time: Utc::now(),
+            server_time,
             direction: Direction::Received,
             target: Target::Query {
                 query: query.clone(),
@@ -472,7 +472,7 @@ impl<'de> Deserialize<'de> for Message {
             Content::Plain("".to_string())
         };
 
-        let is_echo = is_echo.unwrap_or(false);
+        let is_echo = is_echo.unwrap_or_default();
 
         let hash = Hash::new(&server_time, &content);
 

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -34,6 +34,7 @@ fn expand(
             id: None,
             hash,
             hidden_urls: HashSet::default(),
+            is_echo: false,
         }
     };
 


### PR DESCRIPTION
Increases the search time interval when inserting an echo (message sent by the user received from the server) into message history.  Unlike the previous implementation (#714), existing history is properly deserialized.