### PR TITLE
Fix typos

### DIFF
--- a/book/src/README.md
+++ b/book/src/README.md
@@ -35,7 +35,7 @@
 * Auto-completion for nicknames, commands, and channels
 * Notifications support
 * Multiple channels at the same time across servers
-* Commandbar for for quick actions
+* Command bar for for quick actions
 * [Custom themes](https://themes.halloy.chat)
 * Portable mode
 

--- a/book/src/configuration/buffer.md
+++ b/book/src/configuration/buffer.md
@@ -318,7 +318,7 @@ Internal messages are messages sent from Halloy itself.
 
 ### `[buffer.internal_messages.success]`
 
-A internal messages which is considered a "success" such as when a connection was restored, or when connected succesfully to a server.
+A internal messages which is considered a "success" such as when a connection was restored, or when connected successfully to a server.
 
 #### `enabled`
 
@@ -549,7 +549,7 @@ smart = 180
 
 ### `exclude`
 
-Exclude channels from receiving the server messag.
+Exclude channels from receiving the server message.
 If you pass `["#halloy"]`, the channel `#halloy` will not receive the server message. You can also exclude all channels by using a wildcard: `["*"]`.
 
 ```toml
@@ -637,7 +637,7 @@ Control if the text input should auto format the input. By default text is only 
 auto_format = "markdown"
 ```
 
-> 💡 Read more about [text formatting](../guides/text-formatting.html).
+> 💡 Read more about [text formatting](../guides/text-formatting.md).
 
 ### `[buffer.text_input.autocomplete]`
 

--- a/book/src/configuration/notifications.md
+++ b/book/src/configuration/notifications.md
@@ -81,7 +81,7 @@ You can also exclude all nicks/channels by using a wildcard: `["*"]` or `["all"]
 # Values: array of strings
 # Default: []
 
-[notifications.<direct_mesage|file_transfer_request>]
+[notifications.<direct_message|file_transfer_request>]
 exclude = ["HalloyUser1"]
 
 [notifications.highlight]
@@ -105,7 +105,7 @@ from.
 # Values: array of strings
 # Default: []
 
-[notifications.<direct_mesage|file_transfer_request>]
+[notifications.<direct_message|file_transfer_request>]
 include = ["HalloyUser1"]
 
 [notifications.highlight]

--- a/book/src/configuration/preview.md
+++ b/book/src/configuration/preview.md
@@ -21,7 +21,7 @@ Request settings for previews.
 
 ### `user_agent`
 
-Some servers will only send opengraph metadata to browser-like user agents. We default to `WhatsApp/2` for wide compatability.
+Some servers will only send opengraph metadata to browser-like user agents. We default to `WhatsApp/2` for wide compatibility.
 
 ```toml
 # Type: string
@@ -34,7 +34,7 @@ user_agent = "WhatsApp/2"
 
 ### `timeout_ms`
 
-Request timeout in millisceonds. Defaults is 10s.
+Request timeout in milliseconds. Defaults is 10s.
 
 ```toml
 # Type: integer
@@ -86,7 +86,7 @@ concurrency = 4
 
 ### `delay_ms`
 
-Numer of milliseconds to wait before requesting another preview when number of requested previews > `concurrency`.
+Number of milliseconds to wait before requesting another preview when number of requested previews > `concurrency`.
 
 ```toml
 # Type: integer

--- a/book/src/configuration/servers.md
+++ b/book/src/configuration/servers.md
@@ -9,7 +9,7 @@ Eg:
 # ...
 ```
 
-> 💡 For a multiple server example see [here](../guides/multiple-servers.html)
+> 💡 For a multiple server example see [here](../guides/multiple-servers.md)
 
 ## `nickname`
 
@@ -368,7 +368,7 @@ who_poll_interval = 2
 
 A list of nicknames to [monitor](https://ircv3.net/specs/extensions/monitor) (if IRCv3 Monitor is supported by the server).
 
-> 💡 Read more about [monitoring users](../guides/monitor-users.html).
+> 💡 Read more about [monitoring users](../guides/monitor-users.md).
 
 ```toml
 # Type: array of string

--- a/book/src/configuration/themes/base16.md
+++ b/book/src/configuration/themes/base16.md
@@ -1,7 +1,7 @@
 # Base16
 
 The [base16](https://github.com/chriskempson/base16) color scheme framework
-includes hundreds of colorschemes build using 16 colors. These colorschemes have
+includes hundreds of color schemes build using 16 colors. These color schemes have
 are compiled for Halloy in the
 [`4e554c4c/base16-halloy`](https://github.com/4e554c4c/base16-halloy)
 repository.

--- a/book/src/guides/monitor-users.md
+++ b/book/src/guides/monitor-users.md
@@ -6,7 +6,7 @@ Halloy has [monitor](https://ircv3.net/specs/extensions/monitor) support if the 
 
 To use the feature you need to add the user(s) you wish to monitor. This can be done in two ways:
 
-* You can add a list of user directly to the configuration file. [See configuration option.](../configuration/servers.html#monitor)
+* You can add a list of user directly to the configuration file. [See configuration option.](../configuration/servers.md#monitor)
 * You can add users through `/monitor` directly in Halloy. 
 
 Examples with the `/monitor` command:

--- a/book/src/guides/multiple-servers.md
+++ b/book/src/guides/multiple-servers.md
@@ -1,7 +1,7 @@
 # Multiple servers
 
 Creating multiple `[servers]` sections lets you connect to multiple servers.  
-All configuration options can be found [here](../configuration/servers.html).
+All configuration options can be found [here](../configuration/servers.md).
 
 ```toml
 [servers.liberachat]

--- a/book/src/url-schemes.md
+++ b/book/src/url-schemes.md
@@ -1,6 +1,6 @@
 # URL Schemes
 
-Halloy is able to recongize different URL schemes.
+Halloy is able to recognize different URL schemes.
 
 ## IRC and IRCS
 


### PR DESCRIPTION
- fixing some typos
- changing internal links from 'html' to 'md' according to https://rust-lang.github.io/mdBook/format/markdown.html#links