### PR TITLE
Shortcuts to Cycle to Next/Previous Buffer with Unread Message(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+Added:
+
+- Shortcuts for cycling buffers with unread message(s)
+  - Cycle to next buffer with unread message(s) <kbd>ctrl</kbd> + <kbd>`</kbd>
+  - Cycle to previous buffer with unread message(s) <kbd>ctrl</kbd> + <kbd>~</kbd>
+
 # 2025.3 (2025-03-14)
 
 Added:
@@ -15,9 +21,6 @@ Added:
   - Scroll buffer down a page <kbd>pagedown</kbd> (<kbd>Fn</kbd> + <kbd>↓</kbd> on macOS)
   - Scroll to top of buffer <kbd>ctrl</kbd> + <kbd>↑</kbd> (<kbd>⌘</kbd> + <kbd>↑</kbd> on macOS)
   - Scroll to bottom of buffer <kbd>ctrl</kbd> + <kbd>↓</kbd> (<kbd>⌘</kbd> + <kbd>↓</kbd> on macOS)
-- Shortcuts for cycling buffers with unread message(s)
-  - Cycle to next buffer with unread message(s) <kbd>ctrl</kbd> + <kbd>`</kbd>
-  - Cycle to previous buffer with unread message(s) <kbd>ctrl</kbd> + <kbd>~</kbd>
 
 Changed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Added:
   - Scroll buffer down a page <kbd>pagedown</kbd> (<kbd>Fn</kbd> + <kbd>↓</kbd> on macOS)
   - Scroll to top of buffer <kbd>ctrl</kbd> + <kbd>↑</kbd> (<kbd>⌘</kbd> + <kbd>↑</kbd> on macOS)
   - Scroll to bottom of buffer <kbd>ctrl</kbd> + <kbd>↓</kbd> (<kbd>⌘</kbd> + <kbd>↓</kbd> on macOS)
+- Shortcuts for cycling buffers with unread message(s)
+  - Cycle to next buffer with unread message(s) <kbd>ctrl</kbd> + <kbd>`</kbd>
+  - Cycle to previous buffer with unread message(s) <kbd>ctrl</kbd> + <kbd>~</kbd>
 
 Changed:
 

--- a/data/src/config/keys.rs
+++ b/data/src/config/keys.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-use crate::shortcut::{KeyBind, Shortcut, shortcut};
+use crate::shortcut::{shortcut, KeyBind, Shortcut};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Keyboard {
@@ -52,6 +52,10 @@ pub struct Keyboard {
     pub scroll_to_top: KeyBind,
     #[serde(default = "KeyBind::scroll_to_bottom")]
     pub scroll_to_bottom: KeyBind,
+    #[serde(default = "KeyBind::cycle_next_unread_buffer")]
+    pub cycle_next_unread_buffer: KeyBind,
+    #[serde(default = "KeyBind::cycle_previous_unread_buffer")]
+    pub cycle_previous_unread_buffer: KeyBind,
     #[serde(default)]
     pub quit_application: Option<KeyBind>,
 }
@@ -83,6 +87,8 @@ impl Default for Keyboard {
             scroll_down_page: KeyBind::scroll_down_page(),
             scroll_to_top: KeyBind::scroll_to_top(),
             scroll_to_bottom: KeyBind::scroll_to_bottom(),
+            cycle_next_unread_buffer: KeyBind::cycle_next_unread_buffer(),
+            cycle_previous_unread_buffer: KeyBind::cycle_previous_unread_buffer(),
             quit_application: None,
         }
     }
@@ -117,6 +123,11 @@ impl Keyboard {
             shortcut(self.scroll_to_top.clone(), ScrollToTop),
             shortcut(self.scroll_to_bottom.clone(), ScrollToBottom),
             shortcut(self.highlight.clone(), Highlight),
+            shortcut(self.cycle_next_unread_buffer.clone(), CycleNextUnreadBuffer),
+            shortcut(
+                self.cycle_previous_unread_buffer.clone(),
+                CyclePreviousUnreadBuffer,
+            ),
         ];
 
         if let Some(quit_application) = self.quit_application.clone() {

--- a/data/src/shortcut.rs
+++ b/data/src/shortcut.rs
@@ -48,6 +48,8 @@ pub enum Command {
     ScrollDownPage,
     ScrollToTop,
     ScrollToBottom,
+    CycleNextUnreadBuffer,
+    CyclePreviousUnreadBuffer,
 }
 
 macro_rules! default {
@@ -144,6 +146,8 @@ impl KeyBind {
     // Don't use HOME / END since text input is always focused
     default!(scroll_to_top, ArrowUp, COMMAND);
     default!(scroll_to_bottom, ArrowDown, COMMAND);
+    default!(cycle_next_unread_buffer, "`", CTRL);
+    default!(cycle_previous_unread_buffer, "`", CTRL | SHIFT);
 
     pub fn is_pressed(
         &self,


### PR DESCRIPTION
Decided I wanted to tackle issue #809, so this pull request is to add that feature.

I'm uncertain what the default shortcuts should be;  I used `` ` `` & `~` as the characters since that key is near `Tab` which is used in the default shortcuts for cycling buffers.