### PR TITLE
add cloned_instead_of_copied clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ opt-level = 1
 opt-level = 3
 
 [lints.clippy]
+cloned_instead_of_copied = "deny"
 default_trait_access ="deny"
 ignored_unit_patterns ="deny"
 manual_string_new = "deny"

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -1928,7 +1928,7 @@ impl Emojis {
             filtered,
         } = self
         {
-            if let Some(shortcode) = filtered.get(*index).cloned() {
+            if let Some(shortcode) = filtered.get(*index).copied() {
                 *self = Self::Idle;
 
                 return pick_emoji(shortcode, config.buffer.emojis.skin_tone)

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -126,7 +126,7 @@ impl Notifications {
         title: &str,
         body: impl ToString,
     ) {
-        let last_notification = self.recent_notifications.get(notification).cloned();
+        let last_notification = self.recent_notifications.get(notification).copied();
 
         if last_notification.is_some()
             && last_notification.unwrap()

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1798,7 +1798,7 @@ impl Dashboard {
             return self.split_pane(axis);
         } else {
             // If there is no focused pane, split the last pane or create a new empty grid
-            let pane = self.panes.main.iter().last().map(|(pane, _)| pane).cloned();
+            let pane = self.panes.main.iter().last().map(|(pane, _)| pane).copied();
 
             if let Some(pane) = pane {
                 let result = self.panes.main.split(axis, pane, Pane::new(Buffer::Empty));
@@ -1849,7 +1849,7 @@ impl Dashboard {
                 .focus_history
                 .iter()
                 .filter(|p| **p != pane)
-                .cloned()
+                .copied()
                 .collect();
 
             if let Some((_, sibling)) = self.panes.main.close(pane) {


### PR DESCRIPTION
This is better as you are making sure the type implements `Copy`. If it doesn't then you can use `cloned` instead. Helps you to identify when types are copy and means wherever you've used clone then you know it is more expensive.