### PR TITLE
`/msg target` to Open Query/Channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changed:
 
 - `[file_transfer.save_directory]` is now default download path for transfers. If set, files will be downloaded there by default. Otherwise, you'll be prompted to choose a location
 - Ability to dynamically select dark or light theme based on OS appearance.
+- `/msg <target>` (without any message text) will now open a pane for the target without sending a message
 
 # 2025.2 (2025-02-20)
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1223,7 +1223,7 @@ impl Client {
 
                 // Loop on connect commands
                 for command in self.config.on_connect.iter() {
-                    if let Ok(cmd) = crate::command::parse(command, None) {
+                    if let Ok(crate::Command::Irc(cmd)) = crate::command::parse(command, None) {
                         if let Ok(command) = proto::Command::try_from(cmd) {
                             self.handle.try_send(command.into())?;
                         };

--- a/data/src/command.rs
+++ b/data/src/command.rs
@@ -6,8 +6,38 @@ use itertools::Itertools;
 
 use crate::{buffer, ctcp, message::formatting};
 
+#[derive(Debug, Clone)]
+pub enum Command {
+    Internal(Internal),
+    Irc(Irc),
+}
+
+#[derive(Debug, Clone)]
+pub enum Internal {
+    OpenBuffer(String),
+}
+
+#[derive(Debug, Clone)]
+pub enum Irc {
+    Join(String, Option<String>),
+    Motd(Option<String>),
+    Nick(String),
+    Quit(Option<String>),
+    Msg(String, String),
+    Me(String, String),
+    Whois(Option<String>, String),
+    Part(String, Option<String>),
+    Topic(String, Option<String>),
+    Kick(String, String, Option<String>),
+    Mode(String, Option<String>, Option<Vec<String>>),
+    Away(Option<String>),
+    SetName(String),
+    Raw(String),
+    Unknown(String, Vec<String>),
+}
+
 #[derive(Debug, Clone, Copy)]
-pub enum Kind {
+enum Kind {
     Join,
     Motd,
     Nick,
@@ -50,49 +80,6 @@ impl FromStr for Kind {
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum Command {
-    Join(String, Option<String>),
-    Motd(Option<String>),
-    Nick(String),
-    Quit(Option<String>),
-    Msg(String, String),
-    Me(String, String),
-    Whois(Option<String>, String),
-    Part(String, Option<String>),
-    Topic(String, Option<String>),
-    Kick(String, String, Option<String>),
-    Mode(String, Option<String>, Option<Vec<String>>),
-    Away(Option<String>),
-    SetName(String),
-    OpenBuffer(String),
-    Raw(String),
-    Unknown(String, Vec<String>),
-}
-
-impl Command {
-    pub fn is_internal(&self) -> bool {
-        match self {
-            Command::Join(_, _) => false,
-            Command::Motd(_) => false,
-            Command::Nick(_) => false,
-            Command::Quit(_) => false,
-            Command::Msg(_, _) => false,
-            Command::Me(_, _) => false,
-            Command::Whois(_, _) => false,
-            Command::Part(_, _) => false,
-            Command::Topic(_, _) => false,
-            Command::Kick(_, _, _) => false,
-            Command::Mode(_, _, _) => false,
-            Command::Away(_) => false,
-            Command::SetName(_) => false,
-            Command::OpenBuffer(_) => true,
-            Command::Raw(_) => false,
-            Command::Unknown(_, _) => false,
-        }
-    }
-}
-
 pub fn parse(s: &str, buffer: Option<&buffer::Upstream>) -> Result<Command, Error> {
     let (head, rest) = s.split_once('/').ok_or(Error::MissingSlash)?;
     // Don't allow leading whitespace before slash
@@ -112,46 +99,52 @@ pub fn parse(s: &str, buffer: Option<&buffer::Upstream>) -> Result<Command, Erro
     };
 
     let unknown = || {
-        Command::Unknown(
+        Command::Irc(Irc::Unknown(
             cmd.to_string(),
             args.iter().map(|s| s.to_string()).collect(),
-        )
+        ))
     };
 
     match cmd.parse::<Kind>() {
         Ok(kind) => match kind {
             Kind::Join => validated::<1, 1, false>(args, |[chanlist], [chankeys]| {
-                Command::Join(chanlist, chankeys)
+                Command::Irc(Irc::Join(chanlist, chankeys))
             }),
-            Kind::Motd => validated::<0, 1, false>(args, |_, [target]| Command::Motd(target)),
-            Kind::Nick => validated::<1, 0, false>(args, |[nick], _| Command::Nick(nick)),
-            Kind::Quit => validated::<0, 1, true>(args, |_, [comment]| Command::Quit(comment)),
+            Kind::Motd => {
+                validated::<0, 1, false>(args, |_, [target]| Command::Irc(Irc::Motd(target)))
+            }
+            Kind::Nick => validated::<1, 0, false>(args, |[nick], _| Command::Irc(Irc::Nick(nick))),
+            Kind::Quit => {
+                validated::<0, 1, true>(args, |_, [comment]| Command::Irc(Irc::Quit(comment)))
+            }
             Kind::Msg => validated::<1, 1, true>(args, |[target], [msg]| {
                 if let Some(msg) = msg {
-                    Command::Msg(target, msg)
+                    Command::Irc(Irc::Msg(target, msg))
                 } else {
-                    Command::OpenBuffer(target)
+                    Command::Internal(Internal::OpenBuffer(target))
                 }
             }),
             Kind::Me => {
                 if let Some(target) = buffer.and_then(|b| b.target()) {
-                    validated::<1, 0, true>(args, |[text], _| Command::Me(target.to_string(), text))
+                    validated::<1, 0, true>(args, |[text], _| {
+                        Command::Irc(Irc::Me(target.to_string(), text))
+                    })
                 } else {
                     Ok(unknown())
                 }
             }
             Kind::Whois => validated::<1, 0, false>(args, |[nick], _| {
                 // Leaving out optional [server] for now.
-                Command::Whois(None, nick)
+                Command::Irc(Irc::Whois(None, nick))
             }),
             Kind::Part => validated::<1, 1, true>(args, |[chanlist], [reason]| {
-                Command::Part(chanlist, reason)
+                Command::Irc(Irc::Part(chanlist, reason))
             }),
-            Kind::Topic => {
-                validated::<1, 1, true>(args, |[channel], [topic]| Command::Topic(channel, topic))
-            }
+            Kind::Topic => validated::<1, 1, true>(args, |[channel], [topic]| {
+                Command::Irc(Irc::Topic(channel, topic))
+            }),
             Kind::Kick => validated::<2, 1, true>(args, |[channel, user], [comment]| {
-                Command::Kick(channel, user, comment)
+                Command::Irc(Irc::Kick(channel, user, comment))
             }),
             Kind::Mode => {
                 if let Some((target, rest)) = args.split_first() {
@@ -162,30 +155,32 @@ pub fn parse(s: &str, buffer: Option<&buffer::Upstream>) -> Result<Command, Erro
                         } else {
                             let mode_arguments: Vec<String> =
                                 mode_arguments.iter().map(|v| v.to_string()).collect();
-                            Ok(Command::Mode(
+                            Ok(Command::Irc(Irc::Mode(
                                 target.to_string(),
                                 Some(mode_string.to_string()),
                                 (!mode_arguments.is_empty()).then_some(mode_arguments),
-                            ))
+                            )))
                         }
                     } else {
-                        Ok(Command::Mode(target.to_string(), None, None))
+                        Ok(Command::Irc(Irc::Mode(target.to_string(), None, None)))
                     }
                 } else {
                     Err(Error::MissingArgs)
                 }
             }
-            Kind::Away => validated::<0, 1, true>(args, |_, [comment]| Command::Away(comment)),
-            Kind::SetName => {
-                validated::<1, 0, true>(args, |[realname], _| Command::SetName(realname))
+            Kind::Away => {
+                validated::<0, 1, true>(args, |_, [comment]| Command::Irc(Irc::Away(comment)))
             }
-            Kind::Raw => Ok(Command::Raw(raw.to_string())),
+            Kind::SetName => {
+                validated::<1, 0, true>(args, |[realname], _| Command::Irc(Irc::SetName(realname)))
+            }
+            Kind::Raw => Ok(Command::Irc(Irc::Raw(raw.to_string()))),
             Kind::Format => {
                 if let Some(target) = buffer.and_then(|b| b.target()) {
-                    Ok(Command::Msg(
+                    Ok(Command::Irc(Irc::Msg(
                         target.to_string(),
                         formatting::encode(raw, false),
-                    ))
+                    )))
                 } else {
                     Ok(unknown())
                 }
@@ -234,36 +229,31 @@ fn validated<const EXACT: usize, const OPT: usize, const TEXT: bool>(
     }
 }
 
-impl TryFrom<Command> for proto::Command {
+impl TryFrom<Irc> for proto::Command {
     type Error = ();
 
-    fn try_from(command: Command) -> Result<Self, Self::Error> {
-        match command {
-            Command::Join(chanlist, chankeys) => Ok(proto::Command::JOIN(chanlist, chankeys)),
-            Command::Motd(target) => Ok(proto::Command::MOTD(target)),
-            Command::Nick(nick) => Ok(proto::Command::NICK(nick)),
-            Command::Quit(comment) => Ok(proto::Command::QUIT(comment)),
-            Command::Msg(target, msg) => Ok(proto::Command::PRIVMSG(target, msg)),
-            Command::Me(target, text) => Ok(ctcp::query_command(
-                &ctcp::Command::Action,
-                target,
-                Some(text),
-            )),
-            Command::Whois(channel, user) => Ok(proto::Command::WHOIS(channel, user)),
-            Command::Part(chanlist, reason) => Ok(proto::Command::PART(chanlist, reason)),
-            Command::Topic(channel, topic) => Ok(proto::Command::TOPIC(channel, topic)),
-            Command::Kick(channel, user, comment) => {
-                Ok(proto::Command::KICK(channel, user, comment))
+    fn try_from(command: Irc) -> Result<Self, Self::Error> {
+        Ok(match command {
+            Irc::Join(chanlist, chankeys) => proto::Command::JOIN(chanlist, chankeys),
+            Irc::Motd(target) => proto::Command::MOTD(target),
+            Irc::Nick(nick) => proto::Command::NICK(nick),
+            Irc::Quit(comment) => proto::Command::QUIT(comment),
+            Irc::Msg(target, msg) => proto::Command::PRIVMSG(target, msg),
+            Irc::Me(target, text) => {
+                ctcp::query_command(&ctcp::Command::Action, target, Some(text))
             }
-            Command::Mode(target, modestring, modearguments) => {
-                Ok(proto::Command::MODE(target, modestring, modearguments))
+            Irc::Whois(channel, user) => proto::Command::WHOIS(channel, user),
+            Irc::Part(chanlist, reason) => proto::Command::PART(chanlist, reason),
+            Irc::Topic(channel, topic) => proto::Command::TOPIC(channel, topic),
+            Irc::Kick(channel, user, comment) => proto::Command::KICK(channel, user, comment),
+            Irc::Mode(target, modestring, modearguments) => {
+                proto::Command::MODE(target, modestring, modearguments)
             }
-            Command::Away(comment) => Ok(proto::Command::AWAY(comment)),
-            Command::SetName(realname) => Ok(proto::Command::SETNAME(realname)),
-            Command::OpenBuffer(_target) => Err(()),
-            Command::Raw(raw) => Ok(proto::Command::Raw(raw)),
-            Command::Unknown(command, args) => Ok(proto::Command::new(&command, args)),
-        }
+            Irc::Away(comment) => proto::Command::AWAY(comment),
+            Irc::SetName(realname) => proto::Command::SETNAME(realname),
+            Irc::Raw(raw) => proto::Command::Raw(raw),
+            Irc::Unknown(command, args) => proto::Command::new(&command, args),
+        })
     }
 }
 

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -180,7 +180,7 @@ impl Manager {
         }
     }
 
-    pub fn record_input(
+    pub fn record_input_message(
         &mut self,
         input: Input,
         user: User,
@@ -205,11 +205,11 @@ impl Manager {
             }
         }
 
-        if let Some(text) = input.raw() {
-            self.data.input.record(&input.buffer, text.to_string());
-        }
-
         tasks
+    }
+
+    pub fn record_input_history(&mut self, buffer: &buffer::Upstream, text: String) {
+        self.data.input.record(buffer, text);
     }
 
     pub fn record_draft(&mut self, draft: input::Draft) {

--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -114,6 +114,10 @@ impl Input {
     pub fn raw(&self) -> Option<&str> {
         self.raw.as_deref()
     }
+
+    pub fn internal(&self) -> Option<Command> {
+        self.content.internal(&self.buffer)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -137,6 +141,10 @@ impl Content {
         self.command(buffer)
             .and_then(|command| proto::Command::try_from(command).ok())
             .map(proto::Message::from)
+    }
+
+    fn internal(&self, buffer: &buffer::Upstream) -> Option<Command> {
+        self.command(buffer).filter(|command| command.is_internal())
     }
 }
 

--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -38,11 +38,7 @@ pub fn parse(
         return Err(Error::ExceedsByteLimit);
     }
 
-    Ok(Parsed::Input(Input {
-        buffer,
-        content,
-        raw: Some(input.to_string()),
-    }))
+    Ok(Parsed::Input(Input { buffer, content }))
 }
 
 pub enum Parsed {
@@ -54,7 +50,6 @@ pub enum Parsed {
 pub struct Input {
     pub buffer: buffer::Upstream,
     content: Content,
-    raw: Option<String>,
 }
 
 impl Input {
@@ -62,7 +57,6 @@ impl Input {
         Self {
             buffer,
             content: Content::Command(command),
-            raw: None,
         }
     }
 
@@ -115,10 +109,6 @@ impl Input {
 
     pub fn encoded(&self) -> Option<message::Encoded> {
         self.content.proto(&self.buffer).map(message::Encoded::from)
-    }
-
-    pub fn raw(&self) -> Option<&str> {
-        self.raw.as_deref()
     }
 }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -48,7 +48,7 @@ pub enum Message {
 
 pub enum Event {
     UserContext(user_context::Event),
-    OpenBuffer(Target, Option<Task<history::manager::Message>>),
+    OpenBuffer(Target),
     GoToMessage(data::Server, target::Channel, message::Hash),
     History(Task<history::manager::Message>),
     RequestOlderChatHistory,
@@ -109,9 +109,7 @@ impl Buffer {
 
                 let event = event.map(|event| match event {
                     channel::Event::UserContext(event) => Event::UserContext(event),
-                    channel::Event::OpenBuffer(target, history_task) => {
-                        Event::OpenBuffer(target, history_task)
-                    }
+                    channel::Event::OpenBuffer(target) => Event::OpenBuffer(target),
                     channel::Event::History(task) => Event::History(task),
                     channel::Event::RequestOlderChatHistory => Event::RequestOlderChatHistory,
                     channel::Event::PreviewChanged => Event::PreviewChanged,
@@ -127,9 +125,7 @@ impl Buffer {
 
                 let event = event.map(|event| match event {
                     server::Event::UserContext(event) => Event::UserContext(event),
-                    server::Event::OpenBuffer(target, history_task) => {
-                        Event::OpenBuffer(target, history_task)
-                    }
+                    server::Event::OpenBuffer(target) => Event::OpenBuffer(target),
                     server::Event::History(task) => Event::History(task),
                 });
 
@@ -140,9 +136,7 @@ impl Buffer {
 
                 let event = event.map(|event| match event {
                     query::Event::UserContext(event) => Event::UserContext(event),
-                    query::Event::OpenBuffer(target, history_task) => {
-                        Event::OpenBuffer(target, history_task)
-                    }
+                    query::Event::OpenBuffer(target) => Event::OpenBuffer(target),
                     query::Event::History(task) => Event::History(task),
                     query::Event::RequestOlderChatHistory => Event::RequestOlderChatHistory,
                     query::Event::PreviewChanged => Event::PreviewChanged,
@@ -164,7 +158,7 @@ impl Buffer {
                 let event = event.map(|event| match event {
                     logs::Event::UserContext(event) => Event::UserContext(event),
                     logs::Event::OpenChannel(channel) => {
-                        Event::OpenBuffer(Target::Channel(channel), None)
+                        Event::OpenBuffer(Target::Channel(channel))
                     }
                     logs::Event::History(task) => Event::History(task),
                 });
@@ -177,7 +171,7 @@ impl Buffer {
                 let event = event.map(|event| match event {
                     highlights::Event::UserContext(event) => Event::UserContext(event),
                     highlights::Event::OpenChannel(channel) => {
-                        Event::OpenBuffer(Target::Channel(channel), None)
+                        Event::OpenBuffer(Target::Channel(channel))
                     }
                     highlights::Event::GoToMessage(server, channel, message) => {
                         Event::GoToMessage(server, channel, message)

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -21,7 +21,7 @@ pub enum Message {
 
 pub enum Event {
     UserContext(user_context::Event),
-    OpenBuffer(Target, Option<Task<history::manager::Message>>),
+    OpenBuffer(Target),
     History(Task<history::manager::Message>),
     RequestOlderChatHistory,
     PreviewChanged,
@@ -370,7 +370,7 @@ impl Channel {
                 let event = event.and_then(|event| match event {
                     scroll_view::Event::UserContext(event) => Some(Event::UserContext(event)),
                     scroll_view::Event::OpenChannel(channel) => {
-                        Some(Event::OpenBuffer(Target::Channel(channel), None))
+                        Some(Event::OpenBuffer(Target::Channel(channel)))
                     }
                     scroll_view::Event::GoToMessage(..) => None,
                     scroll_view::Event::RequestOlderChatHistory => {
@@ -399,10 +399,9 @@ impl Channel {
 
                         (command, Some(Event::History(history_task)))
                     }
-                    Some(input_view::Event::OpenBuffer {
-                        target,
-                        history_task,
-                    }) => (command, Some(Event::OpenBuffer(target, Some(history_task)))),
+                    Some(input_view::Event::OpenBuffer { target }) => {
+                        (command, Some(Event::OpenBuffer(target)))
+                    }
                     None => (command, None),
                 }
             }
@@ -415,7 +414,7 @@ impl Channel {
                 topic::update(message).map(|event| match event {
                     topic::Event::UserContext(event) => Event::UserContext(event),
                     topic::Event::OpenChannel(channel) => {
-                        Event::OpenBuffer(Target::Channel(channel), None)
+                        Event::OpenBuffer(Target::Channel(channel))
                     }
                 }),
             ),

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -1,7 +1,7 @@
 use data::server::Server;
+use data::target::{self, Target};
 use data::user::Nick;
-use data::{buffer, preview, User};
-use data::{history, message, target, Config};
+use data::{buffer, history, message, preview, Config, User};
 use iced::widget::{column, container, row};
 use iced::{alignment, padding, Length, Task};
 
@@ -21,7 +21,7 @@ pub enum Message {
 
 pub enum Event {
     UserContext(user_context::Event),
-    OpenChannel(target::Channel),
+    OpenBuffer(Target, Option<Task<history::manager::Message>>),
     History(Task<history::manager::Message>),
     RequestOlderChatHistory,
     PreviewChanged,
@@ -369,7 +369,9 @@ impl Channel {
 
                 let event = event.and_then(|event| match event {
                     scroll_view::Event::UserContext(event) => Some(Event::UserContext(event)),
-                    scroll_view::Event::OpenChannel(channel) => Some(Event::OpenChannel(channel)),
+                    scroll_view::Event::OpenChannel(channel) => {
+                        Some(Event::OpenBuffer(Target::Channel(channel), None))
+                    }
                     scroll_view::Event::GoToMessage(..) => None,
                     scroll_view::Event::RequestOlderChatHistory => {
                         Some(Event::RequestOlderChatHistory)
@@ -397,6 +399,10 @@ impl Channel {
 
                         (command, Some(Event::History(history_task)))
                     }
+                    Some(input_view::Event::OpenBuffer {
+                        target,
+                        history_task,
+                    }) => (command, Some(Event::OpenBuffer(target, Some(history_task)))),
                     None => (command, None),
                 }
             }
@@ -408,7 +414,9 @@ impl Channel {
                 Task::none(),
                 topic::update(message).map(|event| match event {
                     topic::Event::UserContext(event) => Event::UserContext(event),
-                    topic::Event::OpenChannel(channel) => Event::OpenChannel(channel),
+                    topic::Event::OpenChannel(channel) => {
+                        Event::OpenBuffer(Target::Channel(channel), None)
+                    }
                 }),
             ),
         }

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -15,7 +15,7 @@ pub enum Message {
 
 pub enum Event {
     UserContext(user_context::Event),
-    OpenBuffer(Target, Option<Task<history::manager::Message>>),
+    OpenBuffer(Target),
     History(Task<history::manager::Message>),
     RequestOlderChatHistory,
     PreviewChanged,
@@ -288,7 +288,7 @@ impl Query {
                 let event = event.and_then(|event| match event {
                     scroll_view::Event::UserContext(event) => Some(Event::UserContext(event)),
                     scroll_view::Event::OpenChannel(channel) => {
-                        Some(Event::OpenBuffer(Target::Channel(channel), None))
+                        Some(Event::OpenBuffer(Target::Channel(channel)))
                     }
                     scroll_view::Event::GoToMessage(_, _, _) => None,
                     scroll_view::Event::RequestOlderChatHistory => {
@@ -317,10 +317,9 @@ impl Query {
 
                         (command, Some(Event::History(history_task)))
                     }
-                    Some(input_view::Event::OpenBuffer {
-                        target,
-                        history_task,
-                    }) => (command, Some(Event::OpenBuffer(target, Some(history_task)))),
+                    Some(input_view::Event::OpenBuffer { target }) => {
+                        (command, Some(Event::OpenBuffer(target)))
+                    }
                     None => (command, None),
                 }
             }

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -1,4 +1,5 @@
-use data::{buffer, history, message, preview, target, Config, Server};
+use data::target::{self, Target};
+use data::{buffer, history, message, preview, Config, Server};
 use iced::widget::{column, container, row, vertical_space};
 use iced::{alignment, Length, Task};
 
@@ -14,7 +15,7 @@ pub enum Message {
 
 pub enum Event {
     UserContext(user_context::Event),
-    OpenChannel(target::Channel),
+    OpenBuffer(Target, Option<Task<history::manager::Message>>),
     History(Task<history::manager::Message>),
     RequestOlderChatHistory,
     PreviewChanged,
@@ -286,7 +287,9 @@ impl Query {
 
                 let event = event.and_then(|event| match event {
                     scroll_view::Event::UserContext(event) => Some(Event::UserContext(event)),
-                    scroll_view::Event::OpenChannel(channel) => Some(Event::OpenChannel(channel)),
+                    scroll_view::Event::OpenChannel(channel) => {
+                        Some(Event::OpenBuffer(Target::Channel(channel), None))
+                    }
                     scroll_view::Event::GoToMessage(_, _, _) => None,
                     scroll_view::Event::RequestOlderChatHistory => {
                         Some(Event::RequestOlderChatHistory)
@@ -314,6 +317,10 @@ impl Query {
 
                         (command, Some(Event::History(history_task)))
                     }
+                    Some(input_view::Event::OpenBuffer {
+                        target,
+                        history_task,
+                    }) => (command, Some(Event::OpenBuffer(target, Some(history_task)))),
                     None => (command, None),
                 }
             }

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -1,4 +1,5 @@
-use data::{buffer, history, message, target, Config};
+use data::target::Target;
+use data::{buffer, history, message, Config};
 use iced::widget::{column, container, row, vertical_space};
 use iced::{Length, Task};
 
@@ -14,7 +15,7 @@ pub enum Message {
 
 pub enum Event {
     UserContext(user_context::Event),
-    OpenChannel(target::Channel),
+    OpenBuffer(Target, Option<Task<history::manager::Message>>),
     History(Task<history::manager::Message>),
 }
 
@@ -150,7 +151,9 @@ impl Server {
 
                 let event = event.and_then(|event| match event {
                     scroll_view::Event::UserContext(event) => Some(Event::UserContext(event)),
-                    scroll_view::Event::OpenChannel(channel) => Some(Event::OpenChannel(channel)),
+                    scroll_view::Event::OpenChannel(channel) => {
+                        Some(Event::OpenBuffer(Target::Channel(channel), None))
+                    }
                     scroll_view::Event::GoToMessage(_, _, _) => None,
                     scroll_view::Event::RequestOlderChatHistory => None,
                     scroll_view::Event::PreviewChanged => None,
@@ -173,6 +176,10 @@ impl Server {
                         ]),
                         Some(Event::History(history_task)),
                     ),
+                    Some(input_view::Event::OpenBuffer {
+                        target,
+                        history_task,
+                    }) => (command, Some(Event::OpenBuffer(target, Some(history_task)))),
                     None => (command, None),
                 }
             }

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -15,7 +15,7 @@ pub enum Message {
 
 pub enum Event {
     UserContext(user_context::Event),
-    OpenBuffer(Target, Option<Task<history::manager::Message>>),
+    OpenBuffer(Target),
     History(Task<history::manager::Message>),
 }
 
@@ -152,7 +152,7 @@ impl Server {
                 let event = event.and_then(|event| match event {
                     scroll_view::Event::UserContext(event) => Some(Event::UserContext(event)),
                     scroll_view::Event::OpenChannel(channel) => {
-                        Some(Event::OpenBuffer(Target::Channel(channel), None))
+                        Some(Event::OpenBuffer(Target::Channel(channel)))
                     }
                     scroll_view::Event::GoToMessage(_, _, _) => None,
                     scroll_view::Event::RequestOlderChatHistory => None,
@@ -176,10 +176,9 @@ impl Server {
                         ]),
                         Some(Event::History(history_task)),
                     ),
-                    Some(input_view::Event::OpenBuffer {
-                        target,
-                        history_task,
-                    }) => (command, Some(Event::OpenBuffer(target, Some(history_task)))),
+                    Some(input_view::Event::OpenBuffer { target }) => {
+                        (command, Some(Event::OpenBuffer(target)))
+                    }
                     None => (command, None),
                 }
             }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -11,9 +11,10 @@ use data::history::ReadMarker;
 use data::isupport::{self, ChatHistorySubcommand, MessageReference};
 use data::target::{self, Target};
 use data::user::Nick;
-use data::{client, environment, history, Config, Server, Version};
-use data::{config, preview};
-use data::{file_transfer, Notification};
+use data::{
+    client, command, config, environment, file_transfer, history, preview, Config, Notification,
+    Server, Version,
+};
 use iced::widget::pane_grid::{self, PaneGrid};
 use iced::widget::{column, container, row, Space};
 use iced::{clipboard, Length, Task, Vector};
@@ -189,7 +190,7 @@ impl Dashboard {
                                                 channel.clone(),
                                             );
 
-                                            let command = data::Command::Mode(
+                                            let command = command::Irc::Mode(
                                                 channel.to_string(),
                                                 Some(mode),
                                                 Some(vec![nick.to_string()]),
@@ -207,7 +208,7 @@ impl Dashboard {
                                                 );
 
                                             let command =
-                                                data::Command::Whois(None, nick.to_string());
+                                                command::Irc::Whois(None, nick.to_string());
 
                                             let input =
                                                 data::Input::command(buffer.clone(), command);
@@ -331,12 +332,8 @@ impl Dashboard {
                                         }
                                     }
                                 }
-                                buffer::Event::OpenBuffer(target, history_task) => {
-                                    let mut tasks = vec![task];
-
-                                    if let Some(history_task) = history_task {
-                                        tasks.push(history_task.map(Message::History))
-                                    }
+                                buffer::Event::OpenBuffer(target) => {
+                                    let mut tasks = vec![];
 
                                     if let Some(server) = pane
                                         .buffer
@@ -1505,7 +1502,7 @@ impl Dashboard {
             }
             buffer::Upstream::Channel(server, channel) => {
                 // Send part & close history file
-                let command = data::Command::Part(channel.to_string(), None);
+                let command = command::Irc::Part(channel.to_string(), None);
                 let input = data::Input::command(buffer.clone(), command);
 
                 if let Some(encoded) = input.encoded() {


### PR DESCRIPTION
Allows `/msg target` (without any message text following) in the input to open the target (query or channel) in a new pane.  This behavior matches the description given for `/msg` in `src/buffer/input_view/completion.rs`, and allows for the user to open a query without sending a message or right-clicking the target user's name and selecting "Message".