### PR TITLE
Two clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ opt-level = 3
 cloned_instead_of_copied = "deny"
 default_trait_access = "deny"
 ignored_unit_patterns = "deny"
+manual_is_variant_and = "deny"
 manual_string_new = "deny"
 map_unwrap_or = "deny"
 uninlined_format_args = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ opt-level = 1
 opt-level = 3
 
 [lints.clippy]
+cloned_instead_of_copied = "deny"
 default_trait_access = "deny"
 ignored_unit_patterns = "deny"
 manual_string_new = "deny"

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -1928,7 +1928,7 @@ impl Emojis {
             filtered,
         } = self
         {
-            if let Some(shortcode) = filtered.get(*index).cloned() {
+            if let Some(shortcode) = filtered.get(*index).copied() {
                 *self = Self::Idle;
 
                 return pick_emoji(shortcode, config.buffer.emojis.skin_tone)

--- a/src/buffer/user_context.rs
+++ b/src/buffer/user_context.rs
@@ -247,7 +247,7 @@ fn user_info<'a>(
     };
 
     // Dimmed if away or offline.
-    let is_user_away = current_user.map(|u| u.is_away()).unwrap_or_default();
+    let is_user_away = current_user.is_some_and(|u| u.is_away());
     let away_appearance = config.buffer.away.appearance(is_user_away);
     let seed = match config.buffer.nickname.color {
         data::buffer::Color::Solid => None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,8 +45,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let version = args
         .next()
-        .map(|s| s == "--version" || s == "-V")
-        .unwrap_or_default();
+        .is_some_and(|s| s == "--version" || s == "-V");
 
     if version {
         println!("halloy {}", environment::formatted_version());

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -126,7 +126,7 @@ impl Notifications {
         title: &str,
         body: impl ToString,
     ) {
-        let last_notification = self.recent_notifications.get(notification).cloned();
+        let last_notification = self.recent_notifications.get(notification).copied();
 
         if last_notification.is_some()
             && last_notification.unwrap()

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1798,7 +1798,7 @@ impl Dashboard {
             return self.split_pane(axis);
         } else {
             // If there is no focused pane, split the last pane or create a new empty grid
-            let pane = self.panes.main.iter().last().map(|(pane, _)| pane).cloned();
+            let pane = self.panes.main.iter().last().map(|(pane, _)| pane).copied();
 
             if let Some(pane) = pane {
                 let result = self.panes.main.split(axis, pane, Pane::new(Buffer::Empty));
@@ -1849,7 +1849,7 @@ impl Dashboard {
                 .focus_history
                 .iter()
                 .filter(|p| **p != pane)
-                .cloned()
+                .copied()
                 .collect();
 
             if let Some((_, sibling)) = self.panes.main.close(pane) {

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -2198,8 +2198,7 @@ impl Dashboard {
         } else if self
             .theme_editor
             .as_ref()
-            .map(|e| e.window == id)
-            .unwrap_or_default()
+            .is_some_and(|e| e.window == id)
         {
             match event {
                 window::Event::CloseRequested => {


### PR DESCRIPTION
Adds the following 2 lints:

`manual_is_variant_and`: This is more concise by using one method call instead of two.
`cloned_instead_of_copied`: This allows you to know whether the type implements `Copy`. If it doesn't then you know any call to `cloned` is something that doesn't implement `Copy`.