### PR TITLE
add manual_is_variant_and clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ opt-level = 3
 [lints.clippy]
 default_trait_access ="deny"
 ignored_unit_patterns ="deny"
+manual_is_variant_and = "deny"
 manual_string_new = "deny"
 map_unwrap_or = "deny"
 uninlined_format_args = "deny"

--- a/src/buffer/user_context.rs
+++ b/src/buffer/user_context.rs
@@ -247,7 +247,7 @@ fn user_info<'a>(
     };
 
     // Dimmed if away or offline.
-    let is_user_away = current_user.map(|u| u.is_away()).unwrap_or_default();
+    let is_user_away = current_user.is_some_and(|u| u.is_away());
     let away_appearance = config.buffer.away.appearance(is_user_away);
     let seed = match config.buffer.nickname.color {
         data::buffer::Color::Solid => None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,8 +45,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let version = args
         .next()
-        .map(|s| s == "--version" || s == "-V")
-        .unwrap_or_default();
+        .is_some_and(|s| s == "--version" || s == "-V");
 
     if version {
         println!("halloy {}", environment::formatted_version());

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -2198,8 +2198,7 @@ impl Dashboard {
         } else if self
             .theme_editor
             .as_ref()
-            .map(|e| e.window == id)
-            .unwrap_or_default()
+            .is_some_and(|e| e.window == id)
         {
             match event {
                 window::Event::CloseRequested => {


### PR DESCRIPTION
Another lint that helps avoid `unwrap_*` method calls.