### PR TITLE
Optionally exclude `direct_message`, `file_transfer_request` and `highlight` notifications.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Added:
 - Date separators in buffers when day changes
 - Toggle fullscreen (<kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>f</kbd> (macOS: <kbd>ctrl</kbd> + <kbd>⌥</kbd> + <kbd>f</kbd>))
 - Show nickname in user-context menu
+- Optionally exclude `direct_message`, `file_transfer_request` and `highlight` notifications. See [configuration](https://halloy.squidowl.org/configuration/notifications.html#exclude).
 
 Fixed:
 

--- a/book/src/configuration/notifications.md
+++ b/book/src/configuration/notifications.md
@@ -66,3 +66,48 @@ Delay in milliseconds before triggering the next notification.
 [notifications.<notification>]
 delay = 250
 ```
+
+## `exclude`
+
+Exclude notifications for nicks (and/or channels in `highlight`'s case).
+
+Only available for `direct_message`, `highlight` and `file_transfer_request`
+notifications.
+
+You can also exclude all nicks/channels by using a wildcard: `["*"]` or `["all"]`.
+
+```toml
+# Type: array of strings
+# Values: array of strings
+# Default: []
+
+[notifications.<direct_mesage|file_transfer_request>]
+exclude = ["HalloyUser1"]
+
+[notifications.highlight]
+exclude = ["HalloyUser1", "#halloy"]
+```
+
+## `include`
+
+Include notifications for nicks (and/or channels in `highlight`'s case).
+
+Only available for `direct_message`, `highlight` and `file_transfer_request`
+notifications.
+
+The include rule takes priority over exclude, so you can use both together.
+For example, you can exclude all nicks with `["*"]` for `direct_message` and
+then only include a few specific nicks to receive `direct_message` notifications
+from.
+
+```toml
+# Type: array of strings
+# Values: array of strings
+# Default: []
+
+[notifications.<direct_mesage|file_transfer_request>]
+include = ["HalloyUser1"]
+
+[notifications.highlight]
+include = ["HalloyUser1", "#halloy"]
+```

--- a/book/src/configuration/notifications.md
+++ b/book/src/configuration/notifications.md
@@ -6,7 +6,10 @@ Customize and enable notifications.
 
 ```toml
 [notifications]
-highlight = { sound = "dong" }
+highlight = {
+    sound = "dong"
+    exclude = ["NickServ", "#halloy"]
+}
 direct_message = { sound = "peck", show_toast = true }
 ```
 

--- a/data/src/config/notification.rs
+++ b/data/src/config/notification.rs
@@ -10,6 +10,7 @@ pub struct Notification<T = String> {
     pub show_toast: bool,
     pub sound: Option<T>,
     pub delay: Option<u64>,
+    pub exclude: Option<Vec<String>>
 }
 
 impl<T> Default for Notification<T> {
@@ -18,6 +19,7 @@ impl<T> Default for Notification<T> {
             show_toast: false,
             sound: None,
             delay: Some(500),
+            exclude: None
         }
     }
 }
@@ -64,6 +66,7 @@ impl Notifications {
                 show_toast: notification.show_toast,
                 sound: notification.sound.as_deref().map(Sound::load).transpose()?,
                 delay: notification.delay,
+                exclude: notification.exclude.to_owned(),
             })
         };
 

--- a/data/src/config/notification.rs
+++ b/data/src/config/notification.rs
@@ -10,7 +10,8 @@ pub struct Notification<T = String> {
     pub show_toast: bool,
     pub sound: Option<T>,
     pub delay: Option<u64>,
-    pub exclude: Option<Vec<String>>
+    #[serde(default)]
+    pub exclude: Vec<String>
 }
 
 impl<T> Default for Notification<T> {
@@ -19,7 +20,7 @@ impl<T> Default for Notification<T> {
             show_toast: false,
             sound: None,
             delay: Some(500),
-            exclude: None
+            exclude: vec![],
         }
     }
 }

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -89,10 +89,9 @@ impl Notifications {
             }
             Notification::FileTransferRequest(nick) => {
                 if let Some(server) = server {
-                    if !config
+                    if config
                         .file_transfer_request
-                        .exclude
-                        .contains(&nick.to_string())
+                        .should_notify(vec![nick.to_string()])
                     {
                         self.execute(
                             &config.file_transfer_request,
@@ -104,10 +103,9 @@ impl Notifications {
                 }
             }
             Notification::DirectMessage(user) => {
-                if !config
+                if config
                     .direct_message
-                    .exclude
-                    .contains(&user.nickname().to_string())
+                    .should_notify(vec![user.nickname().to_string()])
                 {
                     self.execute(
                         &config.direct_message,
@@ -122,14 +120,9 @@ impl Notifications {
                 user,
                 target,
             } => {
-                if !config
+                if config
                     .highlight
-                    .exclude
-                    .contains(&target.to_string())
-                    && !config
-                        .highlight
-                        .exclude
-                        .contains(&user.nickname().to_string())
+                    .should_notify(vec![target.to_string(), user.nickname().to_string()])
                     && *enabled
                 {
                     self.execute(

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -93,7 +93,7 @@ impl Notifications {
                         .file_transfer_request
                         .exclude
                         .as_ref()
-                        .map_or(false, |exclude| exclude.contains(&nick.to_string()))
+                        .is_some_and(|exclude| exclude.contains(&nick.to_string()))
                     {
                         self.execute(
                             &config.file_transfer_request,
@@ -109,9 +109,7 @@ impl Notifications {
                     .direct_message
                     .exclude
                     .as_ref()
-                    .map_or(false, |exclude| {
-                        exclude.contains(&user.nickname().to_string())
-                    })
+                    .is_some_and(|exclude| exclude.contains(&user.nickname().to_string()))
                 {
                     self.execute(
                         &config.direct_message,
@@ -126,7 +124,7 @@ impl Notifications {
                 user,
                 target,
             } => {
-                if !config.highlight.exclude.as_ref().map_or(false, |exclude| {
+                if !config.highlight.exclude.as_ref().is_some_and(|exclude| {
                     exclude.contains(&target.to_string())
                         || exclude.contains(&user.nickname().to_string())
                 }) && *enabled

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -92,8 +92,7 @@ impl Notifications {
                     if !config
                         .file_transfer_request
                         .exclude
-                        .as_ref()
-                        .is_some_and(|exclude| exclude.contains(&nick.to_string()))
+                        .contains(&nick.to_string())
                     {
                         self.execute(
                             &config.file_transfer_request,
@@ -108,8 +107,7 @@ impl Notifications {
                 if !config
                     .direct_message
                     .exclude
-                    .as_ref()
-                    .is_some_and(|exclude| exclude.contains(&user.nickname().to_string()))
+                    .contains(&user.nickname().to_string())
                 {
                     self.execute(
                         &config.direct_message,
@@ -124,10 +122,15 @@ impl Notifications {
                 user,
                 target,
             } => {
-                if !config.highlight.exclude.as_ref().is_some_and(|exclude| {
-                    exclude.contains(&target.to_string())
-                        || exclude.contains(&user.nickname().to_string())
-                }) && *enabled
+                if !config
+                    .highlight
+                    .exclude
+                    .contains(&target.to_string())
+                    && !config
+                        .highlight
+                        .exclude
+                        .contains(&user.nickname().to_string())
+                    && *enabled
                 {
                     self.execute(
                         &config.highlight,


### PR DESCRIPTION
Addresses #733.

Example config:
```
[notifications.highlight]
show_toast = true
sound = "dong"
exclude = ["ChanServ", "NickServ", "#halloy"]
```

Also, added the `include` property with support for wildcards: `*` and `all`.