### PR TITLE
add clippy manual_string_new lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,3 +105,4 @@ opt-level = 3
 
 [lints.clippy]
 uninlined_format_args = "warn"
+manual_string_new = "deny"

--- a/data/src/audio.rs
+++ b/data/src/audio.rs
@@ -87,7 +87,7 @@ fn find_external_sound(sound: &str) -> Result<PathBuf, LoadError> {
     let sounds_dir = if let Ok(sounds_dir) = sounds_dir.into_os_string().into_string() {
         format!(" in {sounds_dir}")
     } else {
-        "".to_string()
+        String::new()
     };
 
     Err(LoadError::NoSoundFound(sound.to_string(), sounds_dir))

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -504,7 +504,7 @@ impl<'de> Deserialize<'de> for Message {
             parse_fragments(text)
         } else {
             // Unreachable
-            Content::Plain("".to_string())
+            Content::Plain(String::new())
         };
 
         let is_echo = is_echo.unwrap_or_default();

--- a/irc/proto/src/command.rs
+++ b/irc/proto/src/command.rs
@@ -404,7 +404,7 @@ impl Command {
             NOTE(_, _, _, _) => "NOTE".to_string(),
             Numeric(numeric, _) => format!("{:03}", *numeric as u16),
             Unknown(tag, _) => tag.clone(),
-            Raw(_) => "".to_string(),
+            Raw(_) => String::new(),
         }
     }
 }

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -57,7 +57,7 @@ impl Pane {
         is_popout: bool,
     ) -> widget::Content<'a, Message> {
         let title_bar_text = match &self.buffer {
-            Buffer::Empty => "".to_string(),
+            Buffer::Empty => String::new(),
             Buffer::Channel(state) => {
                 let channel = state.target.as_str();
                 let server = &state.server;


### PR DESCRIPTION
This will ensure consistency across the codebase and is considered idiomatic.

Not many places it was needed so I set it to `deny` so future contributions will be consistant in using `String::new()`.