### PR TITLE
Focus on Launch Fix

### DIFF
--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -2064,7 +2064,7 @@ impl Dashboard {
         let mut dashboard = Self {
             panes,
             focus,
-            focus_history: VecDeque::new(),
+            focus_history: VecDeque::from([focus.pane]),
             side_menu: Sidebar::new(),
             history: history::Manager::default(),
             last_changed: None,


### PR DESCRIPTION
At some point in the always focus input development there was a regression and the pane focused on quit was not refocused on next application launch.  This fixes that issue, so that focus is restored to the correct pane on application launch.