### PR TITLE
Control default pane split direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+Added:
+
+- Customize default pane splitting direction (vertical or horizontal)
+
 # 2025.2 (2025-02-20)
 
 Added:

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -25,6 +25,7 @@
   - [Font](configuration/font.md)
   - [Keyboard](configuration/keyboard.md)
   - [Notifications](configuration/notifications.md)
+  - [Pane](configuration/pane.md)
   - [Proxy](configuration/proxy.md)
   - [Preview](configuration/preview.md)
   - [Scale factor](configuration/scale-factor.md)

--- a/book/src/configuration/pane.md
+++ b/book/src/configuration/pane.md
@@ -4,7 +4,7 @@ Pane settings for Halloy. A pane contains a [buffer](../configuration//buffer.md
 
 ## `split_axis`
 
-Default axis used when splitting a pane.
+Default axis used when splitting a pane (i.e. default orientation of the divider between panes).
 
 ```toml
 # Type: string

--- a/book/src/configuration/pane.md
+++ b/book/src/configuration/pane.md
@@ -1,0 +1,16 @@
+# `[pane]`
+
+Pane settings for Halloy. A pane contains a [buffer](../configuration//buffer.md).
+
+## `split_axis`
+
+Default axis used when splitting a pane.
+
+```toml
+# Type: string
+# Values: "horizontal", "vertical"
+# Default: "horizontal"
+
+[pane]
+split_axis = "vertical"
+```

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -15,6 +15,7 @@ pub use self::channel::Channel;
 pub use self::file_transfer::FileTransfer;
 pub use self::keys::Keyboard;
 pub use self::notification::Notifications;
+pub use self::pane::Pane;
 pub use self::preview::Preview;
 pub use self::proxy::Proxy;
 pub use self::server::Server;
@@ -32,6 +33,7 @@ pub mod channel;
 pub mod file_transfer;
 pub mod keys;
 pub mod notification;
+pub mod pane;
 pub mod preview;
 pub mod proxy;
 pub mod server;
@@ -48,6 +50,7 @@ pub struct Config {
     pub font: Font,
     pub scale_factor: ScaleFactor,
     pub buffer: Buffer,
+    pub pane: Pane,
     pub sidebar: Sidebar,
     pub keyboard: Keyboard,
     pub notifications: Notifications<Sound>,
@@ -159,6 +162,8 @@ impl Config {
             #[serde(default)]
             pub buffer: Buffer,
             #[serde(default)]
+            pub pane: Pane,
+            #[serde(default)]
             pub sidebar: Sidebar,
             #[serde(default)]
             pub keyboard: Keyboard,
@@ -195,6 +200,7 @@ impl Config {
             file_transfer,
             tooltips,
             preview,
+            pane,
         } = toml::from_str(content.as_ref()).map_err(|e| Error::Parse(e.to_string()))?;
 
         servers.read_passwords().await?;
@@ -218,6 +224,7 @@ impl Config {
             file_transfer,
             tooltips,
             preview,
+            pane,
         })
     }
 

--- a/data/src/config/pane.rs
+++ b/data/src/config/pane.rs
@@ -1,0 +1,16 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct Pane {
+    /// Default axis used when splitting a pane.
+    #[serde(default)]
+    pub split_axis: SplitAxis,
+}
+
+#[derive(Debug, Copy, Clone, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum SplitAxis {
+    #[default]
+    Horizontal,
+    Vertical,
+}


### PR DESCRIPTION
Fixes https://github.com/squidowl/halloy/issues/647.
Introduced a new `[pane]` config which intention is to control global pane settings.