### PR TITLE
Default dcc save path & and show remaining time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Unreleased
 
+Added:
+
+- Time remaining is now displayed during file transfers
+
+Changed:
+
+- [file_transfer.save_directory] is now default download path for transfers. If set, files will be downloaded there by default. Otherwise, you'll be prompted to choose a location.
+  
 # 2025.2 (2025-02-20)
 
 Added:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,6 +2619,7 @@ dependencies = [
  "emojis",
  "fern",
  "futures",
+ "humantime",
  "iced",
  "image 0.24.9",
  "ipc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ rodio = "0.19.0"
 strum = { version = "0.26.3", features = ["derive"] }
 tokio-stream = { version = "0.1.16", features = ["fs"] }
 url = "2.5.0"
+humantime = "2.1.0"
 
 # change to 1.2.0 when it is released https://github.com/frewsxcv/rust-dark-light/issues/38
 dark-light = { git = "https://github.com/frewsxcv/rust-dark-light", rev = "3eb3e93dd0fa30733c3e93082dd9517fb580ae95" }

--- a/book/src/configuration/file_transfer.md
+++ b/book/src/configuration/file_transfer.md
@@ -4,15 +4,15 @@ File transfer configuration options.
 
 ## `save_directory`
 
-Default directory to open when prompted to save a file.
+Default directory to save files in. If not set, user will see a file dialog.
 
 ```toml
 # Type: string
 # Values: any string
-# Default: "$HOME/Downloads"
+# Default: not set
 
 [file_transfer]
-save_directory = "$HOME/Downloads"
+save_directory = "/Users/halloy/Downloads"
 ```
 
 ## `passive`

--- a/data/src/config/file_transfer.rs
+++ b/data/src/config/file_transfer.rs
@@ -4,9 +4,9 @@ use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct FileTransfer {
-    /// Directory opened when prompted to save a file
-    #[serde(default = "default_save_directory")]
-    pub save_directory: PathBuf,
+    /// Default directory to save files in. If not set, user will see a file dialog.
+    #[serde(default)]
+    pub save_directory: Option<PathBuf>,
     /// If true, act as the "client" for the transfer. Requires the remote user act as the server.
     #[serde(default = "default_passive")]
     pub passive: bool,
@@ -19,7 +19,7 @@ pub struct FileTransfer {
 impl Default for FileTransfer {
     fn default() -> Self {
         Self {
-            save_directory: default_save_directory(),
+            save_directory: None,
             passive: default_passive(),
             timeout: default_timeout(),
             server: None,

--- a/data/src/config/file_transfer.rs
+++ b/data/src/config/file_transfer.rs
@@ -35,10 +35,6 @@ fn default_timeout() -> u64 {
     60 * 5
 }
 
-fn default_save_directory() -> PathBuf {
-    dirs_next::download_dir().unwrap_or(PathBuf::from("/tmp/"))
-}
-
 #[derive(Debug, Clone)]
 pub struct Server {
     /// Address advertised to the remote user to connect to

--- a/data/src/message/formatting/encode.rs
+++ b/data/src/message/formatting/encode.rs
@@ -77,7 +77,7 @@ fn markdown<'a>(
     // Prev char is whitespace or punctuation, not matching delimiter char
     let prev_is_ws_or_punc = move |d, i: &str| {
         // None == Start of input which is considered whitespace
-        prev(i).map_or(true, |c| {
+        prev(i).is_none_or(|c| {
             c != d && (c.is_whitespace() || c.is_ascii_punctuation())
         })
     };

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -302,16 +302,12 @@ impl Dashboard {
                                             );
                                         }
                                         buffer::user_context::Event::SendFile(server, nick) => {
-                                            let starting_directory =
-                                                config.file_transfer.save_directory.clone();
-
                                             return (
                                                 Task::batch(vec![
                                                     task,
                                                     Task::perform(
                                                         async move {
                                                             rfd::AsyncFileDialog::new()
-                                                                .set_directory(starting_directory)
                                                                 .pick_file()
                                                                 .await
                                                                 .map(|handle| {
@@ -737,11 +733,11 @@ impl Dashboard {
                                 command_bar::Configuration::OpenCacheDirectory => {
                                     let _ = open::that_detached(environment::cache_dir());
                                     (Task::none(), None)
-                                },
+                                }
                                 command_bar::Configuration::OpenDataDirectory => {
                                     let _ = open::that_detached(environment::data_dir());
                                     (Task::none(), None)
-                                },
+                                }
                                 command_bar::Configuration::OpenWebsite => {
                                     let _ = open::that_detached(environment::WIKI_WEBSITE);
                                     (Task::none(), None)
@@ -774,7 +770,9 @@ impl Dashboard {
                                 }
                             },
                             command_bar::Command::Window(command) => match command {
-                                command_bar::Window::ToggleFullscreen => (window::toggle_fullscreen(), None),
+                                command_bar::Window::ToggleFullscreen => {
+                                    (window::toggle_fullscreen(), None)
+                                }
                             },
                         };
 
@@ -951,9 +949,7 @@ impl Dashboard {
                             None,
                         );
                     }
-                    ToggleFullscreen => {
-                        return (window::toggle_fullscreen(), None)
-                    },
+                    ToggleFullscreen => return (window::toggle_fullscreen(), None),
                 }
             }
             Message::FileTransfer(update) => {

--- a/src/widget/selectable_rich_text.rs
+++ b/src/widget/selectable_rich_text.rs
@@ -627,9 +627,7 @@ where
         {
             let line_height = f32::from(
                 self.line_height.to_absolute(
-                    self.size
-                        .map(Pixels::from)
-                        .unwrap_or_else(|| renderer.default_size()),
+                    self.size.unwrap_or_else(|| renderer.default_size()),
                 ),
             );
 

--- a/src/widget/selectable_text.rs
+++ b/src/widget/selectable_text.rs
@@ -151,9 +151,7 @@ where
             let bounds = limits.max();
 
             let size = self
-                .size
-                .map(Pixels::from)
-                .unwrap_or_else(|| renderer.default_size());
+                .size.unwrap_or_else(|| renderer.default_size());
             let font = self.font.unwrap_or_else(|| renderer.default_font());
 
             state.paragraph.update(text::Text {
@@ -255,9 +253,7 @@ where
         {
             let line_height = f32::from(
                 self.line_height.to_absolute(
-                    self.size
-                        .map(Pixels::from)
-                        .unwrap_or_else(|| renderer.default_size()),
+                    self.size.unwrap_or_else(|| renderer.default_size()),
                 ),
             );
 


### PR DESCRIPTION
I've changed the `file_transfer.save_directory` to now work as the default download directory. That means if you set it, and press approve on a transfer it will start instantly and save the file to the above mentioned directory (fixes #615).

I've also added time remaining to easier see when a transfer is done. (fixes #738).
