### PR TITLE
Sidebar Theming Tweak

### DIFF
--- a/src/appearance/theme/button.rs
+++ b/src/appearance/theme/button.rs
@@ -65,6 +65,7 @@ pub fn sidebar_buffer(theme: &Theme, status: Status, is_focused: bool, is_open: 
 
     let background_hover = match (is_focused, is_open) {
         (true, true) => button_colors.background_selected_hover,
+        (false, true) => button_colors.background_selected,
         (_, _) => button_colors.background_hover,
     };
 

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -552,25 +552,27 @@ fn upstream_buffer_button(
         .style(move |theme, status| {
             theme::button::sidebar_buffer(theme, status, is_focused.is_some(), open.is_some())
         })
-        .on_press_maybe({
+        .on_press({
             match is_focused {
                 Some((window, pane)) => {
                     if let Some(focus_action) = focused_buffer_action {
                         match focus_action {
-                            BufferFocusedAction::ClosePane => Some(Message::Close(window, pane)),
+                            BufferFocusedAction::ClosePane => Message::Close(window, pane),
                         }
                     } else {
-                        None
+                        // Re-focus pane on press instead of disabling the button in order
+                        // to have hover status of the button for styling
+                        Message::Focus(window, pane)
                     }
                 }
                 None => {
                     if let Some((window, pane)) = open {
-                        Some(Message::Focus(window, pane))
+                        Message::Focus(window, pane)
                     } else {
                         match buffer_action {
-                            BufferAction::NewPane => Some(Message::New(buffer.clone())),
-                            BufferAction::ReplacePane => Some(Message::Replace(buffer.clone())),
-                            BufferAction::NewWindow => Some(Message::Popout(buffer.clone())),
+                            BufferAction::NewPane => Message::New(buffer.clone()),
+                            BufferAction::ReplacePane => Message::Replace(buffer.clone()),
+                            BufferAction::NewWindow => Message::Popout(buffer.clone()),
                         }
                     }
                 }


### PR DESCRIPTION
While working on some themes I noticed that the sidebar buttons don't have hover state for open/focused buffers.  This PR adds those hover states, with the downside of not disabling the focused buffer's button.