### PR TITLE
Update Timestamps from Echoes

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -754,11 +754,9 @@ impl Client {
                     }
                     if contains("labeled-response") {
                         requested.push("labeled-response");
-
-                        // We require labeled-response so we can properly tag echo-messages
-                        if contains("echo-message") {
-                            requested.push("echo-message");
-                        }
+                    }
+                    if contains("echo-message") {
+                        requested.push("echo-message");
                     }
                     if self.listed_caps.iter().any(|cap| cap.starts_with("sasl")) {
                         requested.push("sasl");
@@ -892,15 +890,11 @@ impl Client {
                         }
                     }
                 }
-                if contains("labeled-response") || newly_contains("labeled-response") {
-                    if newly_contains("labeled-response") {
-                        requested.push("labeled-response");
-                    }
-
-                    // We require labeled-response so we can properly tag echo-messages
-                    if newly_contains("echo-message") {
-                        requested.push("echo-message");
-                    }
+                if newly_contains("labeled-response") {
+                    requested.push("labeled-response");
+                }
+                if newly_contains("echo-message") {
+                    requested.push("echo-message");
                 }
                 if newly_contains("multi-prefix") {
                     requested.push("multi-prefix");
@@ -1090,15 +1084,7 @@ impl Client {
                             self.highlight_notification_blackout.allowed(),
                         );
 
-                        if user.nickname() == self.nickname()
-                            && context.is_some()
-                            && message_id(&message).is_none()
-                        {
-                            // If we sent (echo) & context exists (we sent from this client),
-                            // then ignore unless it has a message id (in which case the local
-                            // copy should be updated with the message id)
-                            return Ok(vec![]);
-                        } else if direct_message {
+                        if direct_message {
                             return Ok(vec![event, Event::DirectMessage(user)]);
                         } else {
                             return Ok(vec![event]);

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -539,15 +539,15 @@ pub fn insert_message(messages: &mut Vec<Message>, message: Message) {
     let mut replace_at = None;
 
     for stored in &messages[start_index..end_index] {
-        if (message.id.is_some() && stored.id == message.id)
-            || ((stored.server_time == message.server_time
-                || (matches!(stored.direction, message::Direction::Sent)
-                    && matches!(message.direction, message::Direction::Received)
-                    && message.is_echo))
-                && has_matching_content(stored, &message))
+        if replace_at.is_none()
+            && ((message.id.is_some() && stored.id == message.id)
+                || ((stored.server_time == message.server_time
+                    || (matches!(stored.direction, message::Direction::Sent)
+                        && matches!(message.direction, message::Direction::Received)
+                        && message.is_echo))
+                    && has_matching_content(stored, &message)))
         {
             replace_at = Some(current_index);
-            break;
         }
 
         if message.server_time >= stored.server_time {
@@ -566,13 +566,6 @@ pub fn insert_message(messages: &mut Vec<Message>, message: Message) {
                 messages[index] = message;
             }
         } else {
-            let insert_at = match messages
-                .binary_search_by(|stored| stored.server_time.cmp(&message.server_time))
-            {
-                Ok(match_index) => match_index,
-                Err(sorted_insert_index) => sorted_insert_index,
-            };
-
             match insert_at.cmp(&index) {
                 Ordering::Less => {
                     messages.remove(index);

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::path::PathBuf;
 use std::time::Duration;
 use std::{fmt, io};
@@ -10,7 +11,7 @@ use tokio::time::Instant;
 
 use crate::message::{self, MessageReferences};
 use crate::target::{self, Target};
-use crate::{Buffer, Message, Server, buffer, compression, environment, isupport};
+use crate::{buffer, compression, environment, isupport, Buffer, Message, Server};
 
 pub use self::manager::{Manager, Resource};
 pub use self::metadata::{Metadata, ReadMarker};
@@ -510,7 +511,7 @@ impl History {
 pub fn insert_message(messages: &mut Vec<Message>, message: Message) {
     let fuzz_seconds =
         if matches!(message.direction, message::Direction::Received) && message.is_echo {
-            chrono::Duration::seconds(120)
+            chrono::Duration::seconds(300)
         } else {
             chrono::Duration::seconds(1)
         };
@@ -557,11 +558,32 @@ pub fn insert_message(messages: &mut Vec<Message>, message: Message) {
     }
 
     if let Some(index) = replace_at {
-        if has_matching_content(&messages[index], &message) {
-            messages[index].id = message.id;
-            messages[index].received_at = message.received_at;
+        if messages[index].server_time == message.server_time {
+            if has_matching_content(&messages[index], &message) {
+                messages[index].id = message.id;
+                messages[index].received_at = message.received_at;
+            } else {
+                messages[index] = message;
+            }
         } else {
-            messages[index] = message;
+            let insert_at = match messages
+                .binary_search_by(|stored| stored.server_time.cmp(&message.server_time))
+            {
+                Ok(match_index) => match_index,
+                Err(sorted_insert_index) => sorted_insert_index,
+            };
+
+            match insert_at.cmp(&index) {
+                Ordering::Less => {
+                    messages.remove(index);
+                    messages.insert(insert_at, message);
+                }
+                Ordering::Equal => messages[index] = message,
+                Ordering::Greater => {
+                    messages.insert(insert_at, message);
+                    messages.remove(index);
+                }
+            }
         }
     } else {
         messages.insert(insert_at, message);


### PR DESCRIPTION
Changes to `insert_message` in order to update a message's timestamp.  Primarily used for updating a sent message's timestamp when receiving an echo.  May also be used when updating a message via id.

Should help with #864.  But, to limit the required computation, only if the clock difference is less than or equal to 5m.

Also enables requesting the `echo-message` capability even when the `labeled-response` capability is not available.  The heuristic echo determination seems to be working well, and `labeled-response` has limited support.