### PR TITLE
User aware server messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Added:
 
+- Server messages (join, part, etc.) are now user-aware and will color nicknames accordingly
 - Shortcuts for cycling buffers with unread message(s)
   - Cycle to next buffer with unread message(s) <kbd>ctrl</kbd> + <kbd>`</kbd>
   - Cycle to previous buffer with unread message(s) <kbd>ctrl</kbd> + <kbd>~</kbd>

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -15,17 +15,17 @@ use url::Url;
 
 pub use self::formatting::Formatting;
 pub use self::source::{
-    server::{Kind, StandardReply},
     Source,
+    server::{Kind, StandardReply},
 };
 
-use crate::config::buffer::UsernameFormat;
 use crate::config::Highlights;
+use crate::config::buffer::UsernameFormat;
 use crate::serde::fail_as_none;
 use crate::target::Channel;
 use crate::time::Posix;
 use crate::user::{Nick, NickRef};
-use crate::{ctcp, isupport, target, Config, Server, User};
+use crate::{Config, Server, User, ctcp, isupport, target};
 
 // References:
 // - https://datatracker.ietf.org/doc/html/rfc1738#section-5
@@ -1254,7 +1254,9 @@ fn content<'a>(
             Some(parse_fragments(format!("{nick} {status_text} {account}")))
         }
         Command::Numeric(RPL_TOPICWHOTIME, params) => {
-            let nick = params.get(2)?;
+            let user = User::try_from(params.get(2)?.as_str()).ok()?;
+            let nickname = user.nickname();
+
             let datetime = params
                 .get(3)?
                 .parse::<u64>()
@@ -1265,7 +1267,7 @@ fn content<'a>(
                 .to_rfc2822();
 
             Some(parse_fragments(format!(
-                "topic set by {nick} at {datetime}"
+                "topic set by {nickname} at {datetime}"
             )))
         }
         Command::Numeric(RPL_CHANNELMODEIS, params) => {

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 use chrono::{DateTime, Utc};
 
 use super::{
-    Content, Direction, Message, Source, Target, parse_fragments_with_user, plain, source,
+    parse_fragments_with_user, parse_fragments_with_users, plain, source, Content, Direction, Message, Source, Target
 };
 use crate::config::buffer::UsernameFormat;
 use crate::time::Posix;
@@ -188,10 +188,13 @@ pub fn nickname(
     ourself: bool,
     sent_time: DateTime<Utc>,
 ) -> Vec<Message> {
+    let old_user = User::from(old_nick.clone());
+    let new_user = User::from(new_nick.clone());
+
     let content = if ourself {
-        plain(format!("You're now known as {new_nick}"))
+        parse_fragments_with_user(format!("You're now known as {new_nick}"), &new_user)
     } else {
-        plain(format!("{old_nick} is now known as {new_nick}"))
+        parse_fragments_with_users(format!("{old_nick} is now known as {new_nick}"), &[old_user, new_user])
     };
 
     expand(

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -4,8 +4,7 @@ use std::collections::HashSet;
 use chrono::{DateTime, Utc};
 
 use super::{
-    Content, Direction, Message, Source, Target, parse_fragments, parse_fragments_with_user, plain,
-    source,
+    Content, Direction, Message, Source, Target, parse_fragments_with_user, plain, source,
 };
 use crate::config::buffer::UsernameFormat;
 use crate::time::Posix;

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -1,14 +1,14 @@
 use data::server::Server;
 use data::target::{self, Target};
 use data::user::Nick;
-use data::{buffer, history, message, preview, Config, User};
+use data::{Config, User, buffer, history, message, preview};
 use iced::advanced::text;
 use iced::widget::{column, container, row};
-use iced::{padding, Length, Task};
+use iced::{Length, Task, padding};
 
 use super::{input_view, scroll_view, user_context};
-use crate::widget::{message_content, message_marker, selectable_text, Element};
-use crate::{theme, Theme};
+use crate::widget::{Element, message_content, message_marker, selectable_text};
+use crate::{Theme, theme};
 
 mod topic;
 
@@ -91,10 +91,7 @@ pub fn view<'a>(
                         .style(theme::selectable_text::tertiary);
 
                         if let Some(width) = max_prefix_width {
-                            Some(
-                                text.width(width)
-                                    .align_x(text::Alignment::Right),
-                            )
+                            Some(text.width(width).align_x(text::Alignment::Right))
                         } else {
                             Some(text)
                         }
@@ -106,7 +103,8 @@ pub fn view<'a>(
 
                 match message.target.source() {
                     message::Source::User(user) => {
-                        let current_user = users.iter().find(|current_user| *current_user == user);
+                        let current_user: Option<&User> =
+                            users.iter().find(|current_user| *current_user == user);
 
                         let mut text = selectable_text(
                             config
@@ -118,9 +116,7 @@ pub fn view<'a>(
                         .style(|theme| theme::selectable_text::nickname(theme, config, user));
 
                         if let Some(width) = max_nick_width {
-                            text = text
-                                .width(width)
-                                .align_x(text::Alignment::Right);
+                            text = text.width(width).align_x(text::Alignment::Right);
                         }
 
                         let nick = user_context::view(
@@ -186,21 +182,41 @@ pub fn view<'a>(
                             ),
                         }
                     }
-                    message::Source::Server(server) => {
+                    message::Source::Server(server_message) => {
                         let message_style = move |message_theme: &Theme| {
-                            theme::selectable_text::server(message_theme, server.as_ref())
+                            theme::selectable_text::server(message_theme, server_message.as_ref())
                         };
 
                         let marker = message_marker(max_nick_width, message_style);
 
-                        let message = message_content(
+                        let message_content = message_content::with_context(
                             &message.content,
                             casemapping,
                             theme,
                             scroll_view::Message::Link,
                             message_style,
+                            move |link| match link {
+                                message::Link::User(_) => user_context::Entry::list(true, our_user),
+                                _ => vec![],
+                            },
+                            move |link, entry, length| match link {
+                                message::Link::User(user) => entry
+                                    .view(
+                                        server,
+                                        casemapping,
+                                        Some(channel),
+                                        user,
+                                        users.iter().find(|current_user| *current_user == user),
+                                        length,
+                                        config,
+                                    )
+                                    .map(scroll_view::Message::UserContext),
+                                _ => row![].into(),
+                            },
                             config,
                         );
+
+                        let text_container = container(message_content);
 
                         Some(
                             container(
@@ -209,7 +225,7 @@ pub fn view<'a>(
                                     .push_maybe(prefixes)
                                     .push(marker)
                                     .push(space)
-                                    .push(message),
+                                    .push(text_container),
                             )
                             .into(),
                         )
@@ -471,14 +487,14 @@ fn topic<'a>(
 }
 
 mod nick_list {
-    use data::{config, isupport, target, Config, Server, User};
-    use iced::advanced::text;
-    use iced::widget::{column, scrollable, Scrollable};
+    use data::{Config, Server, User, config, isupport, target};
     use iced::Length;
+    use iced::advanced::text;
+    use iced::widget::{Scrollable, column, scrollable};
     use user_context::Message;
 
     use crate::buffer::user_context;
-    use crate::widget::{selectable_text, Element};
+    use crate::widget::{Element, selectable_text};
     use crate::{font, theme};
 
     pub fn view<'a>(

--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -1,11 +1,11 @@
 use chrono::{DateTime, Utc};
-use data::{isupport, message, target, Config, Server, User};
-use iced::widget::{column, container, horizontal_rule, row, scrollable, Scrollable};
+use data::{Config, Server, User, isupport, message, target};
 use iced::Length;
+use iced::widget::{Scrollable, column, container, horizontal_rule, row, scrollable};
 
 use super::user_context;
-use crate::widget::{double_pass, message_content, selectable_text, Element};
-use crate::{theme, Theme};
+use crate::widget::{Element, double_pass, message_content, selectable_text};
+use crate::{Theme, theme};
 
 #[derive(Debug, Clone)]
 pub enum Event {
@@ -56,10 +56,8 @@ pub fn view<'a>(
             // Otherwise selectable_text component.
             let content = if let Some(user) = channel_user {
                 user_context::view(
-                    selectable_text(
-                        user.display(config.buffer.channel.nicklist.show_access_levels),
-                    )
-                    .style(|theme| theme::selectable_text::topic_nickname(theme, config, user)),
+                    selectable_text(user.nickname().to_string())
+                        .style(|theme| theme::selectable_text::topic_nickname(theme, config, user)),
                     server,
                     casemapping,
                     Some(channel),


### PR DESCRIPTION
This will show nicknames colored correctly in server messages.

Fixes: https://github.com/squidowl/halloy/issues/845

<img width="581" alt="Screenshot 2025-03-29 at 19 47 38" src="https://github.com/user-attachments/assets/c29fa652-fe11-4eac-947c-6c43484529b1" />
