### PR TITLE
Enable dynamic switching of themes again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changed:
 
 - [file_transfer.save_directory] is now default download path for transfers. If set, files will be downloaded there by default. Otherwise, you'll be prompted to choose a location.
 - Customize default pane splitting direction (vertical or horizontal)
+- Ability to dynamically select dark or light theme based on OS appearance.
 
 # 2025.2 (2025-02-20)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1457,7 +1457,7 @@ dependencies = [
 [[package]]
 name = "dark-light"
 version = "2.0.0"
-source = "git+https://github.com/casperstorm/dark-light?rev=ccdb87c962c8b37bfd63409a4791116935c67c7b#ccdb87c962c8b37bfd63409a4791116935c67c7b"
+source = "git+https://github.com/rust-dark-light/dark-light?rev=8e1f745f91e1e805fa772a83e4744afe95d70aa1#8e1f745f91e1e805fa772a83e4744afe95d70aa1"
 dependencies = [
  "ashpd 0.11.0",
  "async-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,28 +300,12 @@ dependencies = [
 
 [[package]]
 name = "ashpd"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d43c03d9e36dd40cab48435be0b09646da362c278223ca535493877b2c1dee9"
-dependencies = [
- "async-fs",
- "async-net",
- "enumflags2",
- "futures-channel",
- "futures-util",
- "rand",
- "serde",
- "serde_repr",
- "url",
- "zbus 4.4.0",
-]
-
-[[package]]
-name = "ashpd"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9c39d707614dbcc6bed00015539f488d8e3fe3e66ed60961efc0c90f4b380b3"
 dependencies = [
+ "async-fs",
+ "async-net",
  "enumflags2",
  "futures-channel",
  "futures-util",
@@ -381,10 +365,21 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.0",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
 ]
 
 [[package]]
@@ -440,6 +435,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
 name = "async-http-proxy"
 version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,7 +486,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.0",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -498,14 +508,14 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
 dependencies = [
- "async-channel",
+ "async-channel 2.3.1",
  "async-io",
  "async-lock",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener",
+ "event-listener 5.4.0",
  "futures-lite",
  "rustix",
  "tracing",
@@ -538,6 +548,32 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c634475f29802fde2b8f0b505b1bd00dfe4df7d4a000f0b36f7671197d5c3615"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -790,7 +826,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
 dependencies = [
- "async-channel",
+ "async-channel 2.3.1",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -1404,16 +1440,14 @@ dependencies = [
 
 [[package]]
 name = "dark-light"
-version = "1.1.1"
-source = "git+https://github.com/frewsxcv/rust-dark-light?rev=3eb3e93dd0fa30733c3e93082dd9517fb580ae95#3eb3e93dd0fa30733c3e93082dd9517fb580ae95"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e1a09f280e29a8b00bc7e81eca5ac87dca0575639c9422a5fa25a07bb884b8"
 dependencies = [
- "ashpd 0.9.2",
- "futures",
- "log",
+ "ashpd",
+ "async-std",
  "objc2",
- "objc2-app-kit",
  "objc2-foundation",
- "pollster 0.3.0",
  "web-sys",
  "winreg",
 ]
@@ -2005,6 +2039,12 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
@@ -2020,7 +2060,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.0",
  "pin-project-lite",
 ]
 
@@ -2471,6 +2511,18 @@ name = "glob-match"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985c9503b412198aa4197559e9a318524ebc4519c229bfa05a535828c950b9d"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "glow"
@@ -3599,6 +3651,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3726,6 +3787,9 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "loop9"
@@ -4897,12 +4961,6 @@ dependencies = [
 
 [[package]]
 name = "pollster"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
-
-[[package]]
-name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
@@ -5355,7 +5413,7 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a24763657bff09769a8ccf12c8b8a50416fb035fe199263b4c5071e4e3f006f"
 dependencies = [
- "ashpd 0.10.2",
+ "ashpd",
  "block2",
  "core-foundation 0.10.0",
  "core-foundation-sys",
@@ -5364,7 +5422,7 @@ dependencies = [
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
- "pollster 0.4.0",
+ "pollster",
  "raw-window-handle",
  "urlencoding",
  "wasm-bindgen",
@@ -6989,7 +7047,7 @@ dependencies = [
  "derive_more",
  "digest",
  "educe",
- "event-listener",
+ "event-listener 5.4.0",
  "fs-mistrust",
  "fslock",
  "futures",
@@ -7839,6 +7897,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "value-bag"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2"
 
 [[package]]
 name = "vcpkg"
@@ -9010,7 +9074,7 @@ dependencies = [
  "async-trait",
  "blocking",
  "enumflags2",
- "event-listener",
+ "event-listener 5.4.0",
  "futures-core",
  "futures-sink",
  "futures-util",
@@ -9038,10 +9102,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "192a0d989036cd60a1e91a54c9851fb9ad5bd96125d41803eed79d2e2ef74bd7"
 dependencies = [
  "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-process",
  "async-recursion",
+ "async-task",
  "async-trait",
+ "blocking",
  "enumflags2",
- "event-listener",
+ "event-listener 5.4.0",
  "futures-core",
  "futures-util",
  "hex",
@@ -9264,7 +9335,6 @@ dependencies = [
  "enumflags2",
  "serde",
  "static_assertions",
- "url",
  "zvariant_derive 4.2.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,10 +52,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -251,7 +251,7 @@ dependencies = [
  "libc",
  "once_cell",
  "postage",
- "rand",
+ "rand 0.8.5",
  "safelog",
  "serde",
  "thiserror 2.0.11",
@@ -304,12 +304,10 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9c39d707614dbcc6bed00015539f488d8e3fe3e66ed60961efc0c90f4b380b3"
 dependencies = [
- "async-fs",
- "async-net",
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand",
+ "rand 0.8.5",
  "raw-window-handle",
  "serde",
  "serde_repr",
@@ -318,6 +316,24 @@ dependencies = [
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
+ "zbus 5.3.0",
+]
+
+[[package]]
+name = "ashpd"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbdf310d77fd3aaee6ea2093db7011dc2d35d2eb3481e5607f1f8d942ed99df"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.0",
+ "serde",
+ "serde_repr",
+ "url",
  "zbus 5.3.0",
 ]
 
@@ -1375,7 +1391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -1441,10 +1457,9 @@ dependencies = [
 [[package]]
 name = "dark-light"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e1a09f280e29a8b00bc7e81eca5ac87dca0575639c9422a5fa25a07bb884b8"
+source = "git+https://github.com/casperstorm/dark-light?rev=ccdb87c962c8b37bfd63409a4791116935c67c7b#ccdb87c962c8b37bfd63409a4791116935c67c7b"
 dependencies = [
- "ashpd",
+ "ashpd 0.11.0",
  "async-std",
  "objc2",
  "objc2-foundation",
@@ -1552,8 +1567,8 @@ dependencies = [
  "nom",
  "once_cell",
  "palette",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "regex",
  "reqwest",
  "seahash",
@@ -1880,7 +1895,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "merlin",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -1918,7 +1933,7 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -2141,7 +2156,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2463,8 +2478,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2615,7 +2642,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -3433,8 +3460,8 @@ dependencies = [
  "data",
  "futures",
  "interprocess",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "thiserror 1.0.69",
  "tokio",
  "url",
@@ -3899,7 +3926,7 @@ checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
  "keccak",
- "rand_core",
+ "rand_core 0.6.4",
  "zeroize",
 ]
 
@@ -3948,7 +3975,7 @@ checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -4156,7 +4183,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -4710,7 +4737,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2",
 ]
 
@@ -4836,7 +4863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -4992,7 +5019,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -5138,8 +5165,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.2",
+ "zerocopy 0.8.21",
 ]
 
 [[package]]
@@ -5149,7 +5187,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.2",
 ]
 
 [[package]]
@@ -5158,7 +5206,17 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a509b1a2ffbe92afab0e55c8fd99dea1c280e8171bd2d88682bb20bc41cbc2c"
+dependencies = [
+ "getrandom 0.3.1",
+ "zerocopy 0.8.21",
 ]
 
 [[package]]
@@ -5199,8 +5257,8 @@ dependencies = [
  "once_cell",
  "paste",
  "profiling",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "simd_helpers",
  "system-deps",
  "thiserror 1.0.69",
@@ -5292,7 +5350,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -5413,7 +5471,7 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a24763657bff09769a8ccf12c8b8a50416fb035fe199263b4c5071e4e3f006f"
 dependencies = [
- "ashpd",
+ "ashpd 0.10.2",
  "block2",
  "core-foundation 0.10.0",
  "core-foundation-sys",
@@ -5460,7 +5518,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -5500,7 +5558,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2",
  "signature",
  "spki",
@@ -5962,7 +6020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -6201,7 +6259,7 @@ dependencies = [
  "p256",
  "p384",
  "p521",
- "rand_core",
+ "rand_core 0.6.4",
  "rsa",
  "sec1",
  "sha2",
@@ -6452,7 +6510,7 @@ checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -6784,8 +6842,8 @@ dependencies = [
  "itertools 0.14.0",
  "libc",
  "paste",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "serde",
  "slab",
  "smallvec",
@@ -6802,7 +6860,7 @@ dependencies = [
  "derive-deftly",
  "digest",
  "educe",
- "getrandom",
+ "getrandom 0.2.15",
  "safelog",
  "thiserror 2.0.11",
  "tor-error",
@@ -6824,7 +6882,7 @@ dependencies = [
  "derive_more",
  "educe",
  "paste",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "thiserror 2.0.11",
  "tor-basic-utils",
@@ -6867,7 +6925,7 @@ dependencies = [
  "futures",
  "oneshot-fused-workaround",
  "postage",
- "rand",
+ "rand 0.8.5",
  "safelog",
  "serde",
  "thiserror 2.0.11",
@@ -6921,7 +6979,7 @@ dependencies = [
  "once_cell",
  "oneshot-fused-workaround",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "retry-error",
  "safelog",
  "serde",
@@ -7060,7 +7118,7 @@ dependencies = [
  "oneshot-fused-workaround",
  "paste",
  "postage",
- "rand",
+ "rand 0.8.5",
  "rusqlite",
  "safelog",
  "scopeguard",
@@ -7137,7 +7195,7 @@ dependencies = [
  "oneshot-fused-workaround",
  "pin-project",
  "postage",
- "rand",
+ "rand 0.8.5",
  "safelog",
  "serde",
  "strum",
@@ -7169,7 +7227,7 @@ dependencies = [
  "digest",
  "itertools 0.14.0",
  "paste",
- "rand",
+ "rand 0.8.5",
  "safelog",
  "signature",
  "subtle",
@@ -7193,7 +7251,7 @@ dependencies = [
  "derive_more",
  "downcast-rs",
  "paste",
- "rand",
+ "rand 0.8.5",
  "signature",
  "ssh-key",
  "thiserror 2.0.11",
@@ -7221,7 +7279,7 @@ dependencies = [
  "humantime",
  "inventory",
  "itertools 0.14.0",
- "rand",
+ "rand 0.8.5",
  "serde",
  "signature",
  "ssh-key",
@@ -7282,9 +7340,9 @@ dependencies = [
  "digest",
  "ed25519-dalek",
  "educe",
- "getrandom",
+ "getrandom 0.2.15",
  "hex",
- "rand_core",
+ "rand_core 0.6.4",
  "rsa",
  "safelog",
  "serde",
@@ -7357,7 +7415,7 @@ dependencies = [
  "humantime",
  "itertools 0.14.0",
  "num_enum",
- "rand",
+ "rand 0.8.5",
  "serde",
  "static_assertions",
  "strum",
@@ -7461,8 +7519,8 @@ dependencies = [
  "hmac",
  "oneshot-fused-workaround",
  "pin-project",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "safelog",
  "slotmap-careful",
  "subtle",
@@ -7506,7 +7564,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2bc9f6f400d52990361bbbda30576895af10efa723c1e25b07b2468e5c5edad"
 dependencies = [
- "rand",
+ "rand 0.8.5",
  "serde",
  "tor-basic-utils",
  "tor-linkspec",
@@ -7878,7 +7936,7 @@ version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b913a3b5fe84142e269d63cc62b64319ccaf89b748fc31fe025177f767a756c4"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -7985,12 +8043,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasix"
 version = "0.12.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fbb4ef9bbca0c1170e0b00dd28abc9e3b68669821600cad1caaed606583c6d"
 dependencies = [
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -8891,6 +8958,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.7.0",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8950,7 +9026,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "zeroize",
 ]
@@ -9081,7 +9157,7 @@ dependencies = [
  "hex",
  "nix",
  "ordered-stream",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_repr",
  "sha1",
@@ -9196,7 +9272,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf01143b2dd5d134f11f545cf9f1431b13b749695cb33bcce051e7568f99478"
+dependencies = [
+ "zerocopy-derive 0.8.21",
 ]
 
 [[package]]
@@ -9204,6 +9289,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712c8386f4f4299382c9abee219bee7084f78fb939d88b6840fcc1320d5f6da2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,7 @@ strum = { version = "0.26.3", features = ["derive"] }
 tokio-stream = { version = "0.1.16", features = ["fs"] }
 url = "2.5.0"
 humantime = "2.1.0"
-
-dark-light = { git = "https://github.com/casperstorm/dark-light", rev = "ccdb87c962c8b37bfd63409a4791116935c67c7b" }
+dark-light = { git = "https://github.com/rust-dark-light/dark-light", rev = "8e1f745f91e1e805fa772a83e4744afe95d70aa1" }
 anyhow = "1.0.91"
 emojis = "0.6.4"
 strsim = "0.11.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ tokio-stream = { version = "0.1.16", features = ["fs"] }
 url = "2.5.0"
 humantime = "2.1.0"
 
-dark-light = "2.0.0"
+dark-light = { git = "https://github.com/casperstorm/dark-light", rev = "ccdb87c962c8b37bfd63409a4791116935c67c7b" }
 anyhow = "1.0.91"
 emojis = "0.6.4"
 strsim = "0.11.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,7 @@ tokio-stream = { version = "0.1.16", features = ["fs"] }
 url = "2.5.0"
 humantime = "2.1.0"
 
-# change to 1.2.0 when it is released https://github.com/frewsxcv/rust-dark-light/issues/38
-dark-light = { git = "https://github.com/frewsxcv/rust-dark-light", rev = "3eb3e93dd0fa30733c3e93082dd9517fb580ae95" }
+dark-light = "2.0.0"
 anyhow = "1.0.91"
 emojis = "0.6.4"
 strsim = "0.11.1"

--- a/data/src/appearance.rs
+++ b/data/src/appearance.rs
@@ -30,6 +30,13 @@ impl Default for Selected {
 }
 
 impl Selected {
+    pub fn is_dynamic(&self) -> bool {
+        match self {
+            Selected::Static(_) => false,
+            Selected::Dynamic { .. } => true,
+        }
+    }
+
     pub fn dynamic(light: Theme, dark: Theme) -> Selected {
         Selected::Dynamic { light, dark }
     }

--- a/src/appearance.rs
+++ b/src/appearance.rs
@@ -1,24 +1,30 @@
+use std::time::Duration;
+
 use data::appearance;
+use futures::stream;
+use futures::{stream::BoxStream, StreamExt};
+use iced::advanced::subscription::Hasher;
+use iced::futures;
+use iced::{advanced::graphics::futures::subscription, Subscription};
+use tokio::time;
 
 pub use theme::Theme;
 
 pub mod theme;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub enum Mode {
     Dark,
     Light,
 }
 
-impl TryFrom<dark_light::Mode> for Mode {
-    type Error = ();
-
-    fn try_from(mode: dark_light::Mode) -> Result<Self, Self::Error> {
+impl From<dark_light::Mode> for Mode {
+    fn from(mode: dark_light::Mode) -> Self {
         match mode {
-            dark_light::Mode::Dark => Ok(Mode::Dark),
-            dark_light::Mode::Light => Ok(Mode::Light),
-            // We ignore `Unspecified`.
-            dark_light::Mode::Unspecified => Err(()),
+            dark_light::Mode::Dark => Mode::Dark,
+            dark_light::Mode::Light => Mode::Light,
+            // We map `Unspecified` to `Light`.
+            dark_light::Mode::Unspecified => Mode::Light,
         }
     }
 }
@@ -28,7 +34,7 @@ pub fn detect() -> Option<Mode> {
         return None;
     };
 
-    Mode::try_from(mode).ok()
+    Some(Mode::from(mode))
 }
 
 pub fn theme(selected: &data::appearance::Selected) -> data::appearance::Theme {
@@ -47,4 +53,39 @@ pub fn theme(selected: &data::appearance::Selected) -> data::appearance::Theme {
             }
         },
     }
+}
+
+struct Appearance;
+
+impl subscription::Recipe for Appearance {
+    type Output = Mode;
+
+    fn hash(&self, state: &mut Hasher) {
+        use std::hash::Hash;
+        struct Marker;
+        std::any::TypeId::of::<Marker>().hash(state);
+    }
+
+    fn stream(self: Box<Self>, _input: subscription::EventStream) -> BoxStream<'static, Mode> {
+        let interval = time::interval(Duration::from_secs(5));
+
+        stream::unfold(
+            (interval, detect().unwrap_or(Mode::Light)),
+            move |(mut interval, old_mode)| async move {
+                loop {
+                    interval.tick().await;
+                    let new_mode = detect().unwrap_or(Mode::Light);
+                    
+                    if new_mode != old_mode {
+                        return Some((new_mode, (interval, new_mode)));
+                    }
+                }
+            },
+        )
+        .boxed()
+    }
+}
+
+pub fn subscription() -> Subscription<Mode> {
+    subscription::from_recipe(Appearance)
 }

--- a/src/appearance.rs
+++ b/src/appearance.rs
@@ -1,8 +1,4 @@
 use data::appearance;
-use futures::{stream::BoxStream, StreamExt};
-use iced::advanced::subscription::Hasher;
-use iced::futures;
-use iced::{advanced::graphics::futures::subscription, Subscription};
 
 pub use theme::Theme;
 
@@ -21,53 +17,18 @@ impl TryFrom<dark_light::Mode> for Mode {
         match mode {
             dark_light::Mode::Dark => Ok(Mode::Dark),
             dark_light::Mode::Light => Ok(Mode::Light),
-            // We ignore `Default` as it is defined as `Unspecified``.
-            dark_light::Mode::Default => Err(()),
+            // We ignore `Unspecified`.
+            dark_light::Mode::Unspecified => Err(()),
         }
     }
 }
 
-struct Appearance;
-
-impl subscription::Recipe for Appearance {
-    type Output = Mode;
-
-    fn hash(&self, state: &mut Hasher) {
-        use std::hash::Hash;
-
-        struct Marker;
-        std::any::TypeId::of::<Marker>().hash(state);
-    }
-
-    fn stream(self: Box<Self>, _input: subscription::EventStream) -> BoxStream<'static, Mode> {
-        let stream_future = async {
-            match dark_light::subscribe().await {
-                Ok(stream) => stream
-                    .filter_map(|m| async move {
-                        match Mode::try_from(m) {
-                            Ok(mode) => Some(mode),
-                            Err(_) => None,
-                        }
-                    })
-                    .boxed(),
-                Err(err) => {
-                    println!("error: {:?}", err);
-                    futures::stream::empty().boxed()
-                }
-            }
-        };
-
-        futures::stream::once(stream_future).flatten().boxed()
-    }
-}
-
-#[allow(dead_code)]
-pub fn subscription() -> Subscription<Mode> {
-    subscription::from_recipe(Appearance)
-}
-
 pub fn detect() -> Option<Mode> {
-    Mode::try_from(dark_light::detect()).ok()
+    let Ok(mode) = dark_light::detect() else {
+        return None;
+    };
+
+    Mode::try_from(mode).ok()
 }
 
 pub fn theme(selected: &data::appearance::Selected) -> data::appearance::Theme {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1127,10 +1127,7 @@ impl Halloy {
         ];
 
         // We only want to listen for appearance changes if user has dynamic themes.
-        if matches!(
-            &self.config.appearance.selected,
-            data::appearance::Selected::Dynamic { .. }
-        ) {
+        if self.config.appearance.selected.is_dynamic() {
             subscriptions.push(appearance::subscription().map(Message::AppearanceChange));
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -901,6 +901,18 @@ impl Halloy {
                     handle_irc_error(e);
                 }
 
+                // Detect apperance changes.
+                if let data::appearance::Selected::Dynamic { light, dark } =
+                    &self.config.appearance.selected
+                {
+                    if let Some(mode) = appearance::detect() {
+                        self.theme = match mode {
+                            appearance::Mode::Dark => dark.clone().into(),
+                            appearance::Mode::Light => light.clone().into(),
+                        }
+                    }
+                }
+
                 if let Screen::Dashboard(dashboard) = &mut self.screen {
                     dashboard.tick(now).map(Message::Dashboard)
                 } else {
@@ -1122,9 +1134,6 @@ impl Halloy {
             url::listen().map(Message::RouteReceived),
             events().map(|(window, event)| Message::Event(window, event)),
             window::events().map(|(window, event)| Message::Window(window, event)),
-            // Enable once dark_light has a proper way to detect appereance changes without spiking CPU.
-            // See: https://github.com/frewsxcv/rust-dark-light/issues/47
-            // appearance::subscription().map(Message::AppearanceChange),
             tick,
             streams,
         ])


### PR DESCRIPTION
Fixes https://github.com/squidowl/halloy/issues/796.

This enables dynamic switching of themes again after it was disabled.