### PR TITLE
add map_unwrap_or clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,4 +108,5 @@ opt-level = 3
 default_trait_access ="deny"
 ignored_unit_patterns ="deny"
 manual_string_new = "deny"
+map_unwrap_or = "deny"
 uninlined_format_args = "deny"

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -324,8 +324,7 @@ pub fn view<'a>(
     let content = column![topic, messages].spacing(4);
 
     let nicklist_enabled = settings
-        .map(|settings| settings.channel.nicklist.enabled)
-        .unwrap_or(config.buffer.channel.nicklist.enabled);
+        .map_or(config.buffer.channel.nicklist.enabled, |settings| settings.channel.nicklist.enabled);
 
     let content = match (nicklist_enabled, config.buffer.channel.nicklist.position) {
         (true, data::channel::Position::Left) => row![nick_list, content],
@@ -459,8 +458,7 @@ fn topic<'a>(
     theme: &'a Theme,
 ) -> Option<Element<'a, Message>> {
     let topic_enabled = settings
-        .map(|settings| settings.channel.topic.enabled)
-        .unwrap_or(config.buffer.channel.topic.enabled);
+        .map_or(config.buffer.channel.topic.enabled, |settings| settings.channel.topic.enabled);
 
     if !topic_enabled {
         return None;

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -93,7 +93,7 @@ pub fn view<'a>(
     config: &'a Config,
     format: impl Fn(&'a data::Message, Option<f32>, Option<f32>) -> Option<Element<'a, Message>> + 'a,
 ) -> Element<'a, Message> {
-    let divider_font_size = config.font.size.map(f32::from).unwrap_or(theme::TEXT_SIZE) - 1.0;
+    let divider_font_size = config.font.size.map_or(theme::TEXT_SIZE, f32::from) - 1.0;
 
     let Some(history::View {
         has_more_older_messages,
@@ -138,9 +138,7 @@ pub fn view<'a>(
     let oldest = old_messages
         .iter()
         .chain(&new_messages)
-        .next()
-        .map(|message| message.server_time)
-        .unwrap_or_else(Utc::now);
+        .next().map_or_else(Utc::now, |message| message.server_time);
     let status = state.status;
 
     let max_nick_width = max_nick_chars.map(|len| {

--- a/src/font.rs
+++ b/src/font.rs
@@ -93,8 +93,7 @@ pub fn width_from_chars(len: usize, config: &config::Font) -> f32 {
         bounds: Size::INFINITY,
         size: config
             .size
-            .map(f32::from)
-            .unwrap_or(theme::TEXT_SIZE)
+            .map_or(theme::TEXT_SIZE, f32::from)
             .into(),
         line_height: text::LineHeight::default(),
         font: MONO.clone().into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,8 +105,7 @@ fn settings(config_load: &Result<Config, config::Error>) -> iced::Settings {
         .as_ref()
         .ok()
         .and_then(|config| config.font.size)
-        .map(f32::from)
-        .unwrap_or(theme::TEXT_SIZE);
+        .map_or(theme::TEXT_SIZE, f32::from);
 
     iced::Settings {
         default_font: font::MONO.clone().into(),

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -903,24 +903,22 @@ impl Dashboard {
                     ScrollUpPage => {
                         return (
                             self.get_focused_mut()
-                                .map(|(window, pane, state)| {
+                                .map_or_else(Task::none, |(window, pane, state)| {
                                     state.buffer.scroll_up_page().map(move |message| {
                                         Message::Pane(window, pane::Message::Buffer(pane, message))
                                     })
-                                })
-                                .unwrap_or_else(Task::none),
+                                }),
                             None,
                         );
                     }
                     ScrollDownPage => {
                         return (
                             self.get_focused_mut()
-                                .map(|(window, pane, state)| {
+                                .map_or_else(Task::none, |(window, pane, state)| {
                                     state.buffer.scroll_down_page().map(move |message| {
                                         Message::Pane(window, pane::Message::Buffer(pane, message))
                                     })
-                                })
-                                .unwrap_or_else(Task::none),
+                                }),
                             None,
                         );
                     }
@@ -935,24 +933,22 @@ impl Dashboard {
 
                         return (
                             self.get_focused_mut()
-                                .map(|(window, id, pane)| {
+                                .map_or_else(Task::none, |(window, id, pane)| {
                                     pane.buffer.scroll_to_start().map(move |message| {
                                         Message::Pane(window, pane::Message::Buffer(id, message))
                                     })
-                                })
-                                .unwrap_or_else(Task::none),
+                                }),
                             None,
                         );
                     }
                     ScrollToBottom => {
                         return (
                             self.get_focused_mut()
-                                .map(|(window, pane, state)| {
+                                .map_or_else(Task::none, |(window, pane, state)| {
                                     state.buffer.scroll_to_end().map(move |message| {
                                         Message::Pane(window, pane::Message::Buffer(pane, message))
                                     })
-                                })
-                                .unwrap_or_else(Task::none),
+                                }),
                             None,
                         );
                     }
@@ -1518,8 +1514,7 @@ impl Dashboard {
                 tasks.push(
                     self.history
                         .close(history::Kind::Channel(server, channel))
-                        .map(|task| Task::perform(task, Message::History))
-                        .unwrap_or_else(Task::none),
+                        .map_or_else(Task::none, |task| Task::perform(task, Message::History)),
                 );
 
                 (Task::batch(tasks), None)
@@ -1528,8 +1523,7 @@ impl Dashboard {
                 tasks.push(
                     self.history
                         .close(history::Kind::Query(server, nick))
-                        .map(|task| Task::perform(task, Message::History))
-                        .unwrap_or_else(Task::none),
+                        .map_or_else(Task::none, |task| Task::perform(task, Message::History)),
                 );
 
                 // No PART to send, just close history
@@ -2341,8 +2335,7 @@ impl<'a> From<&'a Dashboard> for data::Dashboard {
                 Node::Pane(pane) => panes
                     .get(pane)
                     .cloned()
-                    .map(data::Pane::from)
-                    .unwrap_or(data::Pane::Empty),
+                    .map_or(data::Pane::Empty, data::Pane::from),
             }
         }
 

--- a/src/screen/dashboard/command_bar.rs
+++ b/src/screen/dashboard/command_bar.rs
@@ -64,7 +64,7 @@ impl CommandBar {
         main_window: window::Id,
     ) -> Element<'a, Message> {
         // 1px larger than default
-        let font_size = config.font.size.map(f32::from).unwrap_or(theme::TEXT_SIZE) + 1.0;
+        let font_size = config.font.size.map_or(theme::TEXT_SIZE, f32::from) + 1.0;
 
         let combo_box = combo_box(&self.state, "Type a command...", None, Message::Command)
             .on_close(Message::Unfocused)
@@ -323,8 +323,7 @@ impl std::fmt::Display for Version {
                     .remote
                     .as_ref()
                     .filter(|remote| remote != &&version.current)
-                    .map(|remote| format!("(Latest: {remote})"))
-                    .unwrap_or("(Latest release)".to_owned());
+                    .map_or("(Latest release)".to_owned(), |remote| format!("(Latest: {remote})"));
 
                 write!(f, "{} {}", version.current, latest)
             }

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -185,8 +185,7 @@ impl TitleBar {
             if let Some(topic) = clients.get_channel_topic(&state.server, &state.target) {
                 if topic.content.is_some() {
                     let topic_enabled = settings
-                        .map(|settings| settings.channel.topic.enabled)
-                        .unwrap_or(config.buffer.channel.topic.enabled);
+                        .map_or(config.buffer.channel.topic.enabled, |settings| settings.channel.topic.enabled);
 
                     let topic_button = button(center(icon::topic()))
                         .padding(5)
@@ -208,8 +207,7 @@ impl TitleBar {
             }
 
             let nicklist_enabled = settings
-                .map(|settings| settings.channel.nicklist.enabled)
-                .unwrap_or(config.buffer.channel.nicklist.enabled);
+                .map_or(config.buffer.channel.nicklist.enabled, |settings| settings.channel.nicklist.enabled);
 
             let nicklist_button = button(center(icon::people()))
                 .padding(5)

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -376,8 +376,7 @@ impl Sidebar {
                     config
                         .sidebar
                         .max_width
-                        .map(f32::from)
-                        .unwrap_or(f32::INFINITY),
+                        .map_or(f32::INFINITY, f32::from),
                 )
                 .width(Length::Shrink)
                 .padding(padding)


### PR DESCRIPTION
2nd attempt

This lint replaces some `unwrap_*` methods so instead of using 2 methods you only require 1.

The order of declaration is that the failure part comes first.