### PR TITLE
enforce clippy lint for ignored_unit_patterns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ opt-level = 1
 opt-level = 3
 
 [lints.clippy]
-uninlined_format_args = "deny"
-manual_string_new = "deny"
 default_trait_access ="deny"
+ignored_unit_patterns ="deny"
+manual_string_new = "deny"
+uninlined_format_args = "deny"

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -644,7 +644,7 @@ impl Dashboard {
                     }
                 }
             }
-            Message::DashboardSaved(Ok(_)) => {
+            Message::DashboardSaved(Ok(())) => {
                 log::info!("dashboard saved");
             }
             Message::DashboardSaved(Err(error)) => {
@@ -1110,7 +1110,7 @@ impl Dashboard {
                 client::Message::ChatHistoryRequest(server, subcommand) => {
                     clients.send_chathistory_request(&server, subcommand);
                 }
-                client::Message::ChatHistoryTargetsTimestampUpdated(server, timestamp, Ok(_)) => {
+                client::Message::ChatHistoryTargetsTimestampUpdated(server, timestamp, Ok(())) => {
                     log::debug!("updated targets timestamp for {server} to {timestamp}");
                 }
                 client::Message::ChatHistoryTargetsTimestampUpdated(
@@ -2199,7 +2199,7 @@ impl Dashboard {
             async move {
                 if last_changed.is_some() {
                     match dashboard.save().await {
-                        Ok(_) => {
+                        Ok(()) => {
                             log::info!("dashboard saved");
                         }
                         Err(error) => {

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -95,7 +95,7 @@ impl Sidebar {
                 (Task::perform(Config::load(), Message::ConfigReloaded), None)
             }
             Message::ConfigReloaded(config) => (
-                Task::perform(time::sleep(CONFIG_RELOAD_DELAY), |_| {
+                Task::perform(time::sleep(CONFIG_RELOAD_DELAY), |()| {
                     Message::ReloadComplete
                 }),
                 Some(Event::ConfigReloaded(config)),

--- a/src/screen/dashboard/theme_editor.rs
+++ b/src/screen/dashboard/theme_editor.rs
@@ -164,7 +164,7 @@ impl ThemeEditor {
                 return (
                     Task::batch(vec![
                         clipboard::write(url),
-                        Task::perform(time::sleep(Duration::from_secs(2)), |_| Message::ClearCopy),
+                        Task::perform(time::sleep(Duration::from_secs(2)), |()| Message::ClearCopy),
                     ]),
                     None,
                 );
@@ -191,18 +191,18 @@ impl ThemeEditor {
                 self.save_result = Some(false);
 
                 return (
-                    Task::perform(time::sleep(Duration::from_secs(2)), |_| {
+                    Task::perform(time::sleep(Duration::from_secs(2)), |()| {
                         Message::ClearSaveResult
                     }),
                     None,
                 );
             }
-            Message::Saved(Ok(_)) => {
+            Message::Saved(Ok(())) => {
                 log::debug!("Theme saved");
                 self.save_result = Some(true);
 
                 return (
-                    Task::perform(time::sleep(Duration::from_secs(2)), |_| {
+                    Task::perform(time::sleep(Duration::from_secs(2)), |()| {
                         Message::ClearSaveResult
                     }),
                     Some(Event::ReloadThemes),


### PR DESCRIPTION
This lint helps when it comes to future refactors. By explicitly matching on the unit pattern `()` instead of the catch all `_` the type system will come to your rescue to ensure you've not forgot to match against the newly introduced variants.

Also, I reordered the lint list alphabetically.