### PR TITLE
Log In Before Sending `chathistory` TARGETS.

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -98,7 +98,7 @@ pub enum Event {
     FileTransferRequest(file_transfer::ReceiveRequest),
     UpdateReadMarker(Target, ReadMarker),
     JoinedChannel(target::Channel, DateTime<Utc>),
-    ChatHistoryAcknowledged(DateTime<Utc>),
+    LoggedIn(DateTime<Utc>),
     ChatHistoryTargetReceived(Target, DateTime<Utc>),
     ChatHistoryTargetsReceived(DateTime<Utc>),
     DirectMessage(User),
@@ -824,8 +824,6 @@ impl Client {
 
                 if caps.contains(&"draft/chathistory") && self.config.chathistory {
                     self.supports_chathistory = true;
-
-                    return Ok(vec![Event::ChatHistoryAcknowledged(server_time(&message))]);
                 }
             }
             Command::CAP(_, sub, a, b) if sub == "NAK" => {
@@ -987,6 +985,8 @@ impl Client {
                         }
                     });
                 }
+
+                return Ok(vec![Event::LoggedIn(server_time(&message))]);
             }
             Command::Numeric(RPL_LOGGEDOUT, _) => {
                 log::info!("[{}] logged out", self.server);

--- a/src/main.rs
+++ b/src/main.rs
@@ -758,16 +758,18 @@ impl Halloy {
 
                                         commands.push(command);
                                     }
-                                    data::client::Event::ChatHistoryAcknowledged(server_time) => {
-                                        if let Some(command) = dashboard
-                                            .load_chathistory_targets_timestamp(
-                                                &self.clients,
-                                                &server,
-                                                server_time,
-                                            )
-                                            .map(|command| command.map(Message::Dashboard))
-                                        {
-                                            commands.push(command);
+                                    data::client::Event::LoggedIn(server_time) => {
+                                        if self.clients.get_server_supports_chathistory(&server) {
+                                            if let Some(command) = dashboard
+                                                .load_chathistory_targets_timestamp(
+                                                    &self.clients,
+                                                    &server,
+                                                    server_time,
+                                                )
+                                                .map(|command| command.map(Message::Dashboard))
+                                            {
+                                                commands.push(command);
+                                            }
                                         }
                                     }
                                     data::client::Event::ChatHistoryTargetReceived(


### PR DESCRIPTION
Noticed with some servers (Ergo & Apollo) the `chathistory` TARGETS request getting rejected for being before login has completed.  I think the rejection is reasonable/correct, so I've changed the request to be sent after login completes (instead of immediately after the `chathistory` capability is acknowledged). 