### PR TITLE
Ignore errors while adding der certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Fixed:
 - [`infinite_scroll`](https://halloy.squidowl.org/configuration/buffer.html?highlight=infinite#infinite_scroll) was defaulting to `false`, contrary to its documented default value.  Now defaults to `true`
 - A rare issue where the app opens smaller than when closed
 - Closing the application while it is minimized (on Windows) causes it to open with the wrong size and position next time
+- TLS connection issue on Windows (10+)
 
 # 2025.1 (2025-02-02)
 

--- a/irc/src/connection/tls.rs
+++ b/irc/src/connection/tls.rs
@@ -30,7 +30,7 @@ pub async fn connect<'a>(
         let mut roots = rustls::RootCertStore::empty();
 
         for cert in rustls_native_certs::load_native_certs()? {
-            roots.add(cert).unwrap();
+            let _ = roots.add(cert);
         }
 
         if let Some(cert_path) = root_cert_path {


### PR DESCRIPTION
Fixes #678.

The problem in #678 seems to be that Windows (10 specifically) can have some root certificates which rustls does not understand.
This causes a panic, since we assume (unwrap) a result where in fact we have an error:

> InvalidCertificate(Other(OtherError(UnsupportedCriticalExtension)))

Thanks to @impliedgg for tracking this down.