### PR TITLE
Colorize Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Added:
 
 - All toast notifications now display the server name
 - Server messages (join, part, etc.) are now user-aware and will color nicknames accordingly
+- Actions will be colored with the same features as regular messages (nicknames, urls, etc)
 - Shortcuts for cycling buffers with unread message(s)
   - Cycle to next buffer with unread message(s) <kbd>ctrl</kbd> + <kbd>`</kbd>
   - Cycle to previous buffer with unread message(s) <kbd>ctrl</kbd> + <kbd>~</kbd>

--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -103,7 +103,14 @@ impl Input {
             ),
             command::Irc::Me(target, action) => Some(vec![Message::sent(
                 to_target(&target, message::Source::Action(Some(user.clone()))),
-                message::action_text(user.nickname(), Some(&action)),
+                message::action_text(
+                    user.nickname(),
+                    Some(&action),
+                    channel_users,
+                    &target,
+                    None,
+                    &config.highlights,
+                ),
             )]),
             _ => None,
         }


### PR DESCRIPTION
Performs the same colorizing fragment parsing on actions that are performed on privmsgs, to complement the colorizing of server messages.