### PR TITLE
Emoji Auto-Replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Added:
 
-- Emoji picker accessible via `:` in text input.  See [configuration](https://halloy.squidowl.org/configuration/buffer.html#bufferemojis)
+- Emoji picker accessible via `:` in text input and emoji auto-replace for `:shortcode:`.  See [configuration](https://halloy.squidowl.org/configuration/buffer.html#bufferemojis)
 - Added an option to show or hide images in preview cards by default
 
 Fixed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 Added:
 
-- Emoji picker accessible via `:` in text input and emoji auto-replace for `:shortcode:`.  See [configuration](https://halloy.squidowl.org/configuration/buffer.html#bufferemojis)
+- Emoji picker accessible via `:` in text input
+- Automatically replace `:shortcode:` with corresponding emoji
 - Added an option to show or hide images in preview cards by default
 
 Fixed:

--- a/book/src/configuration/buffer.md
+++ b/book/src/configuration/buffer.md
@@ -246,6 +246,7 @@ Emojis settings.
 [buffer.emojis]
 show_picker = true
 skin_tone = "default"
+auto_replace = true
 ```
 
 ### `show_picker`
@@ -272,6 +273,19 @@ Skin tone selected when picking an emoji.
 
 [buffer.emojis]
 skin_tone = "default"
+```
+
+### `auto_replace`
+
+Automatically replace `:shortcode:` in text input with the corresponding emoji.
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: true
+
+[buffer.emojis]
+auto_replace = true
 ```
 
 ## `[buffer.internal_messages]`

--- a/book/src/configuration/buffer.md
+++ b/book/src/configuration/buffer.md
@@ -251,7 +251,7 @@ auto_replace = true
 
 ### `show_picker`
 
-Show the emoji picker when typing `:shortcode` in text input.
+Show the emoji picker when typing `:shortcode:` in text input.
 
 ```toml
 # Type: boolean

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -41,6 +41,8 @@ pub struct Emojis {
     pub show_picker: bool,
     #[serde(default)]
     pub skin_tone: SkinTone,
+    #[serde(default = "default_bool_true")]
+    pub auto_replace: bool,
 }
 
 impl Default for Emojis {
@@ -48,6 +50,7 @@ impl Default for Emojis {
         Self {
             show_picker: default_bool_true(),
             skin_tone: Default::default(),
+            auto_replace: default_bool_true(),
         }
     }
 }

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -148,6 +148,8 @@ impl State {
                 self.completion
                     .process(&input, users, channels, &isupport, config);
 
+                let input = self.completion.complete_emoji(&input).unwrap_or(input);
+
                 history.record_draft(Draft {
                     buffer: buffer.clone(),
                     text: input,

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -1778,6 +1778,8 @@ impl Emojis {
             return;
         }
 
+        let last_word = last_word.strip_suffix(":").unwrap_or(last_word);
+
         let mut filtered = emojis::iter()
             .flat_map(|emoji| {
                 emoji.shortcodes().filter_map(|shortcode| {

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -59,10 +59,8 @@ impl Completion {
             }
 
             self.emojis = Emojis::default();
-        } else if let Some(shortcode) = config
-            .buffer
-            .emojis
-            .show_picker
+        } else if let Some(shortcode) = (config.buffer.emojis.show_picker
+            || config.buffer.emojis.auto_replace)
             .then(|| {
                 input
                     .split(' ')
@@ -71,7 +69,7 @@ impl Completion {
             })
             .flatten()
         {
-            self.emojis.process(shortcode);
+            self.emojis.process(shortcode, config);
 
             self.commands = Commands::default();
             self.text = Text::default();
@@ -90,6 +88,14 @@ impl Completion {
             .select()
             .map(Entry::Command)
             .or(self.emojis.select(config).map(Entry::Emoji))
+    }
+
+    pub fn complete_emoji(&self, input: &str) -> Option<String> {
+        if let Emojis::Selected { emoji } = self.emojis {
+            Some(replace_last_word_with_emoji(input, emoji))
+        } else {
+            None
+        }
     }
 
     pub fn tab(&mut self, reverse: bool) -> Option<Entry> {
@@ -195,15 +201,7 @@ impl Entry {
 
                 new_input
             }
-            Entry::Emoji(emoji) => {
-                let mut words: Vec<_> = input.split(' ').collect();
-
-                if let Some(last_word) = words.last_mut() {
-                    *last_word = emoji;
-                }
-
-                words.join(" ")
-            }
+            Entry::Emoji(emoji) => replace_last_word_with_emoji(input, emoji),
         }
     }
 }
@@ -1743,6 +1741,9 @@ enum Emojis {
         highlighted: Option<usize>,
         filtered: Vec<&'static str>,
     },
+    Selected {
+        emoji: &'static str,
+    },
 }
 
 impl Default for Emojis {
@@ -1752,10 +1753,27 @@ impl Default for Emojis {
 }
 
 impl Emojis {
-    fn process(&mut self, last_word: &str) {
+    fn process(&mut self, last_word: &str, config: &Config) {
         let last_word = last_word.strip_prefix(":").unwrap_or("");
 
         if last_word.is_empty() {
+            *self = Self::default();
+            return;
+        }
+
+        if let Some(shortcode) = config
+            .buffer
+            .emojis
+            .auto_replace
+            .then(|| last_word.strip_suffix(":"))
+            .flatten()
+        {
+            if let Some(emoji) = pick_emoji(shortcode, config.buffer.emojis.skin_tone) {
+                *self = Emojis::Selected { emoji };
+
+                return;
+            }
+        } else if !config.buffer.emojis.show_picker {
             *self = Self::default();
             return;
         }
@@ -1816,7 +1834,7 @@ impl Emojis {
 
     fn view<'a, Message: 'a>(&self, config: &Config) -> Option<Element<'a, Message>> {
         match self {
-            Self::Idle => None,
+            Self::Idle | Self::Selected { .. } => None,
             Self::Selecting {
                 highlighted,
                 filtered,
@@ -1892,6 +1910,16 @@ fn pick_emoji(shortcode: &str, skin_tone: SkinTone) -> Option<&'static str> {
         }
         .as_str()
     })
+}
+
+fn replace_last_word_with_emoji(input: &str, emoji: &str) -> String {
+    let mut words: Vec<_> = input.split(' ').collect();
+
+    if let Some(last_word) = words.last_mut() {
+        *last_word = emoji;
+    }
+
+    words.join(" ")
 }
 
 fn selecting_tab<T>(highlighted: &mut Option<usize>, filtered: &[T], reverse: bool) {


### PR DESCRIPTION
Adds a configuration option for emoji auto-complete, which replaces `:shortcode:` with the corresponding emoji.  Can be used with or without the emoji picker.