### PR TITLE
Update Actions Used by Release Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,10 @@ jobs:
               echo "ARTIFACT_PATH=$(bash scripts/package-linux.sh archive_path)" >> "$GITHUB_ENV"
     runs-on: ${{ matrix.target.os }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
-          override: true
 
       - name: Install linux deps
         if: matrix.target.target == 'linux'
@@ -91,10 +89,10 @@ jobs:
     steps:
       - name: Create Release
         id: create-release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.inputs.tag }}
-          release_name: ${{ github.event.inputs.tag }}
+          name: ${{ github.event.inputs.tag }}
           draft: true
           prerelease: false
 
@@ -123,7 +121,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Updates to the actions used by the release action.  They were producing deprecation warnings.  Updated the one that is still maintained, and found what seemed to be the most straightforward replacements for the two that were no longer maintained.  Appears to work in limited testing on a forked repository.