### PR TITLE
Update iced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+Fixed:
+
+- No longer freezes under Wayland when window(s) are not visible
+
 # 2025.3 (2025-03-14)
 
 Added:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,7 +3039,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced?rev=fd5ed0d0a6e84b3c036ff8e1f0d62d383d4b1e82#fd5ed0d0a6e84b3c036ff8e1f0d62d383d4b1e82"
+source = "git+https://github.com/iced-rs/iced?rev=892ac1ce722a809e73aecd8d47ed4e7254d156df#892ac1ce722a809e73aecd8d47ed4e7254d156df"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -3053,7 +3053,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced?rev=fd5ed0d0a6e84b3c036ff8e1f0d62d383d4b1e82#fd5ed0d0a6e84b3c036ff8e1f0d62d383d4b1e82"
+source = "git+https://github.com/iced-rs/iced?rev=892ac1ce722a809e73aecd8d47ed4e7254d156df#892ac1ce722a809e73aecd8d47ed4e7254d156df"
 dependencies = [
  "bitflags 2.7.0",
  "bytes",
@@ -3071,7 +3071,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced?rev=fd5ed0d0a6e84b3c036ff8e1f0d62d383d4b1e82#fd5ed0d0a6e84b3c036ff8e1f0d62d383d4b1e82"
+source = "git+https://github.com/iced-rs/iced?rev=892ac1ce722a809e73aecd8d47ed4e7254d156df#892ac1ce722a809e73aecd8d47ed4e7254d156df"
 dependencies = [
  "futures",
  "iced_core",
@@ -3085,7 +3085,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced?rev=fd5ed0d0a6e84b3c036ff8e1f0d62d383d4b1e82#fd5ed0d0a6e84b3c036ff8e1f0d62d383d4b1e82"
+source = "git+https://github.com/iced-rs/iced?rev=892ac1ce722a809e73aecd8d47ed4e7254d156df#892ac1ce722a809e73aecd8d47ed4e7254d156df"
 dependencies = [
  "bitflags 2.7.0",
  "bytemuck",
@@ -3105,7 +3105,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced?rev=fd5ed0d0a6e84b3c036ff8e1f0d62d383d4b1e82#fd5ed0d0a6e84b3c036ff8e1f0d62d383d4b1e82"
+source = "git+https://github.com/iced-rs/iced?rev=892ac1ce722a809e73aecd8d47ed4e7254d156df#892ac1ce722a809e73aecd8d47ed4e7254d156df"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -3117,7 +3117,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced?rev=fd5ed0d0a6e84b3c036ff8e1f0d62d383d4b1e82#fd5ed0d0a6e84b3c036ff8e1f0d62d383d4b1e82"
+source = "git+https://github.com/iced-rs/iced?rev=892ac1ce722a809e73aecd8d47ed4e7254d156df#892ac1ce722a809e73aecd8d47ed4e7254d156df"
 dependencies = [
  "bytes",
  "iced_core",
@@ -3130,7 +3130,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced?rev=fd5ed0d0a6e84b3c036ff8e1f0d62d383d4b1e82#fd5ed0d0a6e84b3c036ff8e1f0d62d383d4b1e82"
+source = "git+https://github.com/iced-rs/iced?rev=892ac1ce722a809e73aecd8d47ed4e7254d156df#892ac1ce722a809e73aecd8d47ed4e7254d156df"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -3145,7 +3145,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced?rev=fd5ed0d0a6e84b3c036ff8e1f0d62d383d4b1e82#fd5ed0d0a6e84b3c036ff8e1f0d62d383d4b1e82"
+source = "git+https://github.com/iced-rs/iced?rev=892ac1ce722a809e73aecd8d47ed4e7254d156df#892ac1ce722a809e73aecd8d47ed4e7254d156df"
 dependencies = [
  "bitflags 2.7.0",
  "bytemuck",
@@ -3163,7 +3163,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced?rev=fd5ed0d0a6e84b3c036ff8e1f0d62d383d4b1e82#fd5ed0d0a6e84b3c036ff8e1f0d62d383d4b1e82"
+source = "git+https://github.com/iced-rs/iced?rev=892ac1ce722a809e73aecd8d47ed4e7254d156df#892ac1ce722a809e73aecd8d47ed4e7254d156df"
 dependencies = [
  "iced_renderer",
  "iced_runtime",
@@ -3178,7 +3178,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced?rev=fd5ed0d0a6e84b3c036ff8e1f0d62d383d4b1e82#fd5ed0d0a6e84b3c036ff8e1f0d62d383d4b1e82"
+source = "git+https://github.com/iced-rs/iced?rev=892ac1ce722a809e73aecd8d47ed4e7254d156df#892ac1ce722a809e73aecd8d47ed4e7254d156df"
 dependencies = [
  "iced_futures",
  "iced_graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,8 +90,8 @@ embed-resource = "3.0.2"
 windows_exe_info = "0.4"
 
 [patch.crates-io]
-iced = { git = "https://github.com/iced-rs/iced", rev = "fd5ed0d0a6e84b3c036ff8e1f0d62d383d4b1e82" }
-iced_core = { git = "https://github.com/iced-rs/iced", rev = "fd5ed0d0a6e84b3c036ff8e1f0d62d383d4b1e82" }
+iced = { git = "https://github.com/iced-rs/iced", rev = "892ac1ce722a809e73aecd8d47ed4e7254d156df" }
+iced_core = { git = "https://github.com/iced-rs/iced", rev = "892ac1ce722a809e73aecd8d47ed4e7254d156df" }
 
 [profile.ci]
 inherits = "dev"


### PR DESCRIPTION
Updates iced to include [PR #2849](https://github.com/iced-rs/iced/pull/2849).  Should address #589 and #781.  In my testing it addresses what I believe is the underlying cause of the both issues, that Halloy's event processing would be blocked when not visible on Wayland.