### PR TITLE
Default Value for `infinite_scroll`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+Fixed:
+
+- [`infinite_scroll`](https://halloy.squidowl.org/configuration/buffer.html?highlight=infinite#infinite_scroll) was defaulting to `false`, contrary to its documented default value.  Now defaults to `true`.
+
 # 2025.1 (2025-02-02)
 
 Added:

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -176,10 +176,18 @@ impl Default for InternalMessage {
     }
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ChatHistory {
-    #[serde(default)]
+    #[serde(default = "default_bool_true")]
     pub infinite_scroll: bool,
+}
+
+impl Default for ChatHistory {
+    fn default() -> Self {
+        Self {
+            infinite_scroll: true,
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone, Default, Deserialize)]


### PR DESCRIPTION
The documentation lists the default value as `true`, but the default being set is `false`, this is just to make them consistent.  I decided to go with `true`, because I suspect that is the more modern expectation.