### PR TITLE
add test that includes IRC formatting bytes

### DIFF
--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -1652,6 +1652,13 @@ mod test {
                     Fragment::Url("http://öbb.at".parse().unwrap()),
                 ],
             ),
+            (
+                "\x0f\x0303VLC\x0f \x0305master\x0f \x0306somenick\x0f describe commit \x0314https://someurl/7089\x0f",
+                vec![
+                    Fragment::Text("VLC master somenick describe commit ".into()),
+                    Fragment::Url("https://someurl/7089".parse().unwrap()),
+                ],
+            ),
         ];
 
         for (text, expected) in tests {


### PR DESCRIPTION
Slightly increases code coverage by testing a message that includes some IRC formatting bytes.

This has the positive side effect of helping me understand how some of the different parts interact together.