### PR TITLE
Quit application thought commandbar and shortcut.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Added:
 - Sidebar now automatically adjusts its width based on content
 - Ability to customize default pane splitting direction (vertical or horizontal)
 - Clicking a nickname is now configurable. The default behavior has changed to open a query.
+- Ability to quit Halloy through commandbar and keyboard shortcut
 
 Changed:
 

--- a/book/src/configuration/keyboard.md
+++ b/book/src/configuration/keyboard.md
@@ -33,3 +33,4 @@ move_right = "alt+l"
 | `file_transfers`        | Toggle File Transfers Buffer | <kbd>⌘</kbd> + <kbd>j</kbd>                         | <kbd>ctrl</kbd> + <kbd>j</kbd>                      |
 | `logs`                  | Toggle Logs Buffer           | <kbd>⌘</kbd> + <kbd>l</kbd>                         | <kbd>ctrl</kbd> + <kbd>l</kbd>                      |
 | `theme_editor`          | Toggle Theme Editor Window   | <kbd>⌘</kbd> + <kbd>t</kbd>                         | <kbd>ctrl</kbd> + <kbd>t</kbd>                      |
+| `quit_application`      | Quit Halloy                  | Not set                                             | Not set                                             |

--- a/data/src/config/keys.rs
+++ b/data/src/config/keys.rs
@@ -44,6 +44,8 @@ pub struct Keyboard {
     pub theme_editor: KeyBind,
     #[serde(default = "KeyBind::highlight")]
     pub highlight: KeyBind,
+    #[serde(default)]
+    pub quit_application: Option<KeyBind>,
 }
 
 impl Default for Keyboard {
@@ -69,6 +71,7 @@ impl Default for Keyboard {
             logs: KeyBind::logs(),
             theme_editor: KeyBind::theme_editor(),
             highlight: KeyBind::highlight(),
+            quit_application: None,
         }
     }
 }
@@ -77,7 +80,7 @@ impl Keyboard {
     pub fn shortcuts(&self) -> Vec<Shortcut> {
         use crate::shortcut::Command::*;
 
-        vec![
+        let mut shortcuts = vec![
             shortcut(self.move_up.clone(), MoveUp),
             shortcut(self.move_down.clone(), MoveDown),
             shortcut(self.move_left.clone(), MoveLeft),
@@ -98,6 +101,12 @@ impl Keyboard {
             shortcut(self.logs.clone(), Logs),
             shortcut(self.theme_editor.clone(), ThemeEditor),
             shortcut(self.highlight.clone(), Highlight),
-        ]
+        ];
+
+        if let Some(quit_application) = self.quit_application.clone() {
+            shortcuts.push(shortcut(quit_application, QuitApplication));
+        }
+
+        shortcuts
     }
 }

--- a/data/src/shortcut.rs
+++ b/data/src/shortcut.rs
@@ -43,6 +43,7 @@ pub enum Command {
     Logs,
     ThemeEditor,
     Highlight,
+    QuitApplication,
 }
 
 macro_rules! default {

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -784,7 +784,7 @@ impl Dashboard {
                                 }
                             },
                             command_bar::Command::Application(application) => match application {
-                                command_bar::Application::Quit => (iced::exit(), None),
+                                command_bar::Application::Quit => (self.exit(), None),
                             },
                         };
 
@@ -973,7 +973,7 @@ impl Dashboard {
                         );
                     }
                     ToggleFullscreen => return (window::toggle_fullscreen(), None),
-                    QuitApplication => return (iced::exit(), None),
+                    QuitApplication => return (self.exit(), None),
                 }
             }
             Message::FileTransfer(update) => {

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -783,6 +783,9 @@ impl Dashboard {
                                     (window::toggle_fullscreen(), None)
                                 }
                             },
+                            command_bar::Command::Application(application) => match application {
+                                command_bar::Application::Quit => (iced::exit(), None),
+                            },
                         };
 
                         return (
@@ -970,6 +973,7 @@ impl Dashboard {
                         );
                     }
                     ToggleFullscreen => return (window::toggle_fullscreen(), None),
+                    QuitApplication => return (iced::exit(), None),
                 }
             }
             Message::FileTransfer(update) => {

--- a/src/screen/dashboard/command_bar.rs
+++ b/src/screen/dashboard/command_bar.rs
@@ -108,12 +108,18 @@ pub enum Event {
 
 #[derive(Debug, Clone)]
 pub enum Command {
+    Application(Application),
     Version(Version),
     Buffer(Buffer),
     Configuration(Configuration),
     UI(Ui),
     Theme(Theme),
     Window(Window),
+}
+
+#[derive(Debug, Clone)]
+pub enum Application {
+    Quit,
 }
 
 #[derive(Debug, Clone)]
@@ -151,7 +157,6 @@ pub enum Window {
     ToggleFullscreen,
 }
 
-
 #[derive(Debug, Clone)]
 pub enum Theme {
     Switch(data::Theme),
@@ -183,7 +188,10 @@ impl Command {
 
         let version = Version::list(version).into_iter().map(Command::Version);
 
+        let application = Application::list().into_iter().map(Command::Application);
+
         version
+            .chain(application)
             .chain(buffers)
             .chain(configs)
             .chain(themes)
@@ -202,6 +210,7 @@ impl std::fmt::Display for Command {
             Command::Theme(theme) => write!(f, "Theme: {}", theme),
             Command::Version(application) => write!(f, "Version: {}", application),
             Command::Window(window) => write!(f, "Window: {}", window),
+            Command::Application(application) => write!(f, "Application: {}", application),
         }
     }
 }
@@ -240,6 +249,12 @@ impl Buffer {
         }
 
         list
+    }
+}
+
+impl Application {
+    fn list() -> Vec<Self> {
+        vec![Application::Quit]
     }
 }
 
@@ -282,6 +297,14 @@ impl Theme {
     }
 }
 
+impl std::fmt::Display for Application {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Application::Quit => write!(f, "Quit"),
+        }
+    }
+}
+
 impl std::fmt::Display for Window {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -289,7 +312,6 @@ impl std::fmt::Display for Window {
         }
     }
 }
-
 
 impl std::fmt::Display for Version {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
Fixes https://github.com/squidowl/halloy/issues/789.

This lets you quit Halloy through the command bar (ctrl+k) or through a keyboard shortcut:

```toml
[keyboard]
quit_application = "alt+k"
```