### PR TITLE
Fix for #916

### DIFF
--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -753,6 +753,10 @@ impl Content {
             Content::Log(record) => (&record.message).into(),
         }
     }
+
+    pub fn echo_cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.text().trim_end().cmp(other.text().trim_end())
+    }
 }
 
 impl PartialEq for Content {


### PR DESCRIPTION
Allows echoed messages with whitespace trimmed to match sent messages with trailing whitespace.  Since the trimmed message is the one returned by the server, it is assumed that is the canonical representation of the message and the message should be saved as such (similar to how the timestamp of the echoed message is treated).

Fixes #916 in my testing.