### PR TITLE
Add trailing 0 to the Windows installer

### DIFF
--- a/scripts/build-windows-installer.sh
+++ b/scripts/build-windows-installer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 WXS_FILE="wix/main.wxs"
-HALLOY_VERSION=$(cat VERSION)
+HALLOY_VERSION=$(cat VERSION).0
 
 # build the binary
 scripts/build-windows.sh


### PR DESCRIPTION
Add trailing 0 to the Windows installer to match the installer version the product version.
Think i missed this in the past. :-/

regards