### PR TITLE
apply items_after_statements clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,10 +109,22 @@ opt-level = 1
 [profile.dev.package."*"]
 opt-level = 3
 
+[lints.clippy]
+cloned_instead_of_copied = "deny"
+default_trait_access = "deny"
+ignored_unit_patterns = "deny"
+items_after_statements = "deny"
+manual_is_variant_and = "deny"
+manual_string_new = "deny"
+map_unwrap_or = "deny"
+semicolon_if_nothing_returned = "deny"
+uninlined_format_args = "deny"
+
 [workspace.lints.clippy]
 cloned_instead_of_copied = "deny"
 default_trait_access = "deny"
 ignored_unit_patterns = "deny"
+items_after_statements = "deny"
 manual_is_variant_and = "deny"
 manual_string_new = "deny"
 map_unwrap_or = "deny"

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -54,9 +54,6 @@ pub fn setup(is_debug: bool) -> Result<ReceiverStream<Vec<Record>>, Error> {
 }
 
 fn channel_logger() -> (Box<dyn Log>, ReceiverStream<Vec<Record>>) {
-    let (log_sender, log_receiver) = mpsc::channel();
-    let (async_sender, async_receiver) = tokio_mpsc::channel(1);
-
     struct Sink {
         sender: mpsc::Sender<Record>,
     }
@@ -76,6 +73,9 @@ fn channel_logger() -> (Box<dyn Log>, ReceiverStream<Vec<Record>>) {
 
         fn flush(&self) {}
     }
+
+    let (log_sender, log_receiver) = mpsc::channel();
+    let (async_sender, async_receiver) = tokio_mpsc::channel(1);
 
     thread::spawn(move || {
         const BATCH_SIZE: usize = 25;


### PR DESCRIPTION
I've discovered that you need both a `[lints.clippy]` and `[workspace.lints.clippy]` section for them to apply to your whole codebase. A little dissapointed at the duplication but seems unavoidable. As a high level overview my ultimate goal is to work through the `clippy::pedantic` lints and eventually replace all the `deny` entries with a single 'deny' for pedantic and have a smaller `allow` list for exceptions.

This particular lint it is quite interesting. Items declared within a function exist and apply for the whole scope of the function, not just where you declare it onwards. Putting items at the start of the scope before any statements makes this clear.