### PR TITLE
add clippy lint unnecessary_wraps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ manual_string_new = "deny"
 map_unwrap_or = "deny"
 semicolon_if_nothing_returned = "deny"
 uninlined_format_args = "deny"
+unnecessary_wraps = "deny"
 
 [workspace.lints.clippy]
 cloned_instead_of_copied = "deny"
@@ -130,3 +131,4 @@ manual_string_new = "deny"
 map_unwrap_or = "deny"
 semicolon_if_nothing_returned = "deny"
 uninlined_format_args = "deny"
+unnecessary_wraps = "deny"

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -430,7 +430,7 @@ impl Channel {
             }
             Message::UserContext(message) => (
                 Task::none(),
-                user_context::update(message).map(Event::UserContext),
+                Some(Event::UserContext(user_context::update(message))),
             ),
             Message::Topic(message) => (
                 Task::none(),

--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -21,7 +21,7 @@ pub enum Message {
 
 pub fn update(message: Message) -> Option<Event> {
     match message {
-        Message::UserContext(message) => user_context::update(message).map(Event::UserContext),
+        Message::UserContext(message) => Some(Event::UserContext(user_context::update(message))),
         Message::Link(message::Link::Channel(channel)) => Some(Event::OpenChannel(channel)),
         Message::Link(message::Link::Url(url)) => {
             let _ = open::that_detached(url);

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -462,7 +462,7 @@ impl State {
             Message::UserContext(message) => {
                 return (
                     Task::none(),
-                    user_context::update(message).map(Event::UserContext),
+                    Some(Event::UserContext(user_context::update(message))),
                 );
             }
             Message::Link(message::Link::Channel(channel)) => {

--- a/src/buffer/user_context.rs
+++ b/src/buffer/user_context.rs
@@ -158,18 +158,17 @@ pub enum Event {
     InsertNickname(Nick),
 }
 
-#[allow(clippy::unnecessary_wraps)]
-pub fn update(message: Message) -> Option<Event> { // enables use of .map()
+pub fn update(message: Message) -> Event {
     match message {
-        Message::Whois(server, nick) => Some(Event::SendWhois(server, nick)),
+        Message::Whois(server, nick) => Event::SendWhois(server, nick),
         Message::Query(server, nick, buffer_action) => {
-            Some(Event::OpenQuery(server, nick, buffer_action))
+            Event::OpenQuery(server, nick, buffer_action)
         }
         Message::ToggleAccessLevel(server, target, nick, mode) => {
-            Some(Event::ToggleAccessLevel(server, target, nick, mode))
+            Event::ToggleAccessLevel(server, target, nick, mode)
         }
-        Message::SendFile(server, nick) => Some(Event::SendFile(server, nick)),
-        Message::InsertNickname(nick) => Some(Event::InsertNickname(nick)),
+        Message::SendFile(server, nick) => Event::SendFile(server, nick),
+        Message::InsertNickname(nick) => Event::InsertNickname(nick),
     }
 }
 

--- a/src/buffer/user_context.rs
+++ b/src/buffer/user_context.rs
@@ -158,7 +158,8 @@ pub enum Event {
     InsertNickname(Nick),
 }
 
-pub fn update(message: Message) -> Option<Event> {
+#[allow(clippy::unnecessary_wraps)]
+pub fn update(message: Message) -> Option<Event> { // enables use of .map()
     match message {
         Message::Whois(server, nick) => Some(Event::SendWhois(server, nick)),
         Message::Query(server, nick, buffer_action) => {


### PR DESCRIPTION
This was an interesting discovery for me.

Part I already knew: If all return places from a function are guaranteed to be `Some` then it is best to not return an `Option<Foo>` but just simply return `Foo`.

Part that interested me: You can `.map()` an `Option<Foo>` to turn it into an `Option<Bar>`. If you didn't return an `Option` then you'd need to manually implement `.map()` for your type.