### PR TITLE
Pre-Login ChangeHost Broadcast to Server Buffer

### DIFF
--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -2,15 +2,15 @@ use std::collections::{HashMap, HashSet};
 
 use chrono::{DateTime, Utc};
 use futures::future::BoxFuture;
-use futures::{Future, FutureExt, future};
+use futures::{future, Future, FutureExt};
 use tokio::time::Instant;
 
 use crate::history::{self, History, MessageReferences};
 use crate::message::{self, Limit};
 use crate::target::{self, Target};
 use crate::user::Nick;
-use crate::{Config, Input, Server, User, server};
 use crate::{buffer, config, input, isupport};
+use crate::{server, Config, Input, Server, User};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Resource {
@@ -406,6 +406,7 @@ impl Manager {
                 new_username,
                 new_hostname,
                 ourself,
+                logged_in,
                 user_channels,
             } => {
                 if ourself {
@@ -417,6 +418,7 @@ impl Manager {
                         &new_username,
                         &new_hostname,
                         ourself,
+                        logged_in,
                         sent_time,
                     )
                 } else {
@@ -429,6 +431,7 @@ impl Manager {
                         &new_username,
                         &new_hostname,
                         ourself,
+                        logged_in,
                         sent_time,
                     )
                 }
@@ -683,7 +686,11 @@ impl Data {
                 .map_or_else(
                     || {
                         // Backlog is before this limit view of messages
-                        if has_read_messages { 0 } else { limited.len() }
+                        if has_read_messages {
+                            0
+                        } else {
+                            limited.len()
+                        }
                     },
                     |position| limited.len() - position,
                 )
@@ -910,6 +917,7 @@ pub enum Broadcast {
         new_username: String,
         new_hostname: String,
         ourself: bool,
+        logged_in: bool,
         user_channels: Vec<target::Channel>,
     },
 }

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -217,6 +217,7 @@ pub fn change_host(
     new_username: &str,
     new_hostname: &str,
     ourself: bool,
+    logged_in: bool,
     sent_time: DateTime<Utc>,
 ) -> Vec<Message> {
     let content = if ourself {
@@ -230,15 +231,29 @@ pub fn change_host(
         ))
     };
 
-    expand(
-        channels,
-        queries,
-        false,
-        Cause::Server(Some(source::Server::new(
-            source::server::Kind::ChangeHost,
-            Some(old_user.nickname().to_owned()),
-        ))),
-        content,
-        sent_time,
-    )
+    if ourself && !logged_in {
+        expand(
+            [],
+            [],
+            true,
+            Cause::Server(Some(source::Server::new(
+                source::server::Kind::ChangeHost,
+                Some(old_user.nickname().to_owned()),
+            ))),
+            content,
+            sent_time,
+        )
+    } else {
+        expand(
+            channels,
+            queries,
+            false,
+            Cause::Server(Some(source::Server::new(
+                source::server::Kind::ChangeHost,
+                Some(old_user.nickname().to_owned()),
+            ))),
+            content,
+            sent_time,
+        )
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -698,6 +698,7 @@ impl Halloy {
                                             new_username,
                                             new_hostname,
                                             ourself,
+                                            logged_in,
                                             channels,
                                             sent_time,
                                         } => {
@@ -712,6 +713,7 @@ impl Halloy {
                                                             new_username,
                                                             new_hostname,
                                                             ourself,
+                                                            logged_in,
                                                             user_channels: channels,
                                                         },
                                                     )


### PR DESCRIPTION
Broadcasts for chghost messages received during the login process would show up in the history of queries only (not in channels, since they haven't been joined at that stage, nor the server buffer).  This PR is to suppress broadcasts from queries (to match the behavior seen in channels), since they can start to pile up, and broadcast to the server buffer instead.  A minor added benefit that the information is available to users even if they don't happen to have a query open at launch.