### PR TITLE
Documentation Link Checker

### DIFF
--- a/.github/workflows/gh-page-unstable.yml
+++ b/.github/workflows/gh-page-unstable.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           mdbook-version: 'latest'
 
+      - name: Install mdbook plugins
+        run: cargo install mdbook-linkcheck
+
       - run: mdbook build book
 
       - name: Publish book

--- a/.github/workflows/gh-page-unstable.yml
+++ b/.github/workflows/gh-page-unstable.yml
@@ -24,4 +24,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages-unstable
-          publish_dir: ./book/book
+          publish_dir: ./book/book/html

--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           mdbook-version: 'latest'
 
+      - name: Install mdbook plugins
+        run: cargo install mdbook-linkcheck
+
       - run: mdbook build book
 
       - name: Publish book

--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -23,4 +23,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./book/book
+          publish_dir: ./book/book/html

--- a/book/book.toml
+++ b/book/book.toml
@@ -8,3 +8,5 @@ src = "src"
 cname = "halloy.squidowl.org"
 git-repository-url = "https://github.com/squidowl/halloy"
 edit-url-template = "https://github.com/squidowl/halloy/edit/main/book/{path}"
+
+[output.linkcheck]

--- a/book/src/configuration/buffer.md
+++ b/book/src/configuration/buffer.md
@@ -554,7 +554,7 @@ Control if the text input should auto format the input. By default text is only 
 auto_format = "markdown"
 ```
 
-> 💡 Read more about [text formatting](../../guides/text-formatting.html).
+> 💡 Read more about [text formatting](../guides/text-formatting.html).
 
 ### `[buffer.text_input.autocomplete]`
 

--- a/book/src/configuration/servers.md
+++ b/book/src/configuration/servers.md
@@ -9,7 +9,7 @@ Eg:
 # ...
 ```
 
-> 💡 For a multiple server example see [here](../../guides/multiple-servers.html)
+> 💡 For a multiple server example see [here](../guides/multiple-servers.html)
 
 ## `nickname`
 
@@ -368,7 +368,7 @@ who_poll_interval = 2
 
 A list of nicknames to [monitor](https://ircv3.net/specs/extensions/monitor) (if IRCv3 Monitor is supported by the server).
 
-> 💡 Read more about [monitoring users](../../guides/monitor-users.html).
+> 💡 Read more about [monitoring users](../guides/monitor-users.html).
 
 ```toml
 # Type: array of string

--- a/book/src/guides/getting-started.md
+++ b/book/src/guides/getting-started.md
@@ -4,7 +4,7 @@ To get started with Halloy, you need to connect to at least one IRC server. The 
 
 Once connected to a server, you can join channels. This can be done automatically from the config file or manually using the join command: `/join #channel`[^1]. To find channels, you can either use the list command: `/list`, or [browse for channels online](https://netsplit.de/channels/).
 
-> 💡 Configuration in Halloy happens through a `config.toml` file. See [Configuration](../configuration/index.html).
+> 💡 Configuration in Halloy happens through a `config.toml` file. See [Configuration](../configuration/).
 
 Here are a few useful IRC commands for a new user[^2]
 

--- a/book/src/guides/multiple-servers.md
+++ b/book/src/guides/multiple-servers.md
@@ -1,7 +1,7 @@
 # Multiple servers
 
 Creating multiple `[servers]` sections lets you connect to multiple servers.  
-All configuration options can be found [here](../configuration/servers/index.html).
+All configuration options can be found [here](../configuration/servers.html).
 
 ```toml
 [servers.liberachat]


### PR DESCRIPTION
To help catch link errors in the documentation this adds [`mdbook-linkcheck`](https://github.com/Michael-F-Bryan/mdbook-linkcheck) to mdbook output.  Running it locally caught a few errors (including recently found broken link fixed by #780), which are fixed in this PR as well.

The changes to GH workflows are due to this note:

> When multiple [output] items are specified, mdbook tries to ensure that each [output] gets its own sub-directory within the build-dir (book/ by default).
> That means if you go from only having the HTML renderer enabled to enabling both HTML and the linkchecker, your HTML will be placed in book/html/ instead of just book/ like before.

But, I'm not sure how to test the change.