### PR TITLE
Expand Commands

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -4,10 +4,10 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use std::{fmt, io};
 
-use anyhow::{Context as ErrorContext, Result, anyhow, bail};
+use anyhow::{anyhow, bail, Context as ErrorContext, Result};
 use chrono::{DateTime, Utc};
-use futures::{Future, FutureExt, channel::mpsc};
-use irc::proto::{self, Command, command};
+use futures::{channel::mpsc, Future, FutureExt};
+use irc::proto::{self, command, Command};
 use itertools::{Either, Itertools};
 use log::error;
 use tokio::fs;
@@ -21,7 +21,7 @@ use crate::target::{self, Target};
 use crate::time::Posix;
 use crate::user::{Nick, NickRef};
 use crate::{
-    Server, User, buffer, compression, config, ctcp, dcc, environment, isupport, message, mode,
+    buffer, compression, config, ctcp, dcc, environment, isupport, message, mode, Server, User,
 };
 use crate::{file_transfer, server};
 
@@ -1223,7 +1223,9 @@ impl Client {
 
                 // Loop on connect commands
                 for command in self.config.on_connect.iter() {
-                    if let Ok(crate::Command::Irc(cmd)) = crate::command::parse(command, None) {
+                    if let Ok(crate::Command::Irc(cmd)) =
+                        crate::command::parse(command, None, &self.isupport)
+                    {
                         if let Ok(command) = proto::Command::try_from(cmd) {
                             self.handle.try_send(command.into())?;
                         };

--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -82,7 +82,7 @@ impl Input {
         let command = self.content.command(&self.buffer)?;
 
         match command {
-            command::Irc::Msg(targets, text) => Some(
+            command::Irc::Msg(targets, text) | command::Irc::Notice(targets, text) => Some(
                 targets
                     .split(',')
                     .map(|target| {

--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -14,8 +14,9 @@ pub fn parse(
     buffer: buffer::Upstream,
     auto_format: AutoFormat,
     input: &str,
+    isupport: &HashMap<isupport::Kind, isupport::Parameter>,
 ) -> Result<Parsed, Error> {
-    let content = match command::parse(input, Some(&buffer)) {
+    let content = match command::parse(input, Some(&buffer), isupport) {
         Ok(Command::Internal(command)) => return Ok(Parsed::Internal(command)),
         Ok(Command::Irc(command)) => Content::Command(command),
         Err(command::Error::MissingSlash) => {
@@ -30,12 +31,13 @@ pub fn parse(
         Err(error) => return Err(Error::Command(error)),
     };
 
-    if content
+    if let Some(message_bytes) = content
         .proto(&buffer)
-        .map(exceeds_byte_limit)
-        .unwrap_or_default()
+        .map(|message| format::message(message).len())
     {
-        return Err(Error::ExceedsByteLimit);
+        if message_bytes > format::BYTE_LIMIT {
+            return Err(Error::ExceedsByteLimit { message_bytes });
+        }
     }
 
     Ok(Parsed::Input(Input { buffer, content }))
@@ -182,14 +184,11 @@ pub struct Cache<'a> {
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error(
-        "message exceeds maximum encoded length of {} bytes",
+        "message exceeds maximum encoded length ({}/{} bytes)",
+        message_bytes,
         format::BYTE_LIMIT
     )]
-    ExceedsByteLimit,
+    ExceedsByteLimit { message_bytes: usize },
     #[error(transparent)]
     Command(#[from] command::Error),
-}
-
-fn exceeds_byte_limit(message: proto::Message) -> bool {
-    format::message(message).len() > format::BYTE_LIMIT
 }

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -70,7 +70,7 @@ impl FromStr for Operation {
                             }
                         }
                         "AWAYLEN" => Ok(Operation::Add(Parameter::AWAYLEN(
-                            parse_optional_positive_integer(value)?,
+                            parse_required_positive_integer(value)?,
                         ))),
                         "BOT" => Ok(Operation::Add(Parameter::BOT(parse_required_letter(
                             value, None,
@@ -410,7 +410,7 @@ impl FromStr for Operation {
                     match token {
                         "ACCEPT" => Err("value required"),
                         "ACCOUNTEXTBAN" => Err("value(s) required"),
-                        "AWAYLEN" => Ok(Operation::Add(Parameter::AWAYLEN(None))),
+                        "AWAYLEN" => Err("value required"),
                         "BOT" => Err("value required"),
                         "CALLERID" => Ok(Operation::Add(Parameter::CALLERID(
                             DEFAULT_CALLER_ID_LETTER,
@@ -524,7 +524,7 @@ impl Operation {
 pub enum Parameter {
     ACCEPT(u16),
     ACCOUNTEXTBAN(Vec<String>),
-    AWAYLEN(Option<u16>),
+    AWAYLEN(u16),
     BOT(char),
     CALLERID(char),
     CASEMAPPING(CaseMap),

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -249,7 +249,7 @@ impl Commands {
             .map(|command| {
                 match command.title {
                     "AWAY" => {
-                        if let Some(isupport::Parameter::AWAYLEN(Some(max_len))) =
+                        if let Some(isupport::Parameter::AWAYLEN(max_len)) =
                             isupport.get(&isupport::Kind::AWAYLEN)
                         {
                             return away_command(max_len);
@@ -283,6 +283,13 @@ impl Commands {
 
                         if channel_len.is_some() || channel_limits.is_some() || key_len.is_some() {
                             return join_command(channel_len, channel_limits, key_len);
+                        }
+                    }
+                    "KICK" => {
+                        if let Some(isupport::Parameter::KICKLEN(max_len)) =
+                            isupport.get(&isupport::Kind::KICKLEN)
+                        {
+                            return kick_command(max_len);
                         }
                     }
                     "MSG" => {
@@ -1407,6 +1414,30 @@ fn join_command(
     }
 }
 
+fn kick_command(max_len: &u16) -> Command {
+    Command {
+        title: "KICK",
+        args: vec![
+            Arg {
+                text: "channel",
+                optional: false,
+                tooltip: None,
+            },
+            Arg {
+                text: "user",
+                optional: false,
+                tooltip: None,
+            },
+            Arg {
+                text: "comment",
+                optional: true,
+                tooltip: Some(format!("maximum length: {}", max_len)),
+            },
+        ],
+        subcommands: None,
+    }
+}
+
 static KNOCK_COMMAND: Lazy<Command> = Lazy::new(|| Command {
     title: "KNOCK",
     args: vec![
@@ -1722,7 +1753,7 @@ fn setname_command(max_len: &u16) -> Command {
     Command {
         title: "SETNAME",
         args: vec![Arg {
-            text: "real name",
+            text: "realname",
             optional: false,
             tooltip: Some(format!("maximum length: {}", max_len)),
         }],

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -314,6 +314,23 @@ impl Commands {
                             return nick_command(max_len);
                         }
                     }
+                    "NOTICE" => {
+                        let channel_membership_prefixes = if let Some(
+                            isupport::Parameter::STATUSMSG(channel_membership_prefixes),
+                        ) =
+                            isupport.get(&isupport::Kind::STATUSMSG)
+                        {
+                            channel_membership_prefixes.clone()
+                        } else {
+                            vec![]
+                        };
+
+                        let target_limit = find_target_limit(isupport, "NOTICE");
+
+                        if !channel_membership_prefixes.is_empty() || target_limit.is_some() {
+                            return notice_command(channel_membership_prefixes, target_limit);
+                        }
+                    }
                     "PART" => {
                         if let Some(isupport::Parameter::CHANNELLEN(max_len)) =
                             isupport.get(&isupport::Kind::CHANNELLEN)
@@ -853,7 +870,25 @@ static COMMAND_LIST: Lazy<Vec<Command>> = Lazy::new(|| {
                 },
                 Arg {
                     text: "text",
+                    optional: true,
+                    tooltip: None,
+                },
+            ],
+            subcommands: None,
+        },
+        Command {
+            title: "NOTICE",
+            args: vec![
+                Arg {
+                    text: "targets",
                     optional: false,
+                    tooltip: Some(String::from(
+                        "comma-separated\n   {user}: user directly\n{channel}: all users in channel",
+                    )),
+                },
+                Arg {
+                    text: "text",
+                    optional: true,
                     tooltip: None,
                 },
             ],
@@ -1573,7 +1608,7 @@ fn msg_command(
             },
             Arg {
                 text: "text",
-                optional: false,
+                optional: true,
                 tooltip: None,
             },
         ],
@@ -1610,6 +1645,53 @@ fn nick_command(max_len: &u16) -> Command {
             optional: false,
             tooltip: Some(format!("maximum length: {}", max_len)),
         }],
+        subcommands: None,
+    }
+}
+
+fn notice_command(
+    channel_membership_prefixes: Vec<char>,
+    target_limit: Option<&isupport::CommandTargetLimit>,
+) -> Command {
+    let mut targets_tooltip = String::from(
+        "comma-separated\n    {user}: user directly\n {channel}: all users in channel",
+    );
+
+    for channel_membership_prefix in channel_membership_prefixes {
+        match channel_membership_prefix {
+            '~' => targets_tooltip.push_str("\n~{channel}: all founders in channel"),
+            '&' => targets_tooltip.push_str("\n&{channel}: all protected users in channel"),
+            '!' => targets_tooltip.push_str("\n!{channel}: all protected users in channel"),
+            '@' => targets_tooltip.push_str("\n@{channel}: all operators in channel"),
+            '%' => targets_tooltip.push_str("\n%{channel}: all half-operators in channel"),
+            '+' => targets_tooltip.push_str("\n+{channel}: all voiced users in channel"),
+            _ => (),
+        }
+    }
+
+    if let Some(target_limit) = target_limit {
+        if let Some(limit) = target_limit.limit {
+            targets_tooltip.push_str(format!("\nup to {} target", limit).as_str());
+            if limit != 1 {
+                targets_tooltip.push('s')
+            }
+        }
+    }
+
+    Command {
+        title: "NOTICE",
+        args: vec![
+            Arg {
+                text: "targets",
+                optional: false,
+                tooltip: Some(targets_tooltip),
+            },
+            Arg {
+                text: "text",
+                optional: true,
+                tooltip: None,
+            },
+        ],
         subcommands: None,
     }
 }


### PR DESCRIPTION
A bit of a grab bag re: input commands.
- Adds the `/notice` command, addressing #832.
- Incorporates ISUPPORT parameters into command parsing.
- Provide immediate feedback for some input errors, rather than waiting for the user to attempt to send, to make them easier for the user to address.