### PR TITLE
Save Dashboard After Cycling via Keyboard Shortcut

### DIFF
--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -849,6 +849,7 @@ impl Dashboard {
                                 &open_buffers,
                             ) {
                                 state.buffer = Buffer::from(data::Buffer::Upstream(buffer));
+                                self.last_changed = Some(Instant::now());
                                 return (self.focus_pane(window, pane), None);
                             }
                         }
@@ -864,6 +865,7 @@ impl Dashboard {
                                 &open_buffers,
                             ) {
                                 state.buffer = Buffer::from(data::Buffer::Upstream(buffer));
+                                self.last_changed = Some(Instant::now());
                                 return (self.focus_pane(window, pane), None);
                             }
                         }
@@ -1020,6 +1022,7 @@ impl Dashboard {
                                 &open_buffers,
                             ) {
                                 state.buffer = Buffer::from(data::Buffer::Upstream(buffer));
+                                self.last_changed = Some(Instant::now());
                                 return (self.focus_pane(window, pane), None);
                             }
                         }
@@ -1035,6 +1038,7 @@ impl Dashboard {
                                 &open_buffers,
                             ) {
                                 state.buffer = Buffer::from(data::Buffer::Upstream(buffer));
+                                self.last_changed = Some(Instant::now());
                                 return (self.focus_pane(window, pane), None);
                             }
                         }


### PR DESCRIPTION
Minor fix to mark the dashboard as changed when cycling a buffer via keyboard shortcut (so that it is saved).