### PR TITLE
Add clippy lint default_trait_access

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,3 +106,4 @@ opt-level = 3
 [lints.clippy]
 uninlined_format_args = "deny"
 manual_string_new = "deny"
+default_trait_access ="deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,5 +104,5 @@ opt-level = 1
 opt-level = 3
 
 [lints.clippy]
-uninlined_format_args = "warn"
+uninlined_format_args = "deny"
 manual_string_new = "deny"

--- a/src/appearance.rs
+++ b/src/appearance.rs
@@ -49,7 +49,7 @@ pub fn theme(selected: &data::appearance::Selected) -> data::appearance::Theme {
                 log::warn!(
                     "[theme] couldn't determine the OS appearance, using the default theme."
                 );
-                Default::default()
+                appearance::Theme::default()
             }
         },
     }

--- a/src/buffer/user_context.rs
+++ b/src/buffer/user_context.rs
@@ -189,7 +189,7 @@ pub fn view<'a>(
 
     let base = widget::button::transparent_button(content, message);
 
-    context_menu(Default::default(), base, entries, move |entry, length| {
+    context_menu(context_menu::MouseButton::default(), base, entries, move |entry, length| {
         entry.view(
             server,
             casemapping,

--- a/src/font.rs
+++ b/src/font.rs
@@ -96,12 +96,12 @@ pub fn width_from_chars(len: usize, config: &config::Font) -> f32 {
             .map(f32::from)
             .unwrap_or(theme::TEXT_SIZE)
             .into(),
-        line_height: Default::default(),
+        line_height: text::LineHeight::default(),
         font: MONO.clone().into(),
         align_x: text::Alignment::Right,
         align_y: alignment::Vertical::Top,
         shaping: text::Shaping::Basic,
-        wrapping: Default::default(),
+        wrapping: text::Wrapping::default(),
     })
     .min_bounds()
     .expand(Size::new(1.0, 0.0))

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,7 +189,7 @@ impl Halloy {
                 version: Version::new(),
                 screen,
                 theme: appearance::theme(&config.appearance.selected).into(),
-                clients: Default::default(),
+                clients: data::client::Map::default(),
                 servers: config.servers.clone(),
                 config,
                 modal: None,

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -104,7 +104,7 @@ impl Dashboard {
             theme_editor: None,
             notifications: notification::Notifications::new(),
             previews: preview::Collection::default(),
-            buffer_settings: Default::default(),
+            buffer_settings: dashboard::BufferSettings::default(),
         };
 
         let command = dashboard.track();

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -577,7 +577,7 @@ fn upstream_buffer_button(
     if entries.is_empty() || !connected {
         base.into()
     } else {
-        context_menu(Default::default(), base, entries, move |entry, length| {
+        context_menu(context_menu::MouseButton::default(), base, entries, move |entry, length| {
             let (content, message) = match entry {
                 Entry::NewPane => ("Open in new pane", Message::Open(buffer.clone())),
                 Entry::Popout => ("Open in new window", Message::Popout(buffer.clone())),

--- a/src/widget/color_picker.rs
+++ b/src/widget/color_picker.rs
@@ -60,7 +60,7 @@ fn bordered<'a, Message: 'a>(element: impl Into<Element<'a, Message>>) -> Contai
             border: border::rounded(2)
                 .width(1)
                 .color(theme.colors().general.border),
-            shadow: Default::default(),
+            shadow: iced::Shadow::default(),
         })
 }
 
@@ -79,8 +79,8 @@ fn preview<'a, Message: 'a>(color: Color) -> Element<'a, Message> {
                 renderer.fill_quad(
                     Quad {
                         bounds: layout.bounds(),
-                        border: Default::default(),
-                        shadow: Default::default(),
+                        border: iced::Border::default(),
+                        shadow: iced::Shadow::default(),
                     },
                     color,
                 )
@@ -418,8 +418,8 @@ fn picker<'a, Message: 'a>(
                             renderer.fill_quad(
                                 Quad {
                                     bounds: Rectangle::new(top_left, Size::new(width, height)),
-                                    border: Default::default(),
-                                    shadow: Default::default(),
+                                    border: iced::Border::default(),
+                                    shadow: iced::Shadow::default(),
                                 },
                                 color,
                             );
@@ -441,8 +441,8 @@ fn picker<'a, Message: 'a>(
                                 width: 1.0,
                                 height: cell_height,
                             },
-                            border: Default::default(),
-                            shadow: Default::default(),
+                            border: iced::Border::default(),
+                            shadow: iced::Shadow::default(),
                         },
                         data::appearance::theme::from_hsva(color),
                     );
@@ -455,7 +455,7 @@ fn picker<'a, Message: 'a>(
                             border: border::rounded(handle.width / 2.0)
                                 .color(Color::BLACK)
                                 .width(1.0),
-                            shadow: Default::default(),
+                            shadow: iced::Shadow::default(),
                         },
                         Color::WHITE,
                     );

--- a/src/widget/selectable_rich_text.rs
+++ b/src/widget/selectable_rich_text.rs
@@ -431,7 +431,7 @@ where
                     align_x: self.align_x,
                     align_y: self.align_y,
                     shaping: Shaping::Advanced,
-                    wrapping: Default::default(),
+                    wrapping: text::Wrapping::default(),
                 };
 
                 // Check spoiler
@@ -800,7 +800,7 @@ where
             align_x,
             align_y,
             shaping: Shaping::Advanced,
-            wrapping: Default::default(),
+            wrapping: text::Wrapping::default(),
         };
 
         if state.spans != spans {
@@ -826,7 +826,7 @@ where
                 align_x,
                 align_y,
                 shaping: Shaping::Advanced,
-                wrapping: Default::default(),
+                wrapping: text::Wrapping::default(),
             }) {
                 text::Difference::None => {}
                 text::Difference::Bounds => {

--- a/src/widget/selectable_text.rs
+++ b/src/widget/selectable_text.rs
@@ -60,7 +60,7 @@ where
             shaping: Shaping::Basic,
             #[cfg(not(debug_assertions))]
             shaping: Shaping::Advanced,
-            wrapping: Default::default(),
+            wrapping: Wrapping::default(),
             class: Theme::default(),
         }
     }


### PR DESCRIPTION
This lint improves the local understanding of the codebase by making calls to `default` unambigous.

I also changed `uninlined_format_args` to deny to enforce it in the codebase.