### PR TITLE
Completion Tweaks

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -435,6 +435,17 @@ impl Buffer {
             Buffer::Highlights(highlights) => Some(highlights.scroll_view.is_scrolled_to_bottom()),
         }
     }
+
+    pub fn close_picker(&mut self) -> bool {
+        match self {
+            Buffer::Empty | Buffer::FileTransfers(_) | Buffer::Logs(_) | Buffer::Highlights(_) => {
+                false
+            }
+            Buffer::Server(state) => state.input_view.close_picker(),
+            Buffer::Channel(state) => state.input_view.close_picker(),
+            Buffer::Query(state) => state.input_view.close_picker(),
+        }
+    }
 }
 
 impl From<data::Buffer> for Buffer {

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -23,6 +23,7 @@ pub enum Message {
     Tab(bool),
     Up,
     Down,
+    Escape,
 }
 
 pub fn view<'a>(
@@ -65,14 +66,19 @@ pub fn view<'a>(
     if buffer_focused {
         input = key_press(
             key_press(
-                input,
-                key_press::Key::Named(key_press::Named::ArrowUp),
+                key_press(
+                    input,
+                    key_press::Key::Named(key_press::Named::ArrowUp),
+                    key_press::Modifiers::default(),
+                    Message::Up,
+                ),
+                key_press::Key::Named(key_press::Named::ArrowDown),
                 key_press::Modifiers::default(),
-                Message::Up,
+                Message::Down,
             ),
-            key_press::Key::Named(key_press::Named::ArrowDown),
+            key_press::Key::Named(key_press::Named::Escape),
             key_press::Modifiers::default(),
-            Message::Down,
+            Message::Escape,
         );
     }
 
@@ -297,6 +303,9 @@ impl State {
 
                 (Task::none(), None)
             }
+            // Capture escape so that closing context menu or commands/emojis picker
+            // does not defocus input
+            Message::Escape => (Task::none(), None),
         }
     }
 

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -344,4 +344,8 @@ impl State {
 
         text_input::move_cursor_to_end(self.input_id.clone())
     }
+
+    pub fn close_picker(&mut self) -> bool {
+        self.completion.close_picker()
+    }
 }

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -130,6 +130,20 @@ impl Completion {
             .view(input, config)
             .or(self.emojis.view(config))
     }
+
+    pub fn close_picker(&mut self) -> bool {
+        if matches!(self.commands, Commands::Selecting { .. }) {
+            self.commands = Commands::Idle;
+
+            return true;
+        } else if matches!(self.emojis, Emojis::Selecting { .. }) {
+            self.emojis = Emojis::Idle;
+
+            return true;
+        }
+
+        false
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -101,7 +101,24 @@ impl Completion {
             return None;
         }
 
-        self.text.tab(reverse).map(Entry::Text)
+        self.text.tab(reverse).map_or(
+            {
+                if self.text.filtered.is_empty() {
+                    None
+                } else {
+                    Some(Entry::Text {
+                        next: self.text.prompt.clone(),
+                        append_suffix: false,
+                    })
+                }
+            },
+            |next| {
+                Some(Entry::Text {
+                    next,
+                    append_suffix: true,
+                })
+            },
+        )
     }
 
     pub fn view<'a, Message: 'a>(
@@ -118,7 +135,7 @@ impl Completion {
 #[derive(Debug, Clone)]
 pub enum Entry {
     Command(Command),
-    Text(String),
+    Text { next: String, append_suffix: bool },
     Emoji(String),
 }
 
@@ -126,10 +143,19 @@ impl Entry {
     pub fn complete_input(&self, input: &str, chantypes: &[char], config: &Config) -> String {
         match self {
             Entry::Command(command) => format!("/{}", command.title.to_lowercase()),
-            Entry::Text(next) => {
+            Entry::Text {
+                next,
+                append_suffix,
+            } => {
                 let autocomplete = &config.buffer.text_input.autocomplete;
                 let is_channel = next.starts_with(chantypes);
                 let mut words: Vec<_> = input.split(' ').collect();
+
+                if let Some(last_word_position) = words.iter().rposition(|word| !word.is_empty()) {
+                    words.truncate(last_word_position + 1);
+                } else {
+                    words.clear();
+                }
 
                 // Replace the last word with the next word
                 if let Some(last_word) = words.last_mut() {
@@ -140,14 +166,17 @@ impl Entry {
 
                 let mut new_input = words.join(" ");
 
-                if words.len() == 1 && !is_channel {
-                    // If completed at the beginning of the input line and not a channel.
-                    let suffix = &autocomplete.completion_suffixes[0];
-                    new_input.push_str(suffix);
-                } else {
-                    // Otherwise, use second suffix.
-                    let suffix = &autocomplete.completion_suffixes[1];
-                    new_input.push_str(suffix);
+                // If next is not the original prompt, then append the configured suffix
+                if *append_suffix {
+                    if words.len() == 1 && !is_channel {
+                        // If completed at the beginning of the input line and not a channel.
+                        let suffix = &autocomplete.completion_suffixes[0];
+                        new_input.push_str(suffix);
+                    } else {
+                        // Otherwise, use second suffix.
+                        let suffix = &autocomplete.completion_suffixes[1];
+                        new_input.push_str(suffix);
+                    }
                 }
 
                 new_input
@@ -350,7 +379,7 @@ impl Commands {
                     .collect();
 
                 *self = Self::Selecting {
-                    highlighted: None,
+                    highlighted: Some(0),
                     filtered,
                 };
             }
@@ -1735,7 +1764,7 @@ impl Emojis {
         filtered.sort_by(|a, b| b.similarity.total_cmp(&a.similarity));
 
         *self = Emojis::Selecting {
-            highlighted: None,
+            highlighted: Some(0),
             filtered: filtered.into_iter().map(|f| f.shortcode).collect(),
         };
     }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -988,6 +988,12 @@ impl Dashboard {
             }
             Message::CloseContextMenu(window, any_closed) => {
                 if !any_closed {
+                    if let Some((_, _, state)) = self.get_focused_mut(main_window) {
+                        if state.buffer.close_picker() {
+                            return (Task::none(), None);
+                        }
+                    }
+
                     if self.is_pane_maximized() && window == main_window.id {
                         self.panes.main.restore();
                     } else {
@@ -1273,6 +1279,7 @@ impl Dashboard {
                 //
                 // - Close command bar (if main window)
                 // - Close context menu
+                // - Close command/emoji picker
                 // - Restore maximized pane (if main window)
                 // - Unfocus
                 if self.command_bar.is_some() && window == main_window.id {


### PR DESCRIPTION
This PR has three ~related changes to completion (which can be split further if needed):
  - Fixes a bug where text completion will not replace the previous completion properly when the specified suffix contains a space (i.e. during typical usage).  This bug was introduced as part of a previous minor bug fix, where whitespace in a message would be compressed (e.g. multiple spaces replaced with a single space) when using text/emoji completion.
  - When cycling through text completions, the last name would require two tab presses to loop back to the first completion from the last completion.  This fixes that behavior by cycling back to the original prompt before looping back to the first completion (with one tab between each).
  - Select the first command/emoji automatically, when using the command/emoji picker.  This was suggested by @englut, and I like how it works;  I think this is more in line with how other messengers work, and will probably be more intuitive to users.  The only drawback I can see is that it will prevent sending "uncompleted emoji" without adding a space afterward.  Maybe we could enable Ctrl-Enter and Command-Enter to bypass the command/emoji picker and send the message?  And/or, we could allow tab to cycle to "no command/emoji" selected as part of its loop.