### PR TITLE
add lints.clippy section to Cargo.toml and specify and tackle one

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,3 +102,6 @@ opt-level = 1
 # Enable a large amount of optimization in the dev profile for dependencies.
 [profile.dev.package."*"]
 opt-level = 3
+
+[lints.clippy]
+uninlined_format_args = "warn"

--- a/data/build.rs
+++ b/data/build.rs
@@ -12,10 +12,10 @@ fn main() {
         .and_then(|x| String::from_utf8(x.stdout).ok());
 
     println!("cargo:rerun-if-changed=../VERSION");
-    println!("cargo:rustc-env=VERSION={}", VERSION);
+    println!("cargo:rustc-env=VERSION={VERSION}");
 
     if let Some(hash) = git_hash.as_ref() {
-        println!("cargo:rustc-env=GIT_HASH={}", hash);
+        println!("cargo:rustc-env=GIT_HASH={hash}");
     }
 
     if git_hash.is_none() {

--- a/data/src/appearance/theme.rs
+++ b/data/src/appearance/theme.rs
@@ -228,12 +228,12 @@ pub fn color_to_hex(color: Color) -> String {
     let [r, g, b, a] = color.into_rgba8();
 
     let _ = write!(&mut hex, "#");
-    let _ = write!(&mut hex, "{:02X}", r);
-    let _ = write!(&mut hex, "{:02X}", g);
-    let _ = write!(&mut hex, "{:02X}", b);
+    let _ = write!(&mut hex, "{r:02X}");
+    let _ = write!(&mut hex, "{g:02X}");
+    let _ = write!(&mut hex, "{b:02X}");
 
     if a < u8::MAX {
-        let _ = write!(&mut hex, "{:02X}", a);
+        let _ = write!(&mut hex, "{a:02X}");
     }
 
     hex

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -56,12 +56,12 @@ impl Buffer {
 impl Upstream {
     pub fn key(&self) -> String {
         match self {
-            Upstream::Server(server) => format!("server:{}", server),
+            Upstream::Server(server) => format!("server:{server}"),
             Upstream::Channel(server, channel) => {
-                format!("server:{}:{}", server, channel.as_str())
+                format!("server:{server}:{}", channel.as_str())
             }
             Upstream::Query(server, query) => {
-                format!("server:{}:{}", server, query.as_str())
+                format!("server:{server}:{}", query.as_str())
             }
         }
     }

--- a/data/src/environment.rs
+++ b/data/src/environment.rs
@@ -16,7 +16,7 @@ pub fn formatted_version() -> String {
         .map(|hash| format!(" ({hash})"))
         .unwrap_or_default();
 
-    format!("{}{hash}", VERSION)
+    format!("{VERSION}{hash}")
 }
 
 pub fn config_dir() -> PathBuf {

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -769,7 +769,7 @@ impl fmt::Display for MessageReference {
                 "timestamp={}",
                 server_time.to_rfc3339_opts(SecondsFormat::Millis, true)
             ),
-            MessageReference::MessageId(id) => write!(f, "msgid={}", id),
+            MessageReference::MessageId(id) => write!(f, "msgid={id}"),
             MessageReference::None => write!(f, "*"),
         }
     }

--- a/data/src/shortcut.rs
+++ b/data/src/shortcut.rs
@@ -335,7 +335,7 @@ impl fmt::Display for KeyCode {
             key::Key::Unidentified => String::new(),
         };
 
-        write!(f, "{}", key)
+        write!(f, "{key}")
     }
 }
 

--- a/data/src/url.rs
+++ b/data/src/url.rs
@@ -121,7 +121,7 @@ fn parse_server_config(url: &url::Url) -> Option<config::Server> {
             if channel.starts_with('#') {
                 Some(channel.to_string())
             } else {
-                Some(format!("#{}", channel))
+                Some(format!("#{channel}"))
             }
         };
 

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -373,7 +373,7 @@ impl std::fmt::Display for AccessLevel {
             AccessLevel::Member => "",
         };
 
-        write!(f, "{}", access_level)
+        write!(f, "{access_level}")
     }
 }
 

--- a/ipc/src/server.rs
+++ b/ipc/src/server.rs
@@ -13,7 +13,7 @@ fn server_path() -> String {
         .unwrap()
         .as_secs();
 
-    format!("halloy-{}", nonce)
+    format!("halloy-{nonce}")
 }
 
 #[cfg(windows)]
@@ -67,7 +67,7 @@ pub fn listen() -> futures::stream::BoxStream<'static, String> {
             State::Uninitialized => match spawn_server().await {
                 Ok(server) => Some((None, State::Waiting(server))),
                 Err(err) => {
-                    println!("error: {:?}", err);
+                    println!("error: {err:?}");
                     None
                 }
             },

--- a/irc/proto/src/command.rs
+++ b/irc/proto/src/command.rs
@@ -298,7 +298,7 @@ impl Command {
             Command::PRIVMSG(a, b) => vec![a, b],
             Command::NOTICE(a, b) => vec![a, b],
             Command::WHO(a, b, c) => std::iter::once(a)
-                .chain(b.map(|b| c.map_or_else(|| format!("%{}", b), |c| format!("%{},{}", b, c))))
+                .chain(b.map(|b| c.map_or_else(|| format!("%{b}"), |c| format!("%{b},{c}"))))
                 .collect(),
             Command::WHOIS(a, b) => a.into_iter().chain(Some(b)).collect(),
             Command::WHOWAS(a, b) => std::iter::once(a).chain(b).collect(),

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -418,11 +418,11 @@ impl State {
         let mut text = history.input(&buffer).draft.to_string();
 
         if text.is_empty() {
-            text = format!("{}: ", nick);
+            text = format!("{nick}: ");
         } else if text.ends_with(' ') {
-            text = format!("{}{}", text, nick);
+            text = format!("{text}{nick}");
         } else {
-            text = format!("{} {}", text, nick);
+            text = format!("{text} {nick}");
         }
 
         history.record_draft(Draft { buffer, text });

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -1094,7 +1094,7 @@ fn away_command(max_len: &u16) -> Command {
         args: vec![Arg {
             text: "reason",
             optional: true,
-            tooltip: Some(format!("maximum length: {}", max_len)),
+            tooltip: Some(format!("maximum length: {max_len}")),
         }],
         subcommands: None,
     }
@@ -1130,7 +1130,7 @@ fn chathistory_after_command(maximum_limit: &u16) -> Command {
     let limit_tooltip = if *maximum_limit == 1 {
         String::from("up to 1 message")
     } else {
-        format!("up to {} messages", maximum_limit)
+        format!("up to {maximum_limit} messages")
     };
 
     Command {
@@ -1162,7 +1162,7 @@ fn chathistory_around_command(maximum_limit: &u16) -> Command {
     let limit_tooltip = if *maximum_limit == 1 {
         String::from("up to 1 message")
     } else {
-        format!("up to {} messages", maximum_limit)
+        format!("up to {maximum_limit} messages")
     };
 
     Command {
@@ -1194,7 +1194,7 @@ fn chathistory_before_command(maximum_limit: &u16) -> Command {
     let limit_tooltip = if *maximum_limit == 1 {
         String::from("up to 1 message")
     } else {
-        format!("up to {} messages", maximum_limit)
+        format!("up to {maximum_limit} messages")
     };
 
     Command {
@@ -1226,7 +1226,7 @@ fn chathistory_between_command(maximum_limit: &u16) -> Command {
     let limit_tooltip = if *maximum_limit == 1 {
         String::from("up to 1 message")
     } else {
-        format!("up to {} messages", maximum_limit)
+        format!("up to {maximum_limit} messages")
     };
 
     Command {
@@ -1265,7 +1265,7 @@ fn chathistory_latest_command(maximum_limit: &u16) -> Command {
     let limit_tooltip = if *maximum_limit == 1 {
         String::from("up to 1 message")
     } else {
-        format!("up to {} messages", maximum_limit)
+        format!("up to {maximum_limit} messages")
     };
 
     Command {
@@ -1298,7 +1298,7 @@ fn chathistory_targets_command(maximum_limit: &u16) -> Command {
     let limit_tooltip = if *maximum_limit == 1 {
         String::from("up to 1 target")
     } else {
-        format!("up to {} targets", maximum_limit)
+        format!("up to {maximum_limit} targets")
     };
 
     Command {
@@ -1380,7 +1380,7 @@ fn join_command(
     let mut channels_tooltip = String::from("comma-separated");
 
     if let Some(channel_len) = channel_len {
-        channels_tooltip.push_str(format!("\nmaximum length of each: {}", channel_len).as_str());
+        channels_tooltip.push_str(format!("\nmaximum length of each: {channel_len}").as_str());
     }
 
     if let Some(channel_limits) = channel_limits {
@@ -1404,7 +1404,7 @@ fn join_command(
     let mut keys_tooltip = String::from("comma-separated");
 
     if let Some(key_len) = key_len {
-        keys_tooltip.push_str(format!("\nmaximum length of each: {}", key_len).as_str())
+        keys_tooltip.push_str(format!("\nmaximum length of each: {key_len}").as_str())
     }
 
     Command {
@@ -1429,13 +1429,13 @@ fn kick_command(target_limit: Option<u16>, max_len: Option<&u16>) -> Command {
     let mut users_tooltip = String::from("comma-separated");
 
     if let Some(target_limit) = target_limit {
-        users_tooltip.push_str(format!("\nup to {} user", target_limit).as_str());
+        users_tooltip.push_str(format!("\nup to {target_limit} user").as_str());
         if target_limit != 1 {
             users_tooltip.push('s')
         }
     }
 
-    let comment_tooltip = max_len.map(|max_len| format!("maximum length: {}", max_len));
+    let comment_tooltip = max_len.map(|max_len| format!("maximum length: {max_len}"));
 
     Command {
         title: "KICK",
@@ -1491,7 +1491,7 @@ fn list_command(search_extensions: Option<&String>, target_limit: Option<u16>) -
     let mut channels_tooltip = String::from("comma-separated");
 
     if let Some(target_limit) = target_limit {
-        channels_tooltip.push_str(format!("\nup to {} channel", target_limit).as_str());
+        channels_tooltip.push_str(format!("\nup to {target_limit} channel").as_str());
         if target_limit != 1 {
             channels_tooltip.push('s')
         }
@@ -1571,7 +1571,7 @@ fn monitor_add_command(target_limit: &Option<u16>) -> Command {
     let mut targets_tooltip = String::from("comma-separated users");
 
     if let Some(target_limit) = target_limit {
-        targets_tooltip.push_str(format!("\nup to {} target", target_limit).as_str());
+        targets_tooltip.push_str(format!("\nup to {target_limit} target").as_str());
         if *target_limit != 1 {
             targets_tooltip.push('s')
         }
@@ -1635,7 +1635,7 @@ fn msg_command(channel_membership_prefixes: Vec<char>, target_limit: Option<u16>
     }
 
     if let Some(target_limit) = target_limit {
-        targets_tooltip.push_str(format!("\nup to {} target", target_limit).as_str());
+        targets_tooltip.push_str(format!("\nup to {target_limit} target").as_str());
         if target_limit != 1 {
             targets_tooltip.push('s')
         }
@@ -1662,7 +1662,7 @@ fn msg_command(channel_membership_prefixes: Vec<char>, target_limit: Option<u16>
 fn names_command(target_limit: u16) -> Command {
     let mut channels_tooltip = String::from("comma-separated");
 
-    channels_tooltip.push_str(format!("\nup to {} channel", target_limit).as_str());
+    channels_tooltip.push_str(format!("\nup to {target_limit} channel").as_str());
     if target_limit != 1 {
         channels_tooltip.push('s')
     }
@@ -1684,7 +1684,7 @@ fn nick_command(max_len: &u16) -> Command {
         args: vec![Arg {
             text: "nickname",
             optional: false,
-            tooltip: Some(format!("maximum length: {}", max_len)),
+            tooltip: Some(format!("maximum length: {max_len}")),
         }],
         subcommands: None,
     }
@@ -1708,7 +1708,7 @@ fn notice_command(channel_membership_prefixes: Vec<char>, target_limit: Option<u
     }
 
     if let Some(target_limit) = target_limit {
-        targets_tooltip.push_str(format!("\nup to {} target", target_limit).as_str());
+        targets_tooltip.push_str(format!("\nup to {target_limit} target").as_str());
         if target_limit != 1 {
             targets_tooltip.push('s')
         }
@@ -1740,8 +1740,7 @@ fn part_command(max_len: &u16) -> Command {
                 text: "channels",
                 optional: false,
                 tooltip: Some(format!(
-                    "comma-separated\nmaximum length of each: {}",
-                    max_len
+                    "comma-separated\nmaximum length of each: {max_len}"
                 )),
             },
             Arg {
@@ -1760,7 +1759,7 @@ fn setname_command(max_len: &u16) -> Command {
         args: vec![Arg {
             text: "realname",
             optional: false,
-            tooltip: Some(format!("maximum length: {}", max_len)),
+            tooltip: Some(format!("maximum length: {max_len}")),
         }],
         subcommands: None,
     }
@@ -1778,7 +1777,7 @@ fn topic_command(max_len: &u16) -> Command {
             Arg {
                 text: "topic",
                 optional: true,
-                tooltip: Some(format!("maximum length: {}", max_len)),
+                tooltip: Some(format!("maximum length: {max_len}")),
             },
         ],
         subcommands: None,
@@ -1834,7 +1833,7 @@ static WHOX_COMMAND: LazyLock<Command> = LazyLock::new(|| Command {
 fn whois_command(target_limit: u16) -> Command {
     let mut nicks_tooltip = String::from("comma-separated");
 
-    nicks_tooltip.push_str(format!("\nup to {} nick", target_limit).as_str());
+    nicks_tooltip.push_str(format!("\nup to {target_limit} nick").as_str());
     if target_limit != 1 {
         nicks_tooltip.push('s')
     }

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -72,7 +72,7 @@ impl Notifications {
                     self.execute(
                         &config.monitored_offline,
                         notification,
-                        &format!("{} is offline", target),
+                        &format!("{target} is offline"),
                         server,
                     );
                 });
@@ -85,7 +85,7 @@ impl Notifications {
                     self.execute(
                         &config.file_transfer_request,
                         notification,
-                        &format!("File transfer from {}", nick),
+                        &format!("File transfer from {nick}"),
                         server,
                     );
                 }

--- a/src/screen/dashboard/command_bar.rs
+++ b/src/screen/dashboard/command_bar.rs
@@ -207,13 +207,13 @@ impl Command {
 impl std::fmt::Display for Command {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Command::Buffer(buffer) => write!(f, "Buffer: {}", buffer),
-            Command::Configuration(config) => write!(f, "Configuration: {}", config),
-            Command::UI(ui) => write!(f, "UI: {}", ui),
-            Command::Theme(theme) => write!(f, "Theme: {}", theme),
-            Command::Version(application) => write!(f, "Version: {}", application),
-            Command::Window(window) => write!(f, "Window: {}", window),
-            Command::Application(application) => write!(f, "Application: {}", application),
+            Command::Buffer(buffer) => write!(f, "Buffer: {buffer}"),
+            Command::Configuration(config) => write!(f, "Configuration: {config}"),
+            Command::UI(ui) => write!(f, "UI: {ui}"),
+            Command::Theme(theme) => write!(f, "Theme: {theme}"),
+            Command::Version(application) => write!(f, "Version: {application}"),
+            Command::Window(window) => write!(f, "Window: {window}"),
+            Command::Application(application) => write!(f, "Application: {application}"),
         }
     }
 }
@@ -323,7 +323,7 @@ impl std::fmt::Display for Version {
                     .remote
                     .as_ref()
                     .filter(|remote| remote != &&version.current)
-                    .map(|remote| format!("(Latest: {})", remote))
+                    .map(|remote| format!("(Latest: {remote})"))
                     .unwrap_or("(Latest release)".to_owned());
 
                 write!(f, "{} {}", version.current, latest)
@@ -349,11 +349,11 @@ impl std::fmt::Display for Buffer {
             Buffer::New => write!(f, "New buffer"),
             Buffer::Close => write!(f, "Close buffer"),
             Buffer::Replace(buffer) => match buffer {
-                buffer::Upstream::Server(server) => write!(f, "Change to {}", server),
+                buffer::Upstream::Server(server) => write!(f, "Change to {server}"),
                 buffer::Upstream::Channel(server, channel) => {
-                    write!(f, "Change to {} ({})", channel, server)
+                    write!(f, "Change to {channel} ({server})")
                 }
-                buffer::Upstream::Query(_, nick) => write!(f, "Change to {}", nick),
+                buffer::Upstream::Query(_, nick) => write!(f, "Change to {nick}"),
             },
             Buffer::Popout => write!(f, "Pop out buffer"),
             Buffer::Merge => write!(f, "Merge buffer"),


### PR DESCRIPTION
Now we are using edition 2024 we can safely include a `[lints.clippy]` section to the `Cargo.toml` without worrying about the MSRV.

I took the liberty to tackle one lint from the pedantic category that I think improves the readability of the codebase. I've kept it at `warn` level for now but not sure if you'd prefer `deny` to really enforce it.

The idea is that we can cherry pick which lints we want. It would likely make for a good first time contribution for people new to the codebase.