### PR TITLE
Recognize Empty `chathistory` as Exhausted

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -425,8 +425,12 @@ impl Client {
                                         ) =
                                             self.chathistory_requests.get(batch_target)
                                         {
-                                            if let ChatHistorySubcommand::Before(_, _, limit) =
-                                                subcommand
+                                            if let ChatHistorySubcommand::Before(_, _, limit)
+                                            | ChatHistorySubcommand::Latest(
+                                                _,
+                                                MessageReference::None,
+                                                limit,
+                                            ) = subcommand
                                             {
                                                 self.chathistory_exhausted.insert(
                                                     batch_target.clone(),


### PR DESCRIPTION
Updates the logic to note that if an unbounded `LATEST` command (with no message reference) returns fewer than the maximum number of messages then there must not be any more `chathistory` available.

Not recognizing that logic would cause the "Request Older Chat History Messages" button to never be disabled if (a) there is no local history and (b) the server returns no messages for an unbounded `LATEST` command.