### PR TITLE
If user who set topic isn't in channel we still format the nick.

### DIFF
--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -48,8 +48,7 @@ pub fn view<'a>(
     theme: &'a Theme,
 ) -> Element<'a, Message> {
     let set_by = who
-        .map(|who| User::try_from(who).ok())
-        .flatten()
+        .and_then(|who| User::try_from(who).ok())
         .and_then(|user| {
             let channel_user = users.iter().find(|u| **u == user);
             

--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -1,5 +1,4 @@
 use chrono::{DateTime, Utc};
-use data::user::Nick;
 use data::{isupport, message, target, Config, Server, User};
 use iced::widget::{column, container, horizontal_rule, row, scrollable, Scrollable};
 use iced::Length;
@@ -48,37 +47,46 @@ pub fn view<'a>(
     config: &'a Config,
     theme: &'a Theme,
 ) -> Element<'a, Message> {
-    let set_by = who.and_then(|who| {
-        let nick = Nick::from(who.split('!').next()?);
-
-        let user = if let Some(user) = users.iter().find(|user| user.nickname() == nick) {
-            user_context::view(
-                selectable_text(user.display(config.buffer.channel.nicklist.show_access_levels))
+    let set_by = who
+        .map(|who| User::try_from(who).ok())
+        .flatten()
+        .and_then(|user| {
+            let channel_user = users.iter().find(|u| **u == user);
+            
+            // If user is in channel, we return user_context component.
+            // Otherwise selectable_text component.
+            let content = if let Some(user) = channel_user {
+                user_context::view(
+                    selectable_text(
+                        user.display(config.buffer.channel.nicklist.show_access_levels),
+                    )
                     .style(|theme| theme::selectable_text::topic_nickname(theme, config, user)),
-                server,
-                casemapping,
-                Some(channel),
-                user,
-                Some(user),
-                our_user,
-                config,
-            )
-        } else {
-            selectable_text(who)
-                .style(theme::selectable_text::tertiary)
-                .into()
-        };
+                    server,
+                    casemapping,
+                    Some(channel),
+                    user,
+                    Some(user),
+                    our_user,
+                    config,
+                )
+            } else {
+                selectable_text(user.display(false))
+                    .style(move |theme| {
+                        theme::selectable_text::topic_nickname(theme, config, &user)
+                    })
+                    .into()
+            };
 
-        Some(
-            Element::new(row![
-                selectable_text("set by ").style(theme::selectable_text::topic),
-                user,
-                selectable_text(format!(" at {}", time?.to_rfc2822()))
-                    .style(theme::selectable_text::topic),
-            ])
-            .map(Message::UserContext),
-        )
-    });
+            Some(
+                Element::new(row![
+                    selectable_text("set by ").style(theme::selectable_text::topic),
+                    content,
+                    selectable_text(format!(" at {}", time?.to_rfc2822()))
+                        .style(theme::selectable_text::topic),
+                ])
+                .map(Message::UserContext),
+            )
+        });
 
     let content = column![message_content(
         content,


### PR DESCRIPTION
Previously the nickname of the user who wrote topic was only formatted if they were in the channel.
This is now fixed:

Previously:
![Screenshot 2025-01-29 153515](https://github.com/user-attachments/assets/c295b177-d008-4a8c-b664-048a647650b3)

Now:
![Screenshot 2025-01-29 153426](https://github.com/user-attachments/assets/d3316ab4-1ac8-4c2c-8524-a1af21d7ce11)