### PR TITLE
Update soju connection guide in docs to use chathistory

### DIFF
--- a/book/src/guides/connect-with-soju.md
+++ b/book/src/guides/connect-with-soju.md
@@ -7,5 +7,7 @@ To connect with a [**soju**](https://soju.im/) bouncer, the configuration below 
 nickname = "casperstorm"
 username = "<your-username>/irc.libera.chat@desktop"
 server = "irc.squidowl.org"
+port = 6697
 password = "<your-password>"
+chathistory = true
 ```


### PR DESCRIPTION
Updates soju connection guide to use IRCv3 chat history feature (which the soju bouncer encourages clients to use) and include line port configuration (as many soju users may run their bouncer on a non-standard port)