### PR TITLE
Allow Queries to be Matched by Preview Include/Exclude Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changed:
 - Clicking to insert a username will now use same suffixes specified for autocomplete
 - Emoji picker will only show once there are two characters after `:` (by default, configurable)
 - Autocomplete will match users based on how recently they were seen in the channel (by default, configurable)
+- Include & exclude settings for previews apply to queries as well as channels
 
 # 2025.4 (2025-04-07)
 

--- a/book/src/configuration/preview.md
+++ b/book/src/configuration/preview.md
@@ -118,8 +118,8 @@ action = "preview"
 
 ### `include`
 
-Include image previews from channels.
-If you pass `["#halloy"]`, the channel `#halloy` will show image previews. The include rule takes priority over exclude, so you can use both together. For example, you can exclude all channels with `["*"]` and then only include a few specific channels.
+Include image previews from channels & queries.
+If you pass `["#halloy"]`, the channel `#halloy` will show image previews. The include rule takes priority over exclude, so you can use both together. For example, you can exclude all channels & queries with `["*"]` and then only include a few specific channels.
 
 ```toml
 # Type: array of strings
@@ -132,8 +132,8 @@ include = []
 
 ### `exclude`
 
-Exclude image previews from channels.
-If you pass `["#halloy"]`, the channel `#halloy` will not show image previews. You can also exclude all channels by using a wildcard: `["*"]`.
+Exclude image previews from channels & queries.
+If you pass `["#halloy"]`, the channel `#halloy` will not show image previews. You can also exclude all channels & queries by using a wildcard: `["*"]`.
 
 ```toml
 # Type: array of strings
@@ -171,8 +171,8 @@ show_image = true
 
 ### `include`
 
-Include card previews from channels.
-If you pass `["#halloy"]`, the channel `#halloy` will show image previews. The include rule takes priority over exclude, so you can use both together. For example, you can exclude all channels with `["*"]` and then only include a few specific channels.
+Include card previews from channels & queries.
+If you pass `["#halloy"]`, the channel `#halloy` will show image previews. The include rule takes priority over exclude, so you can use both together. For example, you can exclude all channels & queries with `["*"]` and then only include a few specific channels.
 
 ```toml
 # Type: array of strings
@@ -186,8 +186,8 @@ include = []
 
 ### `exclude`
 
-Exclude card previews from channels.
-If you pass `["#halloy"]`, the channel `#halloy` will not show image previews. You can also exclude all channels by using a wildcard: `["*"]`.
+Exclude card previews from channels & queries.
+If you pass `["#halloy"]`, the channel `#halloy` will not show image previews. You can also exclude all channels & queries by using a wildcard: `["*"]`.
 
 ```toml
 # Type: array of strings

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -1,13 +1,11 @@
 use core::fmt;
 
 use serde::{Deserialize, Serialize};
-use url::Url;
 
 use crate::config::buffer::NicknameClickAction;
-use crate::preview::{self, Preview};
 use crate::serde::default_bool_true;
 use crate::target::{self, Target};
-use crate::{Server, channel, config, isupport, message};
+use crate::{Server, channel, config, message};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -356,41 +354,6 @@ impl From<SkinTone> for emojis::SkinTone {
             SkinTone::MediumDark => emojis::SkinTone::MediumDark,
             SkinTone::Dark => emojis::SkinTone::Dark,
         }
-    }
-}
-
-#[derive(Clone, Copy)]
-pub struct Previews<'a> {
-    collection: &'a preview::Collection,
-    cards_are_visible: bool,
-    images_are_visible: bool,
-}
-
-impl<'a> Previews<'a> {
-    pub fn from(
-        collection: &'a preview::Collection,
-        target: &Target,
-        config: &config::Preview,
-        casemapping: isupport::CaseMap,
-    ) -> Previews<'a> {
-        Self {
-            collection,
-            cards_are_visible: config.enabled
-                && config.card.visible(target, casemapping),
-            images_are_visible: config.enabled
-                && config.image.visible(target, casemapping),
-        }
-    }
-
-    pub fn get(&self, url: &Url) -> Option<&'a preview::State> {
-        self.collection.get(url).filter(|state| match state {
-            preview::State::Loading => true,
-            preview::State::Loaded(preview) => match preview {
-                Preview::Card(_) => self.cards_are_visible,
-                Preview::Image(_) => self.images_are_visible,
-            },
-            preview::State::Error(_) => true,
-        })
     }
 }
 

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -7,7 +7,7 @@ use crate::config::buffer::NicknameClickAction;
 use crate::preview::{self, Preview};
 use crate::serde::default_bool_true;
 use crate::target::{self, Target};
-use crate::{channel, config, isupport, message, Server};
+use crate::{Server, channel, config, isupport, message};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -375,8 +375,10 @@ impl<'a> Previews<'a> {
     ) -> Previews<'a> {
         Self {
             collection,
-            cards_are_visible: config.enabled && config.card.visible(target, casemapping),
-            images_are_visible: config.enabled && config.image.visible(target, casemapping),
+            cards_are_visible: config.enabled
+                && config.card.visible(target, casemapping),
+            images_are_visible: config.enabled
+                && config.image.visible(target, casemapping),
         }
     }
 

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -1,11 +1,13 @@
 use core::fmt;
 
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 use crate::config::buffer::NicknameClickAction;
+use crate::preview::{self, Preview};
 use crate::serde::default_bool_true;
 use crate::target::{self, Target};
-use crate::{Server, channel, config, message};
+use crate::{channel, config, isupport, message, Server};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -354,6 +356,39 @@ impl From<SkinTone> for emojis::SkinTone {
             SkinTone::MediumDark => emojis::SkinTone::MediumDark,
             SkinTone::Dark => emojis::SkinTone::Dark,
         }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct Previews<'a> {
+    collection: &'a preview::Collection,
+    cards_are_visible: bool,
+    images_are_visible: bool,
+}
+
+impl<'a> Previews<'a> {
+    pub fn from(
+        collection: &'a preview::Collection,
+        target: &Target,
+        config: &config::Preview,
+        casemapping: isupport::CaseMap,
+    ) -> Previews<'a> {
+        Self {
+            collection,
+            cards_are_visible: config.enabled && config.card.visible(target, casemapping),
+            images_are_visible: config.enabled && config.image.visible(target, casemapping),
+        }
+    }
+
+    pub fn get(&self, url: &Url) -> Option<&'a preview::State> {
+        self.collection.get(url).filter(|state| match state {
+            preview::State::Loading => true,
+            preview::State::Loaded(preview) => match preview {
+                Preview::Card(_) => self.cards_are_visible,
+                Preview::Image(_) => self.images_are_visible,
+            },
+            preview::State::Error(_) => true,
+        })
     }
 }
 

--- a/data/src/config/preview.rs
+++ b/data/src/config/preview.rs
@@ -1,9 +1,7 @@
 use serde::Deserialize;
 
-use crate::isupport;
 use crate::serde::default_bool_true;
-use crate::Target;
-use crate::serde::default_bool_true;
+use crate::{Target, isupport};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Preview {
@@ -96,7 +94,11 @@ impl Default for Card {
 }
 
 impl Card {
-    pub fn visible(&self, target: &Target, casemapping: isupport::CaseMap) -> bool {
+    pub fn visible(
+        &self,
+        target: &Target,
+        casemapping: isupport::CaseMap,
+    ) -> bool {
         is_visible(&self.include, &self.exclude, target, casemapping)
     }
 }
@@ -120,7 +122,11 @@ pub enum ImageAction {
 }
 
 impl Image {
-    pub fn visible(&self, target: &Target, casemapping: isupport::CaseMap) -> bool {
+    pub fn visible(
+        &self,
+        target: &Target,
+        casemapping: isupport::CaseMap,
+    ) -> bool {
         is_visible(&self.include, &self.exclude, target, casemapping)
     }
 }
@@ -138,8 +144,10 @@ fn is_visible(
 
     let is_target_filtered = |list: &[String], target: &str| -> bool {
         let wildcards = ["*", "all"];
-        list.iter()
-            .any(|item| wildcards.contains(&item.as_str()) || casemapping.normalize(item) == target)
+        list.iter().any(|item| {
+            wildcards.contains(&item.as_str())
+                || casemapping.normalize(item) == target
+        })
     };
 
     let target_included = is_target_filtered(include, target);

--- a/data/src/config/preview.rs
+++ b/data/src/config/preview.rs
@@ -1,5 +1,7 @@
 use serde::Deserialize;
 
+use crate::isupport;
+use crate::serde::default_bool_true;
 use crate::Target;
 use crate::serde::default_bool_true;
 
@@ -94,8 +96,8 @@ impl Default for Card {
 }
 
 impl Card {
-    pub fn visible(&self, target: &Target) -> bool {
-        is_visible(&self.include, &self.exclude, target)
+    pub fn visible(&self, target: &Target, casemapping: isupport::CaseMap) -> bool {
+        is_visible(&self.include, &self.exclude, target, casemapping)
     }
 }
 
@@ -118,21 +120,26 @@ pub enum ImageAction {
 }
 
 impl Image {
-    pub fn visible(&self, target: &Target) -> bool {
-        is_visible(&self.include, &self.exclude, target)
+    pub fn visible(&self, target: &Target, casemapping: isupport::CaseMap) -> bool {
+        is_visible(&self.include, &self.exclude, target, casemapping)
     }
 }
 
-fn is_visible(include: &[String], exclude: &[String], target: &Target) -> bool {
+fn is_visible(
+    include: &[String],
+    exclude: &[String],
+    target: &Target,
+    casemapping: isupport::CaseMap,
+) -> bool {
     let target = match target {
-        Target::Query(user) => user.as_str(),
-        Target::Channel(channel) => channel.as_str(),
+        Target::Query(user) => user.as_normalized_str(),
+        Target::Channel(channel) => channel.as_normalized_str(),
     };
 
     let is_target_filtered = |list: &[String], target: &str| -> bool {
         let wildcards = ["*", "all"];
         list.iter()
-            .any(|item| wildcards.contains(&item.as_str()) || item == target)
+            .any(|item| wildcards.contains(&item.as_str()) || casemapping.normalize(item) == target)
     };
 
     let target_included = is_target_filtered(include, target);

--- a/data/src/config/preview.rs
+++ b/data/src/config/preview.rs
@@ -124,25 +124,21 @@ impl Image {
 }
 
 fn is_visible(include: &[String], exclude: &[String], target: &Target) -> bool {
-    match target {
-        Target::Query(_) => true,
-        Target::Channel(channel) => {
-            let is_channel_filtered =
-                |list: &[String], channel: &str| -> bool {
-                    let wildcards = ["*", "all"];
-                    list.iter().any(|item| {
-                        wildcards.contains(&item.as_str()) || item == channel
-                    })
-                };
+    let target = match target {
+        Target::Query(user) => user.as_str(),
+        Target::Channel(channel) => channel.as_str(),
+    };
 
-            let channel_included =
-                is_channel_filtered(include, channel.as_str());
-            let channel_excluded =
-                is_channel_filtered(exclude, channel.as_str());
+    let is_target_filtered = |list: &[String], target: &str| -> bool {
+        let wildcards = ["*", "all"];
+        list.iter()
+            .any(|item| wildcards.contains(&item.as_str()) || item == target)
+    };
 
-            channel_included || !channel_excluded
-        }
-    }
+    let target_included = is_target_filtered(include, target);
+    let target_excluded = is_target_filtered(exclude, target);
+
+    target_included || !target_excluded
 }
 
 fn default_user_agent() -> String {

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -1,10 +1,11 @@
 use std::path::PathBuf;
 
 use data::dashboard::BufferAction;
+use data::preview::{self, Previews};
 use data::server::Server;
 use data::target::{self, Target};
 use data::user::Nick;
-use data::{Config, User, buffer, history, message, preview};
+use data::{Config, User, buffer, history, message};
 use iced::advanced::text;
 use iced::widget::{column, container, row};
 use iced::{Length, Task, padding};
@@ -65,7 +66,7 @@ pub fn view<'a>(
     let chathistory_state =
         clients.get_chathistory_state(server, &channel.to_target());
 
-    let previews = Some(buffer::Previews::from(
+    let previews = Some(Previews::new(
         previews,
         &channel.to_target(),
         &config.preview,

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -70,7 +70,7 @@ pub fn view<'a>(
             &state.scroll_view,
             scroll_view::Kind::Channel(&state.server, channel),
             history,
-            Some(previews),
+            Some((previews, casemapping)),
             chathistory_state,
             config,
             move |message, max_nick_width, max_prefix_width| {

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -65,12 +65,19 @@ pub fn view<'a>(
     let chathistory_state =
         clients.get_chathistory_state(server, &channel.to_target());
 
+    let previews = Some(buffer::Previews::from(
+        previews,
+        &channel.to_target(),
+        &config.preview,
+        casemapping,
+    ));
+
     let messages = container(
         scroll_view::view(
             &state.scroll_view,
             scroll_view::Kind::Channel(&state.server, channel),
             history,
-            Some((previews, casemapping)),
+            previews,
             chathistory_state,
             config,
             move |message, max_nick_width, max_prefix_width| {

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -1,8 +1,9 @@
 use std::path::PathBuf;
 
 use data::dashboard::BufferAction;
+use data::preview::{self, Previews};
 use data::target::{self, Target};
-use data::{Config, Server, buffer, history, message, preview};
+use data::{Config, Server, buffer, history, message};
 use iced::advanced::text;
 use iced::widget::{column, container, row, vertical_space};
 use iced::{Length, Task};
@@ -50,7 +51,7 @@ pub fn view<'a>(
     let chathistory_state =
         clients.get_chathistory_state(server, &query.to_target());
 
-    let previews = Some(buffer::Previews::from(
+    let previews = Some(Previews::new(
         previews,
         &query.to_target(),
         &config.preview,

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -50,12 +50,19 @@ pub fn view<'a>(
     let chathistory_state =
         clients.get_chathistory_state(server, &query.to_target());
 
+    let previews = Some(buffer::Previews::from(
+        previews,
+        &query.to_target(),
+        &config.preview,
+        casemapping,
+    ));
+
     let messages = container(
         scroll_view::view(
             &state.scroll_view,
             scroll_view::Kind::Query(server, query),
             history,
-            Some((previews, casemapping)),
+            previews,
             chathistory_state,
             config,
             move |message, max_nick_width, _| {

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -55,7 +55,7 @@ pub fn view<'a>(
             &state.scroll_view,
             scroll_view::Kind::Query(server, query),
             history,
-            Some(previews),
+            Some((previews, casemapping)),
             chathistory_state,
             config,
             move |message, max_nick_width, _| {

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -1088,7 +1088,6 @@ fn preview_row<'a>(
             image: preview::Image { path, .. },
             title,
             description,
-            canonical_url,
             ..
         }) => keyed(
             keyed::Key::Preview(message.hash, idx),
@@ -1120,32 +1119,23 @@ fn preview_row<'a>(
                 )
                 .padding(4)
                 .style(theme::container::image_card),
+            ),
+        ),
+        data::Preview::Image(preview::Image { path, url, .. }) => keyed(
+            keyed::Key::Preview(message.hash, idx),
+            button(
+                container(image(path).content_fit(ContentFit::ScaleDown))
+                    .max_width(550)
+                    .max_height(350),
             )
-        }
-        data::Preview::Image(preview::Image { path, url, .. }) => {
-            if !config.preview.image.visible(&target, casemapping) {
-                return None;
-            }
-
-            keyed(
-                keyed::Key::Preview(message.hash, idx),
-                button(
-                    container(image(path).content_fit(ContentFit::ScaleDown))
-                        .max_width(550)
-                        .max_height(350),
-                )
-                .on_press(match config.preview.image.action {
-                    data::config::preview::ImageAction::OpenUrl => {
-                        Message::Link(message::Link::Url(url.to_string()))
-                    }
-                    data::config::preview::ImageAction::Preview => {
-                        Message::ImagePreview(path.to_path_buf(), url.clone())
-                    }
-                })
-                .padding(0)
-                .style(theme::button::bare),
-            )
-            .on_press(Message::Link(message::Link::Url(url.to_string())))
+            .on_press(match config.preview.image.action {
+                data::config::preview::ImageAction::OpenUrl => {
+                    Message::Link(message::Link::Url(url.to_string()))
+                }
+                data::config::preview::ImageAction::Preview => {
+                    Message::ImagePreview(path.to_path_buf(), url.clone())
+                }
+            })
             .padding(0)
             .style(theme::button::bare),
         ),

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -5,9 +5,10 @@ use chrono::{DateTime, Local, NaiveDate, Utc};
 use data::dashboard::BufferAction;
 use data::isupport::ChatHistoryState;
 use data::message::{self, Limit};
+use data::preview::{self, Previews};
 use data::server::Server;
 use data::target::{self, Target};
-use data::{Config, Preview, client, history, preview};
+use data::{Config, Preview, client, history};
 use iced::widget::{
     Scrollable, button, center, column, container, horizontal_rule,
     horizontal_space, image, mouse_area, row, scrollable, text,
@@ -98,7 +99,7 @@ pub fn view<'a>(
     state: &State,
     kind: Kind,
     history: &'a history::Manager,
-    previews: Option<data::buffer::Previews<'a>>,
+    previews: Option<Previews<'a>>,
     chathistory_state: Option<ChatHistoryState>,
     config: &'a Config,
     format: impl Fn(


### PR DESCRIPTION
I currently use `exclude = ["*"]` to hide all card previews, but since queries are excluded from matching that setting I was still getting card previews inside direct messages.  This change allows queries to be matched as well.

Also changes include/exclude matching to utilize the server's casemapping to normalize the strings.  Can be broken off into a separate PR if needed.