### PR TITLE
Update `rustfmt` Settings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,10 @@
 fn main() {
     #[cfg(windows)]
     {
-        let _ = embed_resource::compile("assets/windows/halloy.rc", embed_resource::NONE);
+        let _ = embed_resource::compile(
+            "assets/windows/halloy.rc",
+            embed_resource::NONE,
+        );
         windows_exe_info::versioninfo::link_cargo_env();
     }
 }

--- a/data/src/appearance/theme.rs
+++ b/data/src/appearance/theme.rs
@@ -574,10 +574,10 @@ mod binary {
                 Tag::GeneralBackground => colors.general.background = color,
                 Tag::GeneralBorder => colors.general.border = color,
                 Tag::GeneralHorizontalRule => {
-                    colors.general.horizontal_rule = color
+                    colors.general.horizontal_rule = color;
                 }
                 Tag::GeneralUnreadIndicator => {
-                    colors.general.unread_indicator = color
+                    colors.general.unread_indicator = color;
                 }
                 Tag::TextPrimary => colors.text.primary = color,
                 Tag::TextSecondary => colors.text.secondary = color,
@@ -587,14 +587,14 @@ mod binary {
                 Tag::BufferAction => colors.buffer.action = color,
                 Tag::BufferBackground => colors.buffer.background = color,
                 Tag::BufferBackgroundTextInput => {
-                    colors.buffer.background_text_input = color
+                    colors.buffer.background_text_input = color;
                 }
                 Tag::BufferBackgroundTitleBar => {
-                    colors.buffer.background_title_bar = color
+                    colors.buffer.background_title_bar = color;
                 }
                 Tag::BufferBorder => colors.buffer.border = color,
                 Tag::BufferBorderSelected => {
-                    colors.buffer.border_selected = color
+                    colors.buffer.border_selected = color;
                 }
                 Tag::BufferCode => colors.buffer.code = color,
                 Tag::BufferHighlight => colors.buffer.highlight = color,
@@ -604,13 +604,13 @@ mod binary {
                 Tag::BufferTopic => colors.buffer.topic = color,
                 Tag::BufferUrl => colors.buffer.url = color,
                 Tag::BufferServerMessagesJoin => {
-                    colors.buffer.server_messages.join = Some(color)
+                    colors.buffer.server_messages.join = Some(color);
                 }
                 Tag::BufferServerMessagesPart => {
-                    colors.buffer.server_messages.part = Some(color)
+                    colors.buffer.server_messages.part = Some(color);
                 }
                 Tag::BufferServerMessagesQuit => {
-                    colors.buffer.server_messages.quit = Some(color)
+                    colors.buffer.server_messages.quit = Some(color);
                 }
                 Tag::BufferServerMessagesReplyTopic => {
                     colors.buffer.server_messages.reply_topic = Some(color);
@@ -639,10 +639,10 @@ mod binary {
                         Some(color);
                 }
                 Tag::BufferServerMessagesDefault => {
-                    colors.buffer.server_messages.default = color
+                    colors.buffer.server_messages.default = color;
                 }
                 Tag::ButtonsPrimaryBackground => {
-                    colors.buttons.primary.background = color
+                    colors.buttons.primary.background = color;
                 }
                 Tag::ButtonsPrimaryBackgroundHover => {
                     colors.buttons.primary.background_hover = color;
@@ -654,7 +654,7 @@ mod binary {
                     colors.buttons.primary.background_selected_hover = color;
                 }
                 Tag::ButtonsSecondaryBackground => {
-                    colors.buttons.secondary.background = color
+                    colors.buttons.secondary.background = color;
                 }
                 Tag::ButtonsSecondaryBackgroundHover => {
                     colors.buttons.secondary.background_hover = color;

--- a/data/src/appearance/theme.rs
+++ b/data/src/appearance/theme.rs
@@ -11,7 +11,8 @@ use thiserror::Error;
 use tokio::fs;
 
 const DEFAULT_THEME_NAME: &str = "Ferra";
-const DEFAULT_THEME_CONTENT: &str = include_str!("../../../assets/themes/ferra.toml");
+const DEFAULT_THEME_CONTENT: &str =
+    include_str!("../../../assets/themes/ferra.toml");
 
 #[derive(Debug, Clone)]
 pub struct Theme {
@@ -64,7 +65,8 @@ impl Colors {
     }
 
     pub fn decode_base64(content: &str) -> Result<Self, Error> {
-        let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(content)?;
+        let bytes =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(content)?;
 
         Ok(binary::decode(&bytes))
     }
@@ -240,7 +242,12 @@ pub fn color_to_hex(color: Color) -> String {
 }
 
 /// Adjusts the transparency of the foreground color based on the background color's lightness.
-pub fn alpha_color_calculate(min_alpha: f32, max_alpha: f32, background: Color, foreground: Color) -> Color {
+pub fn alpha_color_calculate(
+    min_alpha: f32,
+    max_alpha: f32,
+    background: Color,
+    foreground: Color,
+) -> Color {
     alpha_color(
         foreground,
         min_alpha + to_hsl(background).lightness * (max_alpha - min_alpha),
@@ -285,7 +292,6 @@ pub fn to_hsva(color: Color) -> Hsva {
 
 pub fn from_hsva(color: Hsva) -> Color {
     to_color(Srgba::from_color(color))
-
 }
 
 pub fn from_hsl(hsl: Okhsl) -> Color {
@@ -350,14 +356,20 @@ mod color_serde_maybe {
     use iced_core::Color;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Color>, D::Error>
+    pub fn deserialize<'de, D>(
+        deserializer: D,
+    ) -> Result<Option<Color>, D::Error>
     where
         D: Deserializer<'de>,
     {
-        Ok(Option::<String>::deserialize(deserializer)?.and_then(|hex| super::hex_to_color(&hex)))
+        Ok(Option::<String>::deserialize(deserializer)?
+            .and_then(|hex| super::hex_to_color(&hex)))
     }
 
-    pub fn serialize<S>(color: &Option<Color>, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(
+        color: &Option<Color>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
@@ -395,8 +407,12 @@ mod binary {
         for chunk in bytes.chunks(5) {
             if chunk.len() == 5 {
                 if let Ok(tag) = Tag::try_from(chunk[0]) {
-                    let color =
-                        Color::from_rgba8(chunk[1], chunk[2], chunk[3], chunk[4] as f32 / 255.0);
+                    let color = Color::from_rgba8(
+                        chunk[1],
+                        chunk[2],
+                        chunk[3],
+                        chunk[4] as f32 / 255.0,
+                    );
 
                     tag.update_colors(&mut colors, color);
                 }
@@ -408,7 +424,14 @@ mod binary {
 
     // IMPORTANT: Tags cannot be rearranged or deleted to preserve
     // backwards compatability. Only append new items in the future
-    #[derive(Debug, Clone, Copy, strum::EnumIter, strum::VariantArray, derive_more::TryFrom)]
+    #[derive(
+        Debug,
+        Clone,
+        Copy,
+        strum::EnumIter,
+        strum::VariantArray,
+        derive_more::TryFrom,
+    )]
     #[try_from(repr)]
     #[repr(u8)]
     pub enum Tag {
@@ -469,8 +492,12 @@ mod binary {
                 Tag::TextError => colors.text.error,
                 Tag::BufferAction => colors.buffer.action,
                 Tag::BufferBackground => colors.buffer.background,
-                Tag::BufferBackgroundTextInput => colors.buffer.background_text_input,
-                Tag::BufferBackgroundTitleBar => colors.buffer.background_title_bar,
+                Tag::BufferBackgroundTextInput => {
+                    colors.buffer.background_text_input
+                }
+                Tag::BufferBackgroundTitleBar => {
+                    colors.buffer.background_title_bar
+                }
                 Tag::BufferBorder => colors.buffer.border,
                 Tag::BufferBorderSelected => colors.buffer.border_selected,
                 Tag::BufferCode => colors.buffer.code,
@@ -480,11 +507,21 @@ mod binary {
                 Tag::BufferTimestamp => colors.buffer.timestamp,
                 Tag::BufferTopic => colors.buffer.topic,
                 Tag::BufferUrl => colors.buffer.url,
-                Tag::BufferServerMessagesJoin => colors.buffer.server_messages.join?,
-                Tag::BufferServerMessagesPart => colors.buffer.server_messages.part?,
-                Tag::BufferServerMessagesQuit => colors.buffer.server_messages.quit?,
-                Tag::BufferServerMessagesReplyTopic => colors.buffer.server_messages.reply_topic?,
-                Tag::BufferServerMessagesChangeHost => colors.buffer.server_messages.change_host?,
+                Tag::BufferServerMessagesJoin => {
+                    colors.buffer.server_messages.join?
+                }
+                Tag::BufferServerMessagesPart => {
+                    colors.buffer.server_messages.part?
+                }
+                Tag::BufferServerMessagesQuit => {
+                    colors.buffer.server_messages.quit?
+                }
+                Tag::BufferServerMessagesReplyTopic => {
+                    colors.buffer.server_messages.reply_topic?
+                }
+                Tag::BufferServerMessagesChangeHost => {
+                    colors.buffer.server_messages.change_host?
+                }
                 Tag::BufferServerMessagesMonitoredOnline => {
                     colors.buffer.server_messages.monitored_online?
                 }
@@ -500,15 +537,27 @@ mod binary {
                 Tag::BufferServerMessagesStandardReplyNote => {
                     colors.buffer.server_messages.standard_reply_note?
                 }
-                Tag::BufferServerMessagesDefault => colors.buffer.server_messages.default,
-                Tag::ButtonsPrimaryBackground => colors.buttons.primary.background,
-                Tag::ButtonsPrimaryBackgroundHover => colors.buttons.primary.background_hover,
-                Tag::ButtonsPrimaryBackgroundSelected => colors.buttons.primary.background_selected,
+                Tag::BufferServerMessagesDefault => {
+                    colors.buffer.server_messages.default
+                }
+                Tag::ButtonsPrimaryBackground => {
+                    colors.buttons.primary.background
+                }
+                Tag::ButtonsPrimaryBackgroundHover => {
+                    colors.buttons.primary.background_hover
+                }
+                Tag::ButtonsPrimaryBackgroundSelected => {
+                    colors.buttons.primary.background_selected
+                }
                 Tag::ButtonsPrimaryBackgroundSelectedHover => {
                     colors.buttons.primary.background_selected_hover
                 }
-                Tag::ButtonsSecondaryBackground => colors.buttons.secondary.background,
-                Tag::ButtonsSecondaryBackgroundHover => colors.buttons.secondary.background_hover,
+                Tag::ButtonsSecondaryBackground => {
+                    colors.buttons.secondary.background
+                }
+                Tag::ButtonsSecondaryBackgroundHover => {
+                    colors.buttons.secondary.background_hover
+                }
                 Tag::ButtonsSecondaryBackgroundSelected => {
                     colors.buttons.secondary.background_selected
                 }
@@ -524,8 +573,12 @@ mod binary {
             match self {
                 Tag::GeneralBackground => colors.general.background = color,
                 Tag::GeneralBorder => colors.general.border = color,
-                Tag::GeneralHorizontalRule => colors.general.horizontal_rule = color,
-                Tag::GeneralUnreadIndicator => colors.general.unread_indicator = color,
+                Tag::GeneralHorizontalRule => {
+                    colors.general.horizontal_rule = color
+                }
+                Tag::GeneralUnreadIndicator => {
+                    colors.general.unread_indicator = color
+                }
                 Tag::TextPrimary => colors.text.primary = color,
                 Tag::TextSecondary => colors.text.secondary = color,
                 Tag::TextTertiary => colors.text.tertiary = color,
@@ -533,10 +586,16 @@ mod binary {
                 Tag::TextError => colors.text.error = color,
                 Tag::BufferAction => colors.buffer.action = color,
                 Tag::BufferBackground => colors.buffer.background = color,
-                Tag::BufferBackgroundTextInput => colors.buffer.background_text_input = color,
-                Tag::BufferBackgroundTitleBar => colors.buffer.background_title_bar = color,
+                Tag::BufferBackgroundTextInput => {
+                    colors.buffer.background_text_input = color
+                }
+                Tag::BufferBackgroundTitleBar => {
+                    colors.buffer.background_title_bar = color
+                }
                 Tag::BufferBorder => colors.buffer.border = color,
-                Tag::BufferBorderSelected => colors.buffer.border_selected = color,
+                Tag::BufferBorderSelected => {
+                    colors.buffer.border_selected = color
+                }
                 Tag::BufferCode => colors.buffer.code = color,
                 Tag::BufferHighlight => colors.buffer.highlight = color,
                 Tag::BufferNickname => colors.buffer.nickname = color,
@@ -544,9 +603,15 @@ mod binary {
                 Tag::BufferTimestamp => colors.buffer.timestamp = color,
                 Tag::BufferTopic => colors.buffer.topic = color,
                 Tag::BufferUrl => colors.buffer.url = color,
-                Tag::BufferServerMessagesJoin => colors.buffer.server_messages.join = Some(color),
-                Tag::BufferServerMessagesPart => colors.buffer.server_messages.part = Some(color),
-                Tag::BufferServerMessagesQuit => colors.buffer.server_messages.quit = Some(color),
+                Tag::BufferServerMessagesJoin => {
+                    colors.buffer.server_messages.join = Some(color)
+                }
+                Tag::BufferServerMessagesPart => {
+                    colors.buffer.server_messages.part = Some(color)
+                }
+                Tag::BufferServerMessagesQuit => {
+                    colors.buffer.server_messages.quit = Some(color)
+                }
                 Tag::BufferServerMessagesReplyTopic => {
                     colors.buffer.server_messages.reply_topic = Some(color);
                 }
@@ -554,22 +619,31 @@ mod binary {
                     colors.buffer.server_messages.change_host = Some(color);
                 }
                 Tag::BufferServerMessagesMonitoredOnline => {
-                    colors.buffer.server_messages.monitored_online = Some(color);
+                    colors.buffer.server_messages.monitored_online =
+                        Some(color);
                 }
                 Tag::BufferServerMessagesMonitoredOffline => {
-                    colors.buffer.server_messages.monitored_offline = Some(color);
+                    colors.buffer.server_messages.monitored_offline =
+                        Some(color);
                 }
                 Tag::BufferServerMessagesStandardReplyFail => {
-                    colors.buffer.server_messages.standard_reply_fail = Some(color);
+                    colors.buffer.server_messages.standard_reply_fail =
+                        Some(color);
                 }
                 Tag::BufferServerMessagesStandardReplyWarn => {
-                    colors.buffer.server_messages.standard_reply_warn = Some(color);
+                    colors.buffer.server_messages.standard_reply_warn =
+                        Some(color);
                 }
                 Tag::BufferServerMessagesStandardReplyNote => {
-                    colors.buffer.server_messages.standard_reply_note = Some(color);
+                    colors.buffer.server_messages.standard_reply_note =
+                        Some(color);
                 }
-                Tag::BufferServerMessagesDefault => colors.buffer.server_messages.default = color,
-                Tag::ButtonsPrimaryBackground => colors.buttons.primary.background = color,
+                Tag::BufferServerMessagesDefault => {
+                    colors.buffer.server_messages.default = color
+                }
+                Tag::ButtonsPrimaryBackground => {
+                    colors.buttons.primary.background = color
+                }
                 Tag::ButtonsPrimaryBackgroundHover => {
                     colors.buttons.primary.background_hover = color;
                 }
@@ -579,7 +653,9 @@ mod binary {
                 Tag::ButtonsPrimaryBackgroundSelectedHover => {
                     colors.buttons.primary.background_selected_hover = color;
                 }
-                Tag::ButtonsSecondaryBackground => colors.buttons.secondary.background = color,
+                Tag::ButtonsSecondaryBackground => {
+                    colors.buttons.secondary.background = color
+                }
                 Tag::ButtonsSecondaryBackgroundHover => {
                     colors.buttons.secondary.background_hover = color;
                 }

--- a/data/src/audio.rs
+++ b/data/src/audio.rs
@@ -47,8 +47,12 @@ impl Internal {
             Internal::Dong => include_bytes!("../../sounds/dong.ogg").to_vec(),
             Internal::Peck => include_bytes!("../../sounds/peck.ogg").to_vec(),
             Internal::Ring => include_bytes!("../../sounds/ring.ogg").to_vec(),
-            Internal::Squeak => include_bytes!("../../sounds/squeak.ogg").to_vec(),
-            Internal::Whistle => include_bytes!("../../sounds/whistle.ogg").to_vec(),
+            Internal::Squeak => {
+                include_bytes!("../../sounds/squeak.ogg").to_vec()
+            }
+            Internal::Whistle => {
+                include_bytes!("../../sounds/whistle.ogg").to_vec()
+            }
             Internal::Bonk => include_bytes!("../../sounds/bonk.ogg").to_vec(),
             Internal::Sing => include_bytes!("../../sounds/sing.ogg").to_vec(),
         }
@@ -79,16 +83,19 @@ fn find_external_sound(sound: &str) -> Result<PathBuf, LoadError> {
         .into_iter()
         .filter_map(|e| e.ok())
     {
-        if e.metadata().is_ok_and(|data| data.is_file()) && e.file_name() == sound {
+        if e.metadata().is_ok_and(|data| data.is_file())
+            && e.file_name() == sound
+        {
             return Ok(e.path().to_path_buf());
         }
     }
 
-    let sounds_dir = if let Ok(sounds_dir) = sounds_dir.into_os_string().into_string() {
-        format!(" in {sounds_dir}")
-    } else {
-        String::new()
-    };
+    let sounds_dir =
+        if let Ok(sounds_dir) = sounds_dir.into_os_string().into_string() {
+            format!(" in {sounds_dir}")
+        } else {
+            String::new()
+        };
 
     Err(LoadError::NoSoundFound(sound.to_string(), sounds_dir))
 }

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::config::buffer::NicknameClickAction;
 use crate::serde::default_bool_true;
 use crate::target::{self, Target};
-use crate::{channel, config, message, Server};
+use crate::{Server, channel, config, message};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -21,7 +21,17 @@ pub enum Upstream {
     Query(Server, target::Query),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, strum::Display)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    strum::Display,
+)]
 pub enum Internal {
     #[strum(serialize = "File Transfers")]
     FileTransfers,
@@ -69,7 +79,9 @@ impl Upstream {
 
     pub fn server(&self) -> &Server {
         match self {
-            Self::Server(server) | Self::Channel(server, _) | Self::Query(server, _) => server,
+            Self::Server(server)
+            | Self::Channel(server, _)
+            | Self::Query(server, _) => server,
         }
     }
 
@@ -88,7 +100,10 @@ impl Upstream {
         }
     }
 
-    pub fn server_message_target(self, source: Option<message::source::Server>) -> message::Target {
+    pub fn server_message_target(
+        self,
+        source: Option<message::source::Server>,
+    ) -> message::Target {
         match self {
             Self::Server(_) => message::Target::Server {
                 source: message::Source::Server(source),
@@ -106,7 +121,8 @@ impl Upstream {
 }
 
 impl Internal {
-    pub const ALL: &'static [Self] = &[Self::FileTransfers, Self::Logs, Self::Highlights];
+    pub const ALL: &'static [Self] =
+        &[Self::FileTransfers, Self::Logs, Self::Highlights];
 
     pub fn key(&self) -> String {
         match self {

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -4,10 +4,11 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use std::{fmt, io};
 
-use anyhow::{anyhow, bail, Context as ErrorContext, Result};
+use anyhow::{Context as ErrorContext, Result, anyhow, bail};
 use chrono::{DateTime, Utc};
-use futures::{channel::mpsc, Future, FutureExt};
-use irc::proto::{self, command, Command};
+use futures::channel::mpsc;
+use futures::{Future, FutureExt};
+use irc::proto::{self, Command, command};
 use itertools::{Either, Itertools};
 use log::error;
 use tokio::fs;
@@ -15,16 +16,17 @@ use tokio::fs;
 use crate::dashboard::BufferAction;
 use crate::history::ReadMarker;
 use crate::isupport::{
-    ChatHistoryState, ChatHistorySubcommand, MessageReference, WhoToken, WhoXPollParameters,
+    ChatHistoryState, ChatHistorySubcommand, MessageReference, WhoToken,
+    WhoXPollParameters,
 };
 use crate::message::{message_id, server_time, source};
 use crate::target::{self, Target};
 use crate::time::Posix;
 use crate::user::{Nick, NickRef};
 use crate::{
-    buffer, compression, config, ctcp, dcc, environment, isupport, message, mode, Server, User,
+    Server, User, buffer, compression, config, ctcp, dcc, environment,
+    file_transfer, isupport, message, mode, server,
 };
-use crate::{file_transfer, server};
 
 const HIGHLIGHT_BLACKOUT_INTERVAL: Duration = Duration::from_secs(5);
 
@@ -85,7 +87,11 @@ pub enum Broadcast {
 #[derive(Debug)]
 pub enum Message {
     ChatHistoryRequest(Server, ChatHistorySubcommand),
-    ChatHistoryTargetsTimestampUpdated(Server, DateTime<Utc>, Result<(), Error>),
+    ChatHistoryTargetsTimestampUpdated(
+        Server,
+        DateTime<Utc>,
+        Result<(), Error>,
+    ),
     RequestNewerChatHistory(Server, Target, DateTime<Utc>),
     RequestChatHistoryTargets(Server, Option<DateTime<Utc>>, DateTime<Utc>),
 }
@@ -181,11 +187,14 @@ impl Client {
             chathistory_requests: HashMap::new(),
             chathistory_exhausted: HashMap::new(),
             chathistory_targets_request: None,
-            highlight_notification_blackout: HighlightNotificationBlackout::Blackout(Instant::now()),
+            highlight_notification_blackout:
+                HighlightNotificationBlackout::Blackout(Instant::now()),
             registration_required_channels: vec![],
             isupport: HashMap::new(),
             who_polls: VecDeque::new(),
-            who_poll_interval: BackoffInterval::from_duration(config.who_poll_interval),
+            who_poll_interval: BackoffInterval::from_duration(
+                config.who_poll_interval,
+            ),
             config,
         }
     }
@@ -240,7 +249,11 @@ impl Client {
         }
     }
 
-    fn send(&mut self, buffer: &buffer::Upstream, mut message: message::Encoded) {
+    fn send(
+        &mut self,
+        buffer: &buffer::Upstream,
+        mut message: message::Encoded,
+    ) {
         if self.supports_labels {
             use proto::Tag;
 
@@ -256,7 +269,8 @@ impl Client {
             }];
         }
 
-        self.reroute_responses_to = self.start_reroute(&message.command).then(|| buffer.clone());
+        self.reroute_responses_to =
+            self.start_reroute(&message.command).then(|| buffer.clone());
 
         if matches!(message.command, Command::WHO(..)) {
             let params = message.command.clone().parameters();
@@ -354,7 +368,11 @@ impl Client {
         macro_rules! ok {
             ($option:expr) => {
                 $option.ok_or_else(|| {
-                    anyhow!("[{}] Malformed command: {:?}", self.server, message.command)
+                    anyhow!(
+                        "[{}] Malformed command: {:?}",
+                        self.server,
+                        message.command
+                    )
                 })?
             };
         }
@@ -362,7 +380,11 @@ impl Client {
         macro_rules! context {
             ($result:expr) => {
                 $result.with_context(|| {
-                    anyhow!("[{}] Malformed command: {:?}", self.server, message.command)
+                    anyhow!(
+                        "[{}] Malformed command: {:?}",
+                        self.server,
+                        message.command
+                    )
                 })?
             };
         }
@@ -377,18 +399,23 @@ impl Client {
                     '+' => {
                         let mut batch = Batch::new(context);
 
-                        batch.chathistory = match params.first().map(|x| x.as_str()) {
-                            Some("chathistory") => params.get(1).map(|target| {
-                                ChatHistoryBatch::Target(Target::parse(
-                                    target,
-                                    self.chantypes(),
-                                    self.statusmsg(),
-                                    self.casemapping(),
-                                ))
-                            }),
-                            Some("draft/chathistory-targets") => Some(ChatHistoryBatch::Targets),
-                            _ => None,
-                        };
+                        batch.chathistory =
+                            match params.first().map(|x| x.as_str()) {
+                                Some("chathistory") => {
+                                    params.get(1).map(|target| {
+                                        ChatHistoryBatch::Target(Target::parse(
+                                            target,
+                                            self.chantypes(),
+                                            self.statusmsg(),
+                                            self.casemapping(),
+                                        ))
+                                    })
+                                }
+                                Some("draft/chathistory-targets") => {
+                                    Some(ChatHistoryBatch::Targets)
+                                }
+                                _ => None,
+                            };
 
                         self.batches.insert(
                             Target::parse(
@@ -401,31 +428,40 @@ impl Client {
                         );
                     }
                     '-' => {
-                        if let Some(mut finished) = self.batches.remove(&Target::parse(
-                            &reference,
-                            self.chantypes(),
-                            self.statusmsg(),
-                            self.casemapping(),
-                        )) {
+                        if let Some(mut finished) =
+                            self.batches.remove(&Target::parse(
+                                &reference,
+                                self.chantypes(),
+                                self.statusmsg(),
+                                self.casemapping(),
+                            ))
+                        {
                             // If nested, extend events into parent batch
-                            if let Some(parent) = batch_tag.as_ref().and_then(|batch| {
-                                self.batches.get_mut(&Target::parse(
-                                    batch,
-                                    self.chantypes(),
-                                    self.statusmsg(),
-                                    self.casemapping(),
-                                ))
-                            }) {
+                            if let Some(parent) =
+                                batch_tag.as_ref().and_then(|batch| {
+                                    self.batches.get_mut(&Target::parse(
+                                        batch,
+                                        self.chantypes(),
+                                        self.statusmsg(),
+                                        self.casemapping(),
+                                    ))
+                                })
+                            {
                                 parent.events.extend(finished.events);
                             } else {
                                 match &finished.chathistory {
-                                    Some(ChatHistoryBatch::Target(batch_target)) => {
-                                        let continuation_subcommand = if let Some(
-                                            ChatHistoryRequest { subcommand, .. },
-                                        ) =
-                                            self.chathistory_requests.get(batch_target)
-                                        {
-                                            if let ChatHistorySubcommand::Before(_, _, limit)
+                                    Some(ChatHistoryBatch::Target(
+                                        batch_target,
+                                    )) => {
+                                        let continuation_subcommand =
+                                            if let Some(ChatHistoryRequest {
+                                                subcommand,
+                                                ..
+                                            }) = self
+                                                .chathistory_requests
+                                                .get(batch_target)
+                                            {
+                                                if let ChatHistorySubcommand::Before(_, _, limit)
                                             | ChatHistorySubcommand::Latest(
                                                 _,
                                                 MessageReference::None,
@@ -438,7 +474,7 @@ impl Client {
                                                 );
                                             }
 
-                                            match subcommand {
+                                                match subcommand {
                                                 ChatHistorySubcommand::Latest(
                                                     target,
                                                     message_reference,
@@ -520,20 +556,27 @@ impl Client {
                                                     None
                                                 }
                                             }
-                                        } else {
-                                            None
-                                        };
+                                            } else {
+                                                None
+                                            };
 
-                                        self.clear_chathistory_request(Some(batch_target));
+                                        self.clear_chathistory_request(Some(
+                                            batch_target,
+                                        ));
 
                                         if let Some(continuation_subcommand) =
                                             continuation_subcommand
                                         {
-                                            self.send_chathistory_request(continuation_subcommand);
+                                            self.send_chathistory_request(
+                                                continuation_subcommand,
+                                            );
                                         }
                                     }
                                     Some(ChatHistoryBatch::Targets) => {
-                                        if let Some(ChatHistoryRequest { subcommand, .. }) =
+                                        if let Some(ChatHistoryRequest {
+                                            subcommand,
+                                            ..
+                                        }) =
                                             &self.chathistory_targets_request
                                         {
                                             if let ChatHistorySubcommand::Targets(
@@ -596,7 +639,9 @@ impl Client {
                             None
                         }
                     }) {
-                    if Some(User::from(Nick::from("HistServ"))) == message.user() {
+                    if Some(User::from(Nick::from("HistServ")))
+                        == message.user()
+                    {
                         // HistServ provides event-playback without event-playback
                         // which would require client-side parsing to map appropriately.
                         // Avoid that complexity by only providing that functionality
@@ -624,12 +669,17 @@ impl Client {
                                 .map(|channel| {
                                     let target = message::Target::Channel {
                                         channel: channel.clone(),
-                                        source: source::Source::Server(Some(source::Server::new(
-                                            source::server::Kind::Quit,
-                                            message
-                                                .user()
-                                                .map(|user| Nick::from(user.nickname().as_ref())),
-                                        ))),
+                                        source: source::Source::Server(Some(
+                                            source::Server::new(
+                                                source::server::Kind::Quit,
+                                                message.user().map(|user| {
+                                                    Nick::from(
+                                                        user.nickname()
+                                                            .as_ref(),
+                                                    )
+                                                }),
+                                            ),
+                                        )),
                                     };
 
                                     vec![Event::WithTarget(
@@ -639,16 +689,24 @@ impl Client {
                                     )]
                                 })
                                 .unwrap_or_default(),
-                            Command::PRIVMSG(target, text) | Command::NOTICE(target, text) => {
-                                if ctcp::is_query(text) && !message::is_action(text) {
+                            Command::PRIVMSG(target, text)
+                            | Command::NOTICE(target, text) => {
+                                if ctcp::is_query(text)
+                                    && !message::is_action(text)
+                                {
                                     // Ignore historical CTCP queries/responses except for ACTIONs
                                     vec![]
                                 } else {
                                     if let Some(user) = message.user() {
                                         // If direct message, update resolved queries with user
-                                        if target == &self.nickname().to_string() {
+                                        if target
+                                            == &self.nickname().to_string()
+                                        {
                                             self.resolved_queries.replace(
-                                                target::Query::from_user(&user, self.casemapping()),
+                                                target::Query::from_user(
+                                                    &user,
+                                                    self.casemapping(),
+                                                ),
                                             );
                                         }
                                     }
@@ -661,7 +719,10 @@ impl Client {
                                     )]
                                 }
                             }
-                            _ => vec![Event::Single(message, self.nickname().to_owned())],
+                            _ => vec![Event::Single(
+                                message,
+                                self.nickname().to_owned(),
+                            )],
                         }
                     }
                 } else {
@@ -694,7 +755,9 @@ impl Client {
                 }
             }
             // Reroute responses
-            Command::Numeric(..) | Command::Unknown(..) if self.reroute_responses_to.is_some() => {
+            Command::Numeric(..) | Command::Unknown(..)
+                if self.reroute_responses_to.is_some() =>
+            {
                 if let Some(source) = self
                     .reroute_responses_to
                     .clone()
@@ -721,7 +784,8 @@ impl Client {
                 if asterisk.is_none() {
                     let mut requested = vec![];
 
-                    let contains = |s| self.listed_caps.iter().any(|cap| cap == s);
+                    let contains =
+                        |s| self.listed_caps.iter().any(|cap| cap == s);
 
                     if contains("invite-notify") {
                         requested.push("invite-notify");
@@ -769,7 +833,11 @@ impl Client {
                     if contains("echo-message") {
                         requested.push("echo-message");
                     }
-                    if self.listed_caps.iter().any(|cap| cap.starts_with("sasl")) {
+                    if self
+                        .listed_caps
+                        .iter()
+                        .any(|cap| cap.starts_with("sasl"))
+                    {
                         requested.push("sasl");
                     }
                     if contains("multi-prefix") {
@@ -800,7 +868,10 @@ impl Client {
                 // TODO this code is duplicated several times. Fix in `Command`.
                 let caps = ok!(b.as_ref().or(a.as_ref()));
 
-                log::info!("[{}] capabilities acknowledged: {caps}", self.server);
+                log::info!(
+                    "[{}] capabilities acknowledged: {caps}",
+                    self.server
+                );
 
                 let caps = caps.split(' ').collect::<Vec<_>>();
 
@@ -822,7 +893,9 @@ impl Client {
 
                 let supports_sasl = caps.iter().any(|cap| cap.contains("sasl"));
 
-                if let Some(sasl) = self.config.sasl.as_ref().filter(|_| supports_sasl) {
+                if let Some(sasl) =
+                    self.config.sasl.as_ref().filter(|_| supports_sasl)
+                {
                     self.registration_step = RegistrationStep::Sasl;
                     self.handle
                         .try_send(command!("AUTHENTICATE", sasl.command()))?;
@@ -831,14 +904,19 @@ impl Client {
                     self.handle.try_send(command!("CAP", "END"))?;
                 }
 
-                if caps.contains(&"draft/chathistory") && self.config.chathistory {
+                if caps.contains(&"draft/chathistory")
+                    && self.config.chathistory
+                {
                     self.supports_chathistory = true;
                 }
             }
             Command::CAP(_, sub, a, b) if sub == "NAK" => {
                 let caps = ok!(b.as_ref().or(a.as_ref()));
 
-                log::warn!("[{}] capabilities not acknowledged: {caps}", self.server);
+                log::warn!(
+                    "[{}] capabilities not acknowledged: {caps}",
+                    self.server
+                );
 
                 // End if we didn't move to sasl or already ended
                 if self.registration_step < RegistrationStep::Sasl {
@@ -849,7 +927,8 @@ impl Client {
             Command::CAP(_, sub, a, b) if sub == "NEW" => {
                 let caps = ok!(b.as_ref().or(a.as_ref()));
 
-                let new_caps = caps.split(' ').map(String::from).collect::<Vec<String>>();
+                let new_caps =
+                    caps.split(' ').map(String::from).collect::<Vec<String>>();
 
                 let mut requested = vec![];
 
@@ -878,7 +957,9 @@ impl Client {
                 if newly_contains("extended-monitor") {
                     requested.push("extended-monitor");
                 }
-                if contains("account-notify") || newly_contains("account-notify") {
+                if contains("account-notify")
+                    || newly_contains("account-notify")
+                {
                     if newly_contains("account-notify") {
                         requested.push("account-notify");
                     }
@@ -893,7 +974,9 @@ impl Client {
                     }
 
                     // We require batch for our chathistory support
-                    if newly_contains("draft/chathistory") && self.config.chathistory {
+                    if newly_contains("draft/chathistory")
+                        && self.config.chathistory
+                    {
                         requested.push("draft/chathistory");
 
                         if newly_contains("draft/event-playback") {
@@ -928,7 +1011,10 @@ impl Client {
             Command::CAP(_, sub, a, b) if sub == "DEL" => {
                 let caps = ok!(b.as_ref().or(a.as_ref()));
 
-                log::info!("[{}] capabilities no longer supported: {caps}", self.server);
+                log::info!(
+                    "[{}] capabilities no longer supported: {caps}",
+                    self.server
+                );
 
                 let del_caps = caps.split(' ').collect::<Vec<_>>();
 
@@ -951,15 +1037,21 @@ impl Client {
                     self.supports_chathistory = false;
                 }
 
-                self.listed_caps
-                    .retain(|cap| !del_caps.iter().any(|del_cap| del_cap == cap));
+                self.listed_caps.retain(|cap| {
+                    !del_caps.iter().any(|del_cap| del_cap == cap)
+                });
             }
             Command::AUTHENTICATE(param) if param == "+" => {
                 if let Some(sasl) = self.config.sasl.as_ref() {
-                    log::info!("[{}] sasl auth: {}", self.server, sasl.command());
+                    log::info!(
+                        "[{}] sasl auth: {}",
+                        self.server,
+                        sasl.command()
+                    );
 
                     for param in sasl.params() {
-                        self.handle.try_send(command!("AUTHENTICATE", param))?;
+                        self.handle
+                            .try_send(command!("AUTHENTICATE", param))?;
                     }
                 }
             }
@@ -986,7 +1078,9 @@ impl Client {
 
                     self.chanmap.values_mut().for_each(|channel| {
                         if let Some(user) = channel.users.take(&old_user) {
-                            channel.users.insert(user.with_accountname(accountname));
+                            channel
+                                .users
+                                .insert(user.with_accountname(accountname));
                         }
                     });
                 }
@@ -1034,7 +1128,10 @@ impl Client {
                             && !message::is_action(text)
                         {
                             if let Some(query) = ctcp::parse_query(text) {
-                                if matches!(&message.command, Command::PRIVMSG(_, _)) {
+                                if matches!(
+                                    &message.command,
+                                    Command::PRIVMSG(_, _)
+                                ) {
                                     match query.command {
                                         ctcp::Command::Action => (),
                                         ctcp::Command::ClientInfo => {
@@ -1046,11 +1143,13 @@ impl Client {
                                         }
                                         ctcp::Command::DCC => (),
                                         ctcp::Command::Ping => {
-                                            self.handle.try_send(ctcp::response_message(
-                                                &query.command,
-                                                user.nickname().to_string(),
-                                                query.params,
-                                            ))?;
+                                            self.handle.try_send(
+                                                ctcp::response_message(
+                                                    &query.command,
+                                                    user.nickname().to_string(),
+                                                    query.params,
+                                                ),
+                                            )?;
                                         }
                                         ctcp::Command::Source => {
                                             self.handle.try_send(ctcp::response_message(
@@ -1060,14 +1159,16 @@ impl Client {
                                             ))?;
                                         }
                                         ctcp::Command::Version => {
-                                            self.handle.try_send(ctcp::response_message(
-                                                &query.command,
-                                                user.nickname().to_string(),
-                                                Some(format!(
+                                            self.handle.try_send(
+                                                ctcp::response_message(
+                                                    &query.command,
+                                                    user.nickname().to_string(),
+                                                    Some(format!(
                                                     "Halloy {}",
                                                     crate::environment::VERSION
                                                 )),
-                                            ))?;
+                                                ),
+                                            )?;
                                         }
                                         ctcp::Command::Unknown(command) => {
                                             log::debug!(
@@ -1082,11 +1183,16 @@ impl Client {
                         }
 
                         // use `target` to confirm the direct message
-                        let direct_message = target == &self.nickname().to_string();
+                        let direct_message =
+                            target == &self.nickname().to_string();
 
                         if direct_message {
-                            self.resolved_queries
-                                .replace(target::Query::from_user(&user, self.casemapping()));
+                            self.resolved_queries.replace(
+                                target::Query::from_user(
+                                    &user,
+                                    self.casemapping(),
+                                ),
+                            );
                         }
 
                         let event = Event::PrivOrNotice(
@@ -1133,7 +1239,9 @@ impl Client {
 
                 self.chanmap.values_mut().for_each(|channel| {
                     if let Some(user) = channel.users.take(&old_user) {
-                        channel.users.insert(user.with_nickname(new_nick.clone()));
+                        channel
+                            .users
+                            .insert(user.with_nickname(new_nick.clone()));
                     }
                 });
 
@@ -1159,11 +1267,15 @@ impl Client {
                             *index += 1;
                         }
                     }
-                    None if !self.config.alt_nicks.is_empty() => self.alt_nick = Some(0),
+                    None if !self.config.alt_nicks.is_empty() => {
+                        self.alt_nick = Some(0)
+                    }
                     None => {}
                 }
 
-                if let Some(nick) = self.alt_nick.and_then(|i| self.config.alt_nicks.get(i)) {
+                if let Some(nick) =
+                    self.alt_nick.and_then(|i| self.config.alt_nicks.get(i))
+                {
                     self.handle.try_send(command!("NICK", nick))?;
                 }
             }
@@ -1240,11 +1352,15 @@ impl Client {
                         target_channel,
                         server_time(&message),
                     )]);
-                } else if let Some(channel) = self.chanmap.get_mut(&target_channel) {
+                } else if let Some(channel) =
+                    self.chanmap.get_mut(&target_channel)
+                {
                     let user = if self.supports_extended_join {
-                        accountname.as_ref().map_or(user.clone(), |accountname| {
-                            user.with_accountname(accountname)
-                        })
+                        accountname
+                            .as_ref()
+                            .map_or(user.clone(), |accountname| {
+                                user.with_accountname(accountname)
+                            })
                     } else {
                         user
                     };
@@ -1282,20 +1398,34 @@ impl Client {
                     self.statusmsg(),
                     self.casemapping(),
                 ) {
-                    if let Some(client_channel) = self.chanmap.get_mut(&target_channel) {
-                        client_channel.update_user_away(ok!(args.get(5)), ok!(args.get(6)));
+                    if let Some(client_channel) =
+                        self.chanmap.get_mut(&target_channel)
+                    {
+                        client_channel.update_user_away(
+                            ok!(args.get(5)),
+                            ok!(args.get(6)),
+                        );
 
                         let user_request = if let Some(who_poll) = self
                             .who_polls
                             .iter_mut()
                             .find(|who_poll| who_poll.channel == target_channel)
                         {
-                            if let WhoStatus::Requested(source, _, None) = &who_poll.status {
-                                who_poll.status = WhoStatus::Receiving(source.clone(), None);
-                                log::debug!("[{}] {channel} - WHO receiving...", self.server);
+                            if let WhoStatus::Requested(source, _, None) =
+                                &who_poll.status
+                            {
+                                who_poll.status =
+                                    WhoStatus::Receiving(source.clone(), None);
+                                log::debug!(
+                                    "[{}] {channel} - WHO receiving...",
+                                    self.server
+                                );
                             }
 
-                            matches!(who_poll.status, WhoStatus::Receiving(WhoSource::User, None))
+                            matches!(
+                                who_poll.status,
+                                WhoStatus::Receiving(WhoSource::User, None)
+                            )
                         } else {
                             false
                         };
@@ -1316,22 +1446,29 @@ impl Client {
                     self.statusmsg(),
                     self.casemapping(),
                 ) {
-                    if let Some(client_channel) = self.chanmap.get_mut(&target_channel) {
+                    if let Some(client_channel) =
+                        self.chanmap.get_mut(&target_channel)
+                    {
                         let user_request = if let Some(who_poll) = self
                             .who_polls
                             .iter_mut()
                             .find(|who_poll| who_poll.channel == target_channel)
                         {
                             match &who_poll.status {
-                                WhoStatus::Requested(source, _, Some(request_token))
-                                    if matches!(source, WhoSource::Poll) =>
-                                {
-                                    if let Ok(token) = ok!(args.get(1)).parse::<WhoToken>() {
+                                WhoStatus::Requested(
+                                    source,
+                                    _,
+                                    Some(request_token),
+                                ) if matches!(source, WhoSource::Poll) => {
+                                    if let Ok(token) =
+                                        ok!(args.get(1)).parse::<WhoToken>()
+                                    {
                                         if *request_token == token {
-                                            who_poll.status = WhoStatus::Receiving(
-                                                source.clone(),
-                                                Some(*request_token),
-                                            );
+                                            who_poll.status =
+                                                WhoStatus::Receiving(
+                                                    source.clone(),
+                                                    Some(*request_token),
+                                                );
                                             log::debug!(
                                                 "[{}] {channel} - WHO receiving...",
                                                 self.server
@@ -1339,29 +1476,55 @@ impl Client {
                                         }
                                     }
                                 }
-                                WhoStatus::Requested(WhoSource::User, _, Some(request_token)) => {
-                                    who_poll.status =
-                                        WhoStatus::Receiving(WhoSource::User, Some(*request_token));
+                                WhoStatus::Requested(
+                                    WhoSource::User,
+                                    _,
+                                    Some(request_token),
+                                ) => {
+                                    who_poll.status = WhoStatus::Receiving(
+                                        WhoSource::User,
+                                        Some(*request_token),
+                                    );
 
-                                    log::debug!("[{}] {channel} - WHO receiving...", self.server);
+                                    log::debug!(
+                                        "[{}] {channel} - WHO receiving...",
+                                        self.server
+                                    );
                                 }
                                 _ => (),
                             }
 
-                            if let WhoStatus::Receiving(WhoSource::Poll, Some(_)) = &who_poll.status
+                            if let WhoStatus::Receiving(
+                                WhoSource::Poll,
+                                Some(_),
+                            ) = &who_poll.status
                             {
                                 // Check token to ~ensure reply is to poll request
-                                if let Ok(token) = ok!(args.get(1)).parse::<WhoToken>() {
-                                    if token == WhoXPollParameters::Default.token() {
-                                        client_channel
-                                            .update_user_away(ok!(args.get(3)), ok!(args.get(4)));
-                                    } else if token == WhoXPollParameters::WithAccountName.token() {
+                                if let Ok(token) =
+                                    ok!(args.get(1)).parse::<WhoToken>()
+                                {
+                                    if token
+                                        == WhoXPollParameters::Default.token()
+                                    {
+                                        client_channel.update_user_away(
+                                            ok!(args.get(3)),
+                                            ok!(args.get(4)),
+                                        );
+                                    } else if token
+                                        == WhoXPollParameters::WithAccountName
+                                            .token()
+                                    {
                                         let user = ok!(args.get(3));
 
-                                        client_channel.update_user_away(user, ok!(args.get(4)));
+                                        client_channel.update_user_away(
+                                            user,
+                                            ok!(args.get(4)),
+                                        );
 
-                                        client_channel
-                                            .update_user_accountname(user, ok!(args.get(5)));
+                                        client_channel.update_user_accountname(
+                                            user,
+                                            ok!(args.get(5)),
+                                        );
                                     }
                                 }
                             }
@@ -1390,10 +1553,9 @@ impl Client {
                     self.statusmsg(),
                     self.casemapping(),
                 ) {
-                    let pos = self
-                        .who_polls
-                        .iter()
-                        .position(|who_poll| who_poll.channel == target_channel);
+                    let pos = self.who_polls.iter().position(|who_poll| {
+                        who_poll.channel == target_channel
+                    });
 
                     let user_request = pos.is_some_and(|pos| {
                         matches!(
@@ -1418,15 +1580,20 @@ impl Client {
                         if let Some(pos) = self
                             .who_polls
                             .iter()
-                            .position(|who_poll| matches!(who_poll.status, WhoStatus::Joined))
+                            .position(|who_poll| {
+                                matches!(who_poll.status, WhoStatus::Joined)
+                            })
                             .or(self.who_polls.iter().position(|who_poll| {
                                 matches!(who_poll.status, WhoStatus::Received)
                             }))
                         {
-                            self.who_polls[pos].status = WhoStatus::Waiting(Instant::now());
+                            self.who_polls[pos].status =
+                                WhoStatus::Waiting(Instant::now());
 
                             if pos != 0 {
-                                if let Some(who_poll) = self.who_polls.remove(pos) {
+                                if let Some(who_poll) =
+                                    self.who_polls.remove(pos)
+                                {
                                     self.who_polls.push_front(who_poll);
                                 }
                             }
@@ -1435,7 +1602,9 @@ impl Client {
 
                     log::debug!("[{}] {mask} - WHO done", self.server);
 
-                    if let Some(client_channel) = self.chanmap.get_mut(&target_channel) {
+                    if let Some(client_channel) =
+                        self.chanmap.get_mut(&target_channel)
+                    {
                         client_channel.who_init = true;
                     }
 
@@ -1448,7 +1617,8 @@ impl Client {
                 } else if mask == "*" {
                     // Some servers respond with the mask * instead of the requested
                     // channel name when rate-limiting WHO requests
-                    let target_channel = target::Channel::from_str(mask, self.casemapping());
+                    let target_channel =
+                        target::Channel::from_str(mask, self.casemapping());
 
                     if let Some(pos) = self
                         .who_polls
@@ -1460,13 +1630,13 @@ impl Client {
                         // User did not request, treat as part of rate-limiting reesponse
                         // (in conjunction with RPL_TRYAGAIN) and don't save to history.
                         if let Some(who_poll) = self.who_polls.front_mut() {
-                            who_poll.status = WhoStatus::Waiting(Instant::now());
+                            who_poll.status =
+                                WhoStatus::Waiting(Instant::now());
                         }
 
-                        self.who_polls
-                            .iter_mut()
-                            .skip(1)
-                            .for_each(|who_poll| who_poll.status = WhoStatus::Received);
+                        self.who_polls.iter_mut().skip(1).for_each(
+                            |who_poll| who_poll.status = WhoStatus::Received,
+                        );
 
                         return Ok(vec![]);
                     }
@@ -1518,15 +1688,22 @@ impl Client {
                 ) {
                     Target::Channel(ref channel) => {
                         if let Some(channel) = self.chanmap.get_mut(channel) {
-                            let modes = mode::parse::<mode::Channel>(modes, args);
+                            let modes =
+                                mode::parse::<mode::Channel>(modes, args);
 
                             for mode in modes {
-                                if let Some((op, lookup)) = mode
-                                    .operation()
-                                    .zip(mode.arg().map(|nick| User::from(Nick::from(nick))))
+                                if let Some((op, lookup)) =
+                                    mode.operation().zip(mode.arg().map(
+                                        |nick| User::from(Nick::from(nick)),
+                                    ))
                                 {
-                                    if let Some(mut user) = channel.users.take(&lookup) {
-                                        user.update_access_level(op, *mode.value());
+                                    if let Some(mut user) =
+                                        channel.users.take(&lookup)
+                                    {
+                                        user.update_access_level(
+                                            op,
+                                            *mode.value(),
+                                        );
                                         channel.users.insert(user);
                                     }
                                 }
@@ -1544,7 +1721,13 @@ impl Client {
                             let modes = mode::parse::<mode::User>(modes, args);
 
                             if modes.into_iter().any(|mode| {
-                                matches!(mode, mode::Mode::Add(mode::User::Registered, None))
+                                matches!(
+                                    mode,
+                                    mode::Mode::Add(
+                                        mode::User::Registered,
+                                        None
+                                    )
+                                )
                             }) {
                                 for message in group_joins(
                                     &self.registration_required_channels,
@@ -1562,12 +1745,14 @@ impl Client {
             Command::Numeric(RPL_NAMREPLY, args) if args.len() > 3 => {
                 let channel = ok!(args.get(2));
 
-                if let Some(channel) = self.chanmap.get_mut(&context!(target::Channel::parse(
-                    channel,
-                    self.chantypes(),
-                    self.statusmsg(),
-                    self.casemapping(),
-                ))) {
+                if let Some(channel) =
+                    self.chanmap.get_mut(&context!(target::Channel::parse(
+                        channel,
+                        self.chantypes(),
+                        self.statusmsg(),
+                        self.casemapping(),
+                    )))
+                {
                     for user in args[3].split(' ') {
                         if let Ok(user) = User::try_from(user) {
                             channel.users.insert(user);
@@ -1599,31 +1784,38 @@ impl Client {
                 }
             }
             Command::TOPIC(channel, topic) => {
-                if let Some(channel) = self.chanmap.get_mut(&context!(target::Channel::parse(
-                    channel,
-                    self.chantypes(),
-                    self.statusmsg(),
-                    self.casemapping(),
-                ))) {
+                if let Some(channel) =
+                    self.chanmap.get_mut(&context!(target::Channel::parse(
+                        channel,
+                        self.chantypes(),
+                        self.statusmsg(),
+                        self.casemapping(),
+                    )))
+                {
                     if let Some(text) = topic {
-                        channel.topic.content = Some(message::parse_fragments(text.clone()));
+                        channel.topic.content =
+                            Some(message::parse_fragments(text.clone()));
                     }
 
-                    channel.topic.who = message.user().map(|user| user.nickname().to_string());
+                    channel.topic.who =
+                        message.user().map(|user| user.nickname().to_string());
                     channel.topic.time = Some(server_time(&message));
                 }
             }
             Command::Numeric(RPL_TOPIC, args) => {
                 let channel = ok!(args.get(1));
 
-                if let Some(channel) = self.chanmap.get_mut(&context!(target::Channel::parse(
-                    channel,
-                    self.chantypes(),
-                    self.statusmsg(),
-                    self.casemapping(),
-                ))) {
-                    channel.topic.content =
-                        Some(message::parse_fragments(ok!(args.get(2)).to_owned()));
+                if let Some(channel) =
+                    self.chanmap.get_mut(&context!(target::Channel::parse(
+                        channel,
+                        self.chantypes(),
+                        self.statusmsg(),
+                        self.casemapping(),
+                    )))
+                {
+                    channel.topic.content = Some(message::parse_fragments(
+                        ok!(args.get(2)).to_owned(),
+                    ));
                 }
                 // Exclude topic message from history to prevent spam during dev
                 #[cfg(feature = "dev")]
@@ -1632,17 +1824,23 @@ impl Client {
             Command::Numeric(RPL_TOPICWHOTIME, args) => {
                 let channel = ok!(args.get(1));
 
-                if let Some(channel) = self.chanmap.get_mut(&context!(target::Channel::parse(
-                    channel,
-                    self.chantypes(),
-                    self.statusmsg(),
-                    self.casemapping(),
-                ))) {
+                if let Some(channel) =
+                    self.chanmap.get_mut(&context!(target::Channel::parse(
+                        channel,
+                        self.chantypes(),
+                        self.statusmsg(),
+                        self.casemapping(),
+                    )))
+                {
                     channel.topic.who = Some(ok!(args.get(2)).to_string());
-                    let timestamp = Posix::from_seconds(ok!(args.get(3)).parse::<u64>()?);
+                    let timestamp =
+                        Posix::from_seconds(ok!(args.get(3)).parse::<u64>()?);
                     channel.topic.time =
                         Some(timestamp.datetime().ok_or_else(|| {
-                            anyhow!("Unable to parse timestamp: {:?}", timestamp)
+                            anyhow!(
+                                "Unable to parse timestamp: {:?}",
+                                timestamp
+                            )
                         })?);
                 }
                 // Exclude topic message from history to prevent spam during dev
@@ -1661,11 +1859,9 @@ impl Client {
                 // then interpret this numeric as ERR_NEEDREGGEDNICK (which has the
                 // same number as ERR_NOCHANMODES)
                 if !self.chanmap.contains_key(&channel)
-                    && self
-                        .config
-                        .channels
-                        .iter()
-                        .any(|config_channel| config_channel == channel.as_str())
+                    && self.config.channels.iter().any(|config_channel| {
+                        config_channel == channel.as_str()
+                    })
                 {
                     self.registration_required_channels.push(channel.clone());
                 }
@@ -1686,16 +1882,23 @@ impl Client {
                                             parameter
                                         );
 
-                                        self.isupport.insert(kind.clone(), parameter.clone());
+                                        self.isupport.insert(
+                                            kind.clone(),
+                                            parameter.clone(),
+                                        );
 
-                                        if let isupport::Parameter::MONITOR(target_limit) =
-                                            parameter
+                                        if let isupport::Parameter::MONITOR(
+                                            target_limit,
+                                        ) = parameter
                                         {
-                                            let messages =
-                                                group_monitors(&self.config.monitor, target_limit);
+                                            let messages = group_monitors(
+                                                &self.config.monitor,
+                                                target_limit,
+                                            );
 
                                             for message in messages {
-                                                self.handle.try_send(message)?;
+                                                self.handle
+                                                    .try_send(message)?;
                                             }
                                         }
                                     } else {
@@ -1741,7 +1944,9 @@ impl Client {
 
                 self.chanmap.values_mut().for_each(|channel| {
                     if let Some(user) = channel.users.take(&old_user) {
-                        channel.users.insert(user.with_accountname(accountname));
+                        channel
+                            .users
+                            .insert(user.with_accountname(accountname));
                     }
                 });
 
@@ -1839,7 +2044,8 @@ impl Client {
 
                     match target {
                         Target::Channel(ref channel) => {
-                            if !channel.prefixes().is_empty() && self.chanmap.contains_key(channel)
+                            if !channel.prefixes().is_empty()
+                                && self.chanmap.contains_key(channel)
                             {
                                 events.push(Event::ChatHistoryTargetReceived(
                                     target,
@@ -1857,7 +2063,10 @@ impl Client {
 
                     if self.chathistory_targets_request.is_none() {
                         // User requested, save to history
-                        events.push(Event::Single(message.clone(), self.nickname().to_owned()));
+                        events.push(Event::Single(
+                            message.clone(),
+                            self.nickname().to_owned(),
+                        ));
                     }
                 }
 
@@ -1884,7 +2093,10 @@ impl Client {
                     );
 
                     if !self.who_polls.iter().any(|who_poll| {
-                        matches!(who_poll.status, WhoStatus::Requested(WhoSource::User, _, _))
+                        matches!(
+                            who_poll.status,
+                            WhoStatus::Requested(WhoSource::User, _, _)
+                        )
                     }) {
                         // No user request, rate-limited due to WHO polling
                         return Ok(vec![]);
@@ -1900,21 +2112,28 @@ impl Client {
                     self.registration_step = RegistrationStep::Complete;
 
                     // Send nick password & ghost
-                    if let Some(nick_pass) = self.config.nick_password.as_ref() {
+                    if let Some(nick_pass) = self.config.nick_password.as_ref()
+                    {
                         // Try ghost recovery if we couldn't claim our nick
                         if self.config.should_ghost
-                            && self.resolved_nick == Some(self.config.nickname.clone())
+                            && self.resolved_nick
+                                == Some(self.config.nickname.clone())
                         {
                             for sequence in &self.config.ghost_sequence {
                                 self.handle.try_send(command!(
                                     "PRIVMSG",
                                     "NickServ",
-                                    format!("{sequence} {} {nick_pass}", &self.config.nickname)
+                                    format!(
+                                        "{sequence} {} {nick_pass}",
+                                        &self.config.nickname
+                                    )
                                 ))?;
                             }
                         }
 
-                        if let Some(identify_syntax) = &self.config.nick_identify_syntax {
+                        if let Some(identify_syntax) =
+                            &self.config.nick_identify_syntax
+                        {
                             match identify_syntax {
                                 config::server::IdentifySyntax::PasswordNick => {
                                     self.handle.try_send(command!(
@@ -1931,7 +2150,9 @@ impl Client {
                                     ))?;
                                 }
                             }
-                        } else if self.resolved_nick == Some(self.config.nickname.clone()) {
+                        } else if self.resolved_nick
+                            == Some(self.config.nickname.clone())
+                        {
                             // Use nickname-less identification if possible, since it has
                             // no possible argument order issues.
                             self.handle.try_send(command!(
@@ -1944,30 +2165,43 @@ impl Client {
                             self.handle.try_send(command!(
                                 "PRIVMSG",
                                 "NickServ",
-                                format!("IDENTIFY {} {nick_pass}", &self.config.nickname)
+                                format!(
+                                    "IDENTIFY {} {nick_pass}",
+                                    &self.config.nickname
+                                )
                             ))?;
                         }
                     }
 
                     // Send user modestring
-                    if let (Some(nick), Some(modestring)) =
-                        (self.resolved_nick.clone(), self.config.umodes.as_ref())
-                    {
-                        self.handle.try_send(command!("MODE", nick, modestring))?;
+                    if let (Some(nick), Some(modestring)) = (
+                        self.resolved_nick.clone(),
+                        self.config.umodes.as_ref(),
+                    ) {
+                        self.handle
+                            .try_send(command!("MODE", nick, modestring))?;
                     }
 
                     let mut events = vec![];
 
                     // Loop on connect commands
                     for command in self.config.on_connect.iter() {
-                        match crate::command::parse(command, None, &self.isupport) {
+                        match crate::command::parse(
+                            command,
+                            None,
+                            &self.isupport,
+                        ) {
                             Ok(crate::Command::Irc(cmd)) => {
-                                if let Ok(command) = proto::Command::try_from(cmd) {
+                                if let Ok(command) =
+                                    proto::Command::try_from(cmd)
+                                {
                                     self.handle.try_send(command.into())?;
                                 }
                             }
                             Ok(crate::Command::Internal(cmd)) => match cmd {
-                                crate::command::Internal::OpenBuffers(targets) => {
+                                crate::command::Internal::OpenBuffers(
+                                    targets,
+                                ) => {
                                     events.push(Event::OpenBuffers(
                                         targets
                                             .split(",")
@@ -1980,12 +2214,16 @@ impl Client {
                                                 )
                                             })
                                             .map(|target| match target {
-                                                Target::Channel(_) => {
-                                                    (target, config.buffer.message_channel)
-                                                }
-                                                Target::Query(_) => {
-                                                    (target, config.buffer.message_user)
-                                                }
+                                                Target::Channel(_) => (
+                                                    target,
+                                                    config
+                                                        .buffer
+                                                        .message_channel,
+                                                ),
+                                                Target::Query(_) => (
+                                                    target,
+                                                    config.buffer.message_user,
+                                                ),
                                             })
                                             .collect(),
                                     ));
@@ -2011,7 +2249,9 @@ impl Client {
                         .collect::<Vec<_>>();
 
                     // Send JOIN
-                    for message in group_joins(&channels, &self.config.channel_keys) {
+                    for message in
+                        group_joins(&channels, &self.config.channel_keys)
+                    {
                         self.handle.try_send(message)?;
                     }
 
@@ -2024,7 +2264,11 @@ impl Client {
         Ok(vec![Event::Single(message, self.nickname().to_owned())])
     }
 
-    pub fn send_markread(&mut self, target: Target, read_marker: ReadMarker) -> Result<()> {
+    pub fn send_markread(
+        &mut self,
+        target: Target,
+        read_marker: ReadMarker,
+    ) -> Result<()> {
         if self.supports_read_marker {
             self.handle.try_send(command!(
                 "MARKREAD",
@@ -2041,7 +2285,9 @@ impl Client {
     // e.g. '#chat', '##chat-offtopic' and '&chat-local' all get sorted together instead of in
     // wildly different places.
     fn compare_channels(&self, a: &str, b: &str) -> Ordering {
-        let (Some(a_chantype), Some(b_chantype)) = (a.chars().nth(0), b.chars().nth(0)) else {
+        let (Some(a_chantype), Some(b_chantype)) =
+            (a.chars().nth(0), b.chars().nth(0))
+        else {
             return a.cmp(b);
         };
 
@@ -2071,7 +2317,9 @@ impl Client {
         CLIENT_CHATHISTORY_LIMIT
     }
 
-    pub fn chathistory_message_reference_types(&self) -> Vec<isupport::MessageReferenceType> {
+    pub fn chathistory_message_reference_types(
+        &self,
+    ) -> Vec<isupport::MessageReferenceType> {
         if let Some(isupport::Parameter::MSGREFTYPES(message_reference_types)) =
             self.isupport.get(&isupport::Kind::MSGREFTYPES)
         {
@@ -2081,13 +2329,19 @@ impl Client {
         }
     }
 
-    pub fn chathistory_request(&self, target: &Target) -> Option<ChatHistorySubcommand> {
+    pub fn chathistory_request(
+        &self,
+        target: &Target,
+    ) -> Option<ChatHistorySubcommand> {
         self.chathistory_requests
             .get(target)
             .map(|request| request.subcommand.clone())
     }
 
-    pub fn send_chathistory_request(&mut self, subcommand: ChatHistorySubcommand) {
+    pub fn send_chathistory_request(
+        &mut self,
+        subcommand: ChatHistorySubcommand,
+    ) {
         use std::collections::hash_map;
 
         if self.supports_chathistory {
@@ -2117,9 +2371,15 @@ impl Client {
             }
 
             match subcommand {
-                ChatHistorySubcommand::Latest(target, message_reference, limit) => {
+                ChatHistorySubcommand::Latest(
+                    target,
+                    message_reference,
+                    limit,
+                ) => {
                     let command_message_reference =
-                        isupport::fuzz_start_message_reference(message_reference);
+                        isupport::fuzz_start_message_reference(
+                            message_reference,
+                        );
 
                     log::debug!(
                         "[{}] requesting {limit} latest messages in {target} since {}",
@@ -2135,7 +2395,11 @@ impl Client {
                         limit.to_string(),
                     ));
                 }
-                ChatHistorySubcommand::Before(target, message_reference, limit) => {
+                ChatHistorySubcommand::Before(
+                    target,
+                    message_reference,
+                    limit,
+                ) => {
                     let command_message_reference =
                         isupport::fuzz_end_message_reference(message_reference);
 
@@ -2159,11 +2423,13 @@ impl Client {
                     end_message_reference,
                     limit,
                 ) => {
-                    let (command_start_message_reference, command_end_message_reference) =
-                        isupport::fuzz_message_reference_range(
-                            start_message_reference,
-                            end_message_reference,
-                        );
+                    let (
+                        command_start_message_reference,
+                        command_end_message_reference,
+                    ) = isupport::fuzz_message_reference_range(
+                        start_message_reference,
+                        end_message_reference,
+                    );
 
                     log::debug!(
                         "[{}] requesting {limit} messages in {target} between {} and {}",
@@ -2186,21 +2452,33 @@ impl Client {
                     end_message_reference,
                     limit,
                 ) => {
-                    let command_start_message_reference = match start_message_reference {
-                        isupport::MessageReference::Timestamp(_) => start_message_reference,
-                        _ => isupport::MessageReference::Timestamp(DateTime::UNIX_EPOCH),
-                    };
+                    let command_start_message_reference =
+                        match start_message_reference {
+                            isupport::MessageReference::Timestamp(_) => {
+                                start_message_reference
+                            }
+                            _ => isupport::MessageReference::Timestamp(
+                                DateTime::UNIX_EPOCH,
+                            ),
+                        };
 
-                    let command_end_message_reference = match end_message_reference {
-                        isupport::MessageReference::Timestamp(_) => end_message_reference,
-                        _ => isupport::MessageReference::Timestamp(chrono::offset::Utc::now()),
-                    };
+                    let command_end_message_reference =
+                        match end_message_reference {
+                            isupport::MessageReference::Timestamp(_) => {
+                                end_message_reference
+                            }
+                            _ => isupport::MessageReference::Timestamp(
+                                chrono::offset::Utc::now(),
+                            ),
+                        };
 
-                    let (command_start_message_reference, command_end_message_reference) =
-                        isupport::fuzz_message_reference_range(
-                            command_start_message_reference,
-                            command_end_message_reference,
-                        );
+                    let (
+                        command_start_message_reference,
+                        command_end_message_reference,
+                    ) = isupport::fuzz_message_reference_range(
+                        command_start_message_reference,
+                        command_end_message_reference,
+                    );
 
                     log::debug!(
                         "[{}] requesting {limit} targets between {} and {}",
@@ -2250,11 +2528,13 @@ impl Client {
                 .ok()
                 .flatten();
 
-            let start_message_reference = timestamp.map_or(MessageReference::None, |timestamp| {
-                MessageReference::Timestamp(timestamp)
-            });
+            let start_message_reference = timestamp
+                .map_or(MessageReference::None, |timestamp| {
+                    MessageReference::Timestamp(timestamp)
+                });
 
-            let end_message_reference = MessageReference::Timestamp(server_time);
+            let end_message_reference =
+                MessageReference::Timestamp(server_time);
 
             Message::ChatHistoryRequest(
                 server,
@@ -2275,9 +2555,15 @@ impl Client {
         let server = self.server.clone();
 
         async move {
-            let result = overwrite_chathistory_targets_timestamp(server.clone(), timestamp).await;
+            let result = overwrite_chathistory_targets_timestamp(
+                server.clone(),
+                timestamp,
+            )
+            .await;
 
-            Message::ChatHistoryTargetsTimestampUpdated(server, timestamp, result)
+            Message::ChatHistoryTargetsTimestampUpdated(
+                server, timestamp, result,
+            )
         }
         .boxed()
     }
@@ -2287,7 +2573,12 @@ impl Client {
             .chanmap
             .keys()
             .cloned()
-            .sorted_by(|a, b| self.compare_channels(a.as_normalized_str(), b.as_normalized_str()))
+            .sorted_by(|a, b| {
+                self.compare_channels(
+                    a.as_normalized_str(),
+                    b.as_normalized_str(),
+                )
+            })
             .collect();
         self.users = self
             .chanmap
@@ -2338,7 +2629,10 @@ impl Client {
             .collect()
     }
 
-    fn resolve_query<'a>(&'a self, query: &target::Query) -> Option<&'a target::Query> {
+    fn resolve_query<'a>(
+        &'a self,
+        query: &target::Query,
+    ) -> Option<&'a target::Query> {
         self.resolved_queries.get(query)
     }
 
@@ -2355,7 +2649,8 @@ impl Client {
         match self.highlight_notification_blackout {
             HighlightNotificationBlackout::Blackout(instant) => {
                 if now.duration_since(instant) >= HIGHLIGHT_BLACKOUT_INTERVAL {
-                    self.highlight_notification_blackout = HighlightNotificationBlackout::Receiving;
+                    self.highlight_notification_blackout =
+                        HighlightNotificationBlackout::Receiving;
                 }
             }
             HighlightNotificationBlackout::Receiving => {}
@@ -2369,26 +2664,34 @@ impl Client {
             }
 
             let request = match &who_poll.status {
-                WhoStatus::Joined => (self.supports_away_notify || self.config.who_poll_enabled)
+                WhoStatus::Joined => (self.supports_away_notify
+                    || self.config.who_poll_enabled)
                     .then_some(Request::Poll),
                 WhoStatus::Waiting(last) => {
                     if self.supports_away_notify {
-                        self.chanmap.get(&who_poll.channel).and_then(|channel| {
-                            (!channel.who_init
-                                && (now.duration_since(*last) >= self.who_poll_interval.duration))
-                                .then_some(Request::Poll)
-                        })
+                        self.chanmap.get(&who_poll.channel).and_then(
+                            |channel| {
+                                (!channel.who_init
+                                    && (now.duration_since(*last)
+                                        >= self.who_poll_interval.duration))
+                                    .then_some(Request::Poll)
+                            },
+                        )
                     } else {
                         (self.config.who_poll_enabled
-                            && (now.duration_since(*last) >= self.who_poll_interval.duration))
+                            && (now.duration_since(*last)
+                                >= self.who_poll_interval.duration))
                             .then_some(Request::Poll)
                     }
                 }
                 WhoStatus::Requested(source, requested, _) => {
-                    if matches!(source, WhoSource::Poll) && !self.config.who_poll_enabled {
+                    if matches!(source, WhoSource::Poll)
+                        && !self.config.who_poll_enabled
+                    {
                         None
                     } else {
-                        (now.duration_since(*requested) >= 5 * self.who_poll_interval.duration)
+                        (now.duration_since(*requested)
+                            >= 5 * self.who_poll_interval.duration)
                             .then_some(Request::Retry)
                     }
                 }
@@ -2416,10 +2719,16 @@ impl Client {
                         whox_params.token().to_owned()
                     ))?;
                 } else {
-                    who_poll.status = WhoStatus::Requested(WhoSource::Poll, Instant::now(), None);
+                    who_poll.status = WhoStatus::Requested(
+                        WhoSource::Poll,
+                        Instant::now(),
+                        None,
+                    );
 
-                    self.handle
-                        .try_send(command!("WHO", who_poll.channel.to_string()))?;
+                    self.handle.try_send(command!(
+                        "WHO",
+                        who_poll.channel.to_string()
+                    ))?;
                 }
 
                 log::debug!(
@@ -2435,7 +2744,8 @@ impl Client {
         }
 
         self.chathistory_requests.retain(|_, chathistory_request| {
-            now.duration_since(chathistory_request.requested_at) < CHATHISTORY_REQUEST_TIMEOUT
+            now.duration_since(chathistory_request.requested_at)
+                < CHATHISTORY_REQUEST_TIMEOUT
         });
 
         Ok(())
@@ -2485,17 +2795,21 @@ fn continue_chathistory_between(
     end_message_reference: &MessageReference,
     limit: u16,
 ) -> Option<ChatHistorySubcommand> {
-    let start_message_reference = events.first().and_then(|first_event| match first_event {
-        Event::Single(message, _) | Event::WithTarget(message, _, _) => match end_message_reference
-        {
-            MessageReference::MessageId(_) => message_id(message).map(MessageReference::MessageId),
-            MessageReference::Timestamp(_) => {
-                Some(MessageReference::Timestamp(server_time(message)))
+    let start_message_reference =
+        events.first().and_then(|first_event| match first_event {
+            Event::Single(message, _) | Event::WithTarget(message, _, _) => {
+                match end_message_reference {
+                    MessageReference::MessageId(_) => {
+                        message_id(message).map(MessageReference::MessageId)
+                    }
+                    MessageReference::Timestamp(_) => {
+                        Some(MessageReference::Timestamp(server_time(message)))
+                    }
+                    MessageReference::None => None,
+                }
             }
-            MessageReference::None => None,
-        },
-        _ => None,
-    });
+            _ => None,
+        });
 
     start_message_reference.map(|start_message_reference| {
         ChatHistorySubcommand::Between(
@@ -2627,7 +2941,11 @@ impl Map {
         }
     }
 
-    pub fn send(&mut self, buffer: &buffer::Upstream, message: message::Encoded) {
+    pub fn send(
+        &mut self,
+        buffer: &buffer::Upstream,
+        message: message::Encoded,
+    ) {
         if let Some(client) = self.client_mut(buffer.server()) {
             client.send(buffer, message);
         }
@@ -2691,7 +3009,11 @@ impl Map {
             .unwrap_or_default()
     }
 
-    pub fn get_user_channels(&self, server: &Server, nick: NickRef) -> Vec<target::Channel> {
+    pub fn get_user_channels(
+        &self,
+        server: &Server,
+        nick: NickRef,
+    ) -> Vec<target::Channel> {
         self.client(server)
             .map(|client| client.user_channels(nick))
             .unwrap_or_default()
@@ -2707,7 +3029,10 @@ impl Map {
             .unwrap_or_default()
     }
 
-    pub fn get_channels<'a>(&'a self, server: &Server) -> &'a [target::Channel] {
+    pub fn get_channels<'a>(
+        &'a self,
+        server: &Server,
+    ) -> &'a [target::Channel] {
         self.client(server)
             .map(|client| client.channels())
             .unwrap_or_default()
@@ -2722,7 +3047,10 @@ impl Map {
             .and_then(|client| client.resolve_query(query))
     }
 
-    pub fn get_isupport(&self, server: &Server) -> HashMap<isupport::Kind, isupport::Parameter> {
+    pub fn get_isupport(
+        &self,
+        server: &Server,
+    ) -> HashMap<isupport::Kind, isupport::Parameter> {
         self.client(server)
             .map(|client| client.isupport.clone())
             .unwrap_or_default()
@@ -2757,7 +3085,9 @@ impl Map {
 
     pub fn get_server_chathistory_limit(&self, server: &Server) -> u16 {
         self.client(server)
-            .map_or(CLIENT_CHATHISTORY_LIMIT, |client| client.chathistory_limit())
+            .map_or(CLIENT_CHATHISTORY_LIMIT, |client| {
+                client.chathistory_limit()
+            })
     }
 
     pub fn get_server_supports_chathistory(&self, server: &Server) -> bool {
@@ -2774,19 +3104,31 @@ impl Map {
             .and_then(|client| client.chathistory_request(target))
     }
 
-    pub fn send_chathistory_request(&mut self, server: &Server, subcommand: ChatHistorySubcommand) {
+    pub fn send_chathistory_request(
+        &mut self,
+        server: &Server,
+        subcommand: ChatHistorySubcommand,
+    ) {
         if let Some(client) = self.client_mut(server) {
             client.send_chathistory_request(subcommand);
         }
     }
 
-    pub fn clear_chathistory_request(&mut self, server: &Server, target: Option<&Target>) {
+    pub fn clear_chathistory_request(
+        &mut self,
+        server: &Server,
+        target: Option<&Target>,
+    ) {
         if let Some(client) = self.client_mut(server) {
             client.clear_chathistory_request(target);
         }
     }
 
-    pub fn get_chathistory_exhausted(&self, server: &Server, target: &Target) -> bool {
+    pub fn get_chathistory_exhausted(
+        &self,
+        server: &Server,
+        target: &Target,
+    ) -> bool {
         self.client(server)
             .is_some_and(|client| client.chathistory_exhausted(target))
     }
@@ -2816,8 +3158,9 @@ impl Map {
         server: &Server,
         server_time: DateTime<Utc>,
     ) -> Option<impl Future<Output = Message> + use<>> {
-        self.client(server)
-            .map(|client| client.load_chathistory_targets_timestamp(server_time))
+        self.client(server).map(|client| {
+            client.load_chathistory_targets_timestamp(server_time)
+        })
     }
 
     pub fn overwrite_chathistory_targets_timestamp(
@@ -2825,11 +3168,15 @@ impl Map {
         server: &Server,
         server_time: DateTime<Utc>,
     ) -> Option<impl Future<Output = Message> + use<>> {
-        self.client(server)
-            .map(|client| client.overwrite_chathistory_targets_timestamp(server_time))
+        self.client(server).map(|client| {
+            client.overwrite_chathistory_targets_timestamp(server_time)
+        })
     }
 
-    pub fn get_server_handle(&self, server: &Server) -> Option<&server::Handle> {
+    pub fn get_server_handle(
+        &self,
+        server: &Server,
+    ) -> Option<&server::Handle> {
         self.client(server).map(|client| &client.handle)
     }
 
@@ -2848,20 +3195,18 @@ impl Map {
     }
 
     pub fn status(&self, server: &Server) -> Status {
-        self.0
-            .get(server)
-            .map_or(Status::Unavailable, |s| match s {
-                State::Disconnected => Status::Disconnected,
-                State::Ready(_) => Status::Connected,
-            })
+        self.0.get(server).map_or(Status::Unavailable, |s| match s {
+            State::Disconnected => Status::Disconnected,
+            State::Ready(_) => Status::Connected,
+        })
     }
 
     pub fn tick(&mut self, now: Instant) -> Result<()> {
         for client in self.0.values_mut() {
             if let State::Ready(client) = client {
-                client
-                    .tick(now)
-                    .with_context(|| anyhow!("[{}] tick failed", client.server))?;
+                client.tick(now).with_context(|| {
+                    anyhow!("[{}] tick failed", client.server)
+                })?;
             }
         }
         Ok(())
@@ -2904,7 +3249,9 @@ pub enum ChatHistoryBatch {
 impl ChatHistoryBatch {
     pub fn target(&self) -> Option<Target> {
         match self {
-            ChatHistoryBatch::Target(batch_target) => Some(batch_target.clone()),
+            ChatHistoryBatch::Target(batch_target) => {
+                Some(batch_target.clone())
+            }
             ChatHistoryBatch::Targets => None,
         }
     }
@@ -3060,7 +3407,8 @@ impl BackoffInterval {
             BackoffMode::Set => (),
             BackoffMode::EasingOn => {
                 self.previous = self.duration;
-                self.duration = std::cmp::max(self.duration.mul_f64(0.9), self.original);
+                self.duration =
+                    std::cmp::max(self.duration.mul_f64(0.9), self.original);
             }
             BackoffMode::BackingOff(count) => {
                 *count += 1;
@@ -3080,7 +3428,10 @@ impl BackoffInterval {
             }
             _ => {
                 self.mode = BackoffMode::BackingOff(0);
-                self.duration = std::cmp::min(self.duration.mul_f64(2.0), 256 * self.original);
+                self.duration = std::cmp::min(
+                    self.duration.mul_f64(2.0),
+                    256 * self.original,
+                );
             }
         }
     }
@@ -3103,7 +3454,9 @@ fn group_capability_requests<'a>(
         })
         .into_group_map()
         .into_values()
-        .map(|capabilities| command!("CAP", "REQ", capabilities.into_iter().join(" ")))
+        .map(|capabilities| {
+            command!("CAP", "REQ", capabilities.into_iter().join(" "))
+        })
 }
 
 /// Group channels together into as few JOIN messages as possible
@@ -3113,10 +3466,13 @@ fn group_joins<'a>(
 ) -> impl Iterator<Item = proto::Message> + 'a {
     const MAX_LEN: usize = proto::format::BYTE_LIMIT - b"JOIN \r\n".len();
 
-    let (without_keys, with_keys): (Vec<_>, Vec<_>) = channels.iter().partition_map(|channel| {
-        keys.get(channel.as_str())
-            .map_or(Either::Left(channel), |key| Either::Right((channel, key)))
-    });
+    let (without_keys, with_keys): (Vec<_>, Vec<_>) =
+        channels.iter().partition_map(|channel| {
+            keys.get(channel.as_str())
+                .map_or(Either::Left(channel), |key| {
+                    Either::Right((channel, key))
+                })
+        });
 
     let joins_without_keys = without_keys
         .into_iter()

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1268,7 +1268,7 @@ impl Client {
                         }
                     }
                     None if !self.config.alt_nicks.is_empty() => {
-                        self.alt_nick = Some(0)
+                        self.alt_nick = Some(0);
                     }
                     None => {}
                 }

--- a/data/src/command.rs
+++ b/data/src/command.rs
@@ -6,7 +6,8 @@ use irc::proto;
 use itertools::Itertools;
 
 use crate::isupport::{self, find_target_limit};
-use crate::{buffer, ctcp, message::formatting};
+use crate::message::formatting;
+use crate::{buffer, ctcp};
 
 #[derive(Debug, Clone)]
 pub enum Command {
@@ -116,83 +117,93 @@ pub fn parse(
 
     match cmd.parse::<Kind>() {
         Ok(kind) => match kind {
-            Kind::Join => validated::<1, 1, false>(args, |[chanlist], [chankeys]| {
-                let chan_limits = if let Some(isupport::Parameter::CHANLIMIT(limits)) =
-                    isupport.get(&isupport::Kind::CHANLIMIT)
-                {
-                    Some(limits)
-                } else {
-                    None
-                };
+            Kind::Join => {
+                validated::<1, 1, false>(args, |[chanlist], [chankeys]| {
+                    let chan_limits =
+                        if let Some(isupport::Parameter::CHANLIMIT(limits)) =
+                            isupport.get(&isupport::Kind::CHANLIMIT)
+                        {
+                            Some(limits)
+                        } else {
+                            None
+                        };
 
-                let channel_len = if let Some(isupport::Parameter::CHANNELLEN(max_len)) =
-                    isupport.get(&isupport::Kind::CHANNELLEN)
-                {
-                    Some(*max_len as usize)
-                } else {
-                    None
-                };
+                    let channel_len =
+                        if let Some(isupport::Parameter::CHANNELLEN(max_len)) =
+                            isupport.get(&isupport::Kind::CHANNELLEN)
+                        {
+                            Some(*max_len as usize)
+                        } else {
+                            None
+                        };
 
-                if chan_limits.is_some() || channel_len.is_some() {
-                    let channels = chanlist.split(',').collect::<Vec<_>>();
+                    if chan_limits.is_some() || channel_len.is_some() {
+                        let channels = chanlist.split(',').collect::<Vec<_>>();
 
-                    if let Some(chan_limits) = chan_limits {
-                        for chan_limit in chan_limits {
-                            if let Some(limit) = chan_limit.limit {
-                                let limit = limit as usize;
+                        if let Some(chan_limits) = chan_limits {
+                            for chan_limit in chan_limits {
+                                if let Some(limit) = chan_limit.limit {
+                                    let limit = limit as usize;
 
-                                if channels
-                                    .iter()
-                                    .filter(|channel| channel.starts_with(chan_limit.prefix))
-                                    .count()
-                                    > limit
-                                {
-                                    return Err(Error::TooManyTargets {
-                                        name: "channels",
-                                        number: channels.len(),
-                                        max_number: limit,
-                                    });
+                                    if channels
+                                        .iter()
+                                        .filter(|channel| {
+                                            channel
+                                                .starts_with(chan_limit.prefix)
+                                        })
+                                        .count()
+                                        > limit
+                                    {
+                                        return Err(Error::TooManyTargets {
+                                            name: "channels",
+                                            number: channels.len(),
+                                            max_number: limit,
+                                        });
+                                    }
                                 }
+                            }
+                        }
+
+                        if let Some(max_len) = channel_len {
+                            if let Some(channel) = channels
+                                .into_iter()
+                                .find(|channel| channel.len() > max_len)
+                            {
+                                return Err(Error::ArgTooLong {
+                                    name: "channel in chanlist",
+                                    len: channel.len(),
+                                    max_len,
+                                });
                             }
                         }
                     }
 
-                    if let Some(max_len) = channel_len {
-                        if let Some(channel) =
-                            channels.into_iter().find(|channel| channel.len() > max_len)
+                    if let Some(ref chankeys) = chankeys {
+                        if let Some(isupport::Parameter::KEYLEN(max_len)) =
+                            isupport.get(&isupport::Kind::KEYLEN)
                         {
-                            return Err(Error::ArgTooLong {
-                                name: "channel in chanlist",
-                                len: channel.len(),
-                                max_len,
-                            });
+                            let max_len = *max_len as usize;
+
+                            let keys = chankeys.split(',').collect::<Vec<_>>();
+
+                            if let Some(key) =
+                                keys.into_iter().find(|key| key.len() > max_len)
+                            {
+                                return Err(Error::ArgTooLong {
+                                    name: "key in chankeys",
+                                    len: key.len(),
+                                    max_len,
+                                });
+                            }
                         }
                     }
-                }
 
-                if let Some(ref chankeys) = chankeys {
-                    if let Some(isupport::Parameter::KEYLEN(max_len)) =
-                        isupport.get(&isupport::Kind::KEYLEN)
-                    {
-                        let max_len = *max_len as usize;
-
-                        let keys = chankeys.split(',').collect::<Vec<_>>();
-
-                        if let Some(key) = keys.into_iter().find(|key| key.len() > max_len) {
-                            return Err(Error::ArgTooLong {
-                                name: "key in chankeys",
-                                len: key.len(),
-                                max_len,
-                            });
-                        }
-                    }
-                }
-
-                Ok(Command::Irc(Irc::Join(chanlist, chankeys)))
-            }),
-            Kind::Motd => {
-                validated::<0, 1, false>(args, |_, [target]| Ok(Command::Irc(Irc::Motd(target))))
+                    Ok(Command::Irc(Irc::Join(chanlist, chankeys)))
+                })
             }
+            Kind::Motd => validated::<0, 1, false>(args, |_, [target]| {
+                Ok(Command::Irc(Irc::Motd(target)))
+            }),
             Kind::Nick => validated::<1, 0, false>(args, |[nick], _| {
                 if let Some(isupport::Parameter::NICKLEN(max_len)) =
                     isupport.get(&isupport::Kind::NICKLEN)
@@ -210,12 +221,12 @@ pub fn parse(
 
                 Ok(Command::Irc(Irc::Nick(nick)))
             }),
-            Kind::Quit => {
-                validated::<0, 1, true>(args, |_, [comment]| Ok(Command::Irc(Irc::Quit(comment))))
-            }
+            Kind::Quit => validated::<0, 1, true>(args, |_, [comment]| {
+                Ok(Command::Irc(Irc::Quit(comment)))
+            }),
             Kind::Msg => validated::<1, 1, true>(args, |[targets], [msg]| {
-                let target_limit =
-                    find_target_limit(isupport, "PRIVMSG").map(|limit| limit as usize);
+                let target_limit = find_target_limit(isupport, "PRIVMSG")
+                    .map(|limit| limit as usize);
 
                 if let Some(target_limit) = target_limit {
                     let targets = targets.split(',').collect::<Vec<_>>();
@@ -245,7 +256,8 @@ pub fn parse(
                 }
             }
             Kind::Whois => validated::<1, 0, false>(args, |[nicks], _| {
-                let target_limit = find_target_limit(isupport, "WHOIS").map(|limit| limit as usize);
+                let target_limit = find_target_limit(isupport, "WHOIS")
+                    .map(|limit| limit as usize);
 
                 if let Some(target_limit) = target_limit {
                     let nicks = nicks.split(',').collect::<Vec<_>>();
@@ -262,93 +274,107 @@ pub fn parse(
                 // Leaving out optional [server] for now.
                 Ok(Command::Irc(Irc::Whois(None, nicks)))
             }),
-            Kind::Part => validated::<1, 1, true>(args, |[chanlist], [reason]| {
-                if let Some(isupport::Parameter::CHANNELLEN(max_len)) =
-                    isupport.get(&isupport::Kind::CHANNELLEN)
-                {
-                    let max_len = *max_len as usize;
-
-                    let channels = chanlist.split(',').collect::<Vec<_>>();
-
-                    if let Some(channel) =
-                        channels.into_iter().find(|channel| channel.len() > max_len)
-                    {
-                        return Err(Error::ArgTooLong {
-                            name: "channel in chanlist",
-                            len: channel.len(),
-                            max_len,
-                        });
-                    }
-                }
-
-                Ok(Command::Irc(Irc::Part(chanlist, reason)))
-            }),
-            Kind::Topic => validated::<1, 1, true>(args, |[channel], [topic]| {
-                if let Some(ref topic) = topic {
-                    if let Some(isupport::Parameter::TOPICLEN(max_len)) =
-                        isupport.get(&isupport::Kind::TOPICLEN)
+            Kind::Part => {
+                validated::<1, 1, true>(args, |[chanlist], [reason]| {
+                    if let Some(isupport::Parameter::CHANNELLEN(max_len)) =
+                        isupport.get(&isupport::Kind::CHANNELLEN)
                     {
                         let max_len = *max_len as usize;
 
-                        if topic.len() > max_len {
+                        let channels = chanlist.split(',').collect::<Vec<_>>();
+
+                        if let Some(channel) = channels
+                            .into_iter()
+                            .find(|channel| channel.len() > max_len)
+                        {
                             return Err(Error::ArgTooLong {
-                                name: "topic",
-                                len: topic.len(),
+                                name: "channel in chanlist",
+                                len: channel.len(),
                                 max_len,
                             });
                         }
                     }
-                }
 
-                Ok(Command::Irc(Irc::Topic(channel, topic)))
-            }),
-            Kind::Kick => validated::<2, 1, true>(args, |[channel, users], [comment]| {
-                let target_limit = find_target_limit(isupport, "KICK").map(|limit| limit as usize);
+                    Ok(Command::Irc(Irc::Part(chanlist, reason)))
+                })
+            }
+            Kind::Topic => {
+                validated::<1, 1, true>(args, |[channel], [topic]| {
+                    if let Some(ref topic) = topic {
+                        if let Some(isupport::Parameter::TOPICLEN(max_len)) =
+                            isupport.get(&isupport::Kind::TOPICLEN)
+                        {
+                            let max_len = *max_len as usize;
 
-                if let Some(target_limit) = target_limit {
-                    let users = users.split(',').collect::<Vec<_>>();
-
-                    if users.len() > target_limit {
-                        return Err(Error::TooManyTargets {
-                            name: "users",
-                            number: users.len(),
-                            max_number: target_limit,
-                        });
+                            if topic.len() > max_len {
+                                return Err(Error::ArgTooLong {
+                                    name: "topic",
+                                    len: topic.len(),
+                                    max_len,
+                                });
+                            }
+                        }
                     }
-                }
 
-                if let Some(ref comment) = comment {
-                    if let Some(isupport::Parameter::KICKLEN(max_len)) =
-                        isupport.get(&isupport::Kind::KICKLEN)
-                    {
-                        let max_len = *max_len as usize;
+                    Ok(Command::Irc(Irc::Topic(channel, topic)))
+                })
+            }
+            Kind::Kick => {
+                validated::<2, 1, true>(args, |[channel, users], [comment]| {
+                    let target_limit = find_target_limit(isupport, "KICK")
+                        .map(|limit| limit as usize);
 
-                        if comment.len() > max_len {
-                            return Err(Error::ArgTooLong {
-                                name: "comment",
-                                len: comment.len(),
-                                max_len,
+                    if let Some(target_limit) = target_limit {
+                        let users = users.split(',').collect::<Vec<_>>();
+
+                        if users.len() > target_limit {
+                            return Err(Error::TooManyTargets {
+                                name: "users",
+                                number: users.len(),
+                                max_number: target_limit,
                             });
                         }
                     }
-                }
 
-                Ok(Command::Irc(Irc::Kick(channel, users, comment)))
-            }),
-            Kind::Mode => {
-                validated::<1, 2, true>(args, |[target], [mode_string, mode_arguments]| {
+                    if let Some(ref comment) = comment {
+                        if let Some(isupport::Parameter::KICKLEN(max_len)) =
+                            isupport.get(&isupport::Kind::KICKLEN)
+                        {
+                            let max_len = *max_len as usize;
+
+                            if comment.len() > max_len {
+                                return Err(Error::ArgTooLong {
+                                    name: "comment",
+                                    len: comment.len(),
+                                    max_len,
+                                });
+                            }
+                        }
+                    }
+
+                    Ok(Command::Irc(Irc::Kick(channel, users, comment)))
+                })
+            }
+            Kind::Mode => validated::<1, 2, true>(
+                args,
+                |[target], [mode_string, mode_arguments]| {
                     if let Some(mode_string) = mode_string {
-                        let mode_string_regex = Regex::new(r"^((\+|\-)[A-Za-z]*)+$").unwrap();
+                        let mode_string_regex =
+                            Regex::new(r"^((\+|\-)[A-Za-z]*)+$").unwrap();
 
-                        if !mode_string_regex.is_match(&mode_string).unwrap_or_default() {
+                        if !mode_string_regex
+                            .is_match(&mode_string)
+                            .unwrap_or_default()
+                        {
                             Err(Error::InvalidModeString)
                         } else {
-                            let mode_arguments = mode_arguments.map(|mode_arguments| {
-                                mode_arguments
-                                    .split_ascii_whitespace()
-                                    .map(String::from)
-                                    .collect()
-                            });
+                            let mode_arguments =
+                                mode_arguments.map(|mode_arguments| {
+                                    mode_arguments
+                                        .split_ascii_whitespace()
+                                        .map(String::from)
+                                        .collect()
+                                });
 
                             Ok(Command::Irc(Irc::Mode(
                                 target.to_string(),
@@ -357,10 +383,14 @@ pub fn parse(
                             )))
                         }
                     } else {
-                        Ok(Command::Irc(Irc::Mode(target.to_string(), None, None)))
+                        Ok(Command::Irc(Irc::Mode(
+                            target.to_string(),
+                            None,
+                            None,
+                        )))
                     }
-                })
-            }
+                },
+            ),
             Kind::Away => validated::<0, 1, true>(args, |_, [comment]| {
                 if let Some(ref comment) = comment {
                     if let Some(isupport::Parameter::AWAYLEN(max_len)) =
@@ -397,28 +427,30 @@ pub fn parse(
 
                 Ok(Command::Irc(Irc::SetName(realname)))
             }),
-            Kind::Notice => validated::<1, 1, true>(args, |[targets], [msg]| {
-                let target_limit =
-                    find_target_limit(isupport, "NOTICE").map(|limit| limit as usize);
+            Kind::Notice => {
+                validated::<1, 1, true>(args, |[targets], [msg]| {
+                    let target_limit = find_target_limit(isupport, "NOTICE")
+                        .map(|limit| limit as usize);
 
-                if let Some(target_limit) = target_limit {
-                    let targets = targets.split(',').collect::<Vec<_>>();
+                    if let Some(target_limit) = target_limit {
+                        let targets = targets.split(',').collect::<Vec<_>>();
 
-                    if targets.len() > target_limit {
-                        return Err(Error::TooManyTargets {
-                            name: "targets",
-                            number: targets.len(),
-                            max_number: target_limit,
-                        });
+                        if targets.len() > target_limit {
+                            return Err(Error::TooManyTargets {
+                                name: "targets",
+                                number: targets.len(),
+                                max_number: target_limit,
+                            });
+                        }
                     }
-                }
 
-                if let Some(msg) = msg {
-                    Ok(Command::Irc(Irc::Notice(targets, msg)))
-                } else {
-                    Ok(Command::Internal(Internal::OpenBuffers(targets)))
-                }
-            }),
+                    if let Some(msg) = msg {
+                        Ok(Command::Irc(Irc::Notice(targets, msg)))
+                    } else {
+                        Ok(Command::Internal(Internal::OpenBuffers(targets)))
+                    }
+                })
+            }
             Kind::Raw => Ok(Command::Irc(Irc::Raw(raw.to_string()))),
             Kind::Format => {
                 if let Some(target) = buffer.and_then(|b| b.target()) {
@@ -479,7 +511,9 @@ impl TryFrom<Irc> for proto::Command {
 
     fn try_from(command: Irc) -> Result<Self, Self::Error> {
         Ok(match command {
-            Irc::Join(chanlist, chankeys) => proto::Command::JOIN(chanlist, chankeys),
+            Irc::Join(chanlist, chankeys) => {
+                proto::Command::JOIN(chanlist, chankeys)
+            }
             Irc::Motd(target) => proto::Command::MOTD(target),
             Irc::Nick(nick) => proto::Command::NICK(nick),
             Irc::Quit(comment) => proto::Command::QUIT(comment),
@@ -488,9 +522,13 @@ impl TryFrom<Irc> for proto::Command {
                 ctcp::query_command(&ctcp::Command::Action, target, Some(text))
             }
             Irc::Whois(channel, user) => proto::Command::WHOIS(channel, user),
-            Irc::Part(chanlist, reason) => proto::Command::PART(chanlist, reason),
+            Irc::Part(chanlist, reason) => {
+                proto::Command::PART(chanlist, reason)
+            }
             Irc::Topic(channel, topic) => proto::Command::TOPIC(channel, topic),
-            Irc::Kick(channel, user, comment) => proto::Command::KICK(channel, user, comment),
+            Irc::Kick(channel, user, comment) => {
+                proto::Command::KICK(channel, user, comment)
+            }
             Irc::Mode(target, modestring, modearguments) => {
                 proto::Command::MODE(target, modestring, modearguments)
             }
@@ -535,8 +573,12 @@ fn fmt_incorrect_arg_count(min: usize, max: usize, actual: usize) -> String {
     let relational = if actual < min { "few" } else { "many" };
 
     if min == max {
-        format!("too {relational} arguments ({actual} provided, {min} expected)")
+        format!(
+            "too {relational} arguments ({actual} provided, {min} expected)"
+        )
     } else {
-        format!("too {relational} arguments ({actual} provided, {min} to {max} expected)")
+        format!(
+            "too {relational} arguments ({actual} provided, {min} to {max} expected)"
+        )
     }
 }

--- a/data/src/compression.rs
+++ b/data/src/compression.rs
@@ -1,11 +1,11 @@
 use std::io;
 use std::io::prelude::*;
 
+use flate2::Compression;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
-use flate2::Compression;
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 
 pub fn compress<T: Serialize>(value: &T) -> Result<Vec<u8>, Error> {
     let bytes = serde_json::to_vec(&value).map_err(Error::Encode)?;

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -1,18 +1,18 @@
 use chrono::{DateTime, Local, Utc};
 use serde::Deserialize;
 
-use crate::serde::default_bool_true;
-
 pub use self::away::Away;
 pub use self::channel::Channel;
+use crate::serde::default_bool_true;
 
 pub mod away;
 pub mod channel;
 
-use crate::{
-    buffer::{DateSeparators, Nickname, SkinTone, StatusMessagePrefix, TextInput, Timestamp},
-    message::source,
+use crate::buffer::{
+    DateSeparators, Nickname, SkinTone, StatusMessagePrefix, TextInput,
+    Timestamp,
 };
+use crate::message::source;
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct Buffer {
@@ -138,17 +138,21 @@ impl ServerMessages {
             source::server::Kind::Part => Some(&self.part),
             source::server::Kind::Quit => Some(&self.quit),
             source::server::Kind::ChangeHost => Some(&self.change_host),
-            source::server::Kind::MonitoredOnline => Some(&self.monitored_online),
-            source::server::Kind::MonitoredOffline => Some(&self.monitored_offline),
-            source::server::Kind::StandardReply(source::server::StandardReply::Fail) => {
-                Some(&self.standard_reply_fail)
+            source::server::Kind::MonitoredOnline => {
+                Some(&self.monitored_online)
             }
-            source::server::Kind::StandardReply(source::server::StandardReply::Warn) => {
-                Some(&self.standard_reply_warn)
+            source::server::Kind::MonitoredOffline => {
+                Some(&self.monitored_offline)
             }
-            source::server::Kind::StandardReply(source::server::StandardReply::Note) => {
-                Some(&self.standard_reply_note)
-            }
+            source::server::Kind::StandardReply(
+                source::server::StandardReply::Fail,
+            ) => Some(&self.standard_reply_fail),
+            source::server::Kind::StandardReply(
+                source::server::StandardReply::Warn,
+            ) => Some(&self.standard_reply_warn),
+            source::server::Kind::StandardReply(
+                source::server::StandardReply::Note,
+            ) => Some(&self.standard_reply_note),
         }
     }
 }
@@ -189,8 +193,9 @@ impl ServerMessage {
         let is_channel_filtered = |list: &Vec<String>, channel: &str| -> bool {
             let wildcards = ["*", "all"];
 
-            list.iter()
-                .any(|item| wildcards.contains(&item.as_str()) || item == channel)
+            list.iter().any(|item| {
+                wildcards.contains(&item.as_str()) || item == channel
+            })
         };
 
         let channel_included = is_channel_filtered(&self.include, channel);
@@ -258,7 +263,10 @@ pub enum UsernameFormat {
 }
 
 impl Buffer {
-    pub fn format_timestamp(&self, date_time: &DateTime<Utc>) -> Option<String> {
+    pub fn format_timestamp(
+        &self,
+        date_time: &DateTime<Utc>,
+    ) -> Option<String> {
         if self.timestamp.format.is_empty() {
             return None;
         }

--- a/data/src/config/buffer/channel.rs
+++ b/data/src/config/buffer/channel.rs
@@ -1,10 +1,9 @@
 use serde::Deserialize;
 
+use super::NicknameClickAction;
 use crate::buffer::Color;
 use crate::channel::Position;
 use crate::serde::default_bool_true;
-
-use super::NicknameClickAction;
 
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct Channel {

--- a/data/src/config/file_transfer.rs
+++ b/data/src/config/file_transfer.rs
@@ -1,4 +1,7 @@
-use std::{net::IpAddr, num::NonZeroU16, ops::RangeInclusive, path::PathBuf};
+use std::net::IpAddr;
+use std::num::NonZeroU16;
+use std::ops::RangeInclusive;
+use std::path::PathBuf;
 
 use serde::Deserialize;
 

--- a/data/src/config/highlights.rs
+++ b/data/src/config/highlights.rs
@@ -64,15 +64,19 @@ impl<'de> Deserialize<'de> for Match {
                 include,
                 case_insensitive,
             } => {
-                let words = words.iter().map(|s| fancy_regex::escape(s)).join("|");
+                let words =
+                    words.iter().map(|s| fancy_regex::escape(s)).join("|");
 
                 let flags = if case_insensitive { "(?i)" } else { "" };
 
                 let regex = format!(r#"{flags}(?<!\w)({words})(?!\w)"#);
 
-                let regex = RegexBuilder::new(&regex).build().map_err(|err| {
-                    serde::de::Error::custom(format!("invalid regex '{regex}': {err}"))
-                })?;
+                let regex =
+                    RegexBuilder::new(&regex).build().map_err(|err| {
+                        serde::de::Error::custom(format!(
+                            "invalid regex '{regex}': {err}"
+                        ))
+                    })?;
 
                 Ok(Match {
                     regex,
@@ -85,9 +89,12 @@ impl<'de> Deserialize<'de> for Match {
                 exclude,
                 include,
             } => {
-                let regex = RegexBuilder::new(&regex).build().map_err(|err| {
-                    serde::de::Error::custom(format!("invalid regex '{regex}': {err}"))
-                })?;
+                let regex =
+                    RegexBuilder::new(&regex).build().map_err(|err| {
+                        serde::de::Error::custom(format!(
+                            "invalid regex '{regex}': {err}"
+                        ))
+                    })?;
 
                 Ok(Match {
                     regex,
@@ -105,7 +112,11 @@ impl Match {
     }
 }
 
-fn is_target_included(include: &[String], exclude: &[String], target: &str) -> bool {
+fn is_target_included(
+    include: &[String],
+    exclude: &[String],
+    target: &str,
+) -> bool {
     let is_channel_filtered = |list: &[String], target: &str| -> bool {
         let wildcards = ["*", "all"];
         list.iter()

--- a/data/src/config/keys.rs
+++ b/data/src/config/keys.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-use crate::shortcut::{shortcut, KeyBind, Shortcut};
+use crate::shortcut::{KeyBind, Shortcut, shortcut};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Keyboard {
@@ -90,7 +90,8 @@ impl Default for Keyboard {
             scroll_to_top: KeyBind::scroll_to_top(),
             scroll_to_bottom: KeyBind::scroll_to_bottom(),
             cycle_next_unread_buffer: KeyBind::cycle_next_unread_buffer(),
-            cycle_previous_unread_buffer: KeyBind::cycle_previous_unread_buffer(),
+            cycle_previous_unread_buffer: KeyBind::cycle_previous_unread_buffer(
+            ),
             mark_as_read: KeyBind::mark_as_read(),
             quit_application: None,
         }
@@ -126,7 +127,10 @@ impl Keyboard {
             shortcut(self.scroll_to_top.clone(), ScrollToTop),
             shortcut(self.scroll_to_bottom.clone(), ScrollToBottom),
             shortcut(self.highlight.clone(), Highlight),
-            shortcut(self.cycle_next_unread_buffer.clone(), CycleNextUnreadBuffer),
+            shortcut(
+                self.cycle_next_unread_buffer.clone(),
+                CycleNextUnreadBuffer,
+            ),
             shortcut(
                 self.cycle_previous_unread_buffer.clone(),
                 CyclePreviousUnreadBuffer,

--- a/data/src/config/notification.rs
+++ b/data/src/config/notification.rs
@@ -30,12 +30,14 @@ impl<T> Default for Notification<T> {
 
 impl<T> Notification<T> {
     pub fn should_notify(&self, targets: Vec<String>) -> bool {
-        let is_target_filtered = |list: &Vec<String>, targets: &Vec<String>| -> bool {
-            let wildcards = ["*", "all"];
+        let is_target_filtered =
+            |list: &Vec<String>, targets: &Vec<String>| -> bool {
+                let wildcards = ["*", "all"];
 
-            list.iter()
-                .any(|item| wildcards.contains(&item.as_str()) || targets.contains(item))
-        };
+                list.iter().any(|item| {
+                    wildcards.contains(&item.as_str()) || targets.contains(item)
+                })
+            };
         let target_included = is_target_filtered(&self.include, &targets);
         let target_excluded = is_target_filtered(&self.exclude, &targets);
 
@@ -79,7 +81,9 @@ impl<T> Default for Notifications<T> {
 }
 
 impl Notifications {
-    pub fn load_sounds(&self) -> Result<Notifications<Sound>, audio::LoadError> {
+    pub fn load_sounds(
+        &self,
+    ) -> Result<Notifications<Sound>, audio::LoadError> {
         let load = |notification: &Notification<String>| -> Result<_, audio::LoadError> {
             Ok(Notification {
                 show_toast: notification.show_toast,

--- a/data/src/config/preview.rs
+++ b/data/src/config/preview.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 
-use crate::serde::default_bool_true;
 use crate::Target;
+use crate::serde::default_bool_true;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Preview {
@@ -117,14 +117,18 @@ fn is_visible(include: &[String], exclude: &[String], target: &Target) -> bool {
     match target {
         Target::Query(_) => true,
         Target::Channel(channel) => {
-            let is_channel_filtered = |list: &[String], channel: &str| -> bool {
-                let wildcards = ["*", "all"];
-                list.iter()
-                    .any(|item| wildcards.contains(&item.as_str()) || item == channel)
-            };
+            let is_channel_filtered =
+                |list: &[String], channel: &str| -> bool {
+                    let wildcards = ["*", "all"];
+                    list.iter().any(|item| {
+                        wildcards.contains(&item.as_str()) || item == channel
+                    })
+                };
 
-            let channel_included = is_channel_filtered(include, channel.as_str());
-            let channel_excluded = is_channel_filtered(exclude, channel.as_str());
+            let channel_included =
+                is_channel_filtered(include, channel.as_str());
+            let channel_excluded =
+                is_channel_filtered(exclude, channel.as_str());
 
             channel_included || !channel_excluded
         }

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -117,13 +117,22 @@ impl Server {
         }
     }
 
-    pub fn connection(&self, proxy: Option<config::Proxy>) -> connection::Config {
+    pub fn connection(
+        &self,
+        proxy: Option<config::Proxy>,
+    ) -> connection::Config {
         let security = if self.use_tls {
             connection::Security::Secured {
                 accept_invalid_certs: self.dangerously_accept_invalid_certs,
                 root_cert_path: self.root_cert_path.as_ref(),
-                client_cert_path: self.sasl.as_ref().and_then(Sasl::external_cert),
-                client_key_path: self.sasl.as_ref().and_then(Sasl::external_key),
+                client_cert_path: self
+                    .sasl
+                    .as_ref()
+                    .and_then(Sasl::external_cert),
+                client_key_path: self
+                    .sasl
+                    .as_ref()
+                    .and_then(Sasl::external_key),
             }
         } else {
             connection::Security::Unsecured
@@ -242,7 +251,8 @@ impl Sasl {
                 let mut params = chunks
                     .into_iter()
                     .map(|chunk| {
-                        String::from_utf8(chunk.into()).expect("chunks should be valid UTF-8")
+                        String::from_utf8(chunk.into())
+                            .expect("chunks should be valid UTF-8")
                     })
                     .collect::<Vec<String>>();
 
@@ -273,7 +283,9 @@ impl Sasl {
     }
 }
 
-fn deserialize_duration_from_u64<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+fn deserialize_duration_from_u64<'de, D>(
+    deserializer: D,
+) -> Result<Duration, D::Error>
 where
     D: Deserializer<'de>,
 {

--- a/data/src/ctcp.rs
+++ b/data/src/ctcp.rs
@@ -1,5 +1,6 @@
-use irc::proto;
 use std::fmt;
+
+use irc::proto;
 
 // Reference: https://rawgit.com/DanielOaks/irc-rfcs/master/dist/draft-oakley-irc-ctcp-latest.html
 
@@ -30,7 +31,9 @@ pub fn parse_query(text: &str) -> Option<Query> {
         .unwrap_or(text)
         .strip_prefix('\u{1}')?;
 
-    let (command, params) = if let Some((command, params)) = query.split_once(char::is_whitespace) {
+    let (command, params) = if let Some((command, params)) =
+        query.split_once(char::is_whitespace)
+    {
         (command.to_uppercase(), Some(params))
     } else {
         (query.to_uppercase(), None)

--- a/data/src/dcc.rs
+++ b/data/src/dcc.rs
@@ -1,11 +1,10 @@
-use std::{
-    net::{IpAddr, Ipv4Addr},
-    num::NonZeroU16,
-};
+use std::net::{IpAddr, Ipv4Addr};
+use std::num::NonZeroU16;
 
-use crate::ctcp;
 use irc::proto;
 use itertools::Itertools;
+
+use crate::ctcp;
 
 pub fn decode(content: &str) -> Option<Command> {
     let query = ctcp::parse_query(content)?;
@@ -133,7 +132,9 @@ impl Send {
                 ctcp::query_message(
                     &ctcp::Command::DCC,
                     target.to_string(),
-                    Some(format!("SEND {filename} {host} {port} {size} {token}")),
+                    Some(format!(
+                        "SEND {filename} {host} {port} {size} {token}"
+                    )),
                 )
             }
             Self::Direct {

--- a/data/src/environment.rs
+++ b/data/src/environment.rs
@@ -7,8 +7,10 @@ pub const CONFIG_FILE_NAME: &str = "config.toml";
 pub const APPLICATION_ID: &str = "org.squidowl.halloy";
 pub const WIKI_WEBSITE: &str = "https://halloy.chat";
 pub const THEME_WEBSITE: &str = "https://themes.halloy.chat";
-pub const MIGRATION_WEBSITE: &str = "https://halloy.chat/guides/migrating-from-yaml.html";
-pub const RELEASE_WEBSITE: &str = "https://github.com/squidowl/halloy/releases/latest";
+pub const MIGRATION_WEBSITE: &str =
+    "https://halloy.chat/guides/migrating-from-yaml.html";
+pub const RELEASE_WEBSITE: &str =
+    "https://github.com/squidowl/halloy/releases/latest";
 pub const SOURCE_WEBSITE: &str = "https://github.com/squidowl/halloy/";
 
 pub fn formatted_version() -> String {

--- a/data/src/file_transfer.rs
+++ b/data/src/file_transfer.rs
@@ -3,11 +3,10 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 
-use crate::user::Nick;
-use crate::{dcc, server, Server};
-
 pub use self::manager::Manager;
 pub use self::task::Task;
+use crate::user::Nick;
+use crate::{Server, dcc, server};
 
 pub mod manager;
 pub mod task;
@@ -42,7 +41,9 @@ pub struct FileTransfer {
 impl FileTransfer {
     pub fn progress(&self) -> f64 {
         match self.status {
-            Status::Active { transferred, .. } => transferred as f64 / self.size as f64,
+            Status::Active { transferred, .. } => {
+                transferred as f64 / self.size as f64
+            }
             Status::Completed { .. } => 1.0,
             _ => 0.0,
         }

--- a/data/src/file_transfer/manager.rs
+++ b/data/src/file_transfer/manager.rs
@@ -1,16 +1,18 @@
-use std::{
-    collections::{HashMap, VecDeque},
-    num::NonZeroU16,
-    path::PathBuf,
-    time::Duration,
-};
+use std::collections::{HashMap, VecDeque};
+use std::num::NonZeroU16;
+use std::path::PathBuf;
+use std::time::Duration;
 
 use chrono::Utc;
-use futures::{stream::BoxStream, StreamExt};
+use futures::StreamExt;
+use futures::stream::BoxStream;
 use itertools::Itertools;
 use rand::Rng;
 
-use super::{task, Direction, FileTransfer, Id, ReceiveRequest, SendRequest, Status, Task};
+use super::{
+    Direction, FileTransfer, Id, ReceiveRequest, SendRequest, Status, Task,
+    task,
+};
 use crate::{config, dcc};
 
 enum Item {
@@ -78,7 +80,11 @@ impl Manager {
         })
     }
 
-    pub fn send(&mut self, request: SendRequest, proxy: Option<config::Proxy>) -> Option<Event> {
+    pub fn send(
+        &mut self,
+        request: SendRequest,
+        proxy: Option<config::Proxy>,
+    ) -> Option<Event> {
         let SendRequest {
             to,
             path,
@@ -147,7 +153,8 @@ impl Manager {
         } = request;
 
         // Check if this is the response to a reverse send we sent
-        if let Some(id) = dcc_send.token().and_then(|s| s.parse().ok().map(Id)) {
+        if let Some(id) = dcc_send.token().and_then(|s| s.parse().ok().map(Id))
+        {
             if let dcc::Send::Reverse {
                 filename,
                 host,
@@ -268,7 +275,9 @@ impl Manager {
                 elapsed,
                 sha256,
             } => {
-                if let Some(Item::Working { file_transfer, .. }) = self.items.remove(&id) {
+                if let Some(Item::Working { file_transfer, .. }) =
+                    self.items.remove(&id)
+                {
                     log::debug!(
                         "File transfer completed {} {} for {:?} in {:.2}s",
                         match file_transfer.direction {
@@ -317,7 +326,9 @@ impl Manager {
         server
             .bind_ports
             .clone()
-            .find(|port| !self.used_ports.values().any(|used| used.get() == *port))
+            .find(|port| {
+                !self.used_ports.values().any(|used| used.get() == *port)
+            })
             .and_then(NonZeroU16::new)
     }
 

--- a/data/src/history/metadata.rs
+++ b/data/src/history/metadata.rs
@@ -2,13 +2,14 @@ use std::fmt;
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use chrono::{format::SecondsFormat, DateTime, Utc};
+use chrono::format::SecondsFormat;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tokio::fs;
 
-use crate::history::{dir_path, Error, Kind};
-use crate::message::{source, MessageReferences};
 use crate::Message;
+use crate::history::{Error, Kind, dir_path};
+use crate::message::{MessageReferences, source};
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct Metadata {
@@ -17,7 +18,18 @@ pub struct Metadata {
     pub chathistory_references: Option<MessageReferences>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Deserialize, Serialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Default,
+    Deserialize,
+    Serialize,
+)]
 pub struct ReadMarker(DateTime<Utc>);
 
 impl ReadMarker {
@@ -106,13 +118,15 @@ pub async fn save(
     Ok(())
 }
 
-pub async fn update(kind: &Kind, read_marker: &ReadMarker) -> Result<(), Error> {
+pub async fn update(
+    kind: &Kind,
+    read_marker: &ReadMarker,
+) -> Result<(), Error> {
     let metadata = load(kind.clone()).await?;
 
-    if metadata
-        .read_marker
-        .is_some_and(|metadata_read_marker| metadata_read_marker >= *read_marker)
-    {
+    if metadata.read_marker.is_some_and(|metadata_read_marker| {
+        metadata_read_marker >= *read_marker
+    }) {
         return Ok(());
     }
 

--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -6,7 +6,9 @@ use irc::proto::format;
 use crate::buffer::{self, AutoFormat};
 use crate::message::formatting;
 use crate::target::Target;
-use crate::{command, isupport, message, Command, Config, Message, Server, User};
+use crate::{
+    Command, Config, Message, Server, User, command, isupport, message,
+};
 
 const INPUT_HISTORY_LENGTH: usize = 100;
 
@@ -75,21 +77,31 @@ impl Input {
         casemapping: isupport::CaseMap,
         config: &Config,
     ) -> Option<Vec<Message>> {
-        let to_target =
-            |target: &str, source| match Target::parse(target, chantypes, statusmsg, casemapping) {
-                Target::Channel(channel) => message::Target::Channel { channel, source },
-                Target::Query(query) => message::Target::Query { query, source },
-            };
+        let to_target = |target: &str, source| match Target::parse(
+            target,
+            chantypes,
+            statusmsg,
+            casemapping,
+        ) {
+            Target::Channel(channel) => {
+                message::Target::Channel { channel, source }
+            }
+            Target::Query(query) => message::Target::Query { query, source },
+        };
 
         let command = self.content.command(&self.buffer)?;
 
         match command {
-            command::Irc::Msg(targets, text) | command::Irc::Notice(targets, text) => Some(
+            command::Irc::Msg(targets, text)
+            | command::Irc::Notice(targets, text) => Some(
                 targets
                     .split(',')
                     .map(|target| {
                         Message::sent(
-                            to_target(target, message::Source::User(user.clone())),
+                            to_target(
+                                target,
+                                message::Source::User(user.clone()),
+                            ),
                             message::parse_fragments_with_highlights(
                                 text.clone(),
                                 channel_users,
@@ -160,7 +172,11 @@ pub struct Storage {
 impl Storage {
     pub fn get<'a>(&'a self, buffer: &buffer::Upstream) -> Cache<'a> {
         Cache {
-            history: self.sent.get(buffer).map(Vec::as_slice).unwrap_or_default(),
+            history: self
+                .sent
+                .get(buffer)
+                .map(Vec::as_slice)
+                .unwrap_or_default(),
             draft: self
                 .draft
                 .get(buffer)

--- a/data/src/log.rs
+++ b/data/src/log.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 use std::{fs, io};
 
 use chrono::{DateTime, Utc};
-
 use serde::{Deserialize, Serialize};
 
 use crate::environment;
@@ -36,7 +35,17 @@ pub struct Record {
 }
 
 #[derive(
-    Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Serialize, Deserialize, strum::Display,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Debug,
+    Hash,
+    Serialize,
+    Deserialize,
+    strum::Display,
 )]
 #[strum(serialize_all = "UPPERCASE")]
 pub enum Level {

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -4,7 +4,8 @@ use std::collections::HashSet;
 use chrono::{DateTime, Utc};
 
 use super::{
-    parse_fragments_with_user, parse_fragments_with_users, plain, source, Content, Direction, Message, Source, Target
+    Content, Direction, Message, Source, Target, parse_fragments_with_user,
+    parse_fragments_with_users, plain, source,
 };
 use crate::config::buffer::UsernameFormat;
 use crate::time::Posix;
@@ -42,7 +43,9 @@ fn expand(
 
     let source = match cause {
         Cause::Server(server) => Source::Server(server),
-        Cause::Status(status) => Source::Internal(source::Internal::Status(status)),
+        Cause::Status(status) => {
+            Source::Internal(source::Internal::Status(status))
+        }
     };
 
     channels
@@ -100,7 +103,10 @@ pub fn connected(sent_time: DateTime<Utc>) -> Vec<Message> {
     )
 }
 
-pub fn connection_failed(error: String, sent_time: DateTime<Utc>) -> Vec<Message> {
+pub fn connection_failed(
+    error: String,
+    sent_time: DateTime<Utc>,
+) -> Vec<Message> {
     let content = plain(format!("connection to server failed ({error})"));
     expand(
         [],
@@ -192,9 +198,15 @@ pub fn nickname(
     let new_user = User::from(new_nick.clone());
 
     let content = if ourself {
-        parse_fragments_with_user(format!("You're now known as {new_nick}"), &new_user)
+        parse_fragments_with_user(
+            format!("You're now known as {new_nick}"),
+            &new_user,
+        )
     } else {
-        parse_fragments_with_users(format!("{old_nick} is now known as {new_nick}"), &[old_user, new_user])
+        parse_fragments_with_users(
+            format!("{old_nick} is now known as {new_nick}"),
+            &[old_user, new_user],
+        )
     };
 
     expand(

--- a/data/src/message/formatting.rs
+++ b/data/src/message/formatting.rs
@@ -1,12 +1,12 @@
-use std::{collections::HashSet, mem};
+use std::collections::HashSet;
+use std::mem;
 
 use iced_core::color;
 use itertools::PeekingNext;
 use serde::{Deserialize, Serialize};
 
-use crate::appearance::theme;
-
 pub use self::encode::encode;
+use crate::appearance::theme;
 
 pub mod encode;
 
@@ -48,7 +48,8 @@ pub fn parse(
                     if let Some(c) = iter.peeking_next(char::is_ascii_digit) {
                         // 1-2 digiits
                         let mut digits = c.to_string();
-                        if let Some(c) = iter.peeking_next(char::is_ascii_digit) {
+                        if let Some(c) = iter.peeking_next(char::is_ascii_digit)
+                        {
                             digits.push(c);
                         }
 
@@ -58,10 +59,14 @@ pub fn parse(
 
                         if let Some(comma) = iter.peeking_next(|c| *c == ',') {
                             // Has background
-                            if let Some(c) = iter.peeking_next(char::is_ascii_digit) {
+                            if let Some(c) =
+                                iter.peeking_next(char::is_ascii_digit)
+                            {
                                 // 1-2 digits
                                 let mut digits = c.to_string();
-                                if let Some(c) = iter.peeking_next(char::is_ascii_digit) {
+                                if let Some(c) =
+                                    iter.peeking_next(char::is_ascii_digit)
+                                {
                                     digits.push(c);
                                 }
 
@@ -81,7 +86,8 @@ pub fn parse(
                 }
                 Modifier::HexColor => {
                     // Trailing digit for new color, otherwise resets
-                    if let Some(c) = iter.peeking_next(char::is_ascii_hexdigit) {
+                    if let Some(c) = iter.peeking_next(char::is_ascii_hexdigit)
+                    {
                         // 6 digits (hex)
                         let mut hex = c.to_string();
                         for _ in 0..5 {
@@ -96,16 +102,21 @@ pub fn parse(
 
                         if let Some(comma) = iter.peeking_next(|c| *c == ',') {
                             // Has background
-                            if let Some(c) = iter.peeking_next(char::is_ascii_hexdigit) {
+                            if let Some(c) =
+                                iter.peeking_next(char::is_ascii_hexdigit)
+                            {
                                 // 6 digits (hex)
                                 let mut hex = c.to_string();
                                 for _ in 0..5 {
                                     hex.push(iter.next()?);
                                 }
 
-                                let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
-                                let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
-                                let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+                                let r =
+                                    u8::from_str_radix(&hex[0..2], 16).ok()?;
+                                let g =
+                                    u8::from_str_radix(&hex[2..4], 16).ok()?;
+                                let b =
+                                    u8::from_str_radix(&hex[4..6], 16).ok()?;
 
                                 *bg = Some(Color::Rgb(r, g, b));
                             }
@@ -152,7 +163,9 @@ pub fn parse(
     }
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize,
+)]
 pub struct Formatting {
     pub bold: bool,
     pub italics: bool,
@@ -164,7 +177,11 @@ pub struct Formatting {
 }
 
 impl Formatting {
-    fn new(modifiers: &HashSet<Modifier>, fg: Option<Color>, bg: Option<Color>) -> Self {
+    fn new(
+        modifiers: &HashSet<Modifier>,
+        fg: Option<Color>,
+        bg: Option<Color>,
+    ) -> Self {
         let (fg, bg) = if modifiers.contains(&Modifier::ReverseColor) {
             (bg, fg)
         } else {
@@ -553,7 +570,10 @@ impl Color {
         }
     }
 
-    pub fn into_iced(self, _colors: &theme::Colors) -> Option<iced_core::Color> {
+    pub fn into_iced(
+        self,
+        _colors: &theme::Colors,
+    ) -> Option<iced_core::Color> {
         // TODO: Theme aware 0 - 15 colors
         match self {
             Color::White => Some(color!(0xffffff)),

--- a/data/src/message/formatting/encode.rs
+++ b/data/src/message/formatting/encode.rs
@@ -1,15 +1,16 @@
 //! Internal formatting specification
-use std::{convert::identity, fmt::Write};
+use std::convert::identity;
+use std::fmt::Write;
 
-use nom::{
-    branch::alt,
-    bytes::complete::tag,
-    character::complete::{anychar, char, satisfy},
-    combinator::{cond, cut, eof, map, map_opt, not, opt, peek, recognize, value, verify},
-    multi::{count, many_m_n, many_till},
-    sequence::{pair, preceded, tuple},
-    Finish, IResult,
+use nom::branch::alt;
+use nom::bytes::complete::tag;
+use nom::character::complete::{anychar, char, satisfy};
+use nom::combinator::{
+    cond, cut, eof, map, map_opt, not, opt, peek, recognize, value, verify,
 };
+use nom::multi::{count, many_m_n, many_till};
+use nom::sequence::{pair, preceded, tuple};
+use nom::{Finish, IResult};
 
 use super::{Color, Modifier};
 
@@ -36,7 +37,11 @@ fn parse(input: &str, markdown_only: bool) -> Option<Vec<Token>> {
         .map(|(_, (tokens, _))| tokens)
 }
 
-fn token<'a>(source: &'a str, input: &'a str, markdown_only: bool) -> IResult<&'a str, Token> {
+fn token<'a>(
+    source: &'a str,
+    input: &'a str,
+    markdown_only: bool,
+) -> IResult<&'a str, Token> {
     alt((
         map(escaped(markdown_only), Token::Escaped),
         map(markdown(source, markdown_only), Token::Markdown),
@@ -45,7 +50,9 @@ fn token<'a>(source: &'a str, input: &'a str, markdown_only: bool) -> IResult<&'
     ))(input)
 }
 
-fn escaped<'a>(markdown_only: bool) -> impl FnMut(&'a str) -> IResult<&'a str, char> {
+fn escaped<'a>(
+    markdown_only: bool,
+) -> impl FnMut(&'a str) -> IResult<&'a str, char> {
     alt((
         value('*', tag("\\*")),
         value('_', tag("\\_")),
@@ -77,11 +84,14 @@ fn markdown<'a>(
     // Prev char is whitespace or punctuation, not matching delimiter char
     let prev_is_ws_or_punc = move |d, i: &str| {
         // None == Start of input which is considered whitespace
-        prev(i).is_none_or(|c| c != d && (c.is_whitespace() || c.is_ascii_punctuation()))
+        prev(i).is_none_or(|c| {
+            c != d && (c.is_whitespace() || c.is_ascii_punctuation())
+        })
     };
     // Prev char is punctuation, not matching delimiter char
-    let prev_is_punc =
-        move |d, i: &str| prev(i).is_some_and(|c| c != d && c.is_ascii_punctuation());
+    let prev_is_punc = move |d, i: &str| {
+        prev(i).is_some_and(|c| c != d && c.is_ascii_punctuation())
+    };
 
     // A delimiter run is a sequence of one or more characters
     let delimiter_run = |d, n| count(char(d), n);
@@ -124,7 +134,9 @@ fn markdown<'a>(
                 // followed by Unicode whitespace or a Unicode punctuation character
                 map(
                     pair(
-                        verify(delimiter_run(d, n), move |_: &Vec<_>| prev_is_punc(d, i)),
+                        verify(delimiter_run(d, n), move |_: &Vec<_>| {
+                            prev_is_punc(d, i)
+                        }),
                         peek(alt((ws, punc(d)))),
                     ),
                     move |_| prev(i),
@@ -153,7 +165,9 @@ fn markdown<'a>(
                     pair(
                         peek(left_flanking(d, n)),
                         verify(right_flanking(d, n), move |c| {
-                            c.is_some_and(|c| c != d && c.is_ascii_punctuation())
+                            c.is_some_and(|c| {
+                                c != d && c.is_ascii_punctuation()
+                            })
                         }),
                     ),
                     |_| (),
@@ -222,11 +236,17 @@ fn markdown<'a>(
         alt((
             pair(
                 tag("` "),
-                many_till(move |input| token(source, input, markdown_only), tag(" `")),
+                many_till(
+                    move |input| token(source, input, markdown_only),
+                    tag(" `"),
+                ),
             ),
             pair(
                 tag("`"),
-                many_till(move |input| token(source, input, markdown_only), tag("`")),
+                many_till(
+                    move |input| token(source, input, markdown_only),
+                    tag("`"),
+                ),
             ),
         )),
         |(_, (tokens, _))| tokens,
@@ -427,10 +447,7 @@ mod test {
     #[test]
     fn internal_format() {
         let tests = [
-            (
-                ("_hello_", false),
-                String::from("\u{1d}hello\u{1d}"),
-            ),
+            (("_hello_", false), String::from("\u{1d}hello\u{1d}")),
             (
                 ("hello there friend!!", false),
                 String::from("hello there friend!!"),
@@ -470,10 +487,10 @@ mod test {
             (
                 (
                     "$c1,0black on white $c2now blue on white$r$b BOLD $i BOLD AND ITALIC$r $ccode yo",
-                    false
+                    false,
                 ),
                 String::from(
-                    "\u{3}1,0black on white \u{3}2now blue on white\u{f}\u{2} BOLD \u{1d} BOLD AND ITALIC\u{f} \u{3}code yo"
+                    "\u{3}1,0black on white \u{3}2now blue on white\u{f}\u{2} BOLD \u{1d} BOLD AND ITALIC\u{f} \u{3}code yo",
                 ),
             ),
         ];

--- a/data/src/message/source.rs
+++ b/data/src/message/source.rs
@@ -1,8 +1,7 @@
 use serde::{Deserialize, Serialize};
 
-use crate::User;
-
 pub use self::server::Server;
+use crate::User;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Source {
@@ -58,7 +57,9 @@ pub mod server {
         }
     }
 
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    #[derive(
+        Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize,
+    )]
     #[serde(rename_all = "lowercase")]
     pub enum Kind {
         Join,
@@ -71,7 +72,9 @@ pub mod server {
         StandardReply(StandardReply),
     }
 
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    #[derive(
+        Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize,
+    )]
     pub enum StandardReply {
         Fail,
         Warn,

--- a/data/src/notification.rs
+++ b/data/src/notification.rs
@@ -1,4 +1,6 @@
-use crate::{target::Channel, user::Nick, User};
+use crate::User;
+use crate::target::Channel;
+use crate::user::Nick;
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum Notification {

--- a/data/src/preview/cache.rs
+++ b/data/src/preview/cache.rs
@@ -5,9 +5,8 @@ use serde::{Deserialize, Serialize};
 use tokio::fs;
 use url::Url;
 
+use super::{Preview, image};
 use crate::{config, environment};
-
-use super::{image, Preview};
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -23,7 +22,8 @@ pub async fn load(url: &Url, config: &config::Preview) -> Option<State> {
         return None;
     }
 
-    let state: State = serde_json::from_slice(&fs::read(&path).await.ok()?).ok()?;
+    let state: State =
+        serde_json::from_slice(&fs::read(&path).await.ok()?).ok()?;
 
     // Ensure the actual image is cached
     match &state {
@@ -58,7 +58,8 @@ pub async fn save(url: &Url, state: State) {
 }
 
 fn state_path(url: &Url) -> PathBuf {
-    let hash = hex::encode(seahash::hash(url.as_str().as_bytes()).to_be_bytes());
+    let hash =
+        hex::encode(seahash::hash(url.as_str().as_bytes()).to_be_bytes());
 
     environment::cache_dir()
         .join("previews")
@@ -81,7 +82,10 @@ pub(super) fn download_path(url: &Url) -> PathBuf {
         .join(format!("{hash}-{nanos}.part"))
 }
 
-pub(super) fn image_path(format: &image::Format, digest: &image::Digest) -> PathBuf {
+pub(super) fn image_path(
+    format: &image::Format,
+    digest: &image::Digest,
+) -> PathBuf {
     environment::cache_dir()
         .join("previews")
         .join("images")

--- a/data/src/preview/image.rs
+++ b/data/src/preview/image.rs
@@ -46,16 +46,23 @@ pub fn format(bytes: &[u8]) -> Option<Format> {
 }
 
 mod serde_format {
-    use super::Format;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-    pub fn serialize<S: Serializer>(format: &Format, serializer: S) -> Result<S::Ok, S::Error> {
+    use super::Format;
+
+    pub fn serialize<S: Serializer>(
+        format: &Format,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
         format.to_mime_type().serialize(serializer)
     }
 
-    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Format, D::Error> {
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Format, D::Error> {
         let s = String::deserialize(deserializer)?;
 
-        Format::from_mime_type(s).ok_or(serde::de::Error::custom("invalid mime type"))
+        Format::from_mime_type(s)
+            .ok_or(serde::de::Error::custom("invalid mime type"))
     }
 }

--- a/data/src/server.rs
+++ b/data/src/server.rs
@@ -1,19 +1,21 @@
 use std::collections::BTreeMap;
 use std::{fmt, str};
-use tokio::fs;
-use tokio::process::Command;
 
 use futures::channel::mpsc::Sender;
 use irc::proto;
 use serde::{Deserialize, Serialize};
+use tokio::fs;
+use tokio::process::Command;
 
 use crate::config;
-use crate::config::server::Sasl;
 use crate::config::Error;
+use crate::config::server::Sasl;
 
 pub type Handle = Sender<proto::Message>;
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
 pub struct Server(String);
 
 impl From<&str> for Server {
@@ -101,7 +103,9 @@ impl Map {
     pub async fn read_passwords(&mut self) -> Result<(), Error> {
         for (_, config) in self.0.iter_mut() {
             if let Some(pass_file) = &config.password_file {
-                if config.password.is_some() || config.password_command.is_some() {
+                if config.password.is_some()
+                    || config.password_command.is_some()
+                {
                     return Err(Error::DuplicatePassword);
                 }
                 let pass = fs::read_to_string(pass_file).await?;
@@ -114,7 +118,9 @@ impl Map {
                 config.password = Some(read_from_command(pass_command).await?);
             }
             if let Some(nick_pass_file) = &config.nick_password_file {
-                if config.nick_password.is_some() || config.nick_password_command.is_some() {
+                if config.nick_password.is_some()
+                    || config.nick_password_command.is_some()
+                {
                     return Err(Error::DuplicateNickPassword);
                 }
                 let nick_pass = fs::read_to_string(nick_pass_file).await?;
@@ -124,7 +130,8 @@ impl Map {
                 if config.nick_password.is_some() {
                     return Err(Error::DuplicateNickPassword);
                 }
-                config.nick_password = Some(read_from_command(nick_pass_command).await?);
+                config.nick_password =
+                    Some(read_from_command(nick_pass_command).await?);
             }
             if let Some(sasl) = &mut config.sasl {
                 match sasl {

--- a/data/src/shortcut.rs
+++ b/data/src/shortcut.rs
@@ -67,7 +67,9 @@ macro_rules! default {
     ($name:ident, $k:literal, $m:expr) => {
         pub fn $name() -> KeyBind {
             KeyBind {
-                key_code: KeyCode(iced_core::keyboard::Key::Character($k.into())),
+                key_code: KeyCode(iced_core::keyboard::Key::Character(
+                    $k.into(),
+                )),
                 modifiers: $m,
             }
         }
@@ -162,7 +164,9 @@ impl KeyBind {
 }
 
 impl From<(keyboard::Key, keyboard::Modifiers)> for KeyBind {
-    fn from((key_code, modifiers): (keyboard::Key, keyboard::Modifiers)) -> Self {
+    fn from(
+        (key_code, modifiers): (keyboard::Key, keyboard::Modifiers),
+    ) -> Self {
         Self {
             key_code: KeyCode(key_code),
             modifiers: Modifiers(modifiers),
@@ -347,10 +351,13 @@ impl FromStr for KeyCode {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self(match s.to_ascii_lowercase().as_str() {
-            "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "0" | "a" | "b" | "c" | "d"
-            | "e" | "f" | "g" | "h" | "i" | "j" | "k" | "l" | "m" | "n" | "o" | "p" | "q" | "r"
-            | "s" | "t" | "u" | "v" | "w" | "x" | "y" | "z" | "`" | "-" | "=" | "[" | "]"
-            | "\\" | ";" | "'" | "," | "." | "/" => keyboard::Key::Character(s.into()),
+            "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "0" | "a"
+            | "b" | "c" | "d" | "e" | "f" | "g" | "h" | "i" | "j" | "k"
+            | "l" | "m" | "n" | "o" | "p" | "q" | "r" | "s" | "t" | "u"
+            | "v" | "w" | "x" | "y" | "z" | "`" | "-" | "=" | "[" | "]"
+            | "\\" | ";" | "'" | "," | "." | "/" => {
+                keyboard::Key::Character(s.into())
+            }
             "escape" | "esc" => keyboard::Key::Named(key::Named::Escape),
             "f1" => keyboard::Key::Named(key::Named::F1),
             "f2" => keyboard::Key::Named(key::Named::F2),
@@ -403,8 +410,12 @@ impl FromStr for KeyCode {
             "mute" => keyboard::Key::Named(key::Named::AudioVolumeMute),
             "mediastop" => keyboard::Key::Named(key::Named::MediaStop),
             "mediapause" => keyboard::Key::Named(key::Named::MediaPause),
-            "mediatracknext" => keyboard::Key::Named(key::Named::MediaTrackNext),
-            "mediatrackprev" => keyboard::Key::Named(key::Named::MediaTrackPrevious),
+            "mediatracknext" => {
+                keyboard::Key::Named(key::Named::MediaTrackNext)
+            }
+            "mediatrackprev" => {
+                keyboard::Key::Named(key::Named::MediaTrackPrevious)
+            }
             _ => return Err(ParseError::InvalidKeyCode(s.to_string())),
         }))
     }

--- a/data/src/target.rs
+++ b/data/src/target.rs
@@ -237,7 +237,9 @@ impl Query {
         statusmsg: &[char],
         casemapping: isupport::CaseMap,
     ) -> Result<Self, ParseError> {
-        if let Some((_, _)) = proto::parse_channel_from_target(target, chantypes, statusmsg) {
+        if let Some((_, _)) =
+            proto::parse_channel_from_target(target, chantypes, statusmsg)
+        {
             Err(ParseError::InvalidQuery(target.to_string()))
         } else {
             Ok(Query {

--- a/data/src/time.rs
+++ b/data/src/time.rs
@@ -3,7 +3,18 @@ use std::time::SystemTime;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+)]
 pub struct Posix(u64);
 
 impl Posix {

--- a/data/src/url.rs
+++ b/data/src/url.rs
@@ -3,7 +3,8 @@ use std::str::FromStr;
 use fancy_regex::Regex;
 use log::warn;
 
-use crate::{appearance::theme, config, Server};
+use crate::appearance::theme;
+use crate::{Server, config};
 
 #[derive(Debug, Clone)]
 pub enum Url {
@@ -25,7 +26,9 @@ impl std::fmt::Display for Url {
             f,
             "{}",
             match self {
-                Url::ServerConnect { url, .. } | Url::Theme { url, .. } | Url::Unknown(url) => url,
+                Url::ServerConnect { url, .. }
+                | Url::Theme { url, .. }
+                | Url::Unknown(url) => url,
             }
         )
     }
@@ -36,7 +39,10 @@ pub fn theme(colors: &theme::Colors) -> String {
 }
 
 pub fn theme_submit(colors: &theme::Colors) -> String {
-    format!("https://themes.halloy.chat/submit?e={}", colors.encode_base64())
+    format!(
+        "https://themes.halloy.chat/submit?e={}",
+        colors.encode_base64()
+    )
 }
 
 impl Url {

--- a/data/src/window.rs
+++ b/data/src/window.rs
@@ -43,7 +43,8 @@ impl Window {
         let Window { position, size } = serde_json::from_slice(&bytes)?;
 
         let size = size.max(MIN_SIZE);
-        let position = position.filter(|pos| pos.y.is_sign_positive() && pos.x.is_sign_positive());
+        let position = position
+            .filter(|pos| pos.y.is_sign_positive() && pos.x.is_sign_positive());
 
         Ok(Window { position, size })
     }
@@ -87,7 +88,9 @@ mod serde_position {
         y: f32,
     }
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Point>, D::Error>
+    pub fn deserialize<'de, D>(
+        deserializer: D,
+    ) -> Result<Option<Point>, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -126,7 +129,10 @@ mod serde_size {
         Ok(Size { width, height })
     }
 
-    pub fn serialize<S: Serializer>(size: &Size, serializer: S) -> Result<S::Ok, S::Error> {
+    pub fn serialize<S: Serializer>(
+        size: &Size,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
         SerdeSize {
             width: size.width,
             height: size.height,

--- a/ipc/src/server.rs
+++ b/ipc/src/server.rs
@@ -1,6 +1,5 @@
-use std::io;
 use std::path::PathBuf;
-use std::time;
+use std::{io, time};
 
 use interprocess::local_socket::tokio::LocalSocketListener;
 

--- a/irc/proto/src/command.rs
+++ b/irc/proto/src/command.rs
@@ -265,7 +265,9 @@ impl Command {
 
     pub fn parameters(self) -> Vec<String> {
         match self {
-            Command::CAP(a, b, c, d) => a.into_iter().chain(Some(b)).chain(c).chain(d).collect(),
+            Command::CAP(a, b, c, d) => {
+                a.into_iter().chain(Some(b)).chain(c).chain(d).collect()
+            }
             Command::AUTHENTICATE(a) => vec![a],
             Command::PASS(a) => vec![a],
             Command::NICK(a) => vec![a],
@@ -281,11 +283,15 @@ impl Command {
             Command::NAMES(a) => vec![a],
             Command::LIST(a, b) => a.into_iter().chain(b).collect(),
             Command::INVITE(a, b) => vec![a, b],
-            Command::KICK(a, b, c) => std::iter::once(a).chain(Some(b)).chain(c).collect(),
+            Command::KICK(a, b, c) => {
+                std::iter::once(a).chain(Some(b)).chain(c).collect()
+            }
             Command::MOTD(a) => a.into_iter().collect(),
             Command::VERSION(a) => a.into_iter().collect(),
             Command::ADMIN(a) => a.into_iter().collect(),
-            Command::CONNECT(a, b, c) => std::iter::once(a).chain(b).chain(c).collect(),
+            Command::CONNECT(a, b, c) => {
+                std::iter::once(a).chain(b).chain(c).collect()
+            }
             Command::LUSERS => vec![],
             Command::TIME(a) => a.into_iter().collect(),
             Command::STATS(a, b) => std::iter::once(a).chain(b).collect(),
@@ -298,7 +304,9 @@ impl Command {
             Command::PRIVMSG(a, b) => vec![a, b],
             Command::NOTICE(a, b) => vec![a, b],
             Command::WHO(a, b, c) => std::iter::once(a)
-                .chain(b.map(|b| c.map_or_else(|| format!("%{b}"), |c| format!("%{b},{c}"))))
+                .chain(b.map(|b| {
+                    c.map_or_else(|| format!("%{b}"), |c| format!("%{b},{c}"))
+                }))
                 .collect(),
             Command::WHOIS(a, b) => a.into_iter().chain(Some(b)).collect(),
             Command::WHOWAS(a, b) => std::iter::once(a).chain(b).collect(),

--- a/irc/proto/src/format.rs
+++ b/irc/proto/src/format.rs
@@ -71,7 +71,10 @@ fn parameters(parameters: Vec<String>) -> String {
 }
 
 fn trailing(parameter: String) -> String {
-    if parameter.contains(' ') || parameter.is_empty() || parameter.starts_with(':') {
+    if parameter.contains(' ')
+        || parameter.is_empty()
+        || parameter.starts_with(':')
+    {
         format!(":{parameter}")
     } else {
         parameter
@@ -80,7 +83,7 @@ fn trailing(parameter: String) -> String {
 
 #[cfg(test)]
 mod test {
-    use crate::{command, format, Tag};
+    use crate::{Tag, command, format};
 
     #[test]
     fn commands() {

--- a/irc/proto/src/lib.rs
+++ b/irc/proto/src/lib.rs
@@ -105,7 +105,8 @@ mod tests {
     use super::*;
 
     // Reference: https://defs.ircdocs.horse/defs/chanmembers
-    const CHANNEL_MEMBERSHIP_PREFIXES: &[char] = &['~', '&', '!', '@', '%', '+'];
+    const CHANNEL_MEMBERSHIP_PREFIXES: &[char] =
+        &['~', '&', '!', '@', '%', '+'];
 
     #[test]
     fn is_channel_correct() {
@@ -143,6 +144,8 @@ mod tests {
     fn invalid_channels() {
         let chantypes = DEFAULT_CHANNEL_PREFIXES;
         let prefixes = CHANNEL_MEMBERSHIP_PREFIXES;
-        assert!(parse_channel_from_target("+%foo", chantypes, prefixes).is_none());
+        assert!(
+            parse_channel_from_target("+%foo", chantypes, prefixes).is_none()
+        );
     }
 }

--- a/irc/src/codec.rs
+++ b/irc/src/codec.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use bytes::BytesMut;
-use proto::{format, parse, Message};
+use proto::{Message, format, parse};
 use tokio_util::codec::{Decoder, Encoder};
 
 pub type ParseResult<T = Message, E = parse::Error> = std::result::Result<T, E>;
@@ -12,7 +12,10 @@ impl Decoder for Codec {
     type Item = ParseResult;
     type Error = Error;
 
-    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+    fn decode(
+        &mut self,
+        src: &mut BytesMut,
+    ) -> Result<Option<Self::Item>, Self::Error> {
         let Some(pos) = src.windows(2).position(|b| b == [b'\r', b'\n']) else {
             return Ok(None);
         };
@@ -26,7 +29,11 @@ impl Decoder for Codec {
 impl Encoder<Message> for Codec {
     type Error = Error;
 
-    fn encode(&mut self, message: Message, dst: &mut BytesMut) -> Result<(), Self::Error> {
+    fn encode(
+        &mut self,
+        message: Message,
+        dst: &mut BytesMut,
+    ) -> Result<(), Self::Error> {
         let encoded = format::message(message);
 
         dst.extend(encoded.into_bytes());

--- a/irc/src/connection.rs
+++ b/irc/src/connection.rs
@@ -47,7 +47,9 @@ pub struct Config<'a> {
 impl<Codec> Connection<Codec> {
     pub async fn new(config: Config<'_>, codec: Codec) -> Result<Self, Error> {
         let stream = match config.proxy {
-            None => IrcStream::Tcp(TcpStream::connect((config.server, config.port)).await?),
+            None => IrcStream::Tcp(
+                TcpStream::connect((config.server, config.port)).await?,
+            ),
             Some(proxy) => proxy.connect(config.server, config.port).await?,
         };
 
@@ -88,7 +90,9 @@ impl<Codec> Connection<Codec> {
         let stream = IrcStream::Tcp(tcp);
 
         match security {
-            Security::Unsecured => Ok(Self::Unsecured(Framed::new(stream, codec))),
+            Security::Unsecured => {
+                Ok(Self::Unsecured(Framed::new(stream, codec)))
+            }
             Security::Secured { .. } => {
                 todo!();
             }
@@ -154,7 +158,10 @@ where
         delegate!(self.get_mut(), poll_ready_unpin(cx))
     }
 
-    fn start_send(self: std::pin::Pin<&mut Self>, item: Item) -> Result<(), Self::Error> {
+    fn start_send(
+        self: std::pin::Pin<&mut Self>,
+        item: Item,
+    ) -> Result<(), Self::Error> {
         delegate!(self.get_mut(), start_send_unpin(item))
     }
 

--- a/irc/src/connection/proxy.rs
+++ b/irc/src/connection/proxy.rs
@@ -1,5 +1,7 @@
 use arti_client::{TorClient, TorClientConfig};
-use async_http_proxy::{http_connect_tokio, http_connect_tokio_with_basic_auth};
+use async_http_proxy::{
+    http_connect_tokio, http_connect_tokio_with_basic_auth,
+};
 use fast_socks5::client::{Config as Socks5Config, Socks5Stream};
 use thiserror::Error;
 use tokio::net::TcpStream;
@@ -24,7 +26,11 @@ pub enum Proxy {
 }
 
 impl Proxy {
-    pub async fn connect(&self, target_server: &str, target_port: u16) -> Result<IrcStream, Error> {
+    pub async fn connect(
+        &self,
+        target_server: &str,
+        target_port: u16,
+    ) -> Result<IrcStream, Error> {
         match self {
             Proxy::Http {
                 host,
@@ -58,7 +64,9 @@ impl Proxy {
                 )
                 .await
             }
-            Proxy::Tor => connect_tor(target_server.to_string(), target_port).await,
+            Proxy::Tor => {
+                connect_tor(target_server.to_string(), target_port).await
+            }
         }
     }
 }
@@ -120,7 +128,10 @@ pub async fn connect_socks5(
     Ok(IrcStream::Tcp(stream))
 }
 
-pub async fn connect_tor(target_server: String, target_port: u16) -> Result<IrcStream, Error> {
+pub async fn connect_tor(
+    target_server: String,
+    target_port: u16,
+) -> Result<IrcStream, Error> {
     let config = TorClientConfig::default();
     let tor_client = TorClient::create_bootstrapped(config).await?;
 

--- a/irc/src/connection/tls.rs
+++ b/irc/src/connection/tls.rs
@@ -1,16 +1,13 @@
-use std::{io::Cursor, path::PathBuf, sync::Arc};
+use std::io::Cursor;
+use std::path::PathBuf;
+use std::sync::Arc;
 
 use bytes::Bytes;
 use tokio::fs;
-use tokio_rustls::{
-    client::TlsStream,
-    rustls::{
-        self,
-        client::danger::{self, ServerCertVerifier},
-        pki_types,
-    },
-    TlsConnector,
-};
+use tokio_rustls::TlsConnector;
+use tokio_rustls::client::TlsStream;
+use tokio_rustls::rustls::client::danger::{self, ServerCertVerifier};
+use tokio_rustls::rustls::{self, pki_types};
 
 use super::IrcStream;
 
@@ -52,8 +49,8 @@ pub async fn connect<'a>(
             cert_bytes.clone()
         };
 
-        let certs =
-            rustls_pemfile::certs(&mut Cursor::new(&cert_bytes)).collect::<Result<Vec<_>, _>>()?;
+        let certs = rustls_pemfile::certs(&mut Cursor::new(&cert_bytes))
+            .collect::<Result<Vec<_>, _>>()?;
         let key = rustls_pemfile::private_key(&mut Cursor::new(&key_bytes))?
             .ok_or(Error::BadPrivateKey)?;
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,7 @@
-edition = "2021"
-imports_granularity = "Module"
-group_imports = "StdExternalCrate"
+edition = "2024"
+style_edition = "2024"
+
+group_imports = "StdExternalCrate" # unstable
+imports_granularity = "Module" # unstable
+max_width = 80
+unstable_features = true

--- a/src/appearance.rs
+++ b/src/appearance.rs
@@ -1,14 +1,13 @@
 use std::time::Duration;
 
 use data::appearance;
-use futures::stream;
-use futures::{stream::BoxStream, StreamExt};
+use futures::stream::BoxStream;
+use futures::{StreamExt, stream};
+use iced::advanced::graphics::futures::subscription;
 use iced::advanced::subscription::Hasher;
-use iced::futures;
-use iced::{advanced::graphics::futures::subscription, Subscription};
-use tokio::time;
-
+use iced::{Subscription, futures};
 pub use theme::Theme;
+use tokio::time;
 
 pub mod theme;
 
@@ -66,7 +65,10 @@ impl subscription::Recipe for Appearance {
         std::any::TypeId::of::<Marker>().hash(state);
     }
 
-    fn stream(self: Box<Self>, _input: subscription::EventStream) -> BoxStream<'static, Mode> {
+    fn stream(
+        self: Box<Self>,
+        _input: subscription::EventStream,
+    ) -> BoxStream<'static, Mode> {
         let interval = time::interval(Duration::from_secs(5));
 
         stream::unfold(

--- a/src/appearance/theme.rs
+++ b/src/appearance/theme.rs
@@ -1,8 +1,9 @@
-use crate::widget::combo_box;
-
 pub use data::appearance::theme::{
-    color_to_hex, hex_to_color, Buffer, Button, Buttons, Colors, General, ServerMessages, Text,
+    Buffer, Button, Buttons, Colors, General, ServerMessages, Text,
+    color_to_hex, hex_to_color,
 };
+
+use crate::widget::combo_box;
 
 pub mod button;
 pub mod checkbox;
@@ -34,10 +35,12 @@ pub enum Theme {
 impl Theme {
     pub fn preview(&self, theme: data::Theme) -> Self {
         match self {
-            Theme::Selected(selected) | Theme::Preview { selected, .. } => Self::Preview {
-                selected: selected.clone(),
-                preview: theme,
-            },
+            Theme::Selected(selected) | Theme::Preview { selected, .. } => {
+                Self::Preview {
+                    selected: selected.clone(),
+                    preview: theme,
+                }
+            }
         }
     }
 

--- a/src/appearance/theme/button.rs
+++ b/src/appearance/theme/button.rs
@@ -19,7 +19,12 @@ fn default(theme: &Theme, status: Status) -> Style {
     primary(theme, status, false)
 }
 
-fn button(foreground: Color, background: Color, background_hover: Color, status: Status) -> Style {
+fn button(
+    foreground: Color,
+    background: Color,
+    background_hover: Color,
+    status: Status,
+) -> Style {
     match status {
         Status::Active | Status::Pressed => Style {
             background: Some(Background::Color(background)),
@@ -40,7 +45,12 @@ fn button(foreground: Color, background: Color, background_hover: Color, status:
             ..Default::default()
         },
         Status::Disabled => {
-            let active: Style = button(foreground, background, background_hover, Status::Active);
+            let active: Style = button(
+                foreground,
+                background,
+                background_hover,
+                Status::Active,
+            );
 
             Style {
                 text_color: Color {
@@ -53,7 +63,12 @@ fn button(foreground: Color, background: Color, background_hover: Color, status:
     }
 }
 
-pub fn sidebar_buffer(theme: &Theme, status: Status, is_focused: bool, is_open: bool) -> Style {
+pub fn sidebar_buffer(
+    theme: &Theme,
+    status: Status,
+    is_focused: bool,
+    is_open: bool,
+) -> Style {
     let foreground = theme.colors().text.primary;
     let button_colors = theme.colors().buttons.primary;
 

--- a/src/appearance/theme/checkbox.rs
+++ b/src/appearance/theme/checkbox.rs
@@ -1,7 +1,5 @@
-use iced::{
-    widget::checkbox::{Catalog, Status, Style, StyleFn},
-    Border, Color,
-};
+use iced::widget::checkbox::{Catalog, Status, Style, StyleFn};
+use iced::{Border, Color};
 
 use super::Theme;
 
@@ -12,7 +10,11 @@ impl Catalog for Theme {
         Box::new(primary)
     }
 
-    fn style(&self, class: &Self::Class<'_>, status: iced::widget::checkbox::Status) -> Style {
+    fn style(
+        &self,
+        class: &Self::Class<'_>,
+        status: iced::widget::checkbox::Status,
+    ) -> Style {
         class(self, status)
     }
 }

--- a/src/appearance/theme/container.rs
+++ b/src/appearance/theme/container.rs
@@ -1,5 +1,5 @@
-use iced::widget::container::{transparent, Catalog, Style, StyleFn};
-use iced::{border, Background, Border, Color};
+use iced::widget::container::{Catalog, Style, StyleFn, transparent};
+use iced::{Background, Border, Color, border};
 
 use super::Theme;
 

--- a/src/appearance/theme/context_menu.rs
+++ b/src/appearance/theme/context_menu.rs
@@ -1,6 +1,5 @@
-use crate::widget::context_menu::{Catalog, Style, StyleFn};
-
 use super::Theme;
+use crate::widget::context_menu::{Catalog, Style, StyleFn};
 
 impl Catalog for Theme {
     type Class<'a> = StyleFn<'a, Self>;

--- a/src/appearance/theme/menu.rs
+++ b/src/appearance/theme/menu.rs
@@ -1,8 +1,6 @@
 pub use iced::widget::overlay::menu::Style;
-use iced::{
-    widget::overlay::menu::{Catalog, StyleFn},
-    Background, Border,
-};
+use iced::widget::overlay::menu::{Catalog, StyleFn};
+use iced::{Background, Border};
 
 use super::Theme;
 
@@ -32,6 +30,8 @@ pub fn primary(theme: &Theme) -> Style {
             color: general.border,
         },
         selected_text_color: text.primary,
-        selected_background: Background::Color(buttons.primary.background_hover),
+        selected_background: Background::Color(
+            buttons.primary.background_hover,
+        ),
     }
 }

--- a/src/appearance/theme/pane_grid.rs
+++ b/src/appearance/theme/pane_grid.rs
@@ -1,7 +1,5 @@
-use iced::{
-    widget::pane_grid::{Catalog, Highlight, Line, Style, StyleFn},
-    Background, Border, Color,
-};
+use iced::widget::pane_grid::{Catalog, Highlight, Line, Style, StyleFn};
+use iced::{Background, Border, Color};
 
 use super::Theme;
 

--- a/src/appearance/theme/scrollable.rs
+++ b/src/appearance/theme/scrollable.rs
@@ -1,10 +1,8 @@
-use iced::{
-    widget::{
-        container,
-        scrollable::{Catalog, Rail, Scroller, Status, Style, StyleFn},
-    },
-    Background, Border, Color, Shadow,
+use iced::widget::container;
+use iced::widget::scrollable::{
+    Catalog, Rail, Scroller, Status, Style, StyleFn,
 };
+use iced::{Background, Border, Color, Shadow};
 
 use super::Theme;
 
@@ -35,7 +33,9 @@ pub fn primary(theme: &Theme, status: Status) -> Style {
     };
 
     match status {
-        Status::Active { .. } | Status::Hovered { .. } | Status::Dragged { .. } => Style {
+        Status::Active { .. }
+        | Status::Hovered { .. }
+        | Status::Dragged { .. } => Style {
             container: container::Style {
                 text_color: None,
                 background: None,
@@ -68,7 +68,9 @@ pub fn hidden(_theme: &Theme, status: Status) -> Style {
     };
 
     match status {
-        Status::Active { .. } | Status::Hovered { .. } | Status::Dragged { .. } => Style {
+        Status::Active { .. }
+        | Status::Hovered { .. }
+        | Status::Dragged { .. } => Style {
             container: container::Style {
                 text_color: None,
                 background: Some(Background::Color(Color::TRANSPARENT)),

--- a/src/appearance/theme/selectable_text.rs
+++ b/src/appearance/theme/selectable_text.rs
@@ -1,15 +1,11 @@
-use data::{config::buffer::away, message::{
-    self,
-    source::server::{Kind, StandardReply},
-}};
+use data::config::buffer::away;
+use data::message::source::server::{Kind, StandardReply};
+use data::message::{self};
 use data::{Config, User};
 
-use crate::widget::{
-    selectable_rich_text,
-    selectable_text::{Catalog, Style, StyleFn},
-};
-
 use super::{Theme, text};
+use crate::widget::selectable_rich_text;
+use crate::widget::selectable_text::{Catalog, Style, StyleFn};
 
 impl Catalog for Theme {
     type Class<'a> = StyleFn<'a, Self>;
@@ -66,7 +62,10 @@ pub fn topic(theme: &Theme) -> Style {
     }
 }
 
-pub fn server(theme: &Theme, server: Option<&message::source::Server>) -> Style {
+pub fn server(
+    theme: &Theme,
+    server: Option<&message::source::Server>,
+) -> Style {
     let colors = theme.colors().buffer.server_messages;
     let color = server
         .and_then(|server| match server.kind() {
@@ -83,7 +82,9 @@ pub fn server(theme: &Theme, server: Option<&message::source::Server>) -> Style 
             Kind::StandardReply(StandardReply::Warn) => colors
                 .standard_reply_warn
                 .or(Some(theme.colors().text.error)),
-            Kind::StandardReply(StandardReply::Note) => colors.standard_reply_note,
+            Kind::StandardReply(StandardReply::Note) => {
+                colors.standard_reply_note
+            }
         })
         .or(Some(colors.default));
 
@@ -98,10 +99,7 @@ pub fn nicklist_nickname(theme: &Theme, config: &Config, user: &User) -> Style {
         theme,
         config.buffer.channel.nicklist.color,
         user,
-        config
-            .buffer
-            .away
-            .appearance(user.is_away()),
+        config.buffer.away.appearance(user.is_away()),
     )
 }
 
@@ -110,10 +108,7 @@ pub fn nickname(theme: &Theme, config: &Config, user: &User) -> Style {
         theme,
         config.buffer.channel.message.nickname_color,
         user,
-        config
-            .buffer
-            .away
-            .appearance(user.is_away()),
+        config.buffer.away.appearance(user.is_away()),
     )
 }
 

--- a/src/appearance/theme/text.rs
+++ b/src/appearance/theme/text.rs
@@ -1,7 +1,7 @@
-use data::{
-    appearance::theme::{alpha_color, alpha_color_calculate, randomize_color},
-    config::buffer::away,
+use data::appearance::theme::{
+    alpha_color, alpha_color_calculate, randomize_color,
 };
+use data::config::buffer::away;
 use iced::widget::text::{Catalog, Style, StyleFn};
 
 use super::Theme;
@@ -92,7 +92,12 @@ pub fn nickname<T: AsRef<str>>(
         if let Some(away::Appearance::Dimmed(alpha)) = away_appearance {
             match alpha {
                 // Calculate alpha based on background and foreground.
-                None => alpha_color_calculate(0.20, 0.61, theme.colors().buffer.background, color),
+                None => alpha_color_calculate(
+                    0.20,
+                    0.61,
+                    theme.colors().buffer.background,
+                    color,
+                ),
                 // Calculate alpha based on user defined alpha value.
                 Some(a) => alpha_color(color, a),
             }
@@ -103,7 +108,9 @@ pub fn nickname<T: AsRef<str>>(
 
     // If we have a seed we randomize the color based on the seed before adding any alpha value.
     let color = match seed {
-        Some(seed) => calculate_alpha_color(randomize_color(nickname, seed.as_ref())),
+        Some(seed) => {
+            calculate_alpha_color(randomize_color(nickname, seed.as_ref()))
+        }
         None => calculate_alpha_color(nickname),
     };
 

--- a/src/appearance/theme/text_input.rs
+++ b/src/appearance/theme/text_input.rs
@@ -1,7 +1,5 @@
-use iced::{
-    widget::text_input::{Catalog, Status, Style, StyleFn},
-    Background, Border, Color,
-};
+use iced::widget::text_input::{Catalog, Status, Style, StyleFn};
+use iced::{Background, Border, Color};
 
 use super::Theme;
 
@@ -19,7 +17,9 @@ impl Catalog for Theme {
 
 pub fn primary(theme: &Theme, status: Status) -> Style {
     let active = Style {
-        background: Background::Color(theme.colors().buffer.background_text_input),
+        background: Background::Color(
+            theme.colors().buffer.background_text_input,
+        ),
         border: Border {
             radius: 4.0.into(),
             width: 0.0,
@@ -35,7 +35,9 @@ pub fn primary(theme: &Theme, status: Status) -> Style {
     match status {
         Status::Active | Status::Hovered | Status::Focused { .. } => active,
         Status::Disabled => Style {
-            background: Background::Color(theme.colors().buffer.background_text_input),
+            background: Background::Color(
+                theme.colors().buffer.background_text_input,
+            ),
             placeholder: Color {
                 a: 0.2,
                 ..theme.colors().text.secondary

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,4 +1,6 @@
-use std::{io::Cursor, sync::Arc, thread};
+use std::io::Cursor;
+use std::sync::Arc;
+use std::thread;
 
 use data::audio::Sound;
 use rodio::{Decoder, OutputStream, Sink};

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -2,7 +2,7 @@ pub use data::buffer::{Internal, Settings, Upstream};
 use data::dashboard::BufferAction;
 use data::target::{self, Target};
 use data::user::Nick;
-use data::{buffer, file_transfer, history, message, preview, Config};
+use data::{Config, buffer, file_transfer, history, message, preview};
 use iced::Task;
 
 pub use self::channel::Channel;
@@ -11,9 +11,9 @@ pub use self::highlights::Highlights;
 pub use self::logs::Logs;
 pub use self::query::Query;
 pub use self::server::Server;
+use crate::Theme;
 use crate::screen::dashboard::sidebar;
 use crate::widget::Element;
-use crate::Theme;
 
 pub mod channel;
 pub mod empty;
@@ -68,15 +68,19 @@ impl Buffer {
             Buffer::Channel(state) => Some(&state.buffer),
             Buffer::Server(state) => Some(&state.buffer),
             Buffer::Query(state) => Some(&state.buffer),
-            Buffer::Empty | Buffer::FileTransfers(_) | Buffer::Logs(_) | Buffer::Highlights(_) => {
-                None
-            }
+            Buffer::Empty
+            | Buffer::FileTransfers(_)
+            | Buffer::Logs(_)
+            | Buffer::Highlights(_) => None,
         }
     }
 
     pub fn internal(&self) -> Option<buffer::Internal> {
         match self {
-            Buffer::Empty | Buffer::Channel(_) | Buffer::Server(_) | Buffer::Query(_) => None,
+            Buffer::Empty
+            | Buffer::Channel(_)
+            | Buffer::Server(_)
+            | Buffer::Query(_) => None,
             Buffer::FileTransfers(_) => Some(buffer::Internal::FileTransfers),
             Buffer::Logs(_) => Some(buffer::Internal::Logs),
             Buffer::Highlights(_) => Some(buffer::Internal::Highlights),
@@ -86,20 +90,32 @@ impl Buffer {
     pub fn data(&self) -> Option<data::Buffer> {
         match self {
             Buffer::Empty => None,
-            Buffer::Channel(state) => Some(data::Buffer::Upstream(state.buffer.clone())),
-            Buffer::Server(state) => Some(data::Buffer::Upstream(state.buffer.clone())),
-            Buffer::Query(state) => Some(data::Buffer::Upstream(state.buffer.clone())),
+            Buffer::Channel(state) => {
+                Some(data::Buffer::Upstream(state.buffer.clone()))
+            }
+            Buffer::Server(state) => {
+                Some(data::Buffer::Upstream(state.buffer.clone()))
+            }
+            Buffer::Query(state) => {
+                Some(data::Buffer::Upstream(state.buffer.clone()))
+            }
             Buffer::FileTransfers(_) => {
                 Some(data::Buffer::Internal(buffer::Internal::FileTransfers))
             }
-            Buffer::Logs(_) => Some(data::Buffer::Internal(buffer::Internal::Logs)),
-            Buffer::Highlights(_) => Some(data::Buffer::Internal(buffer::Internal::Highlights)),
+            Buffer::Logs(_) => {
+                Some(data::Buffer::Internal(buffer::Internal::Logs))
+            }
+            Buffer::Highlights(_) => {
+                Some(data::Buffer::Internal(buffer::Internal::Highlights))
+            }
         }
     }
 
     pub fn target(&self) -> Option<Target> {
         match self {
-            Buffer::Channel(state) => Some(Target::Channel(state.target.clone())),
+            Buffer::Channel(state) => {
+                Some(Target::Channel(state.target.clone()))
+            }
             Buffer::Query(state) => Some(Target::Query(state.target.clone())),
             Buffer::Empty
             | Buffer::Server(_)
@@ -119,13 +135,20 @@ impl Buffer {
     ) -> (Task<Message>, Option<Event>) {
         match (self, message) {
             (Buffer::Channel(state), Message::Channel(message)) => {
-                let (command, event) = state.update(message, clients, history, config);
+                let (command, event) =
+                    state.update(message, clients, history, config);
 
                 let event = event.map(|event| match event {
-                    channel::Event::UserContext(event) => Event::UserContext(event),
-                    channel::Event::OpenBuffers(targets) => Event::OpenBuffers(targets),
+                    channel::Event::UserContext(event) => {
+                        Event::UserContext(event)
+                    }
+                    channel::Event::OpenBuffers(targets) => {
+                        Event::OpenBuffers(targets)
+                    }
                     channel::Event::History(task) => Event::History(task),
-                    channel::Event::RequestOlderChatHistory => Event::RequestOlderChatHistory,
+                    channel::Event::RequestOlderChatHistory => {
+                        Event::RequestOlderChatHistory
+                    }
                     channel::Event::PreviewChanged => Event::PreviewChanged,
                     channel::Event::HidePreview(kind, hash, url) => {
                         Event::HidePreview(kind, hash, url)
@@ -136,11 +159,16 @@ impl Buffer {
                 (command.map(Message::Channel), event)
             }
             (Buffer::Server(state), Message::Server(message)) => {
-                let (command, event) = state.update(message, clients, history, config);
+                let (command, event) =
+                    state.update(message, clients, history, config);
 
                 let event = event.map(|event| match event {
-                    server::Event::UserContext(event) => Event::UserContext(event),
-                    server::Event::OpenBuffers(targets) => Event::OpenBuffers(targets),
+                    server::Event::UserContext(event) => {
+                        Event::UserContext(event)
+                    }
+                    server::Event::OpenBuffers(targets) => {
+                        Event::OpenBuffers(targets)
+                    }
                     server::Event::History(task) => Event::History(task),
                     server::Event::MarkAsRead(kind) => Event::MarkAsRead(kind),
                 });
@@ -148,13 +176,20 @@ impl Buffer {
                 (command.map(Message::Server), event)
             }
             (Buffer::Query(state), Message::Query(message)) => {
-                let (command, event) = state.update(message, clients, history, config);
+                let (command, event) =
+                    state.update(message, clients, history, config);
 
                 let event = event.map(|event| match event {
-                    query::Event::UserContext(event) => Event::UserContext(event),
-                    query::Event::OpenBuffers(targets) => Event::OpenBuffers(targets),
+                    query::Event::UserContext(event) => {
+                        Event::UserContext(event)
+                    }
+                    query::Event::OpenBuffers(targets) => {
+                        Event::OpenBuffers(targets)
+                    }
                     query::Event::History(task) => Event::History(task),
-                    query::Event::RequestOlderChatHistory => Event::RequestOlderChatHistory,
+                    query::Event::RequestOlderChatHistory => {
+                        Event::RequestOlderChatHistory
+                    }
                     query::Event::PreviewChanged => Event::PreviewChanged,
                     query::Event::HidePreview(kind, hash, url) => {
                         Event::HidePreview(kind, hash, url)
@@ -170,30 +205,40 @@ impl Buffer {
                 (command.map(Message::FileTransfers), None)
             }
             (Buffer::Logs(state), Message::Logs(message)) => {
-                let (command, event) = state.update(message, history, clients, config);
+                let (command, event) =
+                    state.update(message, history, clients, config);
 
                 let event = event.map(|event| match event {
-                    logs::Event::UserContext(event) => Event::UserContext(event),
+                    logs::Event::UserContext(event) => {
+                        Event::UserContext(event)
+                    }
                     logs::Event::OpenBuffer(target, buffer_action) => {
                         Event::OpenBuffers(vec![(target, buffer_action)])
                     }
                     logs::Event::History(task) => Event::History(task),
-                    logs::Event::MarkAsRead => Event::MarkAsRead(history::Kind::Logs),
+                    logs::Event::MarkAsRead => {
+                        Event::MarkAsRead(history::Kind::Logs)
+                    }
                 });
 
                 (command.map(Message::Logs), event)
             }
             (Buffer::Highlights(state), Message::Highlights(message)) => {
-                let (command, event) = state.update(message, history, clients, config);
+                let (command, event) =
+                    state.update(message, history, clients, config);
 
                 let event = event.map(|event| match event {
-                    highlights::Event::UserContext(event) => Event::UserContext(event),
+                    highlights::Event::UserContext(event) => {
+                        Event::UserContext(event)
+                    }
                     highlights::Event::OpenBuffer(target, buffer_action) => {
                         Event::OpenBuffers(vec![(target, buffer_action)])
                     }
-                    highlights::Event::GoToMessage(server, channel, message) => {
-                        Event::GoToMessage(server, channel, message)
-                    }
+                    highlights::Event::GoToMessage(
+                        server,
+                        channel,
+                        message,
+                    ) => Event::GoToMessage(server, channel, message),
                     highlights::Event::History(task) => Event::History(task),
                 });
 
@@ -218,23 +263,28 @@ impl Buffer {
         match self {
             Buffer::Empty => empty::view(config, sidebar),
             Buffer::Channel(state) => channel::view(
-                state, clients, history, previews, settings, config, theme, is_focused,
+                state, clients, history, previews, settings, config, theme,
+                is_focused,
             )
             .map(Message::Channel),
             Buffer::Server(state) => {
                 server::view(state, clients, history, config, theme, is_focused)
                     .map(Message::Server)
             }
-            Buffer::Query(state) => {
-                query::view(state, clients, history, previews, config, theme, is_focused)
-                    .map(Message::Query)
-            }
+            Buffer::Query(state) => query::view(
+                state, clients, history, previews, config, theme, is_focused,
+            )
+            .map(Message::Query),
             Buffer::FileTransfers(state) => {
-                file_transfers::view(state, file_transfers).map(Message::FileTransfers)
+                file_transfers::view(state, file_transfers)
+                    .map(Message::FileTransfers)
             }
-            Buffer::Logs(state) => logs::view(state, history, config, theme).map(Message::Logs),
+            Buffer::Logs(state) => {
+                logs::view(state, history, config, theme).map(Message::Logs)
+            }
             Buffer::Highlights(state) => {
-                highlights::view(state, clients, history, config, theme).map(Message::Highlights)
+                highlights::view(state, clients, history, config, theme)
+                    .map(Message::Highlights)
             }
         }
     }
@@ -257,7 +307,8 @@ impl Buffer {
         channel: &target::Channel,
     ) -> Option<&Channel> {
         if let Buffer::Channel(state) = self {
-            (&state.server == server && state.target == *channel).then_some(state)
+            (&state.server == server && state.target == *channel)
+                .then_some(state)
         } else {
             None
         }
@@ -265,9 +316,10 @@ impl Buffer {
 
     pub fn focus(&self) -> Task<Message> {
         match self {
-            Buffer::Empty | Buffer::FileTransfers(_) | Buffer::Logs(_) | Buffer::Highlights(_) => {
-                Task::none()
-            }
+            Buffer::Empty
+            | Buffer::FileTransfers(_)
+            | Buffer::Logs(_)
+            | Buffer::Highlights(_) => Task::none(),
             Buffer::Channel(channel) => channel.focus().map(Message::Channel),
             Buffer::Server(server) => server.focus().map(Message::Server),
             Buffer::Query(query) => query.focus().map(Message::Query),
@@ -276,7 +328,10 @@ impl Buffer {
 
     pub fn reset(&mut self) {
         match self {
-            Buffer::Empty | Buffer::FileTransfers(_) | Buffer::Logs(_) | Buffer::Highlights(_) => {}
+            Buffer::Empty
+            | Buffer::FileTransfers(_)
+            | Buffer::Logs(_)
+            | Buffer::Highlights(_) => {}
             Buffer::Channel(channel) => channel.reset(),
             Buffer::Server(server) => server.reset(),
             Buffer::Query(query) => query.reset(),
@@ -297,115 +352,147 @@ impl Buffer {
             Buffer::Channel(state) => state
                 .input_view
                 .insert_user(nick, state.buffer.clone(), history)
-                .map(|message| Message::Channel(channel::Message::InputView(message))),
+                .map(|message| {
+                    Message::Channel(channel::Message::InputView(message))
+                }),
             Buffer::Query(state) => state
                 .input_view
                 .insert_user(nick, state.buffer.clone(), history)
-                .map(|message| Message::Query(query::Message::InputView(message))),
+                .map(|message| {
+                    Message::Query(query::Message::InputView(message))
+                }),
         }
     }
 
     pub fn scroll_up_page(&mut self) -> Task<Message> {
         match self {
             Buffer::Empty | Buffer::FileTransfers(_) => Task::none(),
-            Buffer::Channel(channel) => channel
-                .scroll_view
-                .scroll_up_page()
-                .map(|message| Message::Channel(channel::Message::ScrollView(message))),
-            Buffer::Server(server) => server
-                .scroll_view
-                .scroll_up_page()
-                .map(|message| Message::Server(server::Message::ScrollView(message))),
-            Buffer::Query(query) => query
-                .scroll_view
-                .scroll_up_page()
-                .map(|message| Message::Query(query::Message::ScrollView(message))),
-            Buffer::Logs(log) => log
-                .scroll_view
-                .scroll_up_page()
-                .map(|message| Message::Logs(logs::Message::ScrollView(message))),
-            Buffer::Highlights(highlights) => highlights
-                .scroll_view
-                .scroll_up_page()
-                .map(|message| Message::Highlights(highlights::Message::ScrollView(message))),
+            Buffer::Channel(channel) => {
+                channel.scroll_view.scroll_up_page().map(|message| {
+                    Message::Channel(channel::Message::ScrollView(message))
+                })
+            }
+            Buffer::Server(server) => {
+                server.scroll_view.scroll_up_page().map(|message| {
+                    Message::Server(server::Message::ScrollView(message))
+                })
+            }
+            Buffer::Query(query) => {
+                query.scroll_view.scroll_up_page().map(|message| {
+                    Message::Query(query::Message::ScrollView(message))
+                })
+            }
+            Buffer::Logs(log) => {
+                log.scroll_view.scroll_up_page().map(|message| {
+                    Message::Logs(logs::Message::ScrollView(message))
+                })
+            }
+            Buffer::Highlights(highlights) => {
+                highlights.scroll_view.scroll_up_page().map(|message| {
+                    Message::Highlights(highlights::Message::ScrollView(
+                        message,
+                    ))
+                })
+            }
         }
     }
 
     pub fn scroll_down_page(&mut self) -> Task<Message> {
         match self {
             Buffer::Empty | Buffer::FileTransfers(_) => Task::none(),
-            Buffer::Channel(channel) => channel
-                .scroll_view
-                .scroll_down_page()
-                .map(|message| Message::Channel(channel::Message::ScrollView(message))),
-            Buffer::Server(server) => server
-                .scroll_view
-                .scroll_down_page()
-                .map(|message| Message::Server(server::Message::ScrollView(message))),
-            Buffer::Query(query) => query
-                .scroll_view
-                .scroll_down_page()
-                .map(|message| Message::Query(query::Message::ScrollView(message))),
-            Buffer::Logs(log) => log
-                .scroll_view
-                .scroll_down_page()
-                .map(|message| Message::Logs(logs::Message::ScrollView(message))),
-            Buffer::Highlights(highlights) => highlights
-                .scroll_view
-                .scroll_down_page()
-                .map(|message| Message::Highlights(highlights::Message::ScrollView(message))),
+            Buffer::Channel(channel) => {
+                channel.scroll_view.scroll_down_page().map(|message| {
+                    Message::Channel(channel::Message::ScrollView(message))
+                })
+            }
+            Buffer::Server(server) => {
+                server.scroll_view.scroll_down_page().map(|message| {
+                    Message::Server(server::Message::ScrollView(message))
+                })
+            }
+            Buffer::Query(query) => {
+                query.scroll_view.scroll_down_page().map(|message| {
+                    Message::Query(query::Message::ScrollView(message))
+                })
+            }
+            Buffer::Logs(log) => {
+                log.scroll_view.scroll_down_page().map(|message| {
+                    Message::Logs(logs::Message::ScrollView(message))
+                })
+            }
+            Buffer::Highlights(highlights) => {
+                highlights.scroll_view.scroll_down_page().map(|message| {
+                    Message::Highlights(highlights::Message::ScrollView(
+                        message,
+                    ))
+                })
+            }
         }
     }
 
     pub fn scroll_to_start(&mut self) -> Task<Message> {
         match self {
             Buffer::Empty | Buffer::FileTransfers(_) => Task::none(),
-            Buffer::Channel(channel) => channel
-                .scroll_view
-                .scroll_to_start()
-                .map(|message| Message::Channel(channel::Message::ScrollView(message))),
-            Buffer::Server(server) => server
-                .scroll_view
-                .scroll_to_start()
-                .map(|message| Message::Server(server::Message::ScrollView(message))),
-            Buffer::Query(query) => query
-                .scroll_view
-                .scroll_to_start()
-                .map(|message| Message::Query(query::Message::ScrollView(message))),
-            Buffer::Logs(log) => log
-                .scroll_view
-                .scroll_to_start()
-                .map(|message| Message::Logs(logs::Message::ScrollView(message))),
-            Buffer::Highlights(highlights) => highlights
-                .scroll_view
-                .scroll_to_start()
-                .map(|message| Message::Highlights(highlights::Message::ScrollView(message))),
+            Buffer::Channel(channel) => {
+                channel.scroll_view.scroll_to_start().map(|message| {
+                    Message::Channel(channel::Message::ScrollView(message))
+                })
+            }
+            Buffer::Server(server) => {
+                server.scroll_view.scroll_to_start().map(|message| {
+                    Message::Server(server::Message::ScrollView(message))
+                })
+            }
+            Buffer::Query(query) => {
+                query.scroll_view.scroll_to_start().map(|message| {
+                    Message::Query(query::Message::ScrollView(message))
+                })
+            }
+            Buffer::Logs(log) => {
+                log.scroll_view.scroll_to_start().map(|message| {
+                    Message::Logs(logs::Message::ScrollView(message))
+                })
+            }
+            Buffer::Highlights(highlights) => {
+                highlights.scroll_view.scroll_to_start().map(|message| {
+                    Message::Highlights(highlights::Message::ScrollView(
+                        message,
+                    ))
+                })
+            }
         }
     }
 
     pub fn scroll_to_end(&mut self) -> Task<Message> {
         match self {
             Buffer::Empty | Buffer::FileTransfers(_) => Task::none(),
-            Buffer::Channel(channel) => channel
-                .scroll_view
-                .scroll_to_end()
-                .map(|message| Message::Channel(channel::Message::ScrollView(message))),
-            Buffer::Server(server) => server
-                .scroll_view
-                .scroll_to_end()
-                .map(|message| Message::Server(server::Message::ScrollView(message))),
-            Buffer::Query(query) => query
-                .scroll_view
-                .scroll_to_end()
-                .map(|message| Message::Query(query::Message::ScrollView(message))),
-            Buffer::Logs(log) => log
-                .scroll_view
-                .scroll_to_end()
-                .map(|message| Message::Logs(logs::Message::ScrollView(message))),
-            Buffer::Highlights(highlights) => highlights
-                .scroll_view
-                .scroll_to_end()
-                .map(|message| Message::Highlights(highlights::Message::ScrollView(message))),
+            Buffer::Channel(channel) => {
+                channel.scroll_view.scroll_to_end().map(|message| {
+                    Message::Channel(channel::Message::ScrollView(message))
+                })
+            }
+            Buffer::Server(server) => {
+                server.scroll_view.scroll_to_end().map(|message| {
+                    Message::Server(server::Message::ScrollView(message))
+                })
+            }
+            Buffer::Query(query) => {
+                query.scroll_view.scroll_to_end().map(|message| {
+                    Message::Query(query::Message::ScrollView(message))
+                })
+            }
+            Buffer::Logs(log) => {
+                log.scroll_view.scroll_to_end().map(|message| {
+                    Message::Logs(logs::Message::ScrollView(message))
+                })
+            }
+            Buffer::Highlights(highlights) => {
+                highlights.scroll_view.scroll_to_end().map(|message| {
+                    Message::Highlights(highlights::Message::ScrollView(
+                        message,
+                    ))
+                })
+            }
         }
     }
 
@@ -425,7 +512,9 @@ impl Buffer {
                     history,
                     config,
                 )
-                .map(|message| Message::Channel(channel::Message::ScrollView(message))),
+                .map(|message| {
+                    Message::Channel(channel::Message::ScrollView(message))
+                }),
             Buffer::Server(state) => state
                 .scroll_view
                 .scroll_to_message(
@@ -434,7 +523,9 @@ impl Buffer {
                     history,
                     config,
                 )
-                .map(|message| Message::Server(server::Message::ScrollView(message))),
+                .map(|message| {
+                    Message::Server(server::Message::ScrollView(message))
+                }),
             Buffer::Query(state) => state
                 .scroll_view
                 .scroll_to_message(
@@ -443,15 +534,33 @@ impl Buffer {
                     history,
                     config,
                 )
-                .map(|message| Message::Query(query::Message::ScrollView(message))),
+                .map(|message| {
+                    Message::Query(query::Message::ScrollView(message))
+                }),
             Buffer::Logs(state) => state
                 .scroll_view
-                .scroll_to_message(message, scroll_view::Kind::Logs, history, config)
-                .map(|message| Message::Logs(logs::Message::ScrollView(message))),
+                .scroll_to_message(
+                    message,
+                    scroll_view::Kind::Logs,
+                    history,
+                    config,
+                )
+                .map(|message| {
+                    Message::Logs(logs::Message::ScrollView(message))
+                }),
             Buffer::Highlights(state) => state
                 .scroll_view
-                .scroll_to_message(message, scroll_view::Kind::Highlights, history, config)
-                .map(|message| Message::Highlights(highlights::Message::ScrollView(message))),
+                .scroll_to_message(
+                    message,
+                    scroll_view::Kind::Highlights,
+                    history,
+                    config,
+                )
+                .map(|message| {
+                    Message::Highlights(highlights::Message::ScrollView(
+                        message,
+                    ))
+                }),
         }
     }
 
@@ -469,11 +578,19 @@ impl Buffer {
                     history,
                     config,
                 )
-                .map(|message| Message::Channel(channel::Message::ScrollView(message))),
+                .map(|message| {
+                    Message::Channel(channel::Message::ScrollView(message))
+                }),
             Buffer::Server(state) => state
                 .scroll_view
-                .scroll_to_backlog(scroll_view::Kind::Server(&state.server), history, config)
-                .map(|message| Message::Server(server::Message::ScrollView(message))),
+                .scroll_to_backlog(
+                    scroll_view::Kind::Server(&state.server),
+                    history,
+                    config,
+                )
+                .map(|message| {
+                    Message::Server(server::Message::ScrollView(message))
+                }),
             Buffer::Query(state) => state
                 .scroll_view
                 .scroll_to_backlog(
@@ -481,34 +598,55 @@ impl Buffer {
                     history,
                     config,
                 )
-                .map(|message| Message::Query(query::Message::ScrollView(message))),
+                .map(|message| {
+                    Message::Query(query::Message::ScrollView(message))
+                }),
             Buffer::Logs(state) => state
                 .scroll_view
                 .scroll_to_backlog(scroll_view::Kind::Logs, history, config)
-                .map(|message| Message::Logs(logs::Message::ScrollView(message))),
+                .map(|message| {
+                    Message::Logs(logs::Message::ScrollView(message))
+                }),
             Buffer::Highlights(state) => state
                 .scroll_view
-                .scroll_to_backlog(scroll_view::Kind::Highlights, history, config)
-                .map(|message| Message::Highlights(highlights::Message::ScrollView(message))),
+                .scroll_to_backlog(
+                    scroll_view::Kind::Highlights,
+                    history,
+                    config,
+                )
+                .map(|message| {
+                    Message::Highlights(highlights::Message::ScrollView(
+                        message,
+                    ))
+                }),
         }
     }
 
     pub fn is_scrolled_to_bottom(&self) -> Option<bool> {
         match self {
             Buffer::Empty | Buffer::FileTransfers(_) => None,
-            Buffer::Channel(channel) => Some(channel.scroll_view.is_scrolled_to_bottom()),
-            Buffer::Server(server) => Some(server.scroll_view.is_scrolled_to_bottom()),
-            Buffer::Query(query) => Some(query.scroll_view.is_scrolled_to_bottom()),
+            Buffer::Channel(channel) => {
+                Some(channel.scroll_view.is_scrolled_to_bottom())
+            }
+            Buffer::Server(server) => {
+                Some(server.scroll_view.is_scrolled_to_bottom())
+            }
+            Buffer::Query(query) => {
+                Some(query.scroll_view.is_scrolled_to_bottom())
+            }
             Buffer::Logs(log) => Some(log.scroll_view.is_scrolled_to_bottom()),
-            Buffer::Highlights(highlights) => Some(highlights.scroll_view.is_scrolled_to_bottom()),
+            Buffer::Highlights(highlights) => {
+                Some(highlights.scroll_view.is_scrolled_to_bottom())
+            }
         }
     }
 
     pub fn close_picker(&mut self) -> bool {
         match self {
-            Buffer::Empty | Buffer::FileTransfers(_) | Buffer::Logs(_) | Buffer::Highlights(_) => {
-                false
-            }
+            Buffer::Empty
+            | Buffer::FileTransfers(_)
+            | Buffer::Logs(_)
+            | Buffer::Highlights(_) => false,
             Buffer::Server(state) => state.input_view.close_picker(),
             Buffer::Channel(state) => state.input_view.close_picker(),
             Buffer::Query(state) => state.input_view.close_picker(),
@@ -520,16 +658,24 @@ impl From<data::Buffer> for Buffer {
     fn from(buffer: data::Buffer) -> Self {
         match buffer {
             data::Buffer::Upstream(upstream) => match upstream {
-                buffer::Upstream::Server(server) => Self::Server(Server::new(server)),
+                buffer::Upstream::Server(server) => {
+                    Self::Server(Server::new(server))
+                }
                 buffer::Upstream::Channel(server, channel) => {
                     Self::Channel(Channel::new(server, channel))
                 }
-                buffer::Upstream::Query(server, query) => Self::Query(Query::new(server, query)),
+                buffer::Upstream::Query(server, query) => {
+                    Self::Query(Query::new(server, query))
+                }
             },
             data::Buffer::Internal(internal) => match internal {
-                buffer::Internal::FileTransfers => Self::FileTransfers(FileTransfers::new()),
+                buffer::Internal::FileTransfers => {
+                    Self::FileTransfers(FileTransfers::new())
+                }
                 buffer::Internal::Logs => Self::Logs(Logs::new()),
-                buffer::Internal::Highlights => Self::Highlights(Highlights::new()),
+                buffer::Internal::Highlights => {
+                    Self::Highlights(Highlights::new())
+                }
             },
         }
     }

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -2,14 +2,16 @@ use data::dashboard::BufferAction;
 use data::server::Server;
 use data::target::{self, Target};
 use data::user::Nick;
-use data::{buffer, history, message, preview, Config, User};
+use data::{Config, User, buffer, history, message, preview};
 use iced::advanced::text;
 use iced::widget::{column, container, row};
-use iced::{padding, Length, Task};
+use iced::{Length, Task, padding};
 
 use super::{input_view, scroll_view, user_context};
-use crate::widget::{message_content, message_marker, selectable_text, Element};
-use crate::{theme, Theme};
+use crate::widget::{
+    Element, message_content, message_marker, selectable_text,
+};
+use crate::{Theme, theme};
 
 mod topic;
 
@@ -50,11 +52,14 @@ pub fn view<'a>(
 
     let our_user = our_nick
         .map(|our_nick| User::from(Nick::from(our_nick.as_ref())))
-        .and_then(|user| clients.resolve_user_attributes(&state.server, channel, &user));
+        .and_then(|user| {
+            clients.resolve_user_attributes(&state.server, channel, &user)
+        });
 
     let users = clients.get_channel_users(&state.server, channel);
 
-    let chathistory_state = clients.get_chathistory_state(server, &channel.to_target());
+    let chathistory_state =
+        clients.get_chathistory_state(server, &channel.to_target());
 
     let messages = container(
         scroll_view::view(
@@ -65,13 +70,13 @@ pub fn view<'a>(
             chathistory_state,
             config,
             move |message, max_nick_width, max_prefix_width| {
-                let timestamp =
-                    config
-                        .buffer
-                        .format_timestamp(&message.server_time)
-                        .map(|timestamp| {
-                            selectable_text(timestamp).style(theme::selectable_text::timestamp)
-                        });
+                let timestamp = config
+                    .buffer
+                    .format_timestamp(&message.server_time)
+                    .map(|timestamp| {
+                        selectable_text(timestamp)
+                            .style(theme::selectable_text::timestamp)
+                    });
 
                 let prefixes = message.target.prefixes().map_or(
                     max_nick_width.and_then(|_| {
@@ -93,7 +98,10 @@ pub fn view<'a>(
                         .style(theme::selectable_text::tertiary);
 
                         if let Some(width) = max_prefix_width {
-                            Some(text.width(width).align_x(text::Alignment::Right))
+                            Some(
+                                text.width(width)
+                                    .align_x(text::Alignment::Right),
+                            )
                         } else {
                             Some(text)
                         }
@@ -101,12 +109,14 @@ pub fn view<'a>(
                 );
 
                 let space = selectable_text(" ");
-                let with_access_levels = config.buffer.nickname.show_access_levels;
+                let with_access_levels =
+                    config.buffer.nickname.show_access_levels;
 
                 match message.target.source() {
                     message::Source::User(user) => {
-                        let current_user: Option<&User> =
-                            users.iter().find(|current_user| *current_user == user);
+                        let current_user: Option<&User> = users
+                            .iter()
+                            .find(|current_user| *current_user == user);
 
                         let mut text = selectable_text(
                             config
@@ -115,10 +125,16 @@ pub fn view<'a>(
                                 .brackets
                                 .format(user.display(with_access_levels)),
                         )
-                        .style(|theme| theme::selectable_text::nickname(theme, config, user));
+                        .style(|theme| {
+                            theme::selectable_text::nickname(
+                                theme, config, user,
+                            )
+                        });
 
                         if let Some(width) = max_nick_width {
-                            text = text.width(width).align_x(text::Alignment::Right);
+                            text = text
+                                .width(width)
+                                .align_x(text::Alignment::Right);
                         }
 
                         let nick = user_context::view(
@@ -141,7 +157,9 @@ pub fn view<'a>(
                             scroll_view::Message::Link,
                             theme::selectable_text::default,
                             move |link| match link {
-                                message::Link::User(_) => user_context::Entry::list(true, our_user),
+                                message::Link::User(_) => {
+                                    user_context::Entry::list(true, our_user)
+                                }
                                 _ => vec![],
                             },
                             move |link, entry, length| match link {
@@ -170,7 +188,8 @@ pub fn view<'a>(
                         let text_container = container(message_content);
 
                         match &config.buffer.nickname.alignment {
-                            data::buffer::Alignment::Left | data::buffer::Alignment::Right => Some(
+                            data::buffer::Alignment::Left
+                            | data::buffer::Alignment::Right => Some(
                                 row![]
                                     .push(timestamp_nickname_row)
                                     .push(text_container)
@@ -186,10 +205,14 @@ pub fn view<'a>(
                     }
                     message::Source::Server(server_message) => {
                         let message_style = move |message_theme: &Theme| {
-                            theme::selectable_text::server(message_theme, server_message.as_ref())
+                            theme::selectable_text::server(
+                                message_theme,
+                                server_message.as_ref(),
+                            )
                         };
 
-                        let marker = message_marker(max_nick_width, message_style);
+                        let marker =
+                            message_marker(max_nick_width, message_style);
 
                         let message_content = message_content::with_context(
                             &message.content,
@@ -198,7 +221,9 @@ pub fn view<'a>(
                             scroll_view::Message::Link,
                             message_style,
                             move |link| match link {
-                                message::Link::User(_) => user_context::Entry::list(true, our_user),
+                                message::Link::User(_) => {
+                                    user_context::Entry::list(true, our_user)
+                                }
                                 _ => vec![],
                             },
                             move |link, entry, length| match link {
@@ -208,7 +233,9 @@ pub fn view<'a>(
                                         casemapping,
                                         Some(channel),
                                         user,
-                                        users.iter().find(|current_user| *current_user == user),
+                                        users.iter().find(|current_user| {
+                                            *current_user == user
+                                        }),
                                         length,
                                         config,
                                     )
@@ -233,7 +260,10 @@ pub fn view<'a>(
                         )
                     }
                     message::Source::Action(_) => {
-                        let marker = message_marker(max_nick_width, theme::selectable_text::action);
+                        let marker = message_marker(
+                            max_nick_width,
+                            theme::selectable_text::action,
+                        );
 
                         let message_content = message_content(
                             &message.content,
@@ -258,12 +288,18 @@ pub fn view<'a>(
                             .into(),
                         )
                     }
-                    message::Source::Internal(message::source::Internal::Status(status)) => {
+                    message::Source::Internal(
+                        message::source::Internal::Status(status),
+                    ) => {
                         let message_style = move |message_theme: &Theme| {
-                            theme::selectable_text::status(message_theme, *status)
+                            theme::selectable_text::status(
+                                message_theme,
+                                *status,
+                            )
                         };
 
-                        let marker = message_marker(max_nick_width, message_style);
+                        let marker =
+                            message_marker(max_nick_width, message_style);
 
                         let message = message_content(
                             &message.content,
@@ -286,7 +322,9 @@ pub fn view<'a>(
                             .into(),
                         )
                     }
-                    message::Source::Internal(message::source::Internal::Logs) => None,
+                    message::Source::Internal(
+                        message::source::Internal::Logs,
+                    ) => None,
                 }
             },
         )
@@ -295,8 +333,9 @@ pub fn view<'a>(
     .width(Length::FillPortion(2))
     .height(Length::Fill);
 
-    let nick_list = nick_list::view(server, casemapping, channel, users, our_user, config)
-        .map(Message::UserContext);
+    let nick_list =
+        nick_list::view(server, casemapping, channel, users, our_user, config)
+            .map(Message::UserContext);
 
     // If topic toggles from None to Some then it messes with messages' scroll state,
     // so produce a zero-height placeholder when topic is None.
@@ -324,16 +363,18 @@ pub fn view<'a>(
 
     let content = column![topic, messages].spacing(4);
 
-    let nicklist_enabled = settings.map_or(config.buffer.channel.nicklist.enabled, |settings| {
-        settings.channel.nicklist.enabled
-    });
+    let nicklist_enabled = settings
+        .map_or(config.buffer.channel.nicklist.enabled, |settings| {
+            settings.channel.nicklist.enabled
+        });
 
-    let content = match (nicklist_enabled, config.buffer.channel.nicklist.position) {
-        (true, data::channel::Position::Left) => row![nick_list, content],
-        (true, data::channel::Position::Right) => row![content, nick_list],
-        (false, _) => { row![content] }.height(Length::Fill),
-    }
-    .spacing(4);
+    let content =
+        match (nicklist_enabled, config.buffer.channel.nicklist.position) {
+            (true, data::channel::Position::Left) => row![nick_list, content],
+            (true, data::channel::Position::Right) => row![content, nick_list],
+            (false, _) => { row![content] }.height(Length::Fill),
+        }
+        .spacing(4);
 
     let body = column![]
         .push(container(content).height(Length::Fill))
@@ -387,7 +428,9 @@ impl Channel {
                 );
 
                 let event = event.and_then(|event| match event {
-                    scroll_view::Event::UserContext(event) => Some(Event::UserContext(event)),
+                    scroll_view::Event::UserContext(event) => {
+                        Some(Event::UserContext(event))
+                    }
                     scroll_view::Event::OpenBuffer(target, buffer_action) => {
                         Some(Event::OpenBuffers(vec![(target, buffer_action)]))
                     }
@@ -395,29 +438,39 @@ impl Channel {
                     scroll_view::Event::RequestOlderChatHistory => {
                         Some(Event::RequestOlderChatHistory)
                     }
-                    scroll_view::Event::PreviewChanged => Some(Event::PreviewChanged),
+                    scroll_view::Event::PreviewChanged => {
+                        Some(Event::PreviewChanged)
+                    }
                     scroll_view::Event::HidePreview(kind, hash, url) => {
                         Some(Event::HidePreview(kind, hash, url))
                     }
                     scroll_view::Event::MarkAsRead => {
-                        history::Kind::from_buffer(data::Buffer::Upstream(self.buffer.clone()))
-                            .map(Event::MarkAsRead)
+                        history::Kind::from_buffer(data::Buffer::Upstream(
+                            self.buffer.clone(),
+                        ))
+                        .map(Event::MarkAsRead)
                     }
                 });
 
                 (command.map(Message::ScrollView), event)
             }
             Message::InputView(message) => {
-                let (command, event) =
-                    self.input_view
-                        .update(message, &self.buffer, clients, history, config);
+                let (command, event) = self.input_view.update(
+                    message,
+                    &self.buffer,
+                    clients,
+                    history,
+                    config,
+                );
                 let command = command.map(Message::InputView);
 
                 match event {
                     Some(input_view::Event::InputSent { history_task }) => {
                         let command = Task::batch(vec![
                             command,
-                            self.scroll_view.scroll_to_end().map(Message::ScrollView),
+                            self.scroll_view
+                                .scroll_to_end()
+                                .map(Message::ScrollView),
                         ]);
 
                         (command, Some(Event::History(history_task)))
@@ -435,11 +488,15 @@ impl Channel {
             Message::Topic(message) => (
                 Task::none(),
                 topic::update(message).map(|event| match event {
-                    topic::Event::UserContext(event) => Event::UserContext(event),
-                    topic::Event::OpenChannel(channel) => Event::OpenBuffers(vec![(
-                        Target::Channel(channel),
-                        config.actions.buffer.click_channel_name,
-                    )]),
+                    topic::Event::UserContext(event) => {
+                        Event::UserContext(event)
+                    }
+                    topic::Event::OpenChannel(channel) => {
+                        Event::OpenBuffers(vec![(
+                            Target::Channel(channel),
+                            config.actions.buffer.click_channel_name,
+                        )])
+                    }
                 }),
             ),
         }
@@ -463,9 +520,10 @@ fn topic<'a>(
     config: &'a Config,
     theme: &'a Theme,
 ) -> Option<Element<'a, Message>> {
-    let topic_enabled = settings.map_or(config.buffer.channel.topic.enabled, |settings| {
-        settings.channel.topic.enabled
-    });
+    let topic_enabled = settings
+        .map_or(config.buffer.channel.topic.enabled, |settings| {
+            settings.channel.topic.enabled
+        });
 
     if !topic_enabled {
         return None;
@@ -494,14 +552,14 @@ fn topic<'a>(
 }
 
 mod nick_list {
-    use data::{config, isupport, target, Config, Server, User};
-    use iced::advanced::text;
-    use iced::widget::{column, scrollable, Scrollable};
+    use data::{Config, Server, User, config, isupport, target};
     use iced::Length;
+    use iced::advanced::text;
+    use iced::widget::{Scrollable, column, scrollable};
     use user_context::Message;
 
     use crate::buffer::user_context;
-    use crate::widget::{selectable_text, Element};
+    use crate::widget::{Element, selectable_text};
     use crate::{font, theme};
 
     pub fn view<'a>(
@@ -532,13 +590,21 @@ mod nick_list {
         };
 
         let content = column(users.iter().map(|user| {
-            let content = selectable_text(user.display(nicklist_config.show_access_levels))
-                .style(|theme| theme::selectable_text::nicklist_nickname(theme, config, user))
-                .align_x(match nicklist_config.alignment {
-                    config::buffer::channel::Alignment::Left => text::Alignment::Left,
-                    config::buffer::channel::Alignment::Right => text::Alignment::Right,
-                })
-                .width(Length::Fixed(width));
+            let content = selectable_text(
+                user.display(nicklist_config.show_access_levels),
+            )
+            .style(|theme| {
+                theme::selectable_text::nicklist_nickname(theme, config, user)
+            })
+            .align_x(match nicklist_config.alignment {
+                config::buffer::channel::Alignment::Left => {
+                    text::Alignment::Left
+                }
+                config::buffer::channel::Alignment::Right => {
+                    text::Alignment::Right
+                }
+            })
+            .width(Length::Fixed(width));
 
             user_context::view(
                 content,

--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -1,7 +1,9 @@
 use chrono::{DateTime, Utc};
 use data::{Config, Server, User, isupport, message, target};
 use iced::Length;
-use iced::widget::{Scrollable, column, container, horizontal_rule, row, scrollable};
+use iced::widget::{
+    Scrollable, column, container, horizontal_rule, row, scrollable,
+};
 
 use super::user_context;
 use crate::widget::{Element, double_pass, message_content, selectable_text};
@@ -21,8 +23,12 @@ pub enum Message {
 
 pub fn update(message: Message) -> Option<Event> {
     match message {
-        Message::UserContext(message) => Some(Event::UserContext(user_context::update(message))),
-        Message::Link(message::Link::Channel(channel)) => Some(Event::OpenChannel(channel)),
+        Message::UserContext(message) => {
+            Some(Event::UserContext(user_context::update(message)))
+        }
+        Message::Link(message::Link::Channel(channel)) => {
+            Some(Event::OpenChannel(channel))
+        }
         Message::Link(message::Link::Url(url)) => {
             let _ = open::that_detached(url);
             None
@@ -47,44 +53,52 @@ pub fn view<'a>(
     config: &'a Config,
     theme: &'a Theme,
 ) -> Element<'a, Message> {
-    let set_by = who
-        .and_then(|who| User::try_from(who).ok())
-        .and_then(|user| {
-            let channel_user = users.iter().find(|u| **u == user);
+    let set_by =
+        who.and_then(|who| User::try_from(who).ok())
+            .and_then(|user| {
+                let channel_user = users.iter().find(|u| **u == user);
 
-            // If user is in channel, we return user_context component.
-            // Otherwise selectable_text component.
-            let content = if let Some(user) = channel_user {
-                user_context::view(
-                    selectable_text(user.nickname().to_string())
-                        .style(|theme| theme::selectable_text::topic_nickname(theme, config, user)),
-                    server,
-                    casemapping,
-                    Some(channel),
-                    user,
-                    Some(user),
-                    our_user,
-                    config,
-                    &config.buffer.nickname.click,
+                // If user is in channel, we return user_context component.
+                // Otherwise selectable_text component.
+                let content = if let Some(user) = channel_user {
+                    user_context::view(
+                        selectable_text(user.nickname().to_string()).style(
+                            |theme| {
+                                theme::selectable_text::topic_nickname(
+                                    theme, config, user,
+                                )
+                            },
+                        ),
+                        server,
+                        casemapping,
+                        Some(channel),
+                        user,
+                        Some(user),
+                        our_user,
+                        config,
+                        &config.buffer.nickname.click,
+                    )
+                } else {
+                    selectable_text(user.display(false))
+                        .style(move |theme| {
+                            theme::selectable_text::topic_nickname(
+                                theme, config, &user,
+                            )
+                        })
+                        .into()
+                };
+
+                Some(
+                    Element::new(row![
+                        selectable_text("set by ")
+                            .style(theme::selectable_text::topic),
+                        content,
+                        selectable_text(format!(" at {}", time?.to_rfc2822()))
+                            .style(theme::selectable_text::topic),
+                    ])
+                    .map(Message::UserContext),
                 )
-            } else {
-                selectable_text(user.display(false))
-                    .style(move |theme| {
-                        theme::selectable_text::topic_nickname(theme, config, &user)
-                    })
-                    .into()
-            };
-
-            Some(
-                Element::new(row![
-                    selectable_text("set by ").style(theme::selectable_text::topic),
-                    content,
-                    selectable_text(format!(" at {}", time?.to_rfc2822()))
-                        .style(theme::selectable_text::topic),
-                ])
-                .map(Message::UserContext),
-            )
-        });
+            });
 
     let content = column![message_content(
         content,
@@ -96,11 +110,13 @@ pub fn view<'a>(
     )]
     .push_maybe(set_by);
 
-    let scrollable = Scrollable::new(container(content).width(Length::Fill).padding(padding()))
-        .direction(scrollable::Direction::Vertical(
-            scrollable::Scrollbar::new().width(1).scroller_width(1),
-        ))
-        .style(theme::scrollable::hidden);
+    let scrollable = Scrollable::new(
+        container(content).width(Length::Fill).padding(padding()),
+    )
+    .direction(scrollable::Direction::Vertical(
+        scrollable::Scrollbar::new().width(1).scroller_width(1),
+    ))
+    .style(theme::scrollable::hidden);
 
     // Use double pass to limit layout to `max_lines` of text
     column![

--- a/src/buffer/empty.rs
+++ b/src/buffer/empty.rs
@@ -1,6 +1,6 @@
 use data::Config;
 use iced::widget::{column, container, text};
-use iced::{alignment, Length};
+use iced::{Length, alignment};
 
 use crate::screen::dashboard::sidebar;
 use crate::widget::Element;
@@ -21,7 +21,10 @@ pub fn view<'a, Message: 'a>(
     };
 
     let content = column![]
-        .push(text(format!("{arrow} select buffer")).shaping(text::Shaping::Advanced))
+        .push(
+            text(format!("{arrow} select buffer"))
+                .shaping(text::Shaping::Advanced),
+        )
         .align_x(iced::Alignment::Center);
 
     container(content)

--- a/src/buffer/highlights.rs
+++ b/src/buffer/highlights.rs
@@ -1,12 +1,14 @@
 use data::dashboard::BufferAction;
 use data::target::{self, Target};
-use data::{history, message, Config, Server};
+use data::{Config, Server, history, message};
 use iced::widget::{container, row, span};
 use iced::{Length, Task};
 
 use super::{scroll_view, user_context};
-use crate::widget::{message_content, selectable_rich_text, selectable_text, Element};
-use crate::{theme, Theme};
+use crate::widget::{
+    Element, message_content, selectable_rich_text, selectable_text,
+};
+use crate::{Theme, theme};
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -43,29 +45,32 @@ pub fn view<'a>(
                 } => {
                     let users = clients.get_channel_users(server, channel);
 
-                    let timestamp =
-                        config
-                            .buffer
-                            .format_timestamp(&message.server_time)
-                            .map(|timestamp| {
-                                selectable_text(timestamp).style(theme::selectable_text::timestamp)
-                            });
+                    let timestamp = config
+                        .buffer
+                        .format_timestamp(&message.server_time)
+                        .map(|timestamp| {
+                            selectable_text(timestamp)
+                                .style(theme::selectable_text::timestamp)
+                        });
 
-                    let channel_text = selectable_rich_text::<_, _, (), _, _>(vec![
-                        span(channel.as_str())
-                            .color(theme.colors().buffer.url)
-                            .link(message::Link::GoToMessage(
-                                server.clone(),
-                                channel.clone(),
-                                message.hash,
-                            )),
-                        span(" "),
-                    ])
-                    .on_link(scroll_view::Message::Link);
+                    let channel_text =
+                        selectable_rich_text::<_, _, (), _, _>(vec![
+                            span(channel.as_str())
+                                .color(theme.colors().buffer.url)
+                                .link(message::Link::GoToMessage(
+                                    server.clone(),
+                                    channel.clone(),
+                                    message.hash,
+                                )),
+                            span(" "),
+                        ])
+                        .on_link(scroll_view::Message::Link);
 
-                    let with_access_levels = config.buffer.nickname.show_access_levels;
+                    let with_access_levels =
+                        config.buffer.nickname.show_access_levels;
 
-                    let current_user = users.iter().find(|current_user| *current_user == user);
+                    let current_user =
+                        users.iter().find(|current_user| *current_user == user);
 
                     let text = selectable_text(
                         config
@@ -74,7 +79,9 @@ pub fn view<'a>(
                             .brackets
                             .format(user.display(with_access_levels)),
                     )
-                    .style(|theme| theme::selectable_text::nickname(theme, config, user));
+                    .style(|theme| {
+                        theme::selectable_text::nickname(theme, config, user)
+                    });
 
                     let casemapping = clients.get_casemapping(server);
 
@@ -98,7 +105,9 @@ pub fn view<'a>(
                         scroll_view::Message::Link,
                         theme::selectable_text::default,
                         move |link| match link {
-                            message::Link::User(_) => user_context::Entry::list(true, None),
+                            message::Link::User(_) => {
+                                user_context::Entry::list(true, None)
+                            }
                             _ => vec![],
                         },
                         move |link, entry, length| match link {
@@ -135,25 +144,26 @@ pub fn view<'a>(
                     channel,
                     source: message::Source::Action(_),
                 } => {
-                    let timestamp =
-                        config
-                            .buffer
-                            .format_timestamp(&message.server_time)
-                            .map(|timestamp| {
-                                selectable_text(timestamp).style(theme::selectable_text::timestamp)
-                            });
+                    let timestamp = config
+                        .buffer
+                        .format_timestamp(&message.server_time)
+                        .map(|timestamp| {
+                            selectable_text(timestamp)
+                                .style(theme::selectable_text::timestamp)
+                        });
 
-                    let channel_text = selectable_rich_text::<_, _, (), _, _>(vec![
-                        span(channel.as_str())
-                            .color(theme.colors().buffer.url)
-                            .link(message::Link::GoToMessage(
-                                server.clone(),
-                                channel.clone(),
-                                message.hash,
-                            )),
-                        span(" "),
-                    ])
-                    .on_link(scroll_view::Message::Link);
+                    let channel_text =
+                        selectable_rich_text::<_, _, (), _, _>(vec![
+                            span(channel.as_str())
+                                .color(theme.colors().buffer.url)
+                                .link(message::Link::GoToMessage(
+                                    server.clone(),
+                                    channel.clone(),
+                                    message.hash,
+                                )),
+                            span(" "),
+                        ])
+                        .on_link(scroll_view::Message::Link);
 
                     let casemapping = clients.get_casemapping(server);
 
@@ -167,8 +177,13 @@ pub fn view<'a>(
                     );
 
                     Some(
-                        container(row![].push_maybe(timestamp).push(channel_text).push(text))
-                            .into(),
+                        container(
+                            row![]
+                                .push_maybe(timestamp)
+                                .push(channel_text)
+                                .push(text),
+                        )
+                        .into(),
                     )
                 }
                 _ => None,
@@ -214,13 +229,17 @@ impl Highlights {
                 );
 
                 let event = event.and_then(|event| match event {
-                    scroll_view::Event::UserContext(event) => Some(Event::UserContext(event)),
+                    scroll_view::Event::UserContext(event) => {
+                        Some(Event::UserContext(event))
+                    }
                     scroll_view::Event::OpenBuffer(target, buffer_action) => {
                         Some(Event::OpenBuffer(target, buffer_action))
                     }
-                    scroll_view::Event::GoToMessage(server, channel, message) => {
-                        Some(Event::GoToMessage(server, channel, message))
-                    }
+                    scroll_view::Event::GoToMessage(
+                        server,
+                        channel,
+                        message,
+                    ) => Some(Event::GoToMessage(server, channel, message)),
                     scroll_view::Event::RequestOlderChatHistory => None,
                     scroll_view::Event::PreviewChanged => None,
                     scroll_view::Event::HidePreview(..) => None,

--- a/src/buffer/logs.rs
+++ b/src/buffer/logs.rs
@@ -1,12 +1,12 @@
 use data::dashboard::BufferAction;
 use data::target::Target;
-use data::{client, history, isupport, message, Config};
+use data::{Config, client, history, isupport, message};
 use iced::widget::container;
 use iced::{Length, Task};
 
 use super::{scroll_view, user_context};
-use crate::widget::{message_content, Element};
-use crate::{theme, Theme};
+use crate::widget::{Element, message_content};
+use crate::{Theme, theme};
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -35,17 +35,19 @@ pub fn view<'a>(
             None,
             config,
             move |message, _, _| match message.target.source() {
-                message::Source::Internal(message::source::Internal::Logs) => Some(
-                    container(message_content(
-                        &message.content,
-                        isupport::CaseMap::default(),
-                        theme,
-                        scroll_view::Message::Link,
-                        theme::selectable_text::default,
-                        config,
-                    ))
-                    .into(),
-                ),
+                message::Source::Internal(message::source::Internal::Logs) => {
+                    Some(
+                        container(message_content(
+                            &message.content,
+                            isupport::CaseMap::default(),
+                            theme,
+                            scroll_view::Message::Link,
+                            theme::selectable_text::default,
+                            config,
+                        ))
+                        .into(),
+                    )
+                }
                 _ => None,
             },
         )
@@ -89,7 +91,9 @@ impl Logs {
                 );
 
                 let event = event.and_then(|event| match event {
-                    scroll_view::Event::UserContext(event) => Some(Event::UserContext(event)),
+                    scroll_view::Event::UserContext(event) => {
+                        Some(Event::UserContext(event))
+                    }
                     scroll_view::Event::OpenBuffer(target, buffer_action) => {
                         Some(Event::OpenBuffer(target, buffer_action))
                     }

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -1,13 +1,15 @@
 use data::dashboard::BufferAction;
 use data::target::{self, Target};
-use data::{buffer, history, message, preview, Config, Server};
+use data::{Config, Server, buffer, history, message, preview};
 use iced::advanced::text;
 use iced::widget::{column, container, row, vertical_space};
 use iced::{Length, Task};
 
 use super::{input_view, scroll_view, user_context};
-use crate::widget::{message_content, message_marker, selectable_text, Element};
-use crate::{theme, Theme};
+use crate::widget::{
+    Element, message_content, message_marker, selectable_text,
+};
+use crate::{Theme, theme};
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -41,7 +43,8 @@ pub fn view<'a>(
     let buffer = &state.buffer;
     let input = history.input(buffer);
 
-    let chathistory_state = clients.get_chathistory_state(server, &query.to_target());
+    let chathistory_state =
+        clients.get_chathistory_state(server, &query.to_target());
 
     let messages = container(
         scroll_view::view(
@@ -52,19 +55,20 @@ pub fn view<'a>(
             chathistory_state,
             config,
             move |message, max_nick_width, _| {
-                let timestamp =
-                    config
-                        .buffer
-                        .format_timestamp(&message.server_time)
-                        .map(|timestamp| {
-                            selectable_text(timestamp).style(theme::selectable_text::timestamp)
-                        });
+                let timestamp = config
+                    .buffer
+                    .format_timestamp(&message.server_time)
+                    .map(|timestamp| {
+                        selectable_text(timestamp)
+                            .style(theme::selectable_text::timestamp)
+                    });
 
                 let space = selectable_text(" ");
 
                 match message.target.source() {
                     message::Source::User(user) => {
-                        let with_access_levels = config.buffer.nickname.show_access_levels;
+                        let with_access_levels =
+                            config.buffer.nickname.show_access_levels;
                         let mut text = selectable_text(
                             config
                                 .buffer
@@ -72,10 +76,16 @@ pub fn view<'a>(
                                 .brackets
                                 .format(user.display(with_access_levels)),
                         )
-                        .style(|theme| theme::selectable_text::nickname(theme, config, user));
+                        .style(|theme| {
+                            theme::selectable_text::nickname(
+                                theme, config, user,
+                            )
+                        });
 
                         if let Some(width) = max_nick_width {
-                            text = text.width(width).align_x(text::Alignment::Right);
+                            text = text
+                                .width(width)
+                                .align_x(text::Alignment::Right);
                         }
 
                         let nick = user_context::view(
@@ -98,12 +108,22 @@ pub fn view<'a>(
                             scroll_view::Message::Link,
                             theme::selectable_text::default,
                             move |link| match link {
-                                message::Link::User(_) => user_context::Entry::list(false, None),
+                                message::Link::User(_) => {
+                                    user_context::Entry::list(false, None)
+                                }
                                 _ => vec![],
                             },
                             move |link, entry, length| match link {
                                 message::Link::User(user) => entry
-                                    .view(server, casemapping, None, user, None, length, config)
+                                    .view(
+                                        server,
+                                        casemapping,
+                                        None,
+                                        user,
+                                        None,
+                                        length,
+                                        config,
+                                    )
                                     .map(scroll_view::Message::UserContext),
                                 _ => row![].into(),
                             },
@@ -116,7 +136,8 @@ pub fn view<'a>(
                         let text_container = container(message_content);
 
                         match &config.buffer.nickname.alignment {
-                            data::buffer::Alignment::Left | data::buffer::Alignment::Right => Some(
+                            data::buffer::Alignment::Left
+                            | data::buffer::Alignment::Right => Some(
                                 row![]
                                     .push(timestamp_nickname_row)
                                     .push(text_container)
@@ -132,10 +153,14 @@ pub fn view<'a>(
                     }
                     message::Source::Server(server) => {
                         let message_style = move |message_theme: &Theme| {
-                            theme::selectable_text::server(message_theme, server.as_ref())
+                            theme::selectable_text::server(
+                                message_theme,
+                                server.as_ref(),
+                            )
                         };
 
-                        let marker = message_marker(max_nick_width, message_style);
+                        let marker =
+                            message_marker(max_nick_width, message_style);
 
                         let message = message_content(
                             &message.content,
@@ -158,7 +183,10 @@ pub fn view<'a>(
                         )
                     }
                     message::Source::Action(_) => {
-                        let marker = message_marker(max_nick_width, theme::selectable_text::action);
+                        let marker = message_marker(
+                            max_nick_width,
+                            theme::selectable_text::action,
+                        );
 
                         let message_content = message_content(
                             &message.content,
@@ -182,12 +210,18 @@ pub fn view<'a>(
                             .into(),
                         )
                     }
-                    message::Source::Internal(message::source::Internal::Status(status)) => {
+                    message::Source::Internal(
+                        message::source::Internal::Status(status),
+                    ) => {
                         let message_style = move |message_theme: &Theme| {
-                            theme::selectable_text::status(message_theme, *status)
+                            theme::selectable_text::status(
+                                message_theme,
+                                *status,
+                            )
                         };
 
-                        let marker = message_marker(max_nick_width, message_style);
+                        let marker =
+                            message_marker(max_nick_width, message_style);
 
                         let message = message_content(
                             &message.content,
@@ -209,7 +243,9 @@ pub fn view<'a>(
                             .into(),
                         )
                     }
-                    message::Source::Internal(message::source::Internal::Logs) => None,
+                    message::Source::Internal(
+                        message::source::Internal::Logs,
+                    ) => None,
                 }
             },
         )
@@ -287,7 +323,9 @@ impl Query {
                 );
 
                 let event = event.and_then(|event| match event {
-                    scroll_view::Event::UserContext(event) => Some(Event::UserContext(event)),
+                    scroll_view::Event::UserContext(event) => {
+                        Some(Event::UserContext(event))
+                    }
                     scroll_view::Event::OpenBuffer(target, buffer_action) => {
                         Some(Event::OpenBuffers(vec![(target, buffer_action)]))
                     }
@@ -295,29 +333,39 @@ impl Query {
                     scroll_view::Event::RequestOlderChatHistory => {
                         Some(Event::RequestOlderChatHistory)
                     }
-                    scroll_view::Event::PreviewChanged => Some(Event::PreviewChanged),
+                    scroll_view::Event::PreviewChanged => {
+                        Some(Event::PreviewChanged)
+                    }
                     scroll_view::Event::HidePreview(kind, hash, url) => {
                         Some(Event::HidePreview(kind, hash, url))
                     }
                     scroll_view::Event::MarkAsRead => {
-                        history::Kind::from_buffer(data::Buffer::Upstream(self.buffer.clone()))
-                            .map(Event::MarkAsRead)
+                        history::Kind::from_buffer(data::Buffer::Upstream(
+                            self.buffer.clone(),
+                        ))
+                        .map(Event::MarkAsRead)
                     }
                 });
 
                 (command.map(Message::ScrollView), event)
             }
             Message::InputView(message) => {
-                let (command, event) =
-                    self.input_view
-                        .update(message, &self.buffer, clients, history, config);
+                let (command, event) = self.input_view.update(
+                    message,
+                    &self.buffer,
+                    clients,
+                    history,
+                    config,
+                );
                 let command = command.map(Message::InputView);
 
                 match event {
                     Some(input_view::Event::InputSent { history_task }) => {
                         let command = Task::batch(vec![
                             command,
-                            self.scroll_view.scroll_to_end().map(Message::ScrollView),
+                            self.scroll_view
+                                .scroll_to_end()
+                                .map(Message::ScrollView),
                         ]);
 
                         (command, Some(Event::History(history_task)))

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -1,12 +1,12 @@
 use data::dashboard::BufferAction;
 use data::target::Target;
-use data::{buffer, history, message, Config};
+use data::{Config, buffer, history, message};
 use iced::widget::{column, container, row, vertical_space};
 use iced::{Length, Task};
 
 use super::{input_view, scroll_view, user_context};
-use crate::widget::{message_content, selectable_text, Element};
-use crate::{theme, Theme};
+use crate::widget::{Element, message_content, selectable_text};
+use crate::{Theme, theme};
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -43,13 +43,13 @@ pub fn view<'a>(
             None,
             config,
             move |message, _, _| {
-                let timestamp =
-                    config
-                        .buffer
-                        .format_timestamp(&message.server_time)
-                        .map(|timestamp| {
-                            selectable_text(timestamp).style(theme::selectable_text::timestamp)
-                        });
+                let timestamp = config
+                    .buffer
+                    .format_timestamp(&message.server_time)
+                    .map(|timestamp| {
+                        selectable_text(timestamp)
+                            .style(theme::selectable_text::timestamp)
+                    });
 
                 match message.target.source() {
                     message::Source::Server(server) => {
@@ -58,23 +58,42 @@ pub fn view<'a>(
                             casemapping,
                             theme,
                             scroll_view::Message::Link,
-                            move |theme| theme::selectable_text::server(theme, server.as_ref()),
+                            move |theme| {
+                                theme::selectable_text::server(
+                                    theme,
+                                    server.as_ref(),
+                                )
+                            },
                             config,
                         );
 
-                        Some(container(row![].push_maybe(timestamp).push(message)).into())
+                        Some(
+                            container(
+                                row![].push_maybe(timestamp).push(message),
+                            )
+                            .into(),
+                        )
                     }
-                    message::Source::Internal(message::source::Internal::Status(status)) => {
+                    message::Source::Internal(
+                        message::source::Internal::Status(status),
+                    ) => {
                         let message = message_content(
                             &message.content,
                             casemapping,
                             theme,
                             scroll_view::Message::Link,
-                            move |theme| theme::selectable_text::status(theme, *status),
+                            move |theme| {
+                                theme::selectable_text::status(theme, *status)
+                            },
                             config,
                         );
 
-                        Some(container(row![].push_maybe(timestamp).push(message)).into())
+                        Some(
+                            container(
+                                row![].push_maybe(timestamp).push(message),
+                            )
+                            .into(),
+                        )
                     }
                     _ => None,
                 }
@@ -152,7 +171,9 @@ impl Server {
                 );
 
                 let event = event.and_then(|event| match event {
-                    scroll_view::Event::UserContext(event) => Some(Event::UserContext(event)),
+                    scroll_view::Event::UserContext(event) => {
+                        Some(Event::UserContext(event))
+                    }
                     scroll_view::Event::OpenBuffer(target, buffer_action) => {
                         Some(Event::OpenBuffers(vec![(target, buffer_action)]))
                     }
@@ -161,24 +182,32 @@ impl Server {
                     scroll_view::Event::PreviewChanged => None,
                     scroll_view::Event::HidePreview(..) => None,
                     scroll_view::Event::MarkAsRead => {
-                        history::Kind::from_buffer(data::Buffer::Upstream(self.buffer.clone()))
-                            .map(Event::MarkAsRead)
+                        history::Kind::from_buffer(data::Buffer::Upstream(
+                            self.buffer.clone(),
+                        ))
+                        .map(Event::MarkAsRead)
                     }
                 });
 
                 (command.map(Message::ScrollView), event)
             }
             Message::InputView(message) => {
-                let (command, event) =
-                    self.input_view
-                        .update(message, &self.buffer, clients, history, config);
+                let (command, event) = self.input_view.update(
+                    message,
+                    &self.buffer,
+                    clients,
+                    history,
+                    config,
+                );
                 let command = command.map(Message::InputView);
 
                 match event {
                     Some(input_view::Event::InputSent { history_task }) => (
                         Task::batch(vec![
                             command,
-                            self.scroll_view.scroll_to_end().map(Message::ScrollView),
+                            self.scroll_view
+                                .scroll_to_end()
+                                .map(Message::ScrollView),
                         ]),
                         Some(Event::History(history_task)),
                     ),

--- a/src/buffer/user_context.rs
+++ b/src/buffer/user_context.rs
@@ -1,10 +1,12 @@
 use data::dashboard::BufferAction;
 use data::user::Nick;
-use data::{config, isupport, target, Config, Server, User};
-use iced::widget::{button, column, container, horizontal_rule, row, text, Space};
-use iced::{padding, Length, Padding};
+use data::{Config, Server, User, config, isupport, target};
+use iced::widget::{
+    Space, button, column, container, horizontal_rule, row, text,
+};
+use iced::{Length, Padding, padding};
 
-use crate::widget::{context_menu, double_pass, Element};
+use crate::widget::{Element, context_menu, double_pass};
 use crate::{theme, widget};
 
 #[derive(Debug, Clone, Copy)]
@@ -21,7 +23,9 @@ pub enum Entry {
 impl Entry {
     pub fn list(is_channel: bool, our_user: Option<&User>) -> Vec<Self> {
         if is_channel {
-            if our_user.is_some_and(|u| u.has_access_level(data::user::AccessLevel::Oper)) {
+            if our_user.is_some_and(|u| {
+                u.has_access_level(data::user::AccessLevel::Oper)
+            }) {
                 vec![
                     Entry::UserInfo,
                     Entry::HorizontalRule,
@@ -58,7 +62,11 @@ impl Entry {
         let nickname = user.nickname().to_owned();
 
         match self {
-            Entry::Whois => menu_button("Whois", Message::Whois(server.clone(), nickname), length),
+            Entry::Whois => menu_button(
+                "Whois",
+                Message::Whois(server.clone(), nickname),
+                length,
+            ),
             Entry::Query => menu_button(
                 "Message",
                 Message::Query(
@@ -131,9 +139,13 @@ impl Entry {
                 Message::SendFile(server.clone(), nickname),
                 length,
             ),
-            Entry::UserInfo => user_info(current_user, nickname, length, config),
+            Entry::UserInfo => {
+                user_info(current_user, nickname, length, config)
+            }
             Entry::HorizontalRule => match length {
-                Length::Fill => container(horizontal_rule(1)).padding([0, 6]).into(),
+                Length::Fill => {
+                    container(horizontal_rule(1)).padding([0, 6]).into()
+                }
                 _ => Space::new(length, 1).into(),
             },
         }
@@ -217,7 +229,11 @@ pub fn view<'a>(
     .into()
 }
 
-fn menu_button(content: &str, message: Message, length: Length) -> Element<'_, Message> {
+fn menu_button(
+    content: &str,
+    message: Message,
+    length: Length,
+) -> Element<'_, Message> {
     button(text(content).style(theme::text::primary))
         .padding(5)
         .width(length)
@@ -243,7 +259,9 @@ fn user_info<'a>(
                 None
             }
         }
-        None => Some(text("Offline").style(theme::text::secondary).width(length)),
+        None => {
+            Some(text("Offline").style(theme::text::secondary).width(length))
+        }
     };
 
     // Dimmed if away or offline.
@@ -254,12 +272,18 @@ fn user_info<'a>(
         data::buffer::Color::Unique => Some(nickname.to_string()),
     };
 
-    column![container(
-        text(nickname.to_string())
-            .style(move |theme| theme::text::nickname(theme, seed.clone(), away_appearance))
-            .width(length)
-    )
-    .padding(right_justified_padding()),]
+    column![
+        container(
+            text(nickname.to_string())
+                .style(move |theme| theme::text::nickname(
+                    theme,
+                    seed.clone(),
+                    away_appearance
+                ))
+                .width(length)
+        )
+        .padding(right_justified_padding()),
+    ]
     .push_maybe(state.map(|s| container(s).padding(right_justified_padding())))
     .into()
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -28,9 +28,9 @@ fn filtered_events(
             modifiers,
             ..
         }) if c.as_str() == "c" && modifiers.command() => Some(Event::Copy),
-        iced::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) if ignored(status) => {
-            Some(Event::LeftClick)
-        }
+        iced::Event::Mouse(mouse::Event::ButtonPressed(
+            mouse::Button::Left,
+        )) if ignored(status) => Some(Event::LeftClick),
         _ => None,
     };
 

--- a/src/font.rs
+++ b/src/font.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::sync::OnceLock;
 
-use data::{config, Config};
+use data::{Config, config};
 use iced::font;
 
 pub static MONO: Font = Font::new(false, false);
@@ -84,17 +84,14 @@ pub fn load() -> Vec<Cow<'static, [u8]>> {
 pub fn width_from_chars(len: usize, config: &config::Font) -> f32 {
     use iced::advanced::graphics::text::Paragraph;
     use iced::advanced::text::{self, Paragraph as _, Text};
-    use iced::{alignment, Size};
+    use iced::{Size, alignment};
 
     use crate::theme;
 
     Paragraph::with_text(Text {
         content: &" ".repeat(len),
         bounds: Size::INFINITY,
-        size: config
-            .size
-            .map_or(theme::TEXT_SIZE, f32::from)
-            .into(),
+        size: config.size.map_or(theme::TEXT_SIZE, f32::from).into(),
         line_height: text::LineHeight::default(),
         font: MONO.clone().into(),
         align_x: text::Alignment::Right,

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,16 +1,12 @@
-use std::{
-    env, mem,
-    sync::mpsc,
-    thread,
-    time::{Duration, Instant},
-};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+use std::{env, mem, thread};
 
 use chrono::Utc;
+pub use data::log::{Error, Record};
 use log::Log;
 use tokio::sync::mpsc as tokio_mpsc;
 use tokio_stream::wrappers::ReceiverStream;
-
-pub use data::log::{Error, Record};
 
 pub fn setup(is_debug: bool) -> Result<ReceiverStream<Vec<Record>>, Error> {
     let level_filter = env::var("RUST_LOG")
@@ -94,8 +90,10 @@ fn channel_logger() -> (Box<dyn Log>, ReceiverStream<Vec<Record>>) {
             {
                 timeout = Instant::now();
 
-                let _ = async_sender
-                    .blocking_send(mem::replace(&mut batch, Vec::with_capacity(BATCH_SIZE)));
+                let _ = async_sender.blocking_send(mem::replace(
+                    &mut batch,
+                    Vec::with_capacity(BATCH_SIZE),
+                ));
             }
         }
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -1047,13 +1047,13 @@ impl Halloy {
                             self.main_window.position = Some(position);
                         }
                         window::Event::Resized(size) => {
-                            self.main_window.size = size
+                            self.main_window.size = size;
                         }
                         window::Event::Focused => {
-                            self.main_window.focused = true
+                            self.main_window.focused = true;
                         }
                         window::Event::Unfocused => {
-                            self.main_window.focused = false
+                            self.main_window.focused = false;
                         }
                         window::Event::Opened { position, size } => {
                             self.main_window.opened(position, size);

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -1,5 +1,6 @@
+use data::{Server, config};
+
 use crate::widget::Element;
-use data::{config, Server};
 
 pub mod connect_to_server;
 pub mod reload_configuration_error;
@@ -43,7 +44,9 @@ impl Modal {
 
     pub fn view(&self) -> Element<Message> {
         match self {
-            Modal::ReloadConfigurationError(error) => reload_configuration_error::view(error),
+            Modal::ReloadConfigurationError(error) => {
+                reload_configuration_error::view(error)
+            }
             Modal::ServerConnect {
                 url: raw, config, ..
             } => connect_to_server::view(raw, config),

--- a/src/modal/connect_to_server.rs
+++ b/src/modal/connect_to_server.rs
@@ -1,12 +1,10 @@
 use data::config;
-use iced::{
-    alignment,
-    widget::{button, checkbox, column, container, text},
-    Length,
-};
+use iced::widget::{button, checkbox, column, container, text};
+use iced::{Length, alignment};
 
 use super::Message;
-use crate::{theme, widget::Element};
+use crate::theme;
+use crate::widget::Element;
 
 pub fn view<'a>(raw: &'a str, config: &config::Server) -> Element<'a, Message> {
     container(
@@ -30,7 +28,9 @@ pub fn view<'a>(raw: &'a str, config: &config::Server) -> Element<'a, Message> {
                 )
                 .padding(5)
                 .width(Length::Fixed(250.0))
-                .style(|theme, status| theme::button::secondary(theme, status, false))
+                .style(|theme, status| theme::button::secondary(
+                    theme, status, false
+                ))
                 .on_press(Message::AcceptNewServer),
                 button(
                     container(text("Close"))
@@ -39,7 +39,9 @@ pub fn view<'a>(raw: &'a str, config: &config::Server) -> Element<'a, Message> {
                 )
                 .padding(5)
                 .width(Length::Fixed(250.0))
-                .style(|theme, status| theme::button::secondary(theme, status, false))
+                .style(|theme, status| theme::button::secondary(
+                    theme, status, false
+                ))
                 .on_press(Message::Cancel),
             ]
             .spacing(4),

--- a/src/modal/reload_configuration_error.rs
+++ b/src/modal/reload_configuration_error.rs
@@ -1,12 +1,10 @@
 use data::config;
-use iced::{
-    alignment,
-    widget::{button, column, container, text},
-    Length,
-};
+use iced::widget::{button, column, container, text};
+use iced::{Length, alignment};
 
 use super::Message;
-use crate::{theme, widget::Element};
+use crate::theme;
+use crate::widget::Element;
 
 pub fn view<'a>(error: &config::Error) -> Element<'a, Message> {
     container(
@@ -18,7 +16,9 @@ pub fn view<'a>(error: &config::Error) -> Element<'a, Message> {
                     .align_x(alignment::Horizontal::Center)
                     .width(Length::Fill),
             )
-            .style(|theme, status| theme::button::secondary(theme, status, false))
+            .style(|theme, status| theme::button::secondary(
+                theme, status, false
+            ))
             .padding(5)
             .width(Length::Fixed(250.0))
             .on_press(Message::Cancel)

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -2,16 +2,12 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
-
-use data::{
-    audio::Sound,
-    config::{self, notification},
-    Notification, Server,
-};
-
-use crate::audio;
+use data::audio::Sound;
+use data::config::{self, notification};
+use data::{Notification, Server};
 
 pub use self::toast::prepare;
+use crate::audio;
 
 mod toast;
 
@@ -99,20 +95,26 @@ impl Notifications {
                         &config.direct_message,
                         notification,
                         "Direct message",
-                        format!("{} sent you a direct message on {server}", user.nickname()),
+                        format!(
+                            "{} sent you a direct message on {server}",
+                            user.nickname()
+                        ),
                     );
                 }
             }
             Notification::Highlight { user, channel } => {
-                if config
-                    .highlight
-                    .should_notify(vec![channel.to_string(), user.nickname().to_string()])
-                {
+                if config.highlight.should_notify(vec![
+                    channel.to_string(),
+                    user.nickname().to_string(),
+                ]) {
                     self.execute(
                         &config.highlight,
                         notification,
                         "Highlight",
-                        format!("{} highlighted you in {channel} on {server}", user.nickname()),
+                        format!(
+                            "{} highlighted you in {channel} on {server}",
+                            user.nickname()
+                        ),
                     );
                 }
             }
@@ -126,11 +128,13 @@ impl Notifications {
         title: &str,
         body: impl ToString,
     ) {
-        let last_notification = self.recent_notifications.get(notification).copied();
+        let last_notification =
+            self.recent_notifications.get(notification).copied();
 
         if last_notification.is_some()
             && last_notification.unwrap()
-                > Utc::now() - Duration::from_millis(config.delay.unwrap_or(500))
+                > Utc::now()
+                    - Duration::from_millis(config.delay.unwrap_or(500))
         {
             return;
         }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1,4 +1,4 @@
-use std::collections::{hash_map, HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque, hash_map};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use std::{convert, slice};
@@ -6,19 +6,19 @@ use std::{convert, slice};
 use chrono::{DateTime, Utc};
 use data::dashboard::{self, BufferAction};
 use data::environment::{RELEASE_WEBSITE, WIKI_WEBSITE};
-use data::history::manager::Broadcast;
 use data::history::ReadMarker;
+use data::history::manager::Broadcast;
 use data::isupport::{self, ChatHistorySubcommand, MessageReference};
 use data::target::{self, Target};
 use data::user::Nick;
 use data::{
-    client, command, config, environment, file_transfer, history, preview, Config, Notification,
-    Server, Version,
+    Config, Notification, Server, Version, client, command, config,
+    environment, file_transfer, history, preview,
 };
 use iced::widget::pane_grid::{self, PaneGrid};
-use iced::widget::{column, container, row, Space};
+use iced::widget::{Space, column, container, row};
 use iced::window::get_position;
-use iced::{clipboard, Length, Task, Vector};
+use iced::{Length, Task, Vector, clipboard};
 use log::{debug, error};
 
 use self::command_bar::CommandBar;
@@ -27,10 +27,11 @@ use self::sidebar::Sidebar;
 use self::theme_editor::ThemeEditor;
 use crate::buffer::{self, Buffer};
 use crate::widget::{
-    anchored_overlay, context_menu, selectable_text, shortcut, Column, Element, Row,
+    Column, Element, Row, anchored_overlay, context_menu, selectable_text,
+    shortcut,
 };
 use crate::window::Window;
-use crate::{event, notification, theme, window, Theme};
+use crate::{Theme, event, notification, theme, window};
 
 mod command_bar;
 pub mod pane;
@@ -84,8 +85,12 @@ pub enum Event {
 }
 
 impl Dashboard {
-    pub fn empty(config: &Config, main_window: &Window) -> (Self, Task<Message>) {
-        let (main_panes, pane) = pane_grid::State::new(Pane::new(Buffer::Empty));
+    pub fn empty(
+        config: &Config,
+        main_window: &Window,
+    ) -> (Self, Task<Message>) {
+        let (main_panes, pane) =
+            pane_grid::State::new(Pane::new(Buffer::Empty));
 
         let mut dashboard = Dashboard {
             panes: Panes {
@@ -102,7 +107,9 @@ impl Dashboard {
             history: history::Manager::default(),
             last_changed: None,
             command_bar: None,
-            file_transfers: file_transfer::Manager::new(config.file_transfer.clone()),
+            file_transfers: file_transfer::Manager::new(
+                config.file_transfer.clone(),
+            ),
             theme_editor: None,
             notifications: notification::Notifications::new(),
             previews: preview::Collection::default(),
@@ -119,7 +126,8 @@ impl Dashboard {
         config: &Config,
         main_window: &Window,
     ) -> (Self, Task<Message>) {
-        let (mut dashboard, task) = Dashboard::from_data(dashboard, config, main_window);
+        let (mut dashboard, task) =
+            Dashboard::from_data(dashboard, config, main_window);
 
         let tasks = Task::batch(vec![task, dashboard.track(config)]);
 
@@ -141,19 +149,27 @@ impl Dashboard {
                     pane::Message::PaneClicked(pane) => {
                         return (self.focus_pane(window, pane), None);
                     }
-                    pane::Message::PaneResized(pane_grid::ResizeEvent { split, ratio }) => {
+                    pane::Message::PaneResized(pane_grid::ResizeEvent {
+                        split,
+                        ratio,
+                    }) => {
                         // Pane grid interactions only enabled for main window panegrid
                         self.panes.main.resize(split, ratio);
                         self.last_changed = Some(Instant::now());
                     }
-                    pane::Message::PaneDragged(pane_grid::DragEvent::Dropped { pane, target }) => {
+                    pane::Message::PaneDragged(
+                        pane_grid::DragEvent::Dropped { pane, target },
+                    ) => {
                         // Pane grid interactions only enabled for main window panegrid
                         self.panes.main.drop(pane, target);
                         self.last_changed = Some(Instant::now());
                     }
                     pane::Message::PaneDragged(_) => {}
                     pane::Message::ClosePane => {
-                        return (self.close_pane(self.focus.window, self.focus.pane), None);
+                        return (
+                            self.close_pane(self.focus.window, self.focus.pane),
+                            None,
+                        );
                     }
                     pane::Message::SplitPane(axis) => {
                         return (self.split_pane(axis), None);
@@ -169,7 +185,10 @@ impl Dashboard {
                             );
 
                             let task = command.map(move |message| {
-                                Message::Pane(window, pane::Message::Buffer(id, message))
+                                Message::Pane(
+                                    window,
+                                    pane::Message::Buffer(id, message),
+                                )
                             });
 
                             let Some(event) = event else {
@@ -360,23 +379,41 @@ impl Dashboard {
                                 }
                                 buffer::Event::History(history_task) => {
                                     return (
-                                        Task::batch(vec![task, history_task.map(Message::History)]),
+                                        Task::batch(vec![
+                                            task,
+                                            history_task.map(Message::History),
+                                        ]),
                                         None,
                                     );
                                 }
-                                buffer::Event::GoToMessage(server, channel, message) => {
-                                    let buffer = data::Buffer::Upstream(buffer::Upstream::Channel(
-                                        server, channel,
-                                    ));
+                                buffer::Event::GoToMessage(
+                                    server,
+                                    channel,
+                                    message,
+                                ) => {
+                                    let buffer = data::Buffer::Upstream(
+                                        buffer::Upstream::Channel(
+                                            server, channel,
+                                        ),
+                                    );
 
                                     let mut tasks = vec![];
 
-                                    if self.panes.get_mut_by_buffer(&buffer).is_none() {
-                                        tasks.push(self.open_buffer(
-                                            buffer.clone(),
-                                            config.actions.buffer.click_highlight,
-                                            config,
-                                        ));
+                                    if self
+                                        .panes
+                                        .get_mut_by_buffer(&buffer)
+                                        .is_none()
+                                    {
+                                        tasks.push(
+                                            self.open_buffer(
+                                                buffer.clone(),
+                                                config
+                                                    .actions
+                                                    .buffer
+                                                    .click_highlight,
+                                                config,
+                                            ),
+                                        );
                                     }
 
                                     if let Some((window, pane, state)) =
@@ -385,11 +422,17 @@ impl Dashboard {
                                         tasks.push(
                                             state
                                                 .buffer
-                                                .scroll_to_message(message, &self.history, config)
+                                                .scroll_to_message(
+                                                    message,
+                                                    &self.history,
+                                                    config,
+                                                )
                                                 .map(move |message| {
                                                     Message::Pane(
                                                         window,
-                                                        pane::Message::Buffer(pane, message),
+                                                        pane::Message::Buffer(
+                                                            pane, message,
+                                                        ),
                                                     )
                                                 }),
                                         );
@@ -399,19 +442,29 @@ impl Dashboard {
                                 }
                                 buffer::Event::RequestOlderChatHistory => {
                                     if let Some(buffer) = pane.buffer.data() {
-                                        self.request_older_chathistory(clients, &buffer);
+                                        self.request_older_chathistory(
+                                            clients, &buffer,
+                                        );
                                     }
                                 }
                                 buffer::Event::PreviewChanged => {
                                     let visible = self.panes.visible_urls();
-                                    let tracking =
-                                        self.previews.keys().cloned().collect::<HashSet<_>>();
-                                    let missing =
-                                        visible.difference(&tracking).cloned().collect::<Vec<_>>();
+                                    let tracking = self
+                                        .previews
+                                        .keys()
+                                        .cloned()
+                                        .collect::<HashSet<_>>();
+                                    let missing = visible
+                                        .difference(&tracking)
+                                        .cloned()
+                                        .collect::<Vec<_>>();
                                     let removed = tracking.difference(&visible);
 
                                     for url in &missing {
-                                        self.previews.insert(url.clone(), preview::State::Loading);
+                                        self.previews.insert(
+                                            url.clone(),
+                                            preview::State::Loading,
+                                        );
                                     }
 
                                     for url in removed {
@@ -419,17 +472,22 @@ impl Dashboard {
                                     }
 
                                     return (
-                                        Task::batch(missing.into_iter().map(|url| {
-                                            Task::perform(
-                                                data::preview::load(
-                                                    url.clone(),
-                                                    config.preview.clone(),
-                                                ),
-                                                move |result| {
-                                                    Message::LoadPreview((url.clone(), result))
-                                                },
-                                            )
-                                        })),
+                                        Task::batch(missing.into_iter().map(
+                                            |url| {
+                                                Task::perform(
+                                                    data::preview::load(
+                                                        url.clone(),
+                                                        config.preview.clone(),
+                                                    ),
+                                                    move |result| {
+                                                        Message::LoadPreview((
+                                                            url.clone(),
+                                                            result,
+                                                        ))
+                                                    },
+                                                )
+                                            },
+                                        )),
                                         None,
                                     );
                                 }
@@ -447,9 +505,10 @@ impl Dashboard {
                     pane::Message::ToggleShowUserList => {
                         if let Some((_, _, pane)) = self.get_focused_mut() {
                             if let Some(buffer) = pane.buffer.data() {
-                                let settings = self
-                                    .buffer_settings
-                                    .entry(&buffer, Some(config.buffer.clone().into()));
+                                let settings = self.buffer_settings.entry(
+                                    &buffer,
+                                    Some(config.buffer.clone().into()),
+                                );
                                 settings.channel.nicklist.toggle_visibility();
                             }
 
@@ -460,9 +519,10 @@ impl Dashboard {
                     pane::Message::ToggleShowTopic => {
                         if let Some((_, _, pane)) = self.get_focused_mut() {
                             if let Some(buffer) = pane.buffer.data() {
-                                let settings = self
-                                    .buffer_settings
-                                    .entry(&buffer, Some(config.buffer.clone().into()));
+                                let settings = self.buffer_settings.entry(
+                                    &buffer,
+                                    Some(config.buffer.clone().into()),
+                                );
                                 settings.channel.topic.toggle_visibility();
                             }
 
@@ -471,15 +531,24 @@ impl Dashboard {
                         }
                     }
                     pane::Message::MaximizePane => self.maximize_pane(),
-                    pane::Message::Popout => return (self.popout_pane(config), None),
-                    pane::Message::Merge => return (self.merge_pane(config), None),
+                    pane::Message::Popout => {
+                        return (self.popout_pane(config), None);
+                    }
+                    pane::Message::Merge => {
+                        return (self.merge_pane(config), None);
+                    }
                     pane::Message::ScrollToBottom => {
                         let Focus { window, pane } = self.focus;
 
                         if let Some(state) = self.panes.get_mut(window, pane) {
-                            let mut task = state.buffer.scroll_to_end().map(move |message| {
-                                Message::Pane(window, pane::Message::Buffer(pane, message))
-                            });
+                            let mut task = state.buffer.scroll_to_end().map(
+                                move |message| {
+                                    Message::Pane(
+                                        window,
+                                        pane::Message::Buffer(pane, message),
+                                    )
+                                },
+                            );
 
                             if config.buffer.mark_as_read.on_scroll_to_bottom {
                                 task = task.chain(Task::done(Message::Pane(
@@ -493,8 +562,10 @@ impl Dashboard {
                     }
                     pane::Message::MarkAsRead => {
                         if let Some((_, _, pane)) = self.get_focused_mut() {
-                            if let Some(kind) =
-                                pane.buffer.data().and_then(history::Kind::from_buffer)
+                            if let Some(kind) = pane
+                                .buffer
+                                .data()
+                                .and_then(history::Kind::from_buffer)
                             {
                                 self.mark_as_read(kind, clients);
                             }
@@ -526,7 +597,9 @@ impl Dashboard {
                         ),
                         None,
                     ),
-                    sidebar::Event::Focus(window, pane) => (self.focus_pane(window, pane), None),
+                    sidebar::Event::Focus(window, pane) => {
+                        (self.focus_pane(window, pane), None)
+                    }
                     sidebar::Event::Replace(buffer) => (
                         self.open_buffer(
                             data::Buffer::Upstream(buffer),
@@ -535,7 +608,9 @@ impl Dashboard {
                         ),
                         None,
                     ),
-                    sidebar::Event::Close(window, pane) => (self.close_pane(window, pane), None),
+                    sidebar::Event::Close(window, pane) => {
+                        (self.close_pane(window, pane), None)
+                    }
                     sidebar::Event::Swap(window, pane) => {
                         (self.swap_pane_with_focus(window, pane), None)
                     }
@@ -571,9 +646,9 @@ impl Dashboard {
                         (Task::none(), None)
                     }
                     sidebar::Event::MarkAsRead(buffer) => {
-                        if let Some(kind) =
-                            history::Kind::from_buffer(data::Buffer::Upstream(buffer))
-                        {
+                        if let Some(kind) = history::Kind::from_buffer(
+                            data::Buffer::Upstream(buffer),
+                        ) {
                             self.mark_as_read(kind, clients);
                         }
 
@@ -582,15 +657,18 @@ impl Dashboard {
                 };
 
                 return (
-                    Task::batch(vec![event_task, command.map(Message::Sidebar)]),
+                    Task::batch(vec![
+                        event_task,
+                        command.map(Message::Sidebar),
+                    ]),
                     event,
                 );
             }
             Message::SelectedText(contents) => {
                 let mut last_y = None;
-                let contents = contents
-                    .into_iter()
-                    .fold(String::new(), |acc, (y, content)| {
+                let contents = contents.into_iter().fold(
+                    String::new(),
+                    |acc, (y, content)| {
                         if let Some(_y) = last_y {
                             let new_line = if y == _y { "" } else { "\n" };
                             last_y = Some(y);
@@ -601,7 +679,8 @@ impl Dashboard {
 
                             content
                         }
-                    });
+                    },
+                );
 
                 if !contents.is_empty() {
                     return (clipboard::write(contents), None);
@@ -617,36 +696,61 @@ impl Dashboard {
                                 self.panes.get_mut_by_buffer(&buffer)
                             {
                                 return (
-                                    state.buffer.scroll_to_backlog(&self.history, config).map(
-                                        move |message| {
+                                    state
+                                        .buffer
+                                        .scroll_to_backlog(
+                                            &self.history,
+                                            config,
+                                        )
+                                        .map(move |message| {
                                             Message::Pane(
                                                 window,
-                                                pane::Message::Buffer(pane, message),
+                                                pane::Message::Buffer(
+                                                    pane, message,
+                                                ),
                                             )
-                                        },
-                                    ),
+                                        }),
                                     None,
                                 );
                             }
                         }
                         history::manager::Event::Closed(kind, read_marker) => {
-                            if let (Some(server), Some(target), Some(read_marker)) =
-                                (kind.server(), kind.target(), read_marker)
+                            if let (
+                                Some(server),
+                                Some(target),
+                                Some(read_marker),
+                            ) = (kind.server(), kind.target(), read_marker)
                             {
-                                if let Err(e) = clients.send_markread(server, target, read_marker) {
-                                    return (Task::none(), Some(Event::IrcError(e)));
+                                if let Err(e) = clients.send_markread(
+                                    server,
+                                    target,
+                                    read_marker,
+                                ) {
+                                    return (
+                                        Task::none(),
+                                        Some(Event::IrcError(e)),
+                                    );
                                 };
                             }
                         }
                         history::manager::Event::Exited(results) => {
                             for (kind, read_marker) in results {
-                                if let (Some(server), Some(target), Some(read_marker)) =
+                                if let (
+                                    Some(server),
+                                    Some(target),
+                                    Some(read_marker),
+                                ) =
                                     (kind.server(), kind.target(), read_marker)
                                 {
-                                    if let Err(e) =
-                                        clients.send_markread(server, target, read_marker)
-                                    {
-                                        return (Task::none(), Some(Event::IrcError(e)));
+                                    if let Err(e) = clients.send_markread(
+                                        server,
+                                        target,
+                                        read_marker,
+                                    ) {
+                                        return (
+                                            Task::none(),
+                                            Some(Event::IrcError(e)),
+                                        );
                                     };
                                 }
                             }
@@ -668,10 +772,12 @@ impl Dashboard {
                 };
 
                 match command_bar.update(message) {
-                    Some(command_bar::Event::ThemePreview(preview)) => match preview {
-                        Some(preview) => *theme = theme.preview(preview),
-                        None => *theme = theme.selected(),
-                    },
+                    Some(command_bar::Event::ThemePreview(preview)) => {
+                        match preview {
+                            Some(preview) => *theme = theme.preview(preview),
+                            None => *theme = theme.selected(),
+                        }
+                    }
                     Some(command_bar::Event::Command(command)) => {
                         let (command, event) = match command {
                             command_bar::Command::Version(command) => match command {
@@ -799,7 +905,9 @@ impl Dashboard {
                     let Focus { window, pane } = self.focus;
 
                     if window == self.main_window() {
-                        if let Some(adjacent) = self.panes.main.adjacent(pane, direction) {
+                        if let Some(adjacent) =
+                            self.panes.main.adjacent(pane, direction)
+                        {
                             return self.focus_pane(window, adjacent);
                         }
                     }
@@ -808,10 +916,18 @@ impl Dashboard {
                 };
 
                 match shortcut {
-                    MoveUp => return (move_focus(pane_grid::Direction::Up), None),
-                    MoveDown => return (move_focus(pane_grid::Direction::Down), None),
-                    MoveLeft => return (move_focus(pane_grid::Direction::Left), None),
-                    MoveRight => return (move_focus(pane_grid::Direction::Right), None),
+                    MoveUp => {
+                        return (move_focus(pane_grid::Direction::Up), None);
+                    }
+                    MoveDown => {
+                        return (move_focus(pane_grid::Direction::Down), None);
+                    }
+                    MoveLeft => {
+                        return (move_focus(pane_grid::Direction::Left), None);
+                    }
+                    MoveRight => {
+                        return (move_focus(pane_grid::Direction::Right), None);
+                    }
                     CloseBuffer => {
                         let Focus { window, pane } = self.focus;
                         return (self.close_pane(window, pane), None);
@@ -830,13 +946,17 @@ impl Dashboard {
                         let all_buffers = all_buffers(clients, &self.history);
                         let open_buffers = open_buffers(self);
 
-                        if let Some((window, pane, state)) = self.get_focused_mut() {
+                        if let Some((window, pane, state)) =
+                            self.get_focused_mut()
+                        {
                             if let Some(buffer) = cycle_next_buffer(
                                 state.buffer.upstream(),
                                 all_buffers,
                                 &open_buffers,
                             ) {
-                                state.buffer = Buffer::from(data::Buffer::Upstream(buffer));
+                                state.buffer = Buffer::from(
+                                    data::Buffer::Upstream(buffer),
+                                );
                                 self.last_changed = Some(Instant::now());
                                 return (self.focus_pane(window, pane), None);
                             }
@@ -846,13 +966,17 @@ impl Dashboard {
                         let all_buffers = all_buffers(clients, &self.history);
                         let open_buffers = open_buffers(self);
 
-                        if let Some((window, pane, state)) = self.get_focused_mut() {
+                        if let Some((window, pane, state)) =
+                            self.get_focused_mut()
+                        {
                             if let Some(buffer) = cycle_previous_buffer(
                                 state.buffer.upstream(),
                                 all_buffers,
                                 &open_buffers,
                             ) {
-                                state.buffer = Buffer::from(data::Buffer::Upstream(buffer));
+                                state.buffer = Buffer::from(
+                                    data::Buffer::Upstream(buffer),
+                                );
                                 self.last_changed = Some(Instant::now());
                                 return (self.focus_pane(window, pane), None);
                             }
@@ -860,7 +984,9 @@ impl Dashboard {
                     }
                     LeaveBuffer => {
                         if let Some((_, _, state)) = self.get_focused_mut() {
-                            if let Some(buffer) = state.buffer.upstream().cloned() {
+                            if let Some(buffer) =
+                                state.buffer.upstream().cloned()
+                            {
                                 return self.leave_buffer(
                                     clients,
                                     buffer,
@@ -872,9 +998,10 @@ impl Dashboard {
                     ToggleNicklist => {
                         if let Some((_, _, pane)) = self.get_focused_mut() {
                             if let Some(buffer) = pane.buffer.data() {
-                                let settings = self
-                                    .buffer_settings
-                                    .entry(&buffer, Some(config.buffer.clone().into()));
+                                let settings = self.buffer_settings.entry(
+                                    &buffer,
+                                    Some(config.buffer.clone().into()),
+                                );
                                 settings.channel.nicklist.toggle_visibility();
                             }
 
@@ -885,9 +1012,10 @@ impl Dashboard {
                     ToggleTopic => {
                         if let Some((_, _, pane)) = self.get_focused_mut() {
                             if let Some(buffer) = pane.buffer.data() {
-                                let settings = self
-                                    .buffer_settings
-                                    .entry(&buffer, Some(config.buffer.clone().into()));
+                                let settings = self.buffer_settings.entry(
+                                    &buffer,
+                                    Some(config.buffer.clone().into()),
+                                );
                                 settings.channel.topic.toggle_visibility();
                             }
 
@@ -910,39 +1038,66 @@ impl Dashboard {
                         );
                     }
                     ReloadConfiguration => {
-                        return (Task::perform(Config::load(), Message::ConfigReloaded), None);
+                        return (
+                            Task::perform(
+                                Config::load(),
+                                Message::ConfigReloaded,
+                            ),
+                            None,
+                        );
                     }
                     FileTransfers => {
                         return (
-                            self.toggle_internal_buffer(config, buffer::Internal::FileTransfers),
+                            self.toggle_internal_buffer(
+                                config,
+                                buffer::Internal::FileTransfers,
+                            ),
                             None,
                         );
                     }
                     Logs => {
                         return (
-                            self.toggle_internal_buffer(config, buffer::Internal::Logs),
+                            self.toggle_internal_buffer(
+                                config,
+                                buffer::Internal::Logs,
+                            ),
                             None,
                         );
                     }
                     ThemeEditor => {
-                        return (self.toggle_theme_editor(theme, main_window), None);
-                    }
-                    Highlight => {
                         return (
-                            self.toggle_internal_buffer(config, buffer::Internal::Highlights),
+                            self.toggle_theme_editor(theme, main_window),
                             None,
                         );
                     }
-                    ToggleFullscreen => return (window::toggle_fullscreen(), None),
+                    Highlight => {
+                        return (
+                            self.toggle_internal_buffer(
+                                config,
+                                buffer::Internal::Highlights,
+                            ),
+                            None,
+                        );
+                    }
+                    ToggleFullscreen => {
+                        return (window::toggle_fullscreen(), None);
+                    }
                     QuitApplication => return (self.exit(config), None),
                     ScrollUpPage => {
                         return (
                             self.get_focused_mut().map_or_else(
                                 Task::none,
                                 |(window, pane, state)| {
-                                    state.buffer.scroll_up_page().map(move |message| {
-                                        Message::Pane(window, pane::Message::Buffer(pane, message))
-                                    })
+                                    state.buffer.scroll_up_page().map(
+                                        move |message| {
+                                            Message::Pane(
+                                                window,
+                                                pane::Message::Buffer(
+                                                    pane, message,
+                                                ),
+                                            )
+                                        },
+                                    )
                                 },
                             ),
                             None,
@@ -953,9 +1108,16 @@ impl Dashboard {
                             self.get_focused_mut().map_or_else(
                                 Task::none,
                                 |(window, pane, state)| {
-                                    state.buffer.scroll_down_page().map(move |message| {
-                                        Message::Pane(window, pane::Message::Buffer(pane, message))
-                                    })
+                                    state.buffer.scroll_down_page().map(
+                                        move |message| {
+                                            Message::Pane(
+                                                window,
+                                                pane::Message::Buffer(
+                                                    pane, message,
+                                                ),
+                                            )
+                                        },
+                                    )
                                 },
                             ),
                             None,
@@ -965,18 +1127,29 @@ impl Dashboard {
                         if config.buffer.chathistory.infinite_scroll {
                             if let Some((_, _, state)) = self.get_focused() {
                                 if let Some(buffer) = state.buffer.data() {
-                                    self.request_older_chathistory(clients, &buffer);
+                                    self.request_older_chathistory(
+                                        clients, &buffer,
+                                    );
                                 }
                             }
                         }
 
                         return (
-                            self.get_focused_mut()
-                                .map_or_else(Task::none, |(window, id, pane)| {
-                                    pane.buffer.scroll_to_start().map(move |message| {
-                                        Message::Pane(window, pane::Message::Buffer(id, message))
-                                    })
-                                }),
+                            self.get_focused_mut().map_or_else(
+                                Task::none,
+                                |(window, id, pane)| {
+                                    pane.buffer.scroll_to_start().map(
+                                        move |message| {
+                                            Message::Pane(
+                                                window,
+                                                pane::Message::Buffer(
+                                                    id, message,
+                                                ),
+                                            )
+                                        },
+                                    )
+                                },
+                            ),
                             None,
                         );
                     }
@@ -984,15 +1157,28 @@ impl Dashboard {
                         let task = self.get_focused_mut().map_or_else(
                             Task::none,
                             |(window, pane, state)| {
-                                let mut task = state.buffer.scroll_to_end().map(move |message| {
-                                    Message::Pane(window, pane::Message::Buffer(pane, message))
-                                });
+                                let mut task = state
+                                    .buffer
+                                    .scroll_to_end()
+                                    .map(move |message| {
+                                        Message::Pane(
+                                            window,
+                                            pane::Message::Buffer(
+                                                pane, message,
+                                            ),
+                                        )
+                                    });
 
-                                if config.buffer.mark_as_read.on_scroll_to_bottom {
-                                    task = task.chain(Task::done(Message::Pane(
-                                        window,
-                                        pane::Message::MarkAsRead,
-                                    )));
+                                if config
+                                    .buffer
+                                    .mark_as_read
+                                    .on_scroll_to_bottom
+                                {
+                                    task =
+                                        task.chain(Task::done(Message::Pane(
+                                            window,
+                                            pane::Message::MarkAsRead,
+                                        )));
                                 }
 
                                 task
@@ -1002,32 +1188,42 @@ impl Dashboard {
                         return (task, None);
                     }
                     CycleNextUnreadBuffer => {
-                        let all_buffers = all_buffers_with_has_unread(clients, &self.history);
+                        let all_buffers =
+                            all_buffers_with_has_unread(clients, &self.history);
                         let open_buffers = open_buffers(self);
 
-                        if let Some((window, pane, state)) = self.get_focused_mut() {
+                        if let Some((window, pane, state)) =
+                            self.get_focused_mut()
+                        {
                             if let Some(buffer) = cycle_next_unread_buffer(
                                 state.buffer.upstream(),
                                 all_buffers,
                                 &open_buffers,
                             ) {
-                                state.buffer = Buffer::from(data::Buffer::Upstream(buffer));
+                                state.buffer = Buffer::from(
+                                    data::Buffer::Upstream(buffer),
+                                );
                                 self.last_changed = Some(Instant::now());
                                 return (self.focus_pane(window, pane), None);
                             }
                         }
                     }
                     CyclePreviousUnreadBuffer => {
-                        let all_buffers = all_buffers_with_has_unread(clients, &self.history);
+                        let all_buffers =
+                            all_buffers_with_has_unread(clients, &self.history);
                         let open_buffers = open_buffers(self);
 
-                        if let Some((window, pane, state)) = self.get_focused_mut() {
+                        if let Some((window, pane, state)) =
+                            self.get_focused_mut()
+                        {
                             if let Some(buffer) = cycle_previous_unread_buffer(
                                 state.buffer.upstream(),
                                 all_buffers,
                                 &open_buffers,
                             ) {
-                                state.buffer = Buffer::from(data::Buffer::Upstream(buffer));
+                                state.buffer = Buffer::from(
+                                    data::Buffer::Upstream(buffer),
+                                );
                                 self.last_changed = Some(Instant::now());
                                 return (self.focus_pane(window, pane), None);
                             }
@@ -1035,8 +1231,10 @@ impl Dashboard {
                     }
                     MarkAsRead => {
                         if let Some((_, _, pane)) = self.get_focused_mut() {
-                            if let Some(kind) =
-                                pane.buffer.data().and_then(history::Kind::from_buffer)
+                            if let Some(kind) = pane
+                                .buffer
+                                .data()
+                                .and_then(history::Kind::from_buffer)
                             {
                                 self.mark_as_read(kind, clients);
                             }
@@ -1048,7 +1246,8 @@ impl Dashboard {
                 self.file_transfers.update(update);
             }
             Message::SendFileSelected(server, to, path) => {
-                if let Some(server_handle) = clients.get_server_handle(&server) {
+                if let Some(server_handle) = clients.get_server_handle(&server)
+                {
                     if let Some(path) = path {
                         if let Ok(query) = target::Query::parse(
                             to.as_ref(),
@@ -1066,7 +1265,9 @@ impl Dashboard {
                                 config.proxy.clone(),
                             ) {
                                 return (
-                                    self.handle_file_transfer_event(&server, &query, event),
+                                    self.handle_file_transfer_event(
+                                        &server, &query, event,
+                                    ),
                                     None,
                                 );
                             }
@@ -1082,7 +1283,8 @@ impl Dashboard {
                         }
                     }
 
-                    if self.is_pane_maximized() && window == self.main_window() {
+                    if self.is_pane_maximized() && window == self.main_window()
+                    {
                         self.panes.main.restore();
                     }
                 }
@@ -1121,8 +1323,14 @@ impl Dashboard {
                 client::Message::ChatHistoryRequest(server, subcommand) => {
                     clients.send_chathistory_request(&server, subcommand);
                 }
-                client::Message::ChatHistoryTargetsTimestampUpdated(server, timestamp, Ok(())) => {
-                    log::debug!("updated targets timestamp for {server} to {timestamp}");
+                client::Message::ChatHistoryTargetsTimestampUpdated(
+                    server,
+                    timestamp,
+                    Ok(()),
+                ) => {
+                    log::debug!(
+                        "updated targets timestamp for {server} to {timestamp}"
+                    );
                 }
                 client::Message::ChatHistoryTargetsTimestampUpdated(
                     server,
@@ -1133,31 +1341,51 @@ impl Dashboard {
                         "failed to update targets timestamp for {server} to {timestamp}: {error}"
                     );
                 }
-                client::Message::RequestNewerChatHistory(server, target, server_time) => {
-                    let message_reference_types =
-                        clients.get_server_chathistory_message_reference_types(&server);
+                client::Message::RequestNewerChatHistory(
+                    server,
+                    target,
+                    server_time,
+                ) => {
+                    let message_reference_types = clients
+                        .get_server_chathistory_message_reference_types(
+                            &server,
+                        );
 
                     let message_reference = self
                         .history
-                        .last_can_reference_before(server.clone(), target.clone(), server_time)
+                        .last_can_reference_before(
+                            server.clone(),
+                            target.clone(),
+                            server_time,
+                        )
                         .map_or(MessageReference::None, |message_references| {
-                            message_references.message_reference(&message_reference_types)
+                            message_references
+                                .message_reference(&message_reference_types)
                         });
 
                     let limit = clients.get_server_chathistory_limit(&server);
 
                     clients.send_chathistory_request(
                         &server,
-                        ChatHistorySubcommand::Latest(target, message_reference, limit),
+                        ChatHistorySubcommand::Latest(
+                            target,
+                            message_reference,
+                            limit,
+                        ),
                     );
                 }
-                client::Message::RequestChatHistoryTargets(server, timestamp, server_time) => {
+                client::Message::RequestChatHistoryTargets(
+                    server,
+                    timestamp,
+                    server_time,
+                ) => {
                     let start_message_reference = timestamp
                         .map_or(MessageReference::None, |timestamp| {
                             MessageReference::Timestamp(timestamp)
                         });
 
-                    let end_message_reference = MessageReference::Timestamp(server_time);
+                    let end_message_reference =
+                        MessageReference::Timestamp(server_time);
 
                     let limit = clients.get_server_chathistory_limit(&server);
 
@@ -1173,7 +1401,9 @@ impl Dashboard {
             },
             Message::LoadPreview((url, Ok(preview))) => {
                 debug!("Preview loaded for {url}");
-                if let hash_map::Entry::Occupied(mut entry) = self.previews.entry(url) {
+                if let hash_map::Entry::Occupied(mut entry) =
+                    self.previews.entry(url)
+                {
                     *entry.get_mut() = preview::State::Loaded(preview);
                 }
             }
@@ -1206,7 +1436,9 @@ impl Dashboard {
                 PaneGrid::new(state, |id, pane, _maximized| {
                     let is_focused = self.focus == Focus { window, pane: id };
                     let buffer = pane.buffer.data();
-                    let settings = buffer.as_ref().and_then(|b| self.buffer_settings.get(b));
+                    let settings = buffer
+                        .as_ref()
+                        .and_then(|b| self.buffer_settings.get(b));
 
                     pane.view(
                         id,
@@ -1231,7 +1463,8 @@ impl Dashboard {
             .height(Length::Fill)
             .padding(8);
 
-            return Element::new(content).map(move |message| Message::Pane(window, message));
+            return Element::new(content)
+                .map(move |message| Message::Pane(window, message));
         } else if let Some(editor) = self.theme_editor.as_ref() {
             if editor.window == window {
                 return editor.view(theme).map(Message::ThemeEditor);
@@ -1248,43 +1481,47 @@ impl Dashboard {
         config: &'a Config,
         theme: &'a Theme,
     ) -> Element<'a, Message> {
-        let pane_grid: Element<_> = PaneGrid::new(&self.panes.main, |id, pane, maximized| {
-            let is_focused = self.focus
-                == Focus {
-                    window: self.main_window(),
-                    pane: id,
-                };
-            let panes = self.panes.main.panes.len();
-            let buffer = pane.buffer.data();
-            let settings = buffer.as_ref().and_then(|b| self.buffer_settings.get(b));
+        let pane_grid: Element<_> =
+            PaneGrid::new(&self.panes.main, |id, pane, maximized| {
+                let is_focused = self.focus
+                    == Focus {
+                        window: self.main_window(),
+                        pane: id,
+                    };
+                let panes = self.panes.main.panes.len();
+                let buffer = pane.buffer.data();
+                let settings =
+                    buffer.as_ref().and_then(|b| self.buffer_settings.get(b));
 
-            pane.view(
-                id,
-                panes,
-                is_focused,
-                maximized,
-                clients,
-                &self.file_transfers,
-                &self.history,
-                &self.previews,
-                &self.side_menu,
-                config,
-                theme,
-                settings,
-                false,
-            )
-        })
-        .on_click(pane::Message::PaneClicked)
-        .on_resize(6, pane::Message::PaneResized)
-        .on_drag(pane::Message::PaneDragged)
-        .spacing(4)
-        .into();
+                pane.view(
+                    id,
+                    panes,
+                    is_focused,
+                    maximized,
+                    clients,
+                    &self.file_transfers,
+                    &self.history,
+                    &self.previews,
+                    &self.side_menu,
+                    config,
+                    theme,
+                    settings,
+                    false,
+                )
+            })
+            .on_click(pane::Message::PaneClicked)
+            .on_resize(6, pane::Message::PaneResized)
+            .on_drag(pane::Message::PaneDragged)
+            .spacing(4)
+            .into();
 
         let pane_grid =
-            container(pane_grid.map(move |message| Message::Pane(self.main_window(), message)))
-                .width(Length::Fill)
-                .height(Length::Fill)
-                .padding(8);
+            container(pane_grid.map(move |message| {
+                Message::Pane(self.main_window(), message)
+            }))
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .padding(8);
 
         let side_menu = self
             .side_menu
@@ -1300,15 +1537,24 @@ impl Dashboard {
             .map(|e| e.map(Message::Sidebar));
 
         let content = match config.sidebar.position {
-            data::config::sidebar::Position::Left | data::config::sidebar::Position::Top => {
-                vec![side_menu.unwrap_or_else(|| row![].into()), pane_grid.into()]
+            data::config::sidebar::Position::Left
+            | data::config::sidebar::Position::Top => {
+                vec![
+                    side_menu.unwrap_or_else(|| row![].into()),
+                    pane_grid.into(),
+                ]
             }
-            data::config::sidebar::Position::Right | data::config::sidebar::Position::Bottom => {
-                vec![pane_grid.into(), side_menu.unwrap_or_else(|| row![].into())]
+            data::config::sidebar::Position::Right
+            | data::config::sidebar::Position::Bottom => {
+                vec![
+                    pane_grid.into(),
+                    side_menu.unwrap_or_else(|| row![].into()),
+                ]
             }
         };
 
-        let base: Element<Message> = if config.sidebar.position.is_horizontal() {
+        let base: Element<Message> = if config.sidebar.position.is_horizontal()
+        {
             Column::with_children(content)
                 .width(Length::Fill)
                 .height(Length::Fill)
@@ -1377,10 +1623,18 @@ impl Dashboard {
                 // - Close command/emoji picker
                 // - Restore maximized pane (if main window)
                 if self.command_bar.is_some() && window == self.main_window() {
-                    self.toggle_command_bar(&closed_buffers(self, clients), version, config, theme)
+                    self.toggle_command_bar(
+                        &closed_buffers(self, clients),
+                        version,
+                        config,
+                        theme,
+                    )
                 } else {
-                    context_menu::close(convert::identity)
-                        .map(move |any_closed| Message::CloseContextMenu(window, any_closed))
+                    context_menu::close(convert::identity).map(
+                        move |any_closed| {
+                            Message::CloseContextMenu(window, any_closed)
+                        },
+                    )
                 }
             }
             Copy => selectable_text::selected(Message::SelectedText),
@@ -1388,7 +1642,11 @@ impl Dashboard {
         }
     }
 
-    fn toggle_theme_editor(&mut self, theme: &mut Theme, main_window: &Window) -> Task<Message> {
+    fn toggle_theme_editor(
+        &mut self,
+        theme: &mut Theme,
+        main_window: &Window,
+    ) -> Task<Message> {
         if let Some(editor) = self.theme_editor.take() {
             *theme = theme.selected();
             window::close(editor.window)
@@ -1409,7 +1667,8 @@ impl Dashboard {
         let panes = self.panes.clone();
 
         let open = panes.iter().find_map(|(window_id, pane, state)| {
-            (state.buffer.internal().as_ref() == Some(&buffer)).then_some((window_id, pane))
+            (state.buffer.internal().as_ref() == Some(&buffer))
+                .then_some((window_id, pane))
         });
 
         if let Some((window, pane)) = open {
@@ -1438,7 +1697,8 @@ impl Dashboard {
                 // If buffer already is open, we swap it with focused pane.
                 for (window, id, pane) in panes.iter() {
                     if pane.buffer.data().as_ref() == Some(&buffer) {
-                        if window != self.focus.window || id != self.focus.pane {
+                        if window != self.focus.window || id != self.focus.pane
+                        {
                             return self.swap_pane_with_focus(window, id);
                         } else {
                             return Task::none();
@@ -1475,11 +1735,9 @@ impl Dashboard {
                 if self.panes.len() == 1 {
                     for (id, pane) in panes.main.iter() {
                         if matches!(pane.buffer, Buffer::Empty) {
-                            self.panes
-                                .main
-                                .panes
-                                .entry(*id)
-                                .and_modify(|p| *p = Pane::new(Buffer::from(buffer)));
+                            self.panes.main.panes.entry(*id).and_modify(|p| {
+                                *p = Pane::new(Buffer::from(buffer))
+                            });
                             self.last_changed = Some(Instant::now());
 
                             return self.focus_pane(self.main_window(), *id);
@@ -1490,7 +1748,9 @@ impl Dashboard {
                 let pane_to_split = {
                     if self.focus.window == self.main_window() {
                         self.focus.pane
-                    } else if let Some(pane) = self.panes.main.panes.keys().last() {
+                    } else if let Some(pane) =
+                        self.panes.main.panes.keys().last()
+                    {
                         *pane
                     } else {
                         log::error!("Didn't find any panes to split");
@@ -1500,8 +1760,12 @@ impl Dashboard {
 
                 let result = self.panes.main.split(
                     match config.pane.split_axis {
-                        config::pane::SplitAxis::Horizontal => pane_grid::Axis::Horizontal,
-                        config::pane::SplitAxis::Vertical => pane_grid::Axis::Vertical,
+                        config::pane::SplitAxis::Horizontal => {
+                            pane_grid::Axis::Horizontal
+                        }
+                        config::pane::SplitAxis::Vertical => {
+                            pane_grid::Axis::Vertical
+                        }
                     },
                     pane_to_split,
                     Pane::new(Buffer::from(buffer)),
@@ -1514,23 +1778,27 @@ impl Dashboard {
                 Task::none()
             }
             BufferAction::NewWindow => {
-                get_position(self.main_window()).then(move |main_window_position| {
-                    let (_, task) = window::open(window::Settings {
-                        // Just big enough to show all components in combobox
-                        position: main_window_position
-                            .map(|point| {
-                                window::Position::Specific(point + Vector::new(20.0, 20.0))
-                            })
-                            .unwrap_or_default(),
-                        exit_on_close_request: false,
-                        ..window::settings()
-                    });
+                get_position(self.main_window()).then(
+                    move |main_window_position| {
+                        let (_, task) = window::open(window::Settings {
+                            // Just big enough to show all components in combobox
+                            position: main_window_position
+                                .map(|point| {
+                                    window::Position::Specific(
+                                        point + Vector::new(20.0, 20.0),
+                                    )
+                                })
+                                .unwrap_or_default(),
+                            exit_on_close_request: false,
+                            ..window::settings()
+                        });
 
-                    task.map({
-                        let pane = Pane::new(Buffer::from(buffer.clone()));
-                        move |id| Message::NewWindow(id, pane.clone())
-                    })
-                })
+                        task.map({
+                            let pane = Pane::new(Buffer::from(buffer.clone()));
+                            move |id| Message::NewWindow(id, pane.clone())
+                        })
+                    },
+                )
             }
         }
     }
@@ -1569,8 +1837,13 @@ impl Dashboard {
 
                 tasks.push(
                     self.history
-                        .close(history::Kind::Channel(server, channel), mark_as_read)
-                        .map_or_else(Task::none, |task| Task::perform(task, Message::History)),
+                        .close(
+                            history::Kind::Channel(server, channel),
+                            mark_as_read,
+                        )
+                        .map_or_else(Task::none, |task| {
+                            Task::perform(task, Message::History)
+                        }),
                 );
 
                 (Task::batch(tasks), None)
@@ -1579,7 +1852,9 @@ impl Dashboard {
                 tasks.push(
                     self.history
                         .close(history::Kind::Query(server, nick), mark_as_read)
-                        .map_or_else(Task::none, |task| Task::perform(task, Message::History)),
+                        .map_or_else(Task::none, |task| {
+                            Task::perform(task, Message::History)
+                        }),
                 );
 
                 // No PART to send, just close history
@@ -1588,7 +1863,11 @@ impl Dashboard {
         }
     }
 
-    pub fn record_message(&mut self, server: &Server, message: data::Message) -> Task<Message> {
+    pub fn record_message(
+        &mut self,
+        server: &Server,
+        message: data::Message,
+    ) -> Task<Message> {
         if let Some(task) = self.history.record_message(server, message) {
             Task::perform(task, Message::History)
         } else {
@@ -1604,7 +1883,10 @@ impl Dashboard {
         }
     }
 
-    pub fn record_highlight(&mut self, message: data::Message) -> Task<Message> {
+    pub fn record_highlight(
+        &mut self,
+        message: data::Message,
+    ) -> Task<Message> {
         if let Some(task) = self.history.record_highlight(message) {
             Task::perform(task, Message::History)
         } else {
@@ -1630,7 +1912,9 @@ impl Dashboard {
                         }
                     }
                     isupport::MessageReferenceType::Timestamp => {
-                        return MessageReference::Timestamp(first_can_reference.server_time);
+                        return MessageReference::Timestamp(
+                            first_can_reference.server_time,
+                        );
                     }
                 }
             }
@@ -1656,8 +1940,8 @@ impl Dashboard {
                     return;
                 }
 
-                let message_reference_types =
-                    clients.get_server_chathistory_message_reference_types(server);
+                let message_reference_types = clients
+                    .get_server_chathistory_message_reference_types(server);
 
                 let first_can_reference = self.get_oldest_message_reference(
                     server,
@@ -1665,19 +1949,20 @@ impl Dashboard {
                     &message_reference_types,
                 );
 
-                let subcommand = if matches!(first_can_reference, MessageReference::None) {
-                    ChatHistorySubcommand::Latest(
-                        target,
-                        first_can_reference,
-                        clients.get_server_chathistory_limit(server),
-                    )
-                } else {
-                    ChatHistorySubcommand::Before(
-                        target,
-                        first_can_reference,
-                        clients.get_server_chathistory_limit(server),
-                    )
-                };
+                let subcommand =
+                    if matches!(first_can_reference, MessageReference::None) {
+                        ChatHistorySubcommand::Latest(
+                            target,
+                            first_can_reference,
+                            clients.get_server_chathistory_limit(server),
+                        )
+                    } else {
+                        ChatHistorySubcommand::Before(
+                            target,
+                            first_can_reference,
+                            clients.get_server_chathistory_limit(server),
+                        )
+                    };
 
                 clients.send_chathistory_request(server, subcommand);
             }
@@ -1725,7 +2010,11 @@ impl Dashboard {
 
         if clients.get_server_supports_chathistory(&server) {
             command.chain(Task::done(Message::Client(
-                data::client::Message::RequestNewerChatHistory(server, target, server_time),
+                data::client::Message::RequestNewerChatHistory(
+                    server,
+                    target,
+                    server_time,
+                ),
             )))
         } else {
             command
@@ -1761,7 +2050,9 @@ impl Dashboard {
             .map(|state| (window, pane, state))
     }
 
-    fn get_focused_mut(&mut self) -> Option<(window::Id, pane_grid::Pane, &mut Pane)> {
+    fn get_focused_mut(
+        &mut self,
+    ) -> Option<(window::Id, pane_grid::Pane, &mut Pane)> {
         let Focus { window, pane } = self.focus;
         self.panes
             .get_mut(window, pane)
@@ -1790,14 +2081,21 @@ impl Dashboard {
             .find_map(|(w, p, state)| {
                 (w == window && p == pane).then(|| {
                     state.buffer.focus().map(move |message| {
-                        Message::Pane(window, pane::Message::Buffer(pane, message))
+                        Message::Pane(
+                            window,
+                            pane::Message::Buffer(pane, message),
+                        )
                     })
                 })
             })
             .unwrap_or_else(Task::none);
     }
 
-    fn focus_pane(&mut self, window: window::Id, pane: pane_grid::Pane) -> Task<Message> {
+    fn focus_pane(
+        &mut self,
+        window: window::Id,
+        pane: pane_grid::Pane,
+    ) -> Task<Message> {
         if (self.focus != Focus { window, pane }) {
             self.focus = Focus { window, pane };
 
@@ -1854,17 +2152,20 @@ impl Dashboard {
             return self.split_pane(axis);
         } else {
             // If there is no focused pane, split the last pane or create a new empty grid
-            let pane = self.panes.main.iter().last().map(|(pane, _)| pane).copied();
+            let pane =
+                self.panes.main.iter().last().map(|(pane, _)| pane).copied();
 
             if let Some(pane) = pane {
-                let result = self.panes.main.split(axis, pane, Pane::new(Buffer::Empty));
+                let result =
+                    self.panes.main.split(axis, pane, Pane::new(Buffer::Empty));
                 self.last_changed = Some(Instant::now());
 
                 if let Some((pane, _)) = result {
                     return self.focus_pane(self.main_window(), pane);
                 }
             } else {
-                let (state, pane) = pane_grid::State::new(Pane::new(Buffer::Empty));
+                let (state, pane) =
+                    pane_grid::State::new(Pane::new(Buffer::Empty));
                 self.panes.main = state;
                 self.last_changed = Some(Instant::now());
                 return self.focus_pane(self.main_window(), pane);
@@ -1876,10 +2177,11 @@ impl Dashboard {
 
     fn split_pane(&mut self, axis: pane_grid::Axis) -> Task<Message> {
         if self.focus.window == self.main_window() {
-            let result = self
-                .panes
-                .main
-                .split(axis, self.focus.pane, Pane::new(Buffer::Empty));
+            let result = self.panes.main.split(
+                axis,
+                self.focus.pane,
+                Pane::new(Buffer::Empty),
+            );
             self.last_changed = Some(Instant::now());
             if let Some((pane, _)) = result {
                 return self.focus_pane(self.main_window(), pane);
@@ -1889,7 +2191,11 @@ impl Dashboard {
         Task::none()
     }
 
-    fn reset_pane(&mut self, window: window::Id, pane: pane_grid::Pane) -> Task<Message> {
+    fn reset_pane(
+        &mut self,
+        window: window::Id,
+        pane: pane_grid::Pane,
+    ) -> Task<Message> {
         if let Some(state) = self.panes.get_mut(window, pane) {
             state.buffer.reset();
         }
@@ -1897,7 +2203,11 @@ impl Dashboard {
         Task::none()
     }
 
-    fn close_pane(&mut self, window: window::Id, pane: pane_grid::Pane) -> Task<Message> {
+    fn close_pane(
+        &mut self,
+        window: window::Id,
+        pane: pane_grid::Pane,
+    ) -> Task<Message> {
         self.last_changed = Some(Instant::now());
 
         if window == self.main_window() {
@@ -1916,7 +2226,8 @@ impl Dashboard {
                 pane.buffer = Buffer::Empty;
             }
         } else if self.panes.popout.remove(&window).is_some() {
-            return window::close(window).chain(self.focus_window(self.main_window()));
+            return window::close(window)
+                .chain(self.focus_window(self.main_window()));
         }
 
         Task::none()
@@ -1934,7 +2245,11 @@ impl Dashboard {
 
         if let Some((pane, _)) = self.panes.main.close(pane) {
             if let Some(buffer) = pane.buffer.data() {
-                return self.open_buffer(buffer, BufferAction::NewWindow, config);
+                return self.open_buffer(
+                    buffer,
+                    BufferAction::NewWindow,
+                    config,
+                );
             }
         }
 
@@ -1951,7 +2266,9 @@ impl Dashboard {
             .and_then(|panes| panes.get(pane).cloned())
         {
             let task = match pane.buffer.data() {
-                Some(buffer) => self.open_buffer(buffer, BufferAction::NewPane, config),
+                Some(buffer) => {
+                    self.open_buffer(buffer, BufferAction::NewPane, config)
+                }
                 None => self.new_pane(pane_grid::Axis::Horizontal),
             };
 
@@ -1976,7 +2293,8 @@ impl Dashboard {
             pane: to_pane,
         } = self.focus;
 
-        if from_window == self.main_window() && to_window == self.main_window() {
+        if from_window == self.main_window() && to_window == self.main_window()
+        {
             self.panes.main.swap(from_pane, to_pane);
 
             self.focus_pane(from_window, from_pane)
@@ -1987,7 +2305,8 @@ impl Dashboard {
                 .cloned()
                 .zip(self.panes.get(to_window, to_pane).cloned())
             {
-                if let Some(state) = self.panes.get_mut(from_window, from_pane) {
+                if let Some(state) = self.panes.get_mut(from_window, from_pane)
+                {
                     *state = to_state;
                 }
                 if let Some(state) = self.panes.get_mut(to_window, to_pane) {
@@ -2078,8 +2397,12 @@ impl Dashboard {
     }
 
     fn buffer_resize_action(&self) -> data::buffer::Resize {
-        let can_resize_buffer = self.focus.window == self.main_window() && self.panes.len() > 1;
-        data::buffer::Resize::action(can_resize_buffer, self.is_pane_maximized())
+        let can_resize_buffer =
+            self.focus.window == self.main_window() && self.panes.len() > 1;
+        data::buffer::Resize::action(
+            can_resize_buffer,
+            self.is_pane_maximized(),
+        )
     }
 
     pub fn receive_file_transfer(
@@ -2101,8 +2424,13 @@ impl Dashboard {
             server,
         );
 
-        let query =
-            target::Query::parse(request.from.as_ref(), chantypes, statusmsg, casemapping).ok()?;
+        let query = target::Query::parse(
+            request.from.as_ref(),
+            chantypes,
+            statusmsg,
+            casemapping,
+        )
+        .ok()?;
 
         Some(self.handle_file_transfer_event(server, &query, event))
     }
@@ -2156,25 +2484,35 @@ impl Dashboard {
 
         fn configuration(pane: data::Pane) -> Configuration<Pane> {
             match pane {
-                data::Pane::Split { axis, ratio, a, b } => Configuration::Split {
-                    axis: match axis {
-                        data::pane::Axis::Horizontal => pane_grid::Axis::Horizontal,
-                        data::pane::Axis::Vertical => pane_grid::Axis::Vertical,
-                    },
-                    ratio,
-                    a: Box::new(configuration(*a)),
-                    b: Box::new(configuration(*b)),
-                },
+                data::Pane::Split { axis, ratio, a, b } => {
+                    Configuration::Split {
+                        axis: match axis {
+                            data::pane::Axis::Horizontal => {
+                                pane_grid::Axis::Horizontal
+                            }
+                            data::pane::Axis::Vertical => {
+                                pane_grid::Axis::Vertical
+                            }
+                        },
+                        ratio,
+                        a: Box::new(configuration(*a)),
+                        b: Box::new(configuration(*b)),
+                    }
+                }
                 data::Pane::Buffer { buffer } => {
                     Configuration::Pane(Pane::new(Buffer::from(buffer)))
                 }
-                data::Pane::Empty => Configuration::Pane(Pane::new(Buffer::empty())),
+                data::Pane::Empty => {
+                    Configuration::Pane(Pane::new(Buffer::empty()))
+                }
             }
         }
 
         let panes = Panes {
             main_window: main_window.id,
-            main: pane_grid::State::with_configuration(configuration(data.pane)),
+            main: pane_grid::State::with_configuration(configuration(
+                data.pane,
+            )),
             popout: HashMap::new(),
         };
 
@@ -2182,7 +2520,8 @@ impl Dashboard {
             .iter()
             // This should never fail
             .find_map(|(window, pane, state)| {
-                (state.buffer.data() == data.focus_buffer).then_some(Focus { window, pane })
+                (state.buffer.data() == data.focus_buffer)
+                    .then_some(Focus { window, pane })
             })
             // But if somehow it does, we just focus the "first" pane from the main window
             .unwrap_or_else(|| {
@@ -2202,7 +2541,9 @@ impl Dashboard {
             history: history::Manager::default(),
             last_changed: None,
             command_bar: None,
-            file_transfers: file_transfer::Manager::new(config.file_transfer.clone()),
+            file_transfers: file_transfer::Manager::new(
+                config.file_transfer.clone(),
+            ),
             theme_editor: None,
             notifications: notification::Notifications::new(),
             previews: preview::Collection::default(),
@@ -2218,11 +2559,16 @@ impl Dashboard {
             };
 
             if let Some(buffer) = pane.buffer.data() {
-                tasks.push(dashboard.open_buffer(buffer, BufferAction::NewWindow, config));
+                tasks.push(dashboard.open_buffer(
+                    buffer,
+                    BufferAction::NewWindow,
+                    config,
+                ));
             }
         }
 
-        let tasks = Task::batch(tasks).chain(dashboard.focus_pane(focus.window, focus.pane));
+        let tasks = Task::batch(tasks)
+            .chain(dashboard.focus_pane(focus.window, focus.pane));
 
         (dashboard, tasks)
     }
@@ -2348,11 +2694,17 @@ impl Dashboard {
         config: &Config,
     ) -> Task<Message> {
         match target {
-            Target::Channel(channel) => {
-                self.open_channel(server, channel, clients, buffer_action, config)
-            }
+            Target::Channel(channel) => self.open_channel(
+                server,
+                channel,
+                clients,
+                buffer_action,
+                config,
+            ),
             Target::Query(query) => {
-                let buffer = data::Buffer::Upstream(buffer::Upstream::Query(server, query));
+                let buffer = data::Buffer::Upstream(buffer::Upstream::Query(
+                    server, query,
+                ));
 
                 self.open_buffer(buffer.clone(), buffer_action, config)
             }
@@ -2363,7 +2715,11 @@ impl Dashboard {
         self.panes.main_window
     }
 
-    fn mark_as_read(&mut self, kind: history::Kind, clients: &mut data::client::Map) {
+    fn mark_as_read(
+        &mut self,
+        kind: history::Kind,
+        clients: &mut data::client::Map,
+    ) {
         let read_marker = self.history.mark_as_read(&kind);
 
         if let (Some(server), Some(target), Some(read_marker)) =
@@ -2384,13 +2740,18 @@ impl<'a> From<&'a Dashboard> for data::Dashboard {
     fn from(dashboard: &'a Dashboard) -> Self {
         use pane_grid::Node;
 
-        fn from_layout(panes: &pane_grid::State<Pane>, node: pane_grid::Node) -> data::Pane {
+        fn from_layout(
+            panes: &pane_grid::State<Pane>,
+            node: pane_grid::Node,
+        ) -> data::Pane {
             match node {
                 Node::Split {
                     axis, ratio, a, b, ..
                 } => data::Pane::Split {
                     axis: match axis {
-                        pane_grid::Axis::Horizontal => data::pane::Axis::Horizontal,
+                        pane_grid::Axis::Horizontal => {
+                            data::pane::Axis::Horizontal
+                        }
                         pane_grid::Axis::Vertical => data::pane::Axis::Vertical,
                     },
                     ratio,
@@ -2445,7 +2806,11 @@ impl Panes {
         }
     }
 
-    fn get_mut(&mut self, window: window::Id, pane: pane_grid::Pane) -> Option<&mut Pane> {
+    fn get_mut(
+        &mut self,
+        window: window::Id,
+        pane: pane_grid::Pane,
+    ) -> Option<&mut Pane> {
         if self.main_window == window {
             self.main.get_mut(pane)
         } else {
@@ -2459,11 +2824,14 @@ impl Panes {
         &mut self,
         buffer: &data::Buffer,
     ) -> Option<(window::Id, pane_grid::Pane, &mut Pane)> {
-        self.iter_mut()
-            .find(|(_, _, state)| state.buffer.data().is_some_and(|b| b == *buffer))
+        self.iter_mut().find(|(_, _, state)| {
+            state.buffer.data().is_some_and(|b| b == *buffer)
+        })
     }
 
-    fn iter(&self) -> impl Iterator<Item = (window::Id, pane_grid::Pane, &Pane)> {
+    fn iter(
+        &self,
+    ) -> impl Iterator<Item = (window::Id, pane_grid::Pane, &Pane)> {
         self.main
             .iter()
             .map(move |(pane, state)| (self.main_window, *pane, state))
@@ -2472,7 +2840,9 @@ impl Panes {
             }))
     }
 
-    fn iter_mut(&mut self) -> impl Iterator<Item = (window::Id, pane_grid::Pane, &mut Pane)> {
+    fn iter_mut(
+        &mut self,
+    ) -> impl Iterator<Item = (window::Id, pane_grid::Pane, &mut Pane)> {
         let main_window = self.main_window;
 
         self.main
@@ -2487,9 +2857,9 @@ impl Panes {
 
     fn resources(&self) -> impl Iterator<Item = data::history::Resource> + '_ {
         self.main.panes.values().filter_map(Pane::resource).chain(
-            self.popout
-                .values()
-                .flat_map(|state| state.panes.values().filter_map(Pane::resource)),
+            self.popout.values().flat_map(|state| {
+                state.panes.values().filter_map(Pane::resource)
+            }),
         )
     }
 
@@ -2498,33 +2868,30 @@ impl Panes {
             .panes
             .values()
             .flat_map(Pane::visible_urls)
-            .chain(
-                self.popout
-                    .values()
-                    .flat_map(|state| state.panes.values().flat_map(Pane::visible_urls)),
-            )
+            .chain(self.popout.values().flat_map(|state| {
+                state.panes.values().flat_map(Pane::visible_urls)
+            }))
             .cloned()
             .collect()
     }
 }
 
-fn all_buffers(clients: &client::Map, history: &history::Manager) -> Vec<buffer::Upstream> {
+fn all_buffers(
+    clients: &client::Map,
+    history: &history::Manager,
+) -> Vec<buffer::Upstream> {
     clients
         .connected_servers()
         .flat_map(|server| {
             std::iter::once(buffer::Upstream::Server(server.clone()))
-                .chain(
-                    clients
-                        .get_channels(server)
-                        .iter()
-                        .map(|channel| buffer::Upstream::Channel(server.clone(), channel.clone())),
-                )
-                .chain(
-                    history
-                        .get_unique_queries(server)
-                        .into_iter()
-                        .map(|nick| buffer::Upstream::Query(server.clone(), nick.clone())),
-                )
+                .chain(clients.get_channels(server).iter().map(|channel| {
+                    buffer::Upstream::Channel(server.clone(), channel.clone())
+                }))
+                .chain(history.get_unique_queries(server).into_iter().map(
+                    |nick| {
+                        buffer::Upstream::Query(server.clone(), nick.clone())
+                    },
+                ))
         })
         .collect()
 }
@@ -2543,15 +2910,23 @@ fn all_buffers_with_has_unread(
             .chain(clients.get_channels(server).iter().map(|channel| {
                 (
                     buffer::Upstream::Channel(server.clone(), channel.clone()),
-                    history.has_unread(&history::Kind::Channel(server.clone(), channel.clone())),
+                    history.has_unread(&history::Kind::Channel(
+                        server.clone(),
+                        channel.clone(),
+                    )),
                 )
             }))
-            .chain(history.get_unique_queries(server).into_iter().map(|nick| {
-                (
-                    buffer::Upstream::Query(server.clone(), nick.clone()),
-                    history.has_unread(&history::Kind::Query(server.clone(), nick.clone())),
-                )
-            }))
+            .chain(
+                history.get_unique_queries(server).into_iter().map(|nick| {
+                    (
+                        buffer::Upstream::Query(server.clone(), nick.clone()),
+                        history.has_unread(&history::Kind::Query(
+                            server.clone(),
+                            nick.clone(),
+                        )),
+                    )
+                }),
+            )
         })
         .collect()
 }
@@ -2565,7 +2940,10 @@ fn open_buffers(dashboard: &Dashboard) -> Vec<buffer::Upstream> {
         .collect()
 }
 
-fn closed_buffers(dashboard: &Dashboard, clients: &client::Map) -> Vec<buffer::Upstream> {
+fn closed_buffers(
+    dashboard: &Dashboard,
+    clients: &client::Map,
+) -> Vec<buffer::Upstream> {
     let open_buffers = open_buffers(dashboard);
 
     all_buffers(clients, &dashboard.history)
@@ -2612,7 +2990,9 @@ fn cycle_next_unread_buffer(
     mut all: Vec<(buffer::Upstream, bool)>,
     opened: &[buffer::Upstream],
 ) -> Option<buffer::Upstream> {
-    all.retain(|(buffer, _)| Some(buffer) == current || !opened.contains(buffer));
+    all.retain(|(buffer, _)| {
+        Some(buffer) == current || !opened.contains(buffer)
+    });
 
     let buffer = current?;
 
@@ -2638,7 +3018,9 @@ fn cycle_previous_unread_buffer(
     mut all: Vec<(buffer::Upstream, bool)>,
     opened: &[buffer::Upstream],
 ) -> Option<buffer::Upstream> {
-    all.retain(|(buffer, _)| Some(buffer) == current || !opened.contains(buffer));
+    all.retain(|(buffer, _)| {
+        Some(buffer) == current || !opened.contains(buffer)
+    });
 
     let buffer = current?;
 

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1736,7 +1736,7 @@ impl Dashboard {
                     for (id, pane) in panes.main.iter() {
                         if matches!(pane.buffer, Buffer::Empty) {
                             self.panes.main.panes.entry(*id).and_modify(|p| {
-                                *p = Pane::new(Buffer::from(buffer))
+                                *p = Pane::new(Buffer::from(buffer));
                             });
                             self.last_changed = Some(Instant::now());
 

--- a/src/screen/dashboard/command_bar.rs
+++ b/src/screen/dashboard/command_bar.rs
@@ -2,10 +2,9 @@ use data::{Config, buffer};
 use iced::Length;
 use iced::widget::{column, container, text};
 
+use super::Focus;
 use crate::widget::{Element, combo_box, double_pass, key_press};
 use crate::{theme, window};
-
-use super::Focus;
 
 #[derive(Debug, Clone)]
 pub struct CommandBar {
@@ -64,13 +63,15 @@ impl CommandBar {
         main_window: window::Id,
     ) -> Element<'a, Message> {
         // 1px larger than default
-        let font_size = config.font.size.map_or(theme::TEXT_SIZE, f32::from) + 1.0;
+        let font_size =
+            config.font.size.map_or(theme::TEXT_SIZE, f32::from) + 1.0;
 
-        let combo_box = combo_box(&self.state, "Type a command...", None, Message::Command)
-            .on_close(Message::Unfocused)
-            .on_option_hovered(Message::Hovered)
-            .size(font_size)
-            .padding([8, 8]);
+        let combo_box =
+            combo_box(&self.state, "Type a command...", None, Message::Command)
+                .on_close(Message::Unfocused)
+                .on_option_hovered(Message::Hovered)
+                .size(font_size)
+                .padding([8, 8]);
 
         // Capture ESC so we can close the combobox manually from application
         // and prevent undesired effects
@@ -86,9 +87,18 @@ impl CommandBar {
             column(
                 std::iter::once(text("Type a command...").size(font_size))
                     .chain(
-                        Command::list(buffers, config, focus, resize_buffer, version, main_window)
-                            .iter()
-                            .map(|command| text(command.to_string()).size(font_size)),
+                        Command::list(
+                            buffers,
+                            config,
+                            focus,
+                            resize_buffer,
+                            version,
+                            main_window,
+                        )
+                        .iter()
+                        .map(|command| {
+                            text(command.to_string()).size(font_size)
+                        }),
                     )
                     .map(Element::from),
             )
@@ -191,7 +201,8 @@ impl Command {
 
         let version = Version::list(version).into_iter().map(Command::Version);
 
-        let application = Application::list().into_iter().map(Command::Application);
+        let application =
+            Application::list().into_iter().map(Command::Application);
 
         version
             .chain(application)
@@ -208,12 +219,18 @@ impl std::fmt::Display for Command {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Command::Buffer(buffer) => write!(f, "Buffer: {buffer}"),
-            Command::Configuration(config) => write!(f, "Configuration: {config}"),
+            Command::Configuration(config) => {
+                write!(f, "Configuration: {config}")
+            }
             Command::UI(ui) => write!(f, "UI: {ui}"),
             Command::Theme(theme) => write!(f, "Theme: {theme}"),
-            Command::Version(application) => write!(f, "Version: {application}"),
+            Command::Version(application) => {
+                write!(f, "Version: {application}")
+            }
             Command::Window(window) => write!(f, "Window: {window}"),
-            Command::Application(application) => write!(f, "Application: {application}"),
+            Command::Application(application) => {
+                write!(f, "Application: {application}")
+            }
         }
     }
 }
@@ -323,7 +340,9 @@ impl std::fmt::Display for Version {
                     .remote
                     .as_ref()
                     .filter(|remote| remote != &&version.current)
-                    .map_or("(Latest release)".to_owned(), |remote| format!("(Latest: {remote})"));
+                    .map_or("(Latest release)".to_owned(), |remote| {
+                        format!("(Latest: {remote})")
+                    });
 
                 write!(f, "{} {}", version.current, latest)
             }
@@ -348,11 +367,15 @@ impl std::fmt::Display for Buffer {
             Buffer::New => write!(f, "New buffer"),
             Buffer::Close => write!(f, "Close buffer"),
             Buffer::Replace(buffer) => match buffer {
-                buffer::Upstream::Server(server) => write!(f, "Change to {server}"),
+                buffer::Upstream::Server(server) => {
+                    write!(f, "Change to {server}")
+                }
                 buffer::Upstream::Channel(server, channel) => {
                     write!(f, "Change to {channel} ({server})")
                 }
-                buffer::Upstream::Query(_, nick) => write!(f, "Change to {nick}"),
+                buffer::Upstream::Query(_, nick) => {
+                    write!(f, "Change to {nick}")
+                }
             },
             Buffer::Popout => write!(f, "Pop out buffer"),
             Buffer::Merge => write!(f, "Merge buffer"),
@@ -364,11 +387,19 @@ impl std::fmt::Display for Buffer {
 impl std::fmt::Display for Configuration {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Configuration::OpenConfigDirectory => write!(f, "Open config directory"),
-            Configuration::OpenWebsite => write!(f, "Open documentation website"),
+            Configuration::OpenConfigDirectory => {
+                write!(f, "Open config directory")
+            }
+            Configuration::OpenWebsite => {
+                write!(f, "Open documentation website")
+            }
             Configuration::Reload => write!(f, "Reload config file"),
-            Configuration::OpenCacheDirectory => write!(f, "Open cache directory"),
-            Configuration::OpenDataDirectory => write!(f, "Open data directory"),
+            Configuration::OpenCacheDirectory => {
+                write!(f, "Open cache directory")
+            }
+            Configuration::OpenDataDirectory => {
+                write!(f, "Open data directory")
+            }
         }
     }
 }
@@ -376,7 +407,9 @@ impl std::fmt::Display for Configuration {
 impl std::fmt::Display for Ui {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Ui::ToggleSidebarVisibility => write!(f, "Toggle sidebar visibility"),
+            Ui::ToggleSidebarVisibility => {
+                write!(f, "Toggle sidebar visibility")
+            }
         }
     }
 }
@@ -386,7 +419,9 @@ impl std::fmt::Display for Theme {
         match self {
             Theme::Switch(theme) => write!(f, "Switch to {}", theme.name),
             Theme::OpenEditor => write!(f, "Open editor"),
-            Theme::OpenThemesWebsite => write!(f, "Discover more themes (Opens website)"),
+            Theme::OpenThemesWebsite => {
+                write!(f, "Discover more themes (Opens website)")
+            }
         }
     }
 }

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -1,17 +1,18 @@
-use data::config::{self, sidebar, Config};
-use data::dashboard::{BufferAction, BufferFocusedAction};
-use data::{buffer, file_transfer, history, Version};
-use iced::widget::{
-    button, column, container, horizontal_rule, horizontal_space, pane_grid, row, scrollable, text,
-    vertical_rule, vertical_space, Column, Row, Scrollable, Space,
-};
-use iced::{padding, Alignment, Length, Task};
 use std::time::Duration;
 
+use data::config::{self, Config, sidebar};
+use data::dashboard::{BufferAction, BufferFocusedAction};
+use data::{Version, buffer, file_transfer, history};
+use iced::widget::{
+    Column, Row, Scrollable, Space, button, column, container, horizontal_rule,
+    horizontal_space, pane_grid, row, scrollable, text, vertical_rule,
+    vertical_space,
+};
+use iced::{Alignment, Length, Task, padding};
 use tokio::time;
 
 use super::{Focus, Panes};
-use crate::widget::{context_menu, double_pass, Element, Text};
+use crate::widget::{Element, Text, context_menu, double_pass};
 use crate::{icon, theme, window};
 
 const CONFIG_RELOAD_DELAY: Duration = Duration::from_secs(1);
@@ -78,20 +79,39 @@ impl Sidebar {
         self.hidden = !self.hidden;
     }
 
-    pub fn update(&mut self, message: Message) -> (Task<Message>, Option<Event>) {
+    pub fn update(
+        &mut self,
+        message: Message,
+    ) -> (Task<Message>, Option<Event>) {
         match message {
             Message::New(source) => (Task::none(), Some(Event::New(source))),
-            Message::Popout(source) => (Task::none(), Some(Event::Popout(source))),
-            Message::Focus(window, pane) => (Task::none(), Some(Event::Focus(window, pane))),
-            Message::Replace(source) => (Task::none(), Some(Event::Replace(source))),
-            Message::Close(window, pane) => (Task::none(), Some(Event::Close(window, pane))),
-            Message::Swap(window, pane) => (Task::none(), Some(Event::Swap(window, pane))),
-            Message::Leave(buffer) => (Task::none(), Some(Event::Leave(buffer))),
+            Message::Popout(source) => {
+                (Task::none(), Some(Event::Popout(source)))
+            }
+            Message::Focus(window, pane) => {
+                (Task::none(), Some(Event::Focus(window, pane)))
+            }
+            Message::Replace(source) => {
+                (Task::none(), Some(Event::Replace(source)))
+            }
+            Message::Close(window, pane) => {
+                (Task::none(), Some(Event::Close(window, pane)))
+            }
+            Message::Swap(window, pane) => {
+                (Task::none(), Some(Event::Swap(window, pane)))
+            }
+            Message::Leave(buffer) => {
+                (Task::none(), Some(Event::Leave(buffer)))
+            }
             Message::ToggleInternalBuffer(buffer) => {
                 (Task::none(), Some(Event::ToggleInternalBuffer(buffer)))
             }
-            Message::ToggleCommandBar => (Task::none(), Some(Event::ToggleCommandBar)),
-            Message::ToggleThemeEditor => (Task::none(), Some(Event::ToggleThemeEditor)),
+            Message::ToggleCommandBar => {
+                (Task::none(), Some(Event::ToggleCommandBar))
+            }
+            Message::ToggleThemeEditor => {
+                (Task::none(), Some(Event::ToggleThemeEditor))
+            }
             Message::ReloadingConfigFile => {
                 self.reloading_config = true;
                 (Task::perform(Config::load(), Message::ConfigReloaded), None)
@@ -102,13 +122,19 @@ impl Sidebar {
                 }),
                 Some(Event::ConfigReloaded(config)),
             ),
-            Message::OpenReleaseWebsite => (Task::none(), Some(Event::OpenReleaseWebsite)),
+            Message::OpenReleaseWebsite => {
+                (Task::none(), Some(Event::OpenReleaseWebsite))
+            }
             Message::ReloadComplete => {
                 self.reloading_config = false;
                 (Task::none(), None)
             }
-            Message::OpenDocumentation => (Task::none(), Some(Event::OpenDocumentation)),
-            Message::MarkAsRead(buffer) => (Task::none(), Some(Event::MarkAsRead(buffer))),
+            Message::OpenDocumentation => {
+                (Task::none(), Some(Event::OpenDocumentation))
+            }
+            Message::MarkAsRead(buffer) => {
+                (Task::none(), Some(Event::MarkAsRead(buffer)))
+            }
         }
     }
 
@@ -166,30 +192,40 @@ impl Sidebar {
                             Message::ToggleCommandBar,
                         ),
                         Menu::FileTransfers => context_button(
-                            text("File Transfers").style(if file_transfers.is_empty() {
-                                theme::text::primary
-                            } else {
-                                theme::text::tertiary
-                            }),
+                            text("File Transfers").style(
+                                if file_transfers.is_empty() {
+                                    theme::text::primary
+                                } else {
+                                    theme::text::tertiary
+                                },
+                            ),
                             Some(&keyboard.file_transfers),
-                            icon::file_transfer().style(if file_transfers.is_empty() {
-                                theme::text::primary
-                            } else {
-                                theme::text::tertiary
-                            }),
-                            Message::ToggleInternalBuffer(buffer::Internal::FileTransfers),
+                            icon::file_transfer().style(
+                                if file_transfers.is_empty() {
+                                    theme::text::primary
+                                } else {
+                                    theme::text::tertiary
+                                },
+                            ),
+                            Message::ToggleInternalBuffer(
+                                buffer::Internal::FileTransfers,
+                            ),
                         ),
                         Menu::Highlights => context_button(
                             text("Highlights"),
                             Some(&keyboard.highlight),
                             icon::highlights(),
-                            Message::ToggleInternalBuffer(buffer::Internal::Highlights),
+                            Message::ToggleInternalBuffer(
+                                buffer::Internal::Highlights,
+                            ),
                         ),
                         Menu::Logs => context_button(
                             text("Logs"),
                             Some(&keyboard.logs),
                             icon::logs(),
-                            Message::ToggleInternalBuffer(buffer::Internal::Logs),
+                            Message::ToggleInternalBuffer(
+                                buffer::Internal::Logs,
+                            ),
                         ),
                         Menu::ThemeEditor => context_button(
                             text("Theme Editor"),
@@ -198,12 +234,15 @@ impl Sidebar {
                             Message::ToggleThemeEditor,
                         ),
                         Menu::HorizontalRule => match length {
-                            Length::Fill => container(horizontal_rule(1)).padding([0, 6]).into(),
+                            Length::Fill => container(horizontal_rule(1))
+                                .padding([0, 6])
+                                .into(),
                             _ => Space::new(length, 1).into(),
                         },
                         Menu::Version => match version.is_old() {
                             true => context_button(
-                                text("New version available").style(theme::text::tertiary),
+                                text("New version available")
+                                    .style(theme::text::tertiary),
                                 None,
                                 icon::megaphone().style(theme::text::tertiary),
                                 Message::OpenReleaseWebsite,
@@ -243,15 +282,16 @@ impl Sidebar {
         }
 
         let content = |width| {
-            let user_menu_button = config
-                .sidebar
-                .show_user_menu
-                .then(|| self.user_menu_button(&config.keyboard, file_transfers, version));
+            let user_menu_button = config.sidebar.show_user_menu.then(|| {
+                self.user_menu_button(&config.keyboard, file_transfers, version)
+            });
 
             let mut buffers = vec![];
 
             for (i, (server, state)) in clients.iter().enumerate() {
-                let button = |buffer: buffer::Upstream, connected: bool, has_unread: bool| {
+                let button = |buffer: buffer::Upstream,
+                              connected: bool,
+                              has_unread: bool| {
                     upstream_buffer_button(
                         panes,
                         focus,
@@ -272,7 +312,9 @@ impl Sidebar {
                         buffers.push(button(
                             buffer::Upstream::Server(server.clone()),
                             false,
-                            history.has_unread(&history::Kind::Server(server.clone())),
+                            history.has_unread(&history::Kind::Server(
+                                server.clone(),
+                            )),
                         ));
                     }
                     data::client::State::Ready(connection) => {
@@ -280,13 +322,18 @@ impl Sidebar {
                         buffers.push(button(
                             buffer::Upstream::Server(server.clone()),
                             true,
-                            history.has_unread(&history::Kind::Server(server.clone())),
+                            history.has_unread(&history::Kind::Server(
+                                server.clone(),
+                            )),
                         ));
 
                         // Channels from the connected server.
                         for channel in connection.channels() {
                             buffers.push(button(
-                                buffer::Upstream::Channel(server.clone(), channel.clone()),
+                                buffer::Upstream::Channel(
+                                    server.clone(),
+                                    channel.clone(),
+                                ),
                                 true,
                                 history.has_unread(&history::Kind::Channel(
                                     server.clone(),
@@ -298,10 +345,15 @@ impl Sidebar {
                         // Queries from the connected server.
                         let queries = history.get_unique_queries(server);
                         for query in queries {
-                            let query = clients.resolve_query(server, query).unwrap_or(query);
+                            let query = clients
+                                .resolve_query(server, query)
+                                .unwrap_or(query);
 
                             buffers.push(button(
-                                buffer::Upstream::Query(server.clone(), query.clone()),
+                                buffer::Upstream::Query(
+                                    server.clone(),
+                                    query.clone(),
+                                ),
                                 true,
                                 history.has_unread(&history::Kind::Query(
                                     server.clone(),
@@ -332,24 +384,36 @@ impl Sidebar {
             match config.sidebar.position {
                 sidebar::Position::Left | sidebar::Position::Right => {
                     // Add buffers to a column.
-                    let buffers =
-                        column![Scrollable::new(Column::with_children(buffers).spacing(1))
-                            .direction(scrollable::Direction::Vertical(
-                                scrollable::Scrollbar::default().width(2).scroller_width(2)
-                            ))];
+                    let buffers = column![
+                        Scrollable::new(
+                            Column::with_children(buffers).spacing(1)
+                        )
+                        .direction(
+                            scrollable::Direction::Vertical(
+                                scrollable::Scrollbar::default()
+                                    .width(2)
+                                    .scroller_width(2)
+                            )
+                        )
+                    ];
 
                     // Wrap buffers in a column with user_menu_button
-                    let content = column![container(buffers).height(Length::Fill)]
-                        .push_maybe(user_menu_button);
+                    let content =
+                        column![container(buffers).height(Length::Fill)]
+                            .push_maybe(user_menu_button);
 
                     container(content)
                 }
                 sidebar::Position::Top | sidebar::Position::Bottom => {
                     // Add buffers to a row.
-                    let buffers = row![Scrollable::new(Row::with_children(buffers).spacing(2))
-                        .direction(scrollable::Direction::Horizontal(
-                            scrollable::Scrollbar::default().width(2).scroller_width(2)
-                        ))];
+                    let buffers = row![
+                        Scrollable::new(Row::with_children(buffers).spacing(2))
+                            .direction(scrollable::Direction::Horizontal(
+                                scrollable::Scrollbar::default()
+                                    .width(2)
+                                    .scroller_width(2)
+                            ))
+                    ];
 
                     // Wrap buffers in a row with user_menu_button
                     let content = row![container(buffers).width(Length::Fill)]
@@ -369,13 +433,18 @@ impl Sidebar {
         };
 
         let content = if config.sidebar.position.is_horizontal() {
-            container(content(Length::Shrink).width(Length::Fill).padding(padding)).into()
+            container(
+                content(Length::Shrink).width(Length::Fill).padding(padding),
+            )
+            .into()
         } else {
             let first_pass = content(Length::Shrink);
             let second_pass = content(Length::Fill);
 
             container(double_pass(first_pass, second_pass))
-                .max_width(config.sidebar.max_width.map_or(f32::INFINITY, f32::from))
+                .max_width(
+                    config.sidebar.max_width.map_or(f32::INFINITY, f32::from),
+                )
                 .width(Length::Shrink)
                 .padding(padding)
                 .into()
@@ -442,7 +511,10 @@ impl Entry {
             Some((window, pane)) => (num_panes > 1)
                 .then_some(Entry::Close(window, pane))
                 .into_iter()
-                .chain((Focus { window, pane } != focus).then_some(Entry::Swap(window, pane)))
+                .chain(
+                    (Focus { window, pane } != focus)
+                        .then_some(Entry::Swap(window, pane)),
+                )
                 .chain(Some(Entry::Leave))
                 .collect(),
         }
@@ -475,25 +547,26 @@ fn upstream_buffer_button(
 
     let show_unread_indicator =
         has_unread && matches!(unread_indicator, sidebar::UnreadIndicator::Dot);
-    let show_title_indicator =
-        has_unread && matches!(unread_indicator, sidebar::UnreadIndicator::Title);
+    let show_title_indicator = has_unread
+        && matches!(unread_indicator, sidebar::UnreadIndicator::Title);
 
-    let unread_dot_indicator_spacing = horizontal_space().width(match position.is_horizontal() {
-        true => {
-            if show_unread_indicator {
-                5
-            } else {
-                0
+    let unread_dot_indicator_spacing =
+        horizontal_space().width(match position.is_horizontal() {
+            true => {
+                if show_unread_indicator {
+                    5
+                } else {
+                    0
+                }
             }
-        }
-        false => {
-            if show_unread_indicator {
-                11
-            } else {
-                16
+            false => {
+                if show_unread_indicator {
+                    11
+                } else {
+                    16
+                }
             }
-        }
-    });
+        });
     let buffer_title_style = if show_title_indicator {
         theme::text::unread_indicator
     } else {
@@ -519,10 +592,9 @@ fn upstream_buffer_button(
         .align_y(iced::Alignment::Center),
         buffer::Upstream::Channel(_, channel) => row![]
             .push(horizontal_space().width(3))
-            .push_maybe(
-                show_unread_indicator
-                    .then_some(icon::dot().size(6).style(theme::text::unread_indicator)),
-            )
+            .push_maybe(show_unread_indicator.then_some(
+                icon::dot().size(6).style(theme::text::unread_indicator),
+            ))
             .push(unread_dot_indicator_spacing)
             .push(
                 text(channel.to_string())
@@ -533,10 +605,9 @@ fn upstream_buffer_button(
             .align_y(iced::Alignment::Center),
         buffer::Upstream::Query(_, query) => row![]
             .push(horizontal_space().width(3))
-            .push_maybe(
-                show_unread_indicator
-                    .then_some(icon::dot().size(6).style(theme::text::unread_indicator)),
-            )
+            .push_maybe(show_unread_indicator.then_some(
+                icon::dot().size(6).style(theme::text::unread_indicator),
+            ))
             .push(unread_dot_indicator_spacing)
             .push(
                 text(query.to_string())
@@ -550,14 +621,21 @@ fn upstream_buffer_button(
     let base = button(row.width(width))
         .padding(5)
         .style(move |theme, status| {
-            theme::button::sidebar_buffer(theme, status, is_focused.is_some(), open.is_some())
+            theme::button::sidebar_buffer(
+                theme,
+                status,
+                is_focused.is_some(),
+                open.is_some(),
+            )
         })
         .on_press({
             match is_focused {
                 Some((window, pane)) => {
                     if let Some(focus_action) = focused_buffer_action {
                         match focus_action {
-                            BufferFocusedAction::ClosePane => Message::Close(window, pane),
+                            BufferFocusedAction::ClosePane => {
+                                Message::Close(window, pane)
+                            }
                         }
                     } else {
                         // Re-focus pane on press instead of disabling the button in order
@@ -570,9 +648,15 @@ fn upstream_buffer_button(
                         Message::Focus(window, pane)
                     } else {
                         match buffer_action {
-                            BufferAction::NewPane => Message::New(buffer.clone()),
-                            BufferAction::ReplacePane => Message::Replace(buffer.clone()),
-                            BufferAction::NewWindow => Message::Popout(buffer.clone()),
+                            BufferAction::NewPane => {
+                                Message::New(buffer.clone())
+                            }
+                            BufferAction::ReplacePane => {
+                                Message::Replace(buffer.clone())
+                            }
+                            BufferAction::NewWindow => {
+                                Message::Popout(buffer.clone())
+                            }
                         }
                     }
                 }
@@ -598,8 +682,13 @@ fn upstream_buffer_button(
                             None
                         },
                     ),
-                    Entry::NewPane => ("Open in new pane", Some(Message::New(buffer.clone()))),
-                    Entry::Popout => ("Open in new window", Some(Message::Popout(buffer.clone()))),
+                    Entry::NewPane => {
+                        ("Open in new pane", Some(Message::New(buffer.clone())))
+                    }
+                    Entry::Popout => (
+                        "Open in new window",
+                        Some(Message::Popout(buffer.clone())),
+                    ),
                     Entry::Replace => (
                         "Replace current pane",
                         Some(Message::Replace(buffer.clone())),
@@ -607,9 +696,10 @@ fn upstream_buffer_button(
                     Entry::Close(window, pane) => {
                         ("Close pane", Some(Message::Close(window, pane)))
                     }
-                    Entry::Swap(window, pane) => {
-                        ("Swap with current pane", Some(Message::Swap(window, pane)))
-                    }
+                    Entry::Swap(window, pane) => (
+                        "Swap with current pane",
+                        Some(Message::Swap(window, pane)),
+                    ),
                     Entry::Leave => (
                         match &buffer {
                             buffer::Upstream::Server(_) => "Leave server",
@@ -623,7 +713,9 @@ fn upstream_buffer_button(
                 button(text(content))
                     .width(length)
                     .padding(5)
-                    .style(|theme, status| theme::button::primary(theme, status, false))
+                    .style(|theme, status| {
+                        theme::button::primary(theme, status, false)
+                    })
                     .on_press_maybe(message)
                     .into()
             },

--- a/src/screen/dashboard/theme_editor.rs
+++ b/src/screen/dashboard/theme_editor.rs
@@ -413,14 +413,14 @@ impl Component {
     fn update(&self, colors: &mut Colors, color: Option<Color>) {
         match self {
             Component::General(general) => {
-                general.update(&mut colors.general, color)
+                general.update(&mut colors.general, color);
             }
             Component::Text(text) => text.update(&mut colors.text, color),
             Component::Buffer(buffer) => {
-                buffer.update(&mut colors.buffer, color)
+                buffer.update(&mut colors.buffer, color);
             }
             Component::Buttons(buttons) => {
-                buttons.update(&mut colors.buttons, color)
+                buttons.update(&mut colors.buttons, color);
             }
         }
     }
@@ -450,13 +450,13 @@ impl General {
     fn update(&self, colors: &mut theme::General, color: Option<Color>) {
         match self {
             General::Background => {
-                colors.background = color.unwrap_or(Color::TRANSPARENT)
+                colors.background = color.unwrap_or(Color::TRANSPARENT);
             }
             General::Border => {
-                colors.border = color.unwrap_or(Color::TRANSPARENT)
+                colors.border = color.unwrap_or(Color::TRANSPARENT);
             }
             General::HorizontalRule => {
-                colors.horizontal_rule = color.unwrap_or(Color::TRANSPARENT)
+                colors.horizontal_rule = color.unwrap_or(Color::TRANSPARENT);
             }
             General::UnreadIndicator => {
                 colors.unread_indicator = color.unwrap_or(Color::TRANSPARENT);
@@ -491,16 +491,16 @@ impl Text {
     fn update(&self, colors: &mut theme::Text, color: Option<Color>) {
         match self {
             Text::Primary => {
-                colors.primary = color.unwrap_or(Color::TRANSPARENT)
+                colors.primary = color.unwrap_or(Color::TRANSPARENT);
             }
             Text::Secondary => {
-                colors.secondary = color.unwrap_or(Color::TRANSPARENT)
+                colors.secondary = color.unwrap_or(Color::TRANSPARENT);
             }
             Text::Tertiary => {
-                colors.tertiary = color.unwrap_or(Color::TRANSPARENT)
+                colors.tertiary = color.unwrap_or(Color::TRANSPARENT);
             }
             Text::Success => {
-                colors.success = color.unwrap_or(Color::TRANSPARENT)
+                colors.success = color.unwrap_or(Color::TRANSPARENT);
             }
             Text::Error => colors.error = color.unwrap_or(Color::TRANSPARENT),
         }
@@ -554,10 +554,10 @@ impl Buffer {
     fn update(&self, colors: &mut theme::Buffer, color: Option<Color>) {
         match self {
             Buffer::Action => {
-                colors.action = color.unwrap_or(Color::TRANSPARENT)
+                colors.action = color.unwrap_or(Color::TRANSPARENT);
             }
             Buffer::Background => {
-                colors.background = color.unwrap_or(Color::TRANSPARENT)
+                colors.background = color.unwrap_or(Color::TRANSPARENT);
             }
             Buffer::BackgroundTextInput => {
                 colors.background_text_input =
@@ -568,26 +568,26 @@ impl Buffer {
                     color.unwrap_or(Color::TRANSPARENT);
             }
             Buffer::Border => {
-                colors.border = color.unwrap_or(Color::TRANSPARENT)
+                colors.border = color.unwrap_or(Color::TRANSPARENT);
             }
             Buffer::BorderSelected => {
-                colors.border_selected = color.unwrap_or(Color::TRANSPARENT)
+                colors.border_selected = color.unwrap_or(Color::TRANSPARENT);
             }
             Buffer::Code => colors.code = color.unwrap_or(Color::TRANSPARENT),
             Buffer::Highlight => {
-                colors.highlight = color.unwrap_or(Color::TRANSPARENT)
+                colors.highlight = color.unwrap_or(Color::TRANSPARENT);
             }
             Buffer::Nickname => {
-                colors.nickname = color.unwrap_or(Color::TRANSPARENT)
+                colors.nickname = color.unwrap_or(Color::TRANSPARENT);
             }
             Buffer::Selection => {
-                colors.selection = color.unwrap_or(Color::TRANSPARENT)
+                colors.selection = color.unwrap_or(Color::TRANSPARENT);
             }
             Buffer::ServerMessages(server_messages) => {
                 server_messages.update(&mut colors.server_messages, color);
             }
             Buffer::Timestamp => {
-                colors.timestamp = color.unwrap_or(Color::TRANSPARENT)
+                colors.timestamp = color.unwrap_or(Color::TRANSPARENT);
             }
             Buffer::Topic => colors.topic = color.unwrap_or(Color::TRANSPARENT),
             Buffer::Url => colors.url = color.unwrap_or(Color::TRANSPARENT),
@@ -640,19 +640,19 @@ impl ServerMessages {
             ServerMessages::ChangeHost => colors.change_host = color,
             ServerMessages::MonitoredOnline => colors.monitored_online = color,
             ServerMessages::MonitoredOffline => {
-                colors.monitored_offline = color
+                colors.monitored_offline = color;
             }
             ServerMessages::StandardReplyFail => {
-                colors.standard_reply_fail = color
+                colors.standard_reply_fail = color;
             }
             ServerMessages::StandardReplyWarn => {
-                colors.standard_reply_warn = color
+                colors.standard_reply_warn = color;
             }
             ServerMessages::StandardReplyNote => {
-                colors.standard_reply_note = color
+                colors.standard_reply_note = color;
             }
             ServerMessages::Default => {
-                colors.default = color.unwrap_or(Color::TRANSPARENT)
+                colors.default = color.unwrap_or(Color::TRANSPARENT);
             }
         }
     }
@@ -679,10 +679,10 @@ impl Buttons {
     fn update(&self, colors: &mut theme::Buttons, color: Option<Color>) {
         match self {
             Buttons::Primary(button) => {
-                button.update(&mut colors.primary, color)
+                button.update(&mut colors.primary, color);
             }
             Buttons::Secondary(button) => {
-                button.update(&mut colors.secondary, color)
+                button.update(&mut colors.secondary, color);
             }
         }
     }
@@ -713,7 +713,7 @@ impl Button {
     fn update(&self, colors: &mut theme::Button, color: Option<Color>) {
         match self {
             Button::Background => {
-                colors.background = color.unwrap_or(Color::TRANSPARENT)
+                colors.background = color.unwrap_or(Color::TRANSPARENT);
             }
             Button::BackgroundHover => {
                 colors.background_hover = color.unwrap_or(Color::TRANSPARENT);

--- a/src/screen/dashboard/theme_editor.rs
+++ b/src/screen/dashboard/theme_editor.rs
@@ -3,12 +3,11 @@ use std::time::Duration;
 
 use data::{Config, url};
 use futures::TryFutureExt;
+use iced::Length::*;
 use iced::alignment::Vertical;
 use iced::widget::text::LineHeight;
 use iced::widget::{button, center, column, container, row, text_input};
-use iced::{Color, Length};
-use iced::{Length::*, alignment, clipboard};
-use iced::{Task, Vector};
+use iced::{Color, Length, Task, Vector, alignment, clipboard};
 use strum::IntoEnumIterator;
 use tokio::time;
 
@@ -59,7 +58,9 @@ impl ThemeEditor {
             resizable: false,
             position: main_window
                 .position
-                .map(|point| window::Position::Specific(point + Vector::new(20.0, 20.0)))
+                .map(|point| {
+                    window::Position::Specific(point + Vector::new(20.0, 20.0))
+                })
                 .unwrap_or_default(),
             exit_on_close_request: false,
             ..window::settings()
@@ -95,7 +96,8 @@ impl ThemeEditor {
 
                 self.component.update(&mut colors, Some(color));
 
-                *theme = theme.preview(data::Theme::new("Custom Theme".into(), colors));
+                *theme = theme
+                    .preview(data::Theme::new("Custom Theme".into(), colors));
             }
             Message::Component(component) => {
                 self.hex_input = None;
@@ -109,7 +111,10 @@ impl ThemeEditor {
 
                     self.component.update(&mut colors, Some(color));
 
-                    *theme = theme.preview(data::Theme::new("Custom Theme".into(), colors));
+                    *theme = theme.preview(data::Theme::new(
+                        "Custom Theme".into(),
+                        colors,
+                    ));
                 }
 
                 self.hex_input = Some(input);
@@ -145,7 +150,8 @@ impl ThemeEditor {
 
                 self.component.update(&mut colors, original);
 
-                *theme = theme.preview(data::Theme::new("Custom Theme".into(), colors));
+                *theme = theme
+                    .preview(data::Theme::new("Custom Theme".into(), colors));
             }
             Message::Clear => {
                 self.hex_input = None;
@@ -154,7 +160,8 @@ impl ThemeEditor {
 
                 self.component.update(&mut colors, None);
 
-                *theme = theme.preview(data::Theme::new("Custom Theme".into(), colors));
+                *theme = theme
+                    .preview(data::Theme::new("Custom Theme".into(), colors));
             }
             Message::Copy => {
                 self.copied = true;
@@ -164,7 +171,10 @@ impl ThemeEditor {
                 return (
                     Task::batch(vec![
                         clipboard::write(url),
-                        Task::perform(time::sleep(Duration::from_secs(2)), |()| Message::ClearCopy),
+                        Task::perform(
+                            time::sleep(Duration::from_secs(2)),
+                            |()| Message::ClearCopy,
+                        ),
                     ]),
                     None,
                 );
@@ -182,7 +192,10 @@ impl ThemeEditor {
                 let colors = *theme.colors();
 
                 return (
-                    Task::perform(colors.save(path).map_err(|e| e.to_string()), Message::Saved),
+                    Task::perform(
+                        colors.save(path).map_err(|e| e.to_string()),
+                        Message::Saved,
+                    ),
                     None,
                 );
             }
@@ -267,7 +280,8 @@ impl ThemeEditor {
             icon(icon::copy(), "Copy Theme to URL", Message::Copy)
         };
 
-        let share = icon(icon::share(), "Share Theme with community", Message::Share);
+        let share =
+            icon(icon::share(), "Share Theme with community", Message::Share);
 
         let color_picker = color_picker(color, Message::Color);
 
@@ -295,7 +309,11 @@ impl ThemeEditor {
     }
 }
 
-fn icon<'a>(icon: widget::Text<'a>, tip: &'a str, message: Message) -> Element<'a, Message> {
+fn icon<'a>(
+    icon: widget::Text<'a>,
+    tip: &'a str,
+    message: Message,
+) -> Element<'a, Message> {
     tooltip(
         button(center(icon.style(theme::text::primary)))
             .width(22)
@@ -394,15 +412,23 @@ impl Component {
 
     fn update(&self, colors: &mut Colors, color: Option<Color>) {
         match self {
-            Component::General(general) => general.update(&mut colors.general, color),
+            Component::General(general) => {
+                general.update(&mut colors.general, color)
+            }
             Component::Text(text) => text.update(&mut colors.text, color),
-            Component::Buffer(buffer) => buffer.update(&mut colors.buffer, color),
-            Component::Buttons(buttons) => buttons.update(&mut colors.buttons, color),
+            Component::Buffer(buffer) => {
+                buffer.update(&mut colors.buffer, color)
+            }
+            Component::Buttons(buttons) => {
+                buttons.update(&mut colors.buttons, color)
+            }
         }
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::EnumIter)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::EnumIter,
+)]
 #[strum(serialize_all = "kebab-case")]
 pub enum General {
     Background,
@@ -423,9 +449,15 @@ impl General {
 
     fn update(&self, colors: &mut theme::General, color: Option<Color>) {
         match self {
-            General::Background => colors.background = color.unwrap_or(Color::TRANSPARENT),
-            General::Border => colors.border = color.unwrap_or(Color::TRANSPARENT),
-            General::HorizontalRule => colors.horizontal_rule = color.unwrap_or(Color::TRANSPARENT),
+            General::Background => {
+                colors.background = color.unwrap_or(Color::TRANSPARENT)
+            }
+            General::Border => {
+                colors.border = color.unwrap_or(Color::TRANSPARENT)
+            }
+            General::HorizontalRule => {
+                colors.horizontal_rule = color.unwrap_or(Color::TRANSPARENT)
+            }
             General::UnreadIndicator => {
                 colors.unread_indicator = color.unwrap_or(Color::TRANSPARENT);
             }
@@ -433,7 +465,9 @@ impl General {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::EnumIter)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::EnumIter,
+)]
 #[strum(serialize_all = "kebab-case")]
 pub enum Text {
     Primary,
@@ -456,16 +490,26 @@ impl Text {
 
     fn update(&self, colors: &mut theme::Text, color: Option<Color>) {
         match self {
-            Text::Primary => colors.primary = color.unwrap_or(Color::TRANSPARENT),
-            Text::Secondary => colors.secondary = color.unwrap_or(Color::TRANSPARENT),
-            Text::Tertiary => colors.tertiary = color.unwrap_or(Color::TRANSPARENT),
-            Text::Success => colors.success = color.unwrap_or(Color::TRANSPARENT),
+            Text::Primary => {
+                colors.primary = color.unwrap_or(Color::TRANSPARENT)
+            }
+            Text::Secondary => {
+                colors.secondary = color.unwrap_or(Color::TRANSPARENT)
+            }
+            Text::Tertiary => {
+                colors.tertiary = color.unwrap_or(Color::TRANSPARENT)
+            }
+            Text::Success => {
+                colors.success = color.unwrap_or(Color::TRANSPARENT)
+            }
             Text::Error => colors.error = color.unwrap_or(Color::TRANSPARENT),
         }
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::EnumIter)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::EnumIter,
+)]
 #[strum(serialize_all = "kebab-case")]
 pub enum Buffer {
     Action,
@@ -509,31 +553,51 @@ impl Buffer {
 
     fn update(&self, colors: &mut theme::Buffer, color: Option<Color>) {
         match self {
-            Buffer::Action => colors.action = color.unwrap_or(Color::TRANSPARENT),
-            Buffer::Background => colors.background = color.unwrap_or(Color::TRANSPARENT),
+            Buffer::Action => {
+                colors.action = color.unwrap_or(Color::TRANSPARENT)
+            }
+            Buffer::Background => {
+                colors.background = color.unwrap_or(Color::TRANSPARENT)
+            }
             Buffer::BackgroundTextInput => {
-                colors.background_text_input = color.unwrap_or(Color::TRANSPARENT);
+                colors.background_text_input =
+                    color.unwrap_or(Color::TRANSPARENT);
             }
             Buffer::BackgroundTitleBar => {
-                colors.background_title_bar = color.unwrap_or(Color::TRANSPARENT);
+                colors.background_title_bar =
+                    color.unwrap_or(Color::TRANSPARENT);
             }
-            Buffer::Border => colors.border = color.unwrap_or(Color::TRANSPARENT),
-            Buffer::BorderSelected => colors.border_selected = color.unwrap_or(Color::TRANSPARENT),
+            Buffer::Border => {
+                colors.border = color.unwrap_or(Color::TRANSPARENT)
+            }
+            Buffer::BorderSelected => {
+                colors.border_selected = color.unwrap_or(Color::TRANSPARENT)
+            }
             Buffer::Code => colors.code = color.unwrap_or(Color::TRANSPARENT),
-            Buffer::Highlight => colors.highlight = color.unwrap_or(Color::TRANSPARENT),
-            Buffer::Nickname => colors.nickname = color.unwrap_or(Color::TRANSPARENT),
-            Buffer::Selection => colors.selection = color.unwrap_or(Color::TRANSPARENT),
+            Buffer::Highlight => {
+                colors.highlight = color.unwrap_or(Color::TRANSPARENT)
+            }
+            Buffer::Nickname => {
+                colors.nickname = color.unwrap_or(Color::TRANSPARENT)
+            }
+            Buffer::Selection => {
+                colors.selection = color.unwrap_or(Color::TRANSPARENT)
+            }
             Buffer::ServerMessages(server_messages) => {
                 server_messages.update(&mut colors.server_messages, color);
             }
-            Buffer::Timestamp => colors.timestamp = color.unwrap_or(Color::TRANSPARENT),
+            Buffer::Timestamp => {
+                colors.timestamp = color.unwrap_or(Color::TRANSPARENT)
+            }
             Buffer::Topic => colors.topic = color.unwrap_or(Color::TRANSPARENT),
             Buffer::Url => colors.url = color.unwrap_or(Color::TRANSPARENT),
         }
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, strum::Display, strum::EnumIter)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, strum::Display, strum::EnumIter,
+)]
 #[strum(serialize_all = "kebab-case")]
 pub enum ServerMessages {
     #[default]
@@ -575,16 +639,28 @@ impl ServerMessages {
             ServerMessages::ReplyTopic => colors.reply_topic = color,
             ServerMessages::ChangeHost => colors.change_host = color,
             ServerMessages::MonitoredOnline => colors.monitored_online = color,
-            ServerMessages::MonitoredOffline => colors.monitored_offline = color,
-            ServerMessages::StandardReplyFail => colors.standard_reply_fail = color,
-            ServerMessages::StandardReplyWarn => colors.standard_reply_warn = color,
-            ServerMessages::StandardReplyNote => colors.standard_reply_note = color,
-            ServerMessages::Default => colors.default = color.unwrap_or(Color::TRANSPARENT),
+            ServerMessages::MonitoredOffline => {
+                colors.monitored_offline = color
+            }
+            ServerMessages::StandardReplyFail => {
+                colors.standard_reply_fail = color
+            }
+            ServerMessages::StandardReplyWarn => {
+                colors.standard_reply_warn = color
+            }
+            ServerMessages::StandardReplyNote => {
+                colors.standard_reply_note = color
+            }
+            ServerMessages::Default => {
+                colors.default = color.unwrap_or(Color::TRANSPARENT)
+            }
         }
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::EnumIter)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::EnumIter,
+)]
 pub enum Buttons {
     #[strum(to_string = "primary-{0}")]
     Primary(Button),
@@ -602,13 +678,19 @@ impl Buttons {
 
     fn update(&self, colors: &mut theme::Buttons, color: Option<Color>) {
         match self {
-            Buttons::Primary(button) => button.update(&mut colors.primary, color),
-            Buttons::Secondary(button) => button.update(&mut colors.secondary, color),
+            Buttons::Primary(button) => {
+                button.update(&mut colors.primary, color)
+            }
+            Buttons::Secondary(button) => {
+                button.update(&mut colors.secondary, color)
+            }
         }
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, strum::Display, strum::EnumIter)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, strum::Display, strum::EnumIter,
+)]
 #[strum(serialize_all = "kebab-case")]
 pub enum Button {
     #[default]
@@ -630,15 +712,19 @@ impl Button {
 
     fn update(&self, colors: &mut theme::Button, color: Option<Color>) {
         match self {
-            Button::Background => colors.background = color.unwrap_or(Color::TRANSPARENT),
+            Button::Background => {
+                colors.background = color.unwrap_or(Color::TRANSPARENT)
+            }
             Button::BackgroundHover => {
                 colors.background_hover = color.unwrap_or(Color::TRANSPARENT);
             }
             Button::BackgroundSelected => {
-                colors.background_selected = color.unwrap_or(Color::TRANSPARENT);
+                colors.background_selected =
+                    color.unwrap_or(Color::TRANSPARENT);
             }
             Button::BackgroundSelectedHover => {
-                colors.background_selected_hover = color.unwrap_or(Color::TRANSPARENT);
+                colors.background_selected_hover =
+                    color.unwrap_or(Color::TRANSPARENT);
             }
         }
     }

--- a/src/screen/help.rs
+++ b/src/screen/help.rs
@@ -1,7 +1,7 @@
 use data::environment::WIKI_WEBSITE;
-use data::{config, Config};
+use data::{Config, config};
 use iced::widget::{button, column, container, text, vertical_space};
-use iced::{alignment, Length};
+use iced::{Length, alignment};
 
 use crate::widget::Element;
 use crate::{icon, theme};

--- a/src/screen/migration.rs
+++ b/src/screen/migration.rs
@@ -1,7 +1,7 @@
-use data::environment::MIGRATION_WEBSITE;
 use data::Config;
+use data::environment::MIGRATION_WEBSITE;
 use iced::widget::{button, column, container, text, vertical_space};
-use iced::{alignment, Length};
+use iced::{Length, alignment};
 
 use crate::widget::Element;
 use crate::{font, theme};

--- a/src/screen/welcome.rs
+++ b/src/screen/welcome.rs
@@ -1,7 +1,9 @@
-use data::environment::WIKI_WEBSITE;
 use data::Config;
-use iced::widget::{button, column, container, image, row, text, vertical_space};
-use iced::{alignment, Length};
+use data::environment::WIKI_WEBSITE;
+use iced::widget::{
+    button, column, container, image, row, text, vertical_space,
+};
+use iced::{Length, alignment};
 
 use crate::widget::Element;
 use crate::{font, theme};

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -5,7 +5,10 @@ use data::{config, server};
 use futures::Stream;
 use iced::Subscription;
 
-pub fn run(entry: server::Entry, proxy: Option<config::Proxy>) -> Subscription<stream::Update> {
+pub fn run(
+    entry: server::Entry,
+    proxy: Option<config::Proxy>,
+) -> Subscription<stream::Update> {
     struct State {
         entry: server::Entry,
         proxy: Option<config::Proxy>,

--- a/src/url.rs
+++ b/src/url.rs
@@ -5,7 +5,9 @@ use iced::{self, Subscription};
 #[cfg(target_os = "macos")]
 pub fn listen() -> Subscription<String> {
     use futures::stream::StreamExt;
-    use iced::advanced::graphics::futures::subscription::{Event, MacOS, PlatformSpecific};
+    use iced::advanced::graphics::futures::subscription::{
+        Event, MacOS, PlatformSpecific,
+    };
 
     struct OnUrl;
 

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,8 +1,6 @@
 #![allow(dead_code)]
 use iced::advanced::text;
 
-use crate::Theme;
-
 pub use self::anchored_overlay::anchored_overlay;
 pub use self::color_picker::color_picker;
 pub use self::combo_box::combo_box;
@@ -17,6 +15,7 @@ pub use self::selectable_rich_text::selectable_rich_text;
 pub use self::selectable_text::selectable_text;
 pub use self::shortcut::shortcut;
 pub use self::tooltip::tooltip;
+use crate::Theme;
 
 pub mod anchored_overlay;
 pub mod collection;
@@ -37,12 +36,16 @@ pub mod tooltip;
 
 pub type Renderer = iced::Renderer;
 pub type Element<'a, Message> = iced::Element<'a, Message, Theme, Renderer>;
-pub type Content<'a, Message> = iced::widget::pane_grid::Content<'a, Message, Theme, Renderer>;
-pub type TitleBar<'a, Message> = iced::widget::pane_grid::TitleBar<'a, Message, Theme, Renderer>;
-pub type Column<'a, Message> = iced::widget::Column<'a, Message, Theme, Renderer>;
+pub type Content<'a, Message> =
+    iced::widget::pane_grid::Content<'a, Message, Theme, Renderer>;
+pub type TitleBar<'a, Message> =
+    iced::widget::pane_grid::TitleBar<'a, Message, Theme, Renderer>;
+pub type Column<'a, Message> =
+    iced::widget::Column<'a, Message, Theme, Renderer>;
 pub type Row<'a, Message> = iced::widget::Row<'a, Message, Theme, Renderer>;
 pub type Text<'a> = iced::widget::Text<'a, Theme, Renderer>;
-pub type Container<'a, Message> = iced::widget::Container<'a, Message, Theme, Renderer>;
+pub type Container<'a, Message> =
+    iced::widget::Container<'a, Message, Theme, Renderer>;
 pub type Button<'a, Message> = iced::widget::Button<'a, Message, Theme>;
 
 pub fn message_marker<'a, M: 'a>(
@@ -52,9 +55,7 @@ pub fn message_marker<'a, M: 'a>(
     let marker = selectable_text(MESSAGE_MARKER_TEXT);
 
     if let Some(width) = width {
-        marker
-            .width(width)
-            .align_x(text::Alignment::Right)
+        marker.width(width).align_x(text::Alignment::Right)
     } else {
         marker
     }
@@ -65,9 +66,8 @@ pub fn message_marker<'a, M: 'a>(
 pub const MESSAGE_MARKER_TEXT: &str = " ∙";
 
 pub mod button {
-    use crate::appearance::theme;
-
     use super::Element;
+    use crate::appearance::theme;
 
     /// Transparent button which simply makes the given content
     /// into a clickable button without additional styling.

--- a/src/widget/anchored_overlay.rs
+++ b/src/widget/anchored_overlay.rs
@@ -1,5 +1,7 @@
-use iced::advanced::{layout, overlay, renderer, widget, Clipboard, Layout, Shell, Widget};
-use iced::{mouse, Event, Length, Point, Rectangle, Size, Vector};
+use iced::advanced::{
+    Clipboard, Layout, Shell, Widget, layout, overlay, renderer, widget,
+};
+use iced::{Event, Length, Point, Rectangle, Size, Vector, mouse};
 
 use super::{Element, Renderer};
 use crate::Theme;
@@ -32,7 +34,9 @@ struct AnchoredOverlay<'a, Message> {
     offset: f32,
 }
 
-impl<Message> Widget<Message, Theme, Renderer> for AnchoredOverlay<'_, Message> {
+impl<Message> Widget<Message, Theme, Renderer>
+    for AnchoredOverlay<'_, Message>
+{
     fn size(&self) -> Size<Length> {
         self.base.as_widget().size()
     }
@@ -91,9 +95,12 @@ impl<Message> Widget<Message, Theme, Renderer> for AnchoredOverlay<'_, Message> 
         renderer: &Renderer,
         operation: &mut dyn widget::Operation<()>,
     ) {
-        self.base
-            .as_widget()
-            .operate(&mut tree.children[0], layout, renderer, operation);
+        self.base.as_widget().operate(
+            &mut tree.children[0],
+            layout,
+            renderer,
+            operation,
+        );
     }
 
     fn update(
@@ -145,10 +152,12 @@ impl<Message> Widget<Message, Theme, Renderer> for AnchoredOverlay<'_, Message> 
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         let (first, second) = tree.children.split_at_mut(1);
 
-        let base = self
-            .base
-            .as_widget_mut()
-            .overlay(&mut first[0], layout, renderer, translation);
+        let base = self.base.as_widget_mut().overlay(
+            &mut first[0],
+            layout,
+            renderer,
+            translation,
+        );
 
         let overlay = overlay::Element::new(Box::new(Overlay {
             content: &mut self.overlay,
@@ -160,8 +169,10 @@ impl<Message> Widget<Message, Theme, Renderer> for AnchoredOverlay<'_, Message> 
         }));
 
         Some(
-            overlay::Group::with_children(base.into_iter().chain(Some(overlay)).collect())
-                .overlay(),
+            overlay::Group::with_children(
+                base.into_iter().chain(Some(overlay)).collect(),
+            )
+            .overlay(),
         )
     }
 }
@@ -184,7 +195,9 @@ struct Overlay<'a, 'b, Message> {
     position: Point,
 }
 
-impl<Message> overlay::Overlay<Message, Theme, Renderer> for Overlay<'_, '_, Message> {
+impl<Message> overlay::Overlay<Message, Theme, Renderer>
+    for Overlay<'_, '_, Message>
+{
     fn layout(&mut self, renderer: &Renderer, bounds: Size) -> layout::Node {
         let height = match self.anchor {
             // From top of base to top of viewport
@@ -210,7 +223,9 @@ impl<Message> overlay::Overlay<Message, Theme, Renderer> for Overlay<'_, '_, Mes
 
         let translation = match self.anchor {
             // Overlay height + offset above the top
-            Anchor::AboveTop => Vector::new(0.0, -(node.size().height + self.offset)),
+            Anchor::AboveTop => {
+                Vector::new(0.0, -(node.size().height + self.offset))
+            }
             // Offset below the top and centered
             Anchor::BelowTopCentered => Vector::new(
                 self.base_layout.width / 2.0 - node.size().width / 2.0,
@@ -284,7 +299,12 @@ impl<Message> overlay::Overlay<Message, Theme, Renderer> for Overlay<'_, '_, Mes
             .mouse_interaction(self.tree, layout, cursor, viewport, renderer)
     }
 
-    fn is_over(&self, layout: Layout<'_>, _renderer: &Renderer, cursor_position: Point) -> bool {
+    fn is_over(
+        &self,
+        layout: Layout<'_>,
+        _renderer: &Renderer,
+        cursor_position: Point,
+    ) -> bool {
         layout.bounds().contains(cursor_position)
     }
 
@@ -293,8 +313,11 @@ impl<Message> overlay::Overlay<Message, Theme, Renderer> for Overlay<'_, '_, Mes
         layout: Layout<'_>,
         renderer: &Renderer,
     ) -> Option<overlay::Element<'c, Message, Theme, Renderer>> {
-        self.content
-            .as_widget_mut()
-            .overlay(self.tree, layout, renderer, Vector::default())
+        self.content.as_widget_mut().overlay(
+            self.tree,
+            layout,
+            renderer,
+            Vector::default(),
+        )
     }
 }

--- a/src/widget/collection.rs
+++ b/src/widget/collection.rs
@@ -1,10 +1,13 @@
-use iced::widget::{Column, Row};
 use iced::Element;
+use iced::widget::{Column, Row};
 
 pub trait Collection<'a, Message, Theme>: Sized {
     fn push(self, element: impl Into<Element<'a, Message, Theme>>) -> Self;
 
-    fn push_maybe(self, element: Option<impl Into<Element<'a, Message, Theme>>>) -> Self {
+    fn push_maybe(
+        self,
+        element: Option<impl Into<Element<'a, Message, Theme>>>,
+    ) -> Self {
         match element {
             Some(element) => self.push(element),
             None => self,
@@ -12,13 +15,17 @@ pub trait Collection<'a, Message, Theme>: Sized {
     }
 }
 
-impl<'a, Message, Theme> Collection<'a, Message, Theme> for Column<'a, Message, Theme> {
+impl<'a, Message, Theme> Collection<'a, Message, Theme>
+    for Column<'a, Message, Theme>
+{
     fn push(self, element: impl Into<Element<'a, Message, Theme>>) -> Self {
         Self::push(self, element)
     }
 }
 
-impl<'a, Message, Theme> Collection<'a, Message, Theme> for Row<'a, Message, Theme> {
+impl<'a, Message, Theme> Collection<'a, Message, Theme>
+    for Row<'a, Message, Theme>
+{
     fn push(self, element: impl Into<Element<'a, Message, Theme>>) -> Self {
         Self::push(self, element)
     }

--- a/src/widget/combo_box.rs
+++ b/src/widget/combo_box.rs
@@ -1,15 +1,16 @@
-use iced::advanced::graphics::text::Paragraph;
-use iced::advanced::{
-    layout, mouse, overlay, renderer, text, widget, Clipboard, Layout, Shell, Widget,
-};
-use iced::overlay::menu;
-use iced::widget::text::LineHeight;
-use iced::widget::{text_input, TextInput};
-use iced::{keyboard, window, Event, Length, Padding, Rectangle, Vector};
-
 use std::cell::RefCell;
 use std::fmt::Display;
 use std::time::Instant;
+
+use iced::advanced::graphics::text::Paragraph;
+use iced::advanced::{
+    Clipboard, Layout, Shell, Widget, layout, mouse, overlay, renderer, text,
+    widget,
+};
+use iced::overlay::menu;
+use iced::widget::text::LineHeight;
+use iced::widget::{TextInput, text_input};
+use iced::{Event, Length, Padding, Rectangle, Vector, keyboard, window};
 
 use super::Element;
 use crate::Theme;
@@ -19,8 +20,13 @@ use crate::Theme;
 /// This widget is composed by a [`TextInput`] that can be filled with the text
 /// to search for corresponding values from the list of options that are displayed
 /// as a [`Menu`].
-pub struct ComboBox<'a, T, Message, Theme = crate::Theme, Renderer = super::Renderer>
-where
+pub struct ComboBox<
+    'a,
+    T,
+    Message,
+    Theme = crate::Theme,
+    Renderer = super::Renderer,
+> where
     Theme: Catalog,
     Renderer: text::Renderer,
 {
@@ -75,14 +81,20 @@ where
 
     /// Sets the message that should be produced when some text is typed into
     /// the [`TextInput`] of the [`ComboBox`].
-    pub fn on_input(mut self, on_input: impl Fn(String) -> Message + 'static) -> Self {
+    pub fn on_input(
+        mut self,
+        on_input: impl Fn(String) -> Message + 'static,
+    ) -> Self {
         self.on_input = Some(Box::new(on_input));
         self
     }
 
     /// Sets the message that will be produced when an option of the
     /// [`ComboBox`] is hovered using the arrow keys.
-    pub fn on_option_hovered(mut self, on_selection: impl Fn(T) -> Message + 'static) -> Self {
+    pub fn on_option_hovered(
+        mut self,
+        on_selection: impl Fn(T) -> Message + 'static,
+    ) -> Self {
         self.on_option_hovered = Some(Box::new(on_selection));
         self
     }
@@ -149,7 +161,8 @@ where
         style: impl Fn(&Theme, text_input::Status) -> text_input::Style + 'a,
     ) -> Self
     where
-        <Theme as text_input::Catalog>::Class<'a>: From<text_input::StyleFn<'a, Theme>>,
+        <Theme as text_input::Catalog>::Class<'a>:
+            From<text_input::StyleFn<'a, Theme>>,
     {
         self.text_input = self.text_input.style(style);
         self
@@ -157,7 +170,10 @@ where
 
     /// Sets the style of the menu of the [`ComboBox`].
     #[must_use]
-    pub fn menu_style(mut self, style: impl Fn(&Theme) -> menu::Style + 'a) -> Self
+    pub fn menu_style(
+        mut self,
+        style: impl Fn(&Theme) -> menu::Style + 'a,
+    ) -> Self
     where
         <Theme as menu::Catalog>::Class<'a>: From<menu::StyleFn<'a, Theme>>,
     {
@@ -177,7 +193,10 @@ where
 
     /// Sets the style class of the menu of the [`ComboBox`].
     #[must_use]
-    pub fn menu_class(mut self, class: impl Into<<Theme as menu::Catalog>::Class<'a>>) -> Self {
+    pub fn menu_class(
+        mut self,
+        class: impl Into<<Theme as menu::Catalog>::Class<'a>>,
+    ) -> Self {
         self.menu_class = class.into();
         self
     }
@@ -465,9 +484,13 @@ where
                 state.value = new_value;
 
                 state.filtered_options.update(
-                    search(&state.options, &state.option_matchers, &state.value)
-                        .cloned()
-                        .collect(),
+                    search(
+                        &state.options,
+                        &state.option_matchers,
+                        &state.value,
+                    )
+                    .cloned()
+                    .collect(),
                 );
             });
             shell.invalidate_layout();
@@ -477,23 +500,36 @@ where
         if self.state.is_focused() {
             self.state.with_inner(|state| {
                 if !started_focused {
-                    if let Some(on_option_hovered) = &mut self.on_option_hovered {
+                    if let Some(on_option_hovered) = &mut self.on_option_hovered
+                    {
                         let hovered_option = menu.hovered_option.unwrap_or(0);
 
-                        if let Some(option) = state.filtered_options.options.get(hovered_option) {
+                        if let Some(option) =
+                            state.filtered_options.options.get(hovered_option)
+                        {
                             shell.publish(on_option_hovered(option.clone()));
                             published_message_to_shell = true;
                         }
                     }
                 }
 
-                if let Event::Keyboard(keyboard::Event::KeyPressed { key, modifiers, .. }) = event {
+                if let Event::Keyboard(keyboard::Event::KeyPressed {
+                    key,
+                    modifiers,
+                    ..
+                }) = event
+                {
                     let shift_modifier = modifiers.shift();
 
                     match (key, shift_modifier) {
-                        (keyboard::Key::Named(keyboard::key::Named::Enter), _) => {
+                        (
+                            keyboard::Key::Named(keyboard::key::Named::Enter),
+                            _,
+                        ) => {
                             if let Some(index) = &menu.hovered_option {
-                                if let Some(option) = state.filtered_options.options.get(*index) {
+                                if let Some(option) =
+                                    state.filtered_options.options.get(*index)
+                                {
                                     menu.new_selection = Some(option.clone());
                                 }
                             }
@@ -501,11 +537,21 @@ where
                             shell.capture_event();
                             shell.request_redraw();
                         }
-                        (keyboard::Key::Named(keyboard::key::Named::ArrowUp), _)
-                        | (keyboard::Key::Named(keyboard::key::Named::Tab), true) => {
+                        (
+                            keyboard::Key::Named(keyboard::key::Named::ArrowUp),
+                            _,
+                        )
+                        | (
+                            keyboard::Key::Named(keyboard::key::Named::Tab),
+                            true,
+                        ) => {
                             if let Some(index) = &mut menu.hovered_option {
                                 if *index == 0 {
-                                    *index = state.filtered_options.options.len().saturating_sub(1);
+                                    *index = state
+                                        .filtered_options
+                                        .options
+                                        .len()
+                                        .saturating_sub(1);
                                 } else {
                                     *index = index.saturating_sub(1);
                                 }
@@ -513,13 +559,21 @@ where
                                 menu.hovered_option = Some(0);
                             }
 
-                            if let Some(on_option_selection) = &mut self.on_option_hovered {
-                                if let Some(option) = menu
-                                    .hovered_option
-                                    .and_then(|index| state.filtered_options.options.get(index))
+                            if let Some(on_option_selection) =
+                                &mut self.on_option_hovered
+                            {
+                                if let Some(option) =
+                                    menu.hovered_option.and_then(|index| {
+                                        state
+                                            .filtered_options
+                                            .options
+                                            .get(index)
+                                    })
                                 {
                                     // Notify the selection
-                                    shell.publish((on_option_selection)(option.clone()));
+                                    shell.publish((on_option_selection)(
+                                        option.clone(),
+                                    ));
                                     published_message_to_shell = true;
                                 }
                             }
@@ -527,28 +581,53 @@ where
                             shell.capture_event();
                             shell.request_redraw();
                         }
-                        (keyboard::Key::Named(keyboard::key::Named::ArrowDown), _)
-                        | (keyboard::Key::Named(keyboard::key::Named::Tab), false) => {
+                        (
+                            keyboard::Key::Named(
+                                keyboard::key::Named::ArrowDown,
+                            ),
+                            _,
+                        )
+                        | (
+                            keyboard::Key::Named(keyboard::key::Named::Tab),
+                            false,
+                        ) => {
                             if let Some(index) = &mut menu.hovered_option {
-                                if *index == state.filtered_options.options.len().saturating_sub(1)
+                                if *index
+                                    == state
+                                        .filtered_options
+                                        .options
+                                        .len()
+                                        .saturating_sub(1)
                                 {
                                     *index = 0;
                                 } else {
                                     *index = index.saturating_add(1).min(
-                                        state.filtered_options.options.len().saturating_sub(1),
+                                        state
+                                            .filtered_options
+                                            .options
+                                            .len()
+                                            .saturating_sub(1),
                                     );
                                 }
                             } else {
                                 menu.hovered_option = Some(0);
                             }
 
-                            if let Some(on_option_selection) = &mut self.on_option_hovered {
-                                if let Some(option) = menu
-                                    .hovered_option
-                                    .and_then(|index| state.filtered_options.options.get(index))
+                            if let Some(on_option_selection) =
+                                &mut self.on_option_hovered
+                            {
+                                if let Some(option) =
+                                    menu.hovered_option.and_then(|index| {
+                                        state
+                                            .filtered_options
+                                            .options
+                                            .get(index)
+                                    })
                                 {
                                     // Notify the selection
-                                    shell.publish((on_option_selection)(option.clone()));
+                                    shell.publish((on_option_selection)(
+                                        option.clone(),
+                                    ));
                                     published_message_to_shell = true;
                                 }
                             }
@@ -578,7 +657,9 @@ where
                 let mut tree = state.text_input_tree();
                 self.text_input.update(
                     &mut tree,
-                    &Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)),
+                    &Event::Mouse(mouse::Event::ButtonPressed(
+                        mouse::Button::Left,
+                    )),
                     layout,
                     mouse::Cursor::Unavailable,
                     renderer,
@@ -590,7 +671,10 @@ where
             }
         });
 
-        if started_focused && !self.state.is_focused() && !published_message_to_shell {
+        if started_focused
+            && !self.state.is_focused()
+            && !published_message_to_shell
+        {
             if let Some(message) = self.on_close.take() {
                 shell.publish(message);
             }
@@ -625,7 +709,8 @@ where
         cursor: mouse::Cursor,
         viewport: &Rectangle,
     ) {
-        let selection = if self.state.is_focused() || self.selection.is_empty() {
+        let selection = if self.state.is_focused() || self.selection.is_empty()
+        {
             None
         } else {
             Some(&self.selection)
@@ -723,7 +808,9 @@ where
 }
 
 /// Build matchers from given list of options.
-pub fn build_matchers<'a, T>(options: impl IntoIterator<Item = T> + 'a) -> Vec<String>
+pub fn build_matchers<'a, T>(
+    options: impl IntoIterator<Item = T> + 'a,
+) -> Vec<String>
 where
     T: Display + 'a,
 {

--- a/src/widget/context_menu.rs
+++ b/src/widget/context_menu.rs
@@ -1,11 +1,14 @@
 use std::slice;
 
-use iced::advanced::widget::{operation, tree, Operation};
-use iced::advanced::{self, layout, overlay, renderer, widget, Clipboard, Layout, Shell, Widget};
-use iced::widget::{column, container};
-use iced::{mouse, Element, Event, Length, Point, Rectangle, Size, Task, Vector};
-
+use iced::advanced::widget::{Operation, operation, tree};
+use iced::advanced::{
+    self, Clipboard, Layout, Shell, Widget, layout, overlay, renderer, widget,
+};
 pub use iced::widget::container::{Style, StyleFn};
+use iced::widget::{column, container};
+use iced::{
+    Element, Event, Length, Point, Rectangle, Size, Task, Vector, mouse,
+};
 
 use super::double_pass;
 
@@ -81,7 +84,8 @@ where
     T: Copy + 'a,
     Message: 'a,
     Theme: 'a + container::Catalog + Catalog,
-    <Theme as container::Catalog>::Class<'a>: From<container::StyleFn<'a, Theme>>,
+    <Theme as container::Catalog>::Class<'a>:
+        From<container::StyleFn<'a, Theme>>,
     Renderer: advanced::Renderer + 'a,
 {
     fn size(&self) -> Size<Length> {
@@ -154,9 +158,12 @@ where
 
         operation.custom(None, layout.bounds(), state);
 
-        self.base
-            .as_widget()
-            .operate(&mut tree.children[0], layout, renderer, operation);
+        self.base.as_widget().operate(
+            &mut tree.children[0],
+            layout,
+            renderer,
+            operation,
+        );
     }
 
     fn update(
@@ -175,14 +182,20 @@ where
 
         let position = match self.activation_button {
             mouse::Button::Left => {
-                if let Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) = event {
+                if let Event::Mouse(mouse::Event::ButtonReleased(
+                    mouse::Button::Left,
+                )) = event
+                {
                     cursor.position_over(layout.bounds())
                 } else {
                     None
                 }
             }
             mouse::Button::Right => {
-                if let Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Right)) = event {
+                if let Event::Mouse(mouse::Event::ButtonPressed(
+                    mouse::Button::Right,
+                )) = event
+                {
                     cursor.position_over(layout.bounds())
                 } else {
                     None
@@ -196,7 +209,8 @@ where
         }
 
         match (state.status, prev_status) {
-            (Status::Closed, Status::Open(_)) | (Status::Open(_), Status::Closed) => {
+            (Status::Closed, Status::Open(_))
+            | (Status::Open(_), Status::Closed) => {
                 shell.request_redraw();
             }
             _ => {}
@@ -236,10 +250,12 @@ where
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         let base_state = tree.children.first_mut().unwrap();
-        let base = self
-            .base
-            .as_widget_mut()
-            .overlay(base_state, layout, renderer, translation);
+        let base = self.base.as_widget_mut().overlay(
+            base_state,
+            layout,
+            renderer,
+            translation,
+        );
 
         let state = tree.state.downcast_mut::<State>();
 
@@ -254,7 +270,12 @@ where
         if base.is_none() && overlay.is_none() {
             None
         } else {
-            Some(overlay::Group::with_children(base.into_iter().chain(overlay).collect()).overlay())
+            Some(
+                overlay::Group::with_children(
+                    base.into_iter().chain(overlay).collect(),
+                )
+                .overlay(),
+            )
         }
     }
 }
@@ -267,16 +288,22 @@ where
     T: Copy + 'a,
     Message: 'a,
     Theme: 'a + container::Catalog + Catalog,
-    <Theme as container::Catalog>::Class<'a>: From<container::StyleFn<'a, Theme>>,
+    <Theme as container::Catalog>::Class<'a>:
+        From<container::StyleFn<'a, Theme>>,
     Renderer: advanced::Renderer + 'a,
 {
     let build_menu =
-        |length, view: &(dyn Fn(T, Length) -> Element<'a, Message, Theme, Renderer> + 'a)| {
+        |length,
+         view: &(
+              dyn Fn(T, Length) -> Element<'a, Message, Theme, Renderer> + 'a
+          )| {
             container(column(
                 entries.iter().copied().map(|entry| view(entry, length)),
             ))
             .padding(4)
-            .style(|theme| <Theme as Catalog>::style(theme, &<Theme as Catalog>::default()))
+            .style(|theme| {
+                <Theme as Catalog>::style(theme, &<Theme as Catalog>::default())
+            })
         };
 
     double_pass(
@@ -296,7 +323,8 @@ where
     T: Copy + 'a,
     Message: 'a,
     Theme: 'a + container::Catalog + Catalog,
-    <Theme as container::Catalog>::Class<'a>: From<container::StyleFn<'a, Theme>>,
+    <Theme as container::Catalog>::Class<'a>:
+        From<container::StyleFn<'a, Theme>>,
     Renderer: advanced::Renderer + 'a,
 {
     if entries.is_empty() {
@@ -372,16 +400,20 @@ pub fn close<Message: 'static + Send>(f: fn(bool) -> Message) -> Task<Message> {
     })
 }
 
-impl<'a, T, Message, Theme, Renderer> From<ContextMenu<'a, T, Message, Theme, Renderer>>
+impl<'a, T, Message, Theme, Renderer>
+    From<ContextMenu<'a, T, Message, Theme, Renderer>>
     for Element<'a, Message, Theme, Renderer>
 where
     T: Copy + 'a,
     Message: 'a,
     Theme: 'a + container::Catalog + Catalog,
-    <Theme as container::Catalog>::Class<'a>: From<container::StyleFn<'a, Theme>>,
+    <Theme as container::Catalog>::Class<'a>:
+        From<container::StyleFn<'a, Theme>>,
     Renderer: advanced::Renderer + 'a,
 {
-    fn from(context_menu: ContextMenu<'a, T, Message, Theme, Renderer>) -> Self {
+    fn from(
+        context_menu: ContextMenu<'a, T, Message, Theme, Renderer>,
+    ) -> Self {
         Element::new(context_menu)
     }
 }
@@ -402,16 +434,20 @@ where
             .width(Length::Fill)
             .height(Length::Fill);
 
-        let node = self
-            .menu
-            .as_widget()
-            .layout(&mut self.state.menu_tree, renderer, &limits);
+        let node = self.menu.as_widget().layout(
+            &mut self.state.menu_tree,
+            renderer,
+            &limits,
+        );
 
         // Small padding to ensure that we don't spawn context menu at the very edge of the viewport.
         let padding = 5.0;
         let viewport = Rectangle::new(
             Point::new(Point::ORIGIN.x + padding, Point::ORIGIN.y + padding),
-            Size::new(bounds.width - 2.0 * padding, bounds.height - 2.0 * padding),
+            Size::new(
+                bounds.width - 2.0 * padding,
+                bounds.height - 2.0 * padding,
+            ),
         );
         let mut bounds = Rectangle::new(self.position, node.size());
 
@@ -455,9 +491,12 @@ where
         renderer: &Renderer,
         operation: &mut dyn widget::Operation<()>,
     ) {
-        self.menu
-            .as_widget_mut()
-            .operate(&mut self.state.menu_tree, layout, renderer, operation);
+        self.menu.as_widget_mut().operate(
+            &mut self.state.menu_tree,
+            layout,
+            renderer,
+            operation,
+        );
     }
 
     fn update(
@@ -475,7 +514,9 @@ where
             }
         }
 
-        if let Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) = &event {
+        if let Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) =
+            &event
+        {
             if cursor.position_over(layout.bounds()).is_some() {
                 self.state.status = Status::Closed;
             }
@@ -513,7 +554,12 @@ where
         )
     }
 
-    fn is_over(&self, layout: Layout<'_>, _renderer: &Renderer, cursor_position: Point) -> bool {
+    fn is_over(
+        &self,
+        layout: Layout<'_>,
+        _renderer: &Renderer,
+        cursor_position: Point,
+    ) -> bool {
         layout.bounds().contains(cursor_position)
     }
 }

--- a/src/widget/decorate.rs
+++ b/src/widget/decorate.rs
@@ -1,9 +1,8 @@
-use std::{marker::PhantomData, slice};
+use std::marker::PhantomData;
+use std::slice;
 
-use iced::{
-    advanced::{self, layout, Widget},
-    Element,
-};
+use iced::Element;
+use iced::advanced::{self, Widget, layout};
 
 pub fn decorate<'a, Message, Theme, Renderer>(
     element: impl Into<Element<'a, Message, Theme, Renderer>>,
@@ -35,7 +34,9 @@ pub struct Decorate<
 }
 
 impl<'a, Message, Theme, Renderer> Decorate<'a, Message, Theme, Renderer> {
-    pub fn new(inner: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
+    pub fn new(
+        inner: impl Into<Element<'a, Message, Theme, Renderer>>,
+    ) -> Self {
         Self {
             inner: inner.into(),
             update: (),
@@ -50,18 +51,18 @@ impl<'a, Message, Theme, Renderer> Decorate<'a, Message, Theme, Renderer> {
 }
 
 impl<
-        'a,
-        Message,
-        Theme,
-        Renderer,
-        Layout,
-        Update,
-        Draw,
-        MouseInteraction,
-        Operate,
-        Overlay,
-        State,
-    >
+    'a,
+    Message,
+    Theme,
+    Renderer,
+    Layout,
+    Update,
+    Draw,
+    MouseInteraction,
+    Operate,
+    Overlay,
+    State,
+>
     Decorate<
         'a,
         Message,
@@ -172,7 +173,19 @@ impl<
     pub fn mouse_interaction<T, U>(
         self,
         mouse_interaction: T,
-    ) -> Decorate<'a, Message, Theme, Renderer, Layout, Update, Draw, T, Operate, Overlay, U>
+    ) -> Decorate<
+        'a,
+        Message,
+        Theme,
+        Renderer,
+        Layout,
+        Update,
+        Draw,
+        T,
+        Operate,
+        Overlay,
+        U,
+    >
     where
         T: self::MouseInteraction<'a, Message, Theme, Renderer, U>,
     {
@@ -191,7 +204,19 @@ impl<
     pub fn operate<T, U>(
         self,
         operate: T,
-    ) -> Decorate<'a, Message, Theme, Renderer, Layout, Update, Draw, MouseInteraction, T, Overlay, U>
+    ) -> Decorate<
+        'a,
+        Message,
+        Theme,
+        Renderer,
+        Layout,
+        Update,
+        Draw,
+        MouseInteraction,
+        T,
+        Overlay,
+        U,
+    >
     where
         T: self::Operate<'a, Message, Theme, Renderer, U>,
     {
@@ -210,7 +235,19 @@ impl<
     pub fn overlay<T, U>(
         self,
         overlay: T,
-    ) -> Decorate<'a, Message, Theme, Renderer, Layout, Update, Draw, MouseInteraction, Operate, T, U>
+    ) -> Decorate<
+        'a,
+        Message,
+        Theme,
+        Renderer,
+        Layout,
+        Update,
+        Draw,
+        MouseInteraction,
+        Operate,
+        T,
+        U,
+    >
     where
         T: self::Operate<'a, Message, Theme, Renderer, U>,
     {
@@ -238,7 +275,8 @@ pub trait Layout<'a, Message, Theme, Renderer, State> {
     ) -> layout::Node;
 }
 
-impl<'a, Message, Theme, Renderer, State> Layout<'a, Message, Theme, Renderer, State> for ()
+impl<'a, Message, Theme, Renderer, State>
+    Layout<'a, Message, Theme, Renderer, State> for ()
 where
     Renderer: advanced::Renderer + 'a,
 {
@@ -254,7 +292,8 @@ where
     }
 }
 
-impl<'a, T, Message, Theme, Renderer, State> Layout<'a, Message, Theme, Renderer, State> for T
+impl<'a, T, Message, Theme, Renderer, State>
+    Layout<'a, Message, Theme, Renderer, State> for T
 where
     T: Fn(
             &mut State,
@@ -293,7 +332,8 @@ pub trait Update<'a, Message, Theme, Renderer, State> {
     );
 }
 
-impl<'a, Message, Theme, Renderer, State> Update<'a, Message, Theme, Renderer, State> for ()
+impl<'a, Message, Theme, Renderer, State>
+    Update<'a, Message, Theme, Renderer, State> for ()
 where
     Renderer: advanced::Renderer + 'a,
 {
@@ -316,7 +356,8 @@ where
     }
 }
 
-impl<'a, T, Message, Theme, Renderer, State> Update<'a, Message, Theme, Renderer, State> for T
+impl<'a, T, Message, Theme, Renderer, State>
+    Update<'a, Message, Theme, Renderer, State> for T
 where
     T: Fn(
             &mut State,
@@ -345,7 +386,8 @@ where
         viewport: &iced::Rectangle,
     ) {
         self(
-            state, inner, tree, event, layout, cursor, renderer, clipboard, shell, viewport,
+            state, inner, tree, event, layout, cursor, renderer, clipboard,
+            shell, viewport,
         );
     }
 }
@@ -365,7 +407,8 @@ pub trait Draw<'a, Message, Theme, Renderer, State> {
     );
 }
 
-impl<'a, Message, Theme, Renderer, State> Draw<'a, Message, Theme, Renderer, State> for ()
+impl<'a, Message, Theme, Renderer, State>
+    Draw<'a, Message, Theme, Renderer, State> for ()
 where
     Renderer: advanced::Renderer + 'a,
 {
@@ -387,7 +430,8 @@ where
     }
 }
 
-impl<'a, T, Message, Theme, Renderer, State> Draw<'a, Message, Theme, Renderer, State> for T
+impl<'a, T, Message, Theme, Renderer, State>
+    Draw<'a, Message, Theme, Renderer, State> for T
 where
     T: Fn(
             &State,
@@ -414,7 +458,8 @@ where
         viewport: &iced::Rectangle,
     ) {
         self(
-            state, inner, tree, renderer, theme, style, layout, cursor, viewport,
+            state, inner, tree, renderer, theme, style, layout, cursor,
+            viewport,
         );
     }
 }
@@ -432,8 +477,8 @@ pub trait MouseInteraction<'a, Message, Theme, Renderer, State> {
     ) -> advanced::mouse::Interaction;
 }
 
-impl<'a, Message, Theme, Renderer, State> MouseInteraction<'a, Message, Theme, Renderer, State>
-    for ()
+impl<'a, Message, Theme, Renderer, State>
+    MouseInteraction<'a, Message, Theme, Renderer, State> for ()
 where
     Renderer: advanced::Renderer + 'a,
 {
@@ -453,8 +498,8 @@ where
     }
 }
 
-impl<'a, T, Message, Theme, Renderer, State> MouseInteraction<'a, Message, Theme, Renderer, State>
-    for T
+impl<'a, T, Message, Theme, Renderer, State>
+    MouseInteraction<'a, Message, Theme, Renderer, State> for T
 where
     T: Fn(
             &State,
@@ -493,7 +538,8 @@ pub trait Operate<'a, Message, Theme, Renderer, State> {
     );
 }
 
-impl<'a, Message, Theme, Renderer, State> Operate<'a, Message, Theme, Renderer, State> for ()
+impl<'a, Message, Theme, Renderer, State>
+    Operate<'a, Message, Theme, Renderer, State> for ()
 where
     Renderer: advanced::Renderer + 'a,
 {
@@ -510,7 +556,8 @@ where
     }
 }
 
-impl<'a, T, Message, Theme, Renderer, State> Operate<'a, Message, Theme, Renderer, State> for T
+impl<'a, T, Message, Theme, Renderer, State>
+    Operate<'a, Message, Theme, Renderer, State> for T
 where
     T: Fn(
             &mut State,
@@ -546,7 +593,8 @@ pub trait Overlay<'a, Message, Theme, Renderer, State> {
     ) -> Option<advanced::overlay::Element<'b, Message, Theme, Renderer>>;
 }
 
-impl<'a, Message, Theme, Renderer, State> Overlay<'a, Message, Theme, Renderer, State> for ()
+impl<'a, Message, Theme, Renderer, State>
+    Overlay<'a, Message, Theme, Renderer, State> for ()
 where
     Renderer: advanced::Renderer + 'a,
 {
@@ -565,7 +613,8 @@ where
     }
 }
 
-impl<'a, T, Message, Theme, Renderer, State> Overlay<'a, Message, Theme, Renderer, State> for T
+impl<'a, T, Message, Theme, Renderer, State>
+    Overlay<'a, Message, Theme, Renderer, State> for T
 where
     T: for<'b> Fn(
             &'b mut State,
@@ -574,8 +623,9 @@ where
             advanced::Layout<'_>,
             &Renderer,
             iced::Vector,
-        ) -> Option<advanced::overlay::Element<'b, Message, Theme, Renderer>>
-        + 'a,
+        ) -> Option<
+            advanced::overlay::Element<'b, Message, Theme, Renderer>,
+        > + 'a,
 {
     fn overlay<'b>(
         &'b mut self,
@@ -591,18 +641,18 @@ where
 }
 
 impl<
-        'a,
-        Message,
-        Theme,
-        Renderer,
-        Layout,
-        Update,
-        Draw,
-        MouseInteraction,
-        Operate,
-        Overlay,
-        State,
-    > Widget<Message, Theme, Renderer>
+    'a,
+    Message,
+    Theme,
+    Renderer,
+    Layout,
+    Update,
+    Draw,
+    MouseInteraction,
+    Operate,
+    Overlay,
+    State,
+> Widget<Message, Theme, Renderer>
     for Decorate<
         'a,
         Message,
@@ -621,7 +671,8 @@ where
     Layout: self::Layout<'a, Message, Theme, Renderer, State>,
     Update: self::Update<'a, Message, Theme, Renderer, State>,
     Draw: self::Draw<'a, Message, Theme, Renderer, State>,
-    MouseInteraction: self::MouseInteraction<'a, Message, Theme, Renderer, State> + 'a,
+    MouseInteraction:
+        self::MouseInteraction<'a, Message, Theme, Renderer, State> + 'a,
     Operate: self::Operate<'a, Message, Theme, Renderer, State> + 'a,
     Overlay: self::Overlay<'a, Message, Theme, Renderer, State> + 'a,
     State: Default + 'static,
@@ -769,18 +820,18 @@ where
 }
 
 impl<
-        'a,
-        Message,
-        Theme,
-        Renderer,
-        Layout,
-        Update,
-        Draw,
-        MouseInteraction,
-        Operate,
-        Overlay,
-        State,
-    >
+    'a,
+    Message,
+    Theme,
+    Renderer,
+    Layout,
+    Update,
+    Draw,
+    MouseInteraction,
+    Operate,
+    Overlay,
+    State,
+>
     From<
         Decorate<
             'a,
@@ -803,7 +854,8 @@ where
     Layout: self::Layout<'a, Message, Theme, Renderer, State> + 'a,
     Update: self::Update<'a, Message, Theme, Renderer, State> + 'a,
     Draw: self::Draw<'a, Message, Theme, Renderer, State> + 'a,
-    MouseInteraction: self::MouseInteraction<'a, Message, Theme, Renderer, State> + 'a,
+    MouseInteraction:
+        self::MouseInteraction<'a, Message, Theme, Renderer, State> + 'a,
     Operate: self::Operate<'a, Message, Theme, Renderer, State> + 'a,
     Overlay: self::Overlay<'a, Message, Theme, Renderer, State> + 'a,
     State: Default + 'static,

--- a/src/widget/double_click.rs
+++ b/src/widget/double_click.rs
@@ -1,13 +1,13 @@
 use std::time;
 
 use iced::advanced::widget::Tree;
-use iced::advanced::{mouse, Clipboard, Layout, Shell};
+use iced::advanced::{Clipboard, Layout, Shell, mouse};
 use iced::event;
 
 const TIMEOUT_MILLIS: u64 = 250;
 
-use crate::widget::{decorate, Renderer};
 use crate::Element;
+use crate::widget::{Renderer, decorate};
 
 pub fn double_click<'a, Message>(
     content: impl Into<Element<'a, Message>>,
@@ -29,7 +29,8 @@ where
                   shell: &mut Shell<'_, Message>,
                   viewport: &iced::Rectangle| {
                 inner.as_widget_mut().update(
-                    tree, event, layout, cursor, renderer, clipboard, shell, viewport,
+                    tree, event, layout, cursor, renderer, clipboard, shell,
+                    viewport,
                 );
 
                 if shell.is_event_captured() {
@@ -40,7 +41,9 @@ where
                     return;
                 }
 
-                let event::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) = event
+                let event::Event::Mouse(mouse::Event::ButtonPressed(
+                    mouse::Button::Left,
+                )) = event
                 else {
                     return;
                 };

--- a/src/widget/double_pass.rs
+++ b/src/widget/double_pass.rs
@@ -28,7 +28,8 @@ struct Layout<'a, Message, Theme, Renderer> {
     first_pass: Element<'a, Message, Theme, Renderer>,
 }
 
-impl<'a, Message, Theme, Renderer> decorate::Layout<'a, Message, Theme, Renderer, ()>
+impl<'a, Message, Theme, Renderer>
+    decorate::Layout<'a, Message, Theme, Renderer, ()>
     for Layout<'a, Message, Theme, Renderer>
 where
     Message: 'a,

--- a/src/widget/key_press.rs
+++ b/src/widget/key_press.rs
@@ -1,8 +1,9 @@
-use iced::advanced::{widget, Clipboard, Layout, Shell};
-pub use iced::keyboard::{key::Named, Key, Modifiers};
-use iced::{keyboard, mouse, Event, Rectangle};
+use iced::advanced::{Clipboard, Layout, Shell, widget};
+pub use iced::keyboard::key::Named;
+pub use iced::keyboard::{Key, Modifiers};
+use iced::{Event, Rectangle, keyboard, mouse};
 
-use super::{decorate, Element, Renderer};
+use super::{Element, Renderer, decorate};
 
 pub fn key_press<'a, Message>(
     base: impl Into<Element<'a, Message>>,
@@ -39,7 +40,8 @@ where
                 }
 
                 inner.as_widget_mut().update(
-                    tree, event, layout, cursor, renderer, clipboard, shell, viewport,
+                    tree, event, layout, cursor, renderer, clipboard, shell,
+                    viewport,
                 );
             },
         )

--- a/src/widget/message_content.rs
+++ b/src/widget/message_content.rs
@@ -1,12 +1,11 @@
 use data::appearance::theme::randomize_color;
-use data::{isupport, message, target, Config};
+use data::{Config, isupport, message, target};
 use iced::widget::span;
 use iced::widget::text::Span;
-use iced::{border, Length};
+use iced::{Length, border};
 
-use crate::{font, Theme};
-
-use super::{selectable_rich_text, selectable_text, Element, Renderer};
+use super::{Element, Renderer, selectable_rich_text, selectable_text};
+use crate::{Theme, font};
 
 pub fn message_content<'a, M: 'a>(
     content: &'a message::Content,
@@ -62,24 +61,41 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
     config: &Config,
 ) -> Element<'a, M> {
     match content {
-        data::message::Content::Plain(text) => selectable_text(text).style(style).into(),
+        data::message::Content::Plain(text) => {
+            selectable_text(text).style(style).into()
+        }
         data::message::Content::Fragments(fragments) => {
-            let mut text = selectable_rich_text::<M, message::Link, T, Theme, Renderer>(
+            let mut text = selectable_rich_text::<
+                M,
+                message::Link,
+                T,
+                Theme,
+                Renderer,
+            >(
                 fragments
                     .iter()
                     .map(|fragment| match fragment {
                         data::message::Fragment::Text(s) => span(s),
                         data::message::Fragment::Channel(s) => span(s.as_str())
                             .color(theme.colors().buffer.url)
-                            .link(message::Link::Channel(target::Channel::from_str(
-                                s.as_str(),
-                                casemapping,
-                            ))),
+                            .link(message::Link::Channel(
+                                target::Channel::from_str(
+                                    s.as_str(),
+                                    casemapping,
+                                ),
+                            )),
                         data::message::Fragment::User(user, text) => {
                             let color = theme.colors().buffer.nickname;
-                            let seed = match &config.buffer.channel.message.nickname_color {
+                            let seed = match &config
+                                .buffer
+                                .channel
+                                .message
+                                .nickname_color
+                            {
                                 data::buffer::Color::Solid => None,
-                                data::buffer::Color::Unique => Some(user.seed()),
+                                data::buffer::Color::Unique => {
+                                    Some(user.seed())
+                                }
                             };
 
                             let color = match seed {
@@ -93,9 +109,16 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
                         }
                         data::message::Fragment::HighlightNick(user, text) => {
                             let color = theme.colors().buffer.nickname;
-                            let seed = match &config.buffer.channel.message.nickname_color {
+                            let seed = match &config
+                                .buffer
+                                .channel
+                                .message
+                                .nickname_color
+                            {
                                 data::buffer::Color::Solid => None,
-                                data::buffer::Color::Unique => Some(user.seed()),
+                                data::buffer::Color::Unique => {
+                                    Some(user.seed())
+                                }
                             };
 
                             let color = match seed {
@@ -108,24 +131,25 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
                                 .background(theme.colors().buffer.highlight)
                                 .link(message::Link::User(user.clone()))
                         }
-                        data::message::Fragment::HighlightMatch(text) => span(text.as_str())
-                            .color(theme.colors().text.primary)
-                            .background(theme.colors().buffer.highlight),
+                        data::message::Fragment::HighlightMatch(text) => {
+                            span(text.as_str())
+                                .color(theme.colors().text.primary)
+                                .background(theme.colors().buffer.highlight)
+                        }
                         data::message::Fragment::Url(s) => span(s.as_str())
                             .color(theme.colors().buffer.url)
                             .link(message::Link::Url(s.as_str().to_string())),
-                        data::message::Fragment::Formatted { text, formatting } => {
+                        data::message::Fragment::Formatted {
+                            text,
+                            formatting,
+                        } => {
                             let mut span = span(text)
-                                .color_maybe(
-                                    formatting
-                                        .fg
-                                        .and_then(|color| color.into_iced(theme.colors())),
-                                )
-                                .background_maybe(
-                                    formatting
-                                        .bg
-                                        .and_then(|color| color.into_iced(theme.colors())),
-                                )
+                                .color_maybe(formatting.fg.and_then(|color| {
+                                    color.into_iced(theme.colors())
+                                }))
+                                .background_maybe(formatting.bg.and_then(
+                                    |color| color.into_iced(theme.colors()),
+                                ))
                                 .underline(formatting.underline)
                                 .strikethrough(formatting.strikethrough);
 
@@ -135,20 +159,24 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
                                     .color(theme.colors().buffer.code)
                                     .border(
                                         border::rounded(3)
-                                            .color(theme.colors().general.border)
+                                            .color(
+                                                theme.colors().general.border,
+                                            )
                                             .width(1),
                                     );
                             }
 
                             match (formatting.bold, formatting.italics) {
                                 (true, true) => {
-                                    span = span.font(font::MONO_BOLD_ITALICS.clone());
+                                    span = span
+                                        .font(font::MONO_BOLD_ITALICS.clone());
                                 }
                                 (true, false) => {
                                     span = span.font(font::MONO_BOLD.clone());
                                 }
                                 (false, true) => {
-                                    span = span.font(font::MONO_ITALICS.clone());
+                                    span =
+                                        span.font(font::MONO_ITALICS.clone());
                                 }
                                 (false, false) => {}
                             }
@@ -178,7 +206,8 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
             );
 
             spans.extend([
-                span(format!("{: <5}", record.level)).color(theme.colors().text.secondary),
+                span(format!("{: <5}", record.level))
+                    .color(theme.colors().text.secondary),
                 span(" "),
                 span(&record.message),
             ]);

--- a/src/widget/modal.rs
+++ b/src/widget/modal.rs
@@ -1,13 +1,12 @@
 use iced::advanced::layout::{self, Layout};
-use iced::advanced::overlay;
-use iced::advanced::renderer;
 use iced::advanced::widget::{self, Widget};
-use iced::advanced::{self, Clipboard, Shell};
+use iced::advanced::{self, Clipboard, Shell, overlay, renderer};
 use iced::alignment::Alignment;
-use iced::keyboard;
 use iced::keyboard::key;
-use iced::mouse;
-use iced::{Color, Element, Event, Length, Point, Rectangle, Size, Vector};
+use iced::{
+    Color, Element, Event, Length, Point, Rectangle, Size, Vector, keyboard,
+    mouse,
+};
 
 pub fn modal<'a, Message, Theme, Renderer>(
     base: impl Into<Element<'a, Message, Theme, Renderer>>,
@@ -159,9 +158,12 @@ where
         renderer: &Renderer,
         operation: &mut dyn widget::Operation<()>,
     ) {
-        self.base
-            .as_widget()
-            .operate(&mut state.children[0], layout, renderer, operation);
+        self.base.as_widget().operate(
+            &mut state.children[0],
+            layout,
+            renderer,
+            operation,
+        );
     }
 }
 
@@ -189,7 +191,8 @@ where
             .layout(self.tree, renderer, &limits)
             .align(Alignment::Center, Alignment::Center, limits.max());
 
-        layout::Node::with_children(self.size, vec![child]).move_to(self.position)
+        layout::Node::with_children(self.size, vec![child])
+            .move_to(self.position)
     }
 
     fn update(

--- a/src/widget/notify_visibility.rs
+++ b/src/widget/notify_visibility.rs
@@ -1,12 +1,9 @@
 use std::cell::RefCell;
 
-use iced::{
-    advanced::{widget, Clipboard, Layout, Shell},
-    window, Padding,
-};
-use iced::{mouse, Event, Rectangle};
+use iced::advanced::{Clipboard, Layout, Shell, widget};
+use iced::{Event, Padding, Rectangle, mouse, window};
 
-use super::{decorate, Element, Renderer};
+use super::{Element, Renderer, decorate};
 
 #[derive(Debug, Clone, Copy)]
 pub enum When {
@@ -38,10 +35,12 @@ where
                   clipboard: &mut dyn Clipboard,
                   shell: &mut Shell<'_, Message>,
                   viewport: &Rectangle| {
-                if let Event::Window(window::Event::RedrawRequested(_)) = &event {
+                if let Event::Window(window::Event::RedrawRequested(_)) = &event
+                {
                     let mut sent = sent.borrow_mut();
 
-                    let is_visible = viewport.expand(margin).intersects(&layout.bounds());
+                    let is_visible =
+                        viewport.expand(margin).intersects(&layout.bounds());
 
                     let should_notify = match when {
                         When::Visible => is_visible,
@@ -55,7 +54,8 @@ where
                 }
 
                 inner.as_widget_mut().update(
-                    tree, event, layout, cursor, renderer, clipboard, shell, viewport,
+                    tree, event, layout, cursor, renderer, clipboard, shell,
+                    viewport,
                 );
             },
         )

--- a/src/widget/selectable_rich_text.rs
+++ b/src/widget/selectable_rich_text.rs
@@ -1,31 +1,23 @@
+use std::borrow::Cow;
+use std::sync::Arc;
+
 use iced::advanced::graphics::core::touch;
-use iced::advanced::layout;
-use iced::advanced::renderer;
 use iced::advanced::renderer::Quad;
-use iced::advanced::text::Highlight;
-use iced::advanced::text::{self, Paragraph, Span, Text};
-use iced::advanced::widget::tree::{self, Tree};
+use iced::advanced::text::{self, Highlight, Paragraph, Span, Text};
 use iced::advanced::widget::Operation;
-use iced::advanced::{Clipboard, Layout, Shell, Widget};
-use iced::alignment;
-use iced::mouse;
-use iced::widget;
+use iced::advanced::widget::tree::{self, Tree};
+use iced::advanced::{Clipboard, Layout, Shell, Widget, layout, renderer};
 use iced::widget::container;
 use iced::widget::text::{LineHeight, Shaping};
 use iced::widget::text_input::Value;
-use iced::Border;
-use iced::Length;
-use iced::Point;
-use iced::Shadow;
-use iced::Vector;
-use iced::{self, Background, Color, Element, Event, Pixels, Rectangle, Size};
+use iced::{
+    self, Background, Border, Color, Element, Event, Length, Pixels, Point,
+    Rectangle, Shadow, Size, Vector, alignment, mouse, widget,
+};
 use itertools::Itertools;
 
 use super::context_menu;
-use super::selectable_text::{selection, Catalog, Interaction, Style, StyleFn};
-
-use std::borrow::Cow;
-use std::sync::Arc;
+use super::selectable_text::{Catalog, Interaction, Style, StyleFn, selection};
 
 /// Creates a new [`Rich`] text widget with the provided spans.
 pub fn selectable_rich_text<'a, Message, Link, Entry, Theme, Renderer>(
@@ -41,8 +33,14 @@ where
 
 /// A bunch of [`Rich`] text.
 #[allow(missing_debug_implementations)]
-pub struct Rich<'a, Message, Link = (), Entry = (), Theme = iced::Theme, Renderer = iced::Renderer>
-where
+pub struct Rich<
+    'a,
+    Message,
+    Link = (),
+    Entry = (),
+    Theme = iced::Theme,
+    Renderer = iced::Renderer,
+> where
     Link: self::Link + 'static,
     Theme: Catalog,
     Renderer: text::Renderer,
@@ -61,13 +59,21 @@ where
     #[allow(clippy::type_complexity)]
     context_menu: Option<(
         Box<dyn Fn(&Link) -> Vec<Entry> + 'a>,
-        Arc<dyn Fn(&Link, Entry, Length) -> Element<'a, Message, Theme, Renderer> + 'a>,
+        Arc<
+            dyn Fn(
+                    &Link,
+                    Entry,
+                    Length,
+                ) -> Element<'a, Message, Theme, Renderer>
+                + 'a,
+        >,
     )>,
     cached_entries: Vec<Entry>,
     cached_menu: Option<Element<'a, Message, Theme, Renderer>>,
 }
 
-impl<'a, Message, Link, Entry, Theme, Renderer> Rich<'a, Message, Link, Entry, Theme, Renderer>
+impl<'a, Message, Link, Entry, Theme, Renderer>
+    Rich<'a, Message, Link, Entry, Theme, Renderer>
 where
     Link: self::Link + 'static,
     Theme: Catalog,
@@ -94,7 +100,9 @@ where
     }
 
     /// Creates a new [`Rich`] text with the given text spans.
-    pub fn with_spans(spans: impl Into<Cow<'a, [Span<'a, Link, Renderer::Font>]>>) -> Self {
+    pub fn with_spans(
+        spans: impl Into<Cow<'a, [Span<'a, Link, Renderer::Font>]>>,
+    ) -> Self {
         Self {
             spans: spans.into(),
             ..Self::new()
@@ -144,7 +152,10 @@ where
     }
 
     /// Sets the [`alignment::Vertical`] of the [`Rich`] text.
-    pub fn align_y(mut self, alignment: impl Into<alignment::Vertical>) -> Self {
+    pub fn align_y(
+        mut self,
+        alignment: impl Into<alignment::Vertical>,
+    ) -> Self {
         self.align_y = alignment.into();
         self
     }
@@ -189,7 +200,8 @@ where
     pub fn context_menu(
         self,
         link_entries: impl Fn(&Link) -> Vec<Entry> + 'a,
-        view: impl Fn(&Link, Entry, Length) -> Element<'a, Message, Theme, Renderer> + 'a,
+        view: impl Fn(&Link, Entry, Length) -> Element<'a, Message, Theme, Renderer>
+        + 'a,
     ) -> Self {
         Self {
             context_menu: Some((Box::new(link_entries), Arc::new(view))),
@@ -271,7 +283,8 @@ where
     Link: self::Link + 'static,
     Entry: Copy + 'a,
     Theme: 'a + container::Catalog + context_menu::Catalog + Catalog,
-    <Theme as container::Catalog>::Class<'a>: From<container::StyleFn<'a, Theme>>,
+    <Theme as container::Catalog>::Class<'a>:
+        From<container::StyleFn<'a, Theme>>,
     Renderer: text::Renderer + 'a,
 {
     fn tag(&self) -> tree::Tag {
@@ -365,7 +378,9 @@ where
         }
 
         match event {
-            iced::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
+            iced::Event::Mouse(mouse::Event::ButtonPressed(
+                mouse::Button::Left,
+            ))
             | iced::Event::Touch(touch::Event::FingerPressed { .. }) => {
                 if let Some(position) = cursor.position_in(bounds) {
                     if let Some(span) = state.paragraph.hit_span(position) {
@@ -375,15 +390,18 @@ where
                 }
 
                 if let Some(cursor) = cursor.position() {
-                    state.interaction = Interaction::Selecting(selection::Raw {
-                        start: cursor,
-                        end: cursor,
-                    });
+                    state.interaction =
+                        Interaction::Selecting(selection::Raw {
+                            start: cursor,
+                            end: cursor,
+                        });
                 } else {
                     state.interaction = Interaction::Idle;
                 }
             }
-            iced::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
+            iced::Event::Mouse(mouse::Event::ButtonReleased(
+                mouse::Button::Left,
+            ))
             | iced::Event::Touch(touch::Event::FingerLifted { .. })
             | iced::Event::Touch(touch::Event::FingerLost { .. }) => {
                 if let Some(on_link_click) = self.on_link.as_ref() {
@@ -393,8 +411,10 @@ where
                         if let Some(position) = cursor.position_in(bounds) {
                             match state.paragraph.hit_span(position) {
                                 Some(span) if span == span_pressed => {
-                                    if let Some(link) =
-                                        self.spans.get(span).and_then(|span| span.link.clone())
+                                    if let Some(link) = self
+                                        .spans
+                                        .get(span)
+                                        .and_then(|span| span.link.clone())
                                     {
                                         shell.publish(on_link_click(link));
                                     }
@@ -414,7 +434,8 @@ where
             iced::Event::Mouse(mouse::Event::CursorMoved { .. })
             | iced::Event::Touch(touch::Event::FingerMoved { .. }) => {
                 if let Some(cursor) = cursor.position() {
-                    if let Interaction::Selecting(raw) = &mut state.interaction {
+                    if let Interaction::Selecting(raw) = &mut state.interaction
+                    {
                         raw.end = cursor;
                     }
                 }
@@ -439,8 +460,11 @@ where
                     if state.shown_spoiler.is_none() {
                         // Find if spoiler is hovered
                         for (index, span) in state.spans.iter().enumerate() {
-                            if let Some((fg, highlight)) = span.color.zip(span.highlight) {
-                                let is_spoiler = highlight.background == Background::Color(fg);
+                            if let Some((fg, highlight)) =
+                                span.color.zip(span.highlight)
+                            {
+                                let is_spoiler = highlight.background
+                                    == Background::Color(fg);
 
                                 if is_spoiler
                                     && state
@@ -449,7 +473,8 @@ where
                                         .into_iter()
                                         .any(|bounds| bounds.contains(cursor))
                                 {
-                                    state.shown_spoiler = Some((index, fg, highlight));
+                                    state.shown_spoiler =
+                                        Some((index, fg, highlight));
                                     break;
                                 }
                             }
@@ -461,27 +486,35 @@ where
                             let span = &mut state.spans[index];
                             span.color = None;
                             span.highlight = None;
-                            state.paragraph = Renderer::Paragraph::with_spans(text_with_spans(
-                                state.spans.as_ref(),
-                            ));
+                            state.paragraph = Renderer::Paragraph::with_spans(
+                                text_with_spans(state.spans.as_ref()),
+                            );
                         }
                     }
                 }
                 // Hide spoiler
-                else if let Some((index, fg, highlight)) = state.shown_spoiler.take() {
+                else if let Some((index, fg, highlight)) =
+                    state.shown_spoiler.take()
+                {
                     if let Some(span) = state.spans.get_mut(index) {
                         span.color = Some(fg);
                         span.highlight = Some(highlight);
                     }
-                    state.paragraph =
-                        Renderer::Paragraph::with_spans(text_with_spans(state.spans.as_ref()));
+                    state.paragraph = Renderer::Paragraph::with_spans(
+                        text_with_spans(state.spans.as_ref()),
+                    );
                 }
             }
-            iced::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Right)) => {
+            iced::Event::Mouse(mouse::Event::ButtonPressed(
+                mouse::Button::Right,
+            )) => {
                 if let Some(position) = cursor.position_in(bounds) {
                     if let Some((link_entries, _)) = &self.context_menu {
-                        if let Some((link, entries)) =
-                            state.spans.iter().enumerate().find_map(|(i, span)| {
+                        if let Some((link, entries)) = state
+                            .spans
+                            .iter()
+                            .enumerate()
+                            .find_map(|(i, span)| {
                                 if span.link.is_some()
                                     && state
                                         .paragraph
@@ -500,10 +533,11 @@ where
                                 None
                             })
                         {
-                            state.context_menu.status = context_menu::Status::Open(
-                                // Need absolute position. Infallible since we're within position_in
-                                cursor.position_over(bounds).unwrap(),
-                            );
+                            state.context_menu.status =
+                                context_menu::Status::Open(
+                                    // Need absolute position. Infallible since we're within position_in
+                                    cursor.position_over(bounds).unwrap(),
+                                );
                             state.context_menu_link = Some(link);
                             self.cached_entries = entries;
                         }
@@ -545,18 +579,30 @@ where
             .and_then(|position| state.paragraph.hit_span(position));
 
         for (index, span) in state.spans.iter().enumerate() {
-            let is_hovered_link = span.link.is_some() && Some(index) == hovered_span;
+            let is_hovered_link =
+                span.link.is_some() && Some(index) == hovered_span;
 
-            if span.highlight.is_some() || span.underline || span.strikethrough || is_hovered_link {
+            if span.highlight.is_some()
+                || span.underline
+                || span.strikethrough
+                || is_hovered_link
+            {
                 let translation = layout.position() - Point::ORIGIN;
                 let regions = state.paragraph.span_bounds(index);
 
                 if let Some(highlight) = span.highlight {
                     for bounds in &regions {
                         let bounds = Rectangle::new(
-                            bounds.position() - Vector::new(span.padding.left, span.padding.top),
+                            bounds.position()
+                                - Vector::new(
+                                    span.padding.left,
+                                    span.padding.top,
+                                ),
                             bounds.size()
-                                + Size::new(span.padding.horizontal(), span.padding.vertical()),
+                                + Size::new(
+                                    span.padding.horizontal(),
+                                    span.padding.vertical(),
+                                ),
                         );
 
                         renderer.fill_quad(
@@ -571,20 +617,30 @@ where
                 }
 
                 if span.underline || span.strikethrough || is_hovered_link {
-                    let size = span.size.or(self.size).unwrap_or(renderer.default_size());
+                    let size = span
+                        .size
+                        .or(self.size)
+                        .unwrap_or(renderer.default_size());
 
                     let line_height = span
                         .line_height
                         .unwrap_or(self.line_height)
                         .to_absolute(size);
 
-                    let color = span.color.or(style.color).unwrap_or(defaults.text_color);
+                    let color = span
+                        .color
+                        .or(style.color)
+                        .unwrap_or(defaults.text_color);
 
-                    let baseline =
-                        translation + Vector::new(0.0, size.0 + (line_height.0 - size.0) / 2.0);
+                    let baseline = translation
+                        + Vector::new(
+                            0.0,
+                            size.0 + (line_height.0 - size.0) / 2.0,
+                        );
 
                     if span.underline
-                        || (is_hovered_link && span.link.as_ref().unwrap().underline())
+                        || (is_hovered_link
+                            && span.link.as_ref().unwrap().underline())
                     {
                         for bounds in &regions {
                             renderer.fill_quad(
@@ -625,13 +681,13 @@ where
             .selection()
             .and_then(|raw| raw.resolve(bounds))
         {
-            let line_height = f32::from(
-                self.line_height
-                    .to_absolute(self.size.unwrap_or_else(|| renderer.default_size())),
-            );
+            let line_height = f32::from(self.line_height.to_absolute(
+                self.size.unwrap_or_else(|| renderer.default_size()),
+            ));
 
-            let baseline_y =
-                bounds.y + ((selection.start.y - bounds.y) / line_height).floor() * line_height;
+            let baseline_y = bounds.y
+                + ((selection.start.y - bounds.y) / line_height).floor()
+                    * line_height;
 
             let height = selection.end.y - baseline_y - 0.5;
             let rows = (height / line_height).ceil() as usize;
@@ -641,7 +697,8 @@ where
                     (
                         selection.start.x,
                         if rows == 1 {
-                            f32::min(selection.end.x, bounds.x + bounds.width) - selection.start.x
+                            f32::min(selection.end.x, bounds.x + bounds.width)
+                                - selection.start.x
                         } else {
                             bounds.x + bounds.width - selection.start.x
                         },
@@ -655,7 +712,10 @@ where
 
                 renderer.fill_quad(
                     Quad {
-                        bounds: Rectangle::new(Point::new(x, y), Size::new(width, line_height)),
+                        bounds: Rectangle::new(
+                            Point::new(x, y),
+                            Size::new(width, line_height),
+                        ),
                         border: Border {
                             radius: 0.0.into(),
                             width: 0.0,
@@ -713,13 +773,15 @@ where
             .downcast_mut::<State<Link, Renderer::Paragraph>>();
 
         let bounds = layout.bounds();
-        let value = Value::new(&self.spans.iter().map(|s| s.text.as_ref()).join(""));
+        let value =
+            Value::new(&self.spans.iter().map(|s| s.text.as_ref()).join(""));
         if let Some(selection) = state
             .interaction
             .selection()
             .and_then(|raw| selection(raw, bounds, &state.paragraph, &value))
         {
-            let mut content = value.select(selection.start, selection.end).to_string();
+            let mut content =
+                value.select(selection.start, selection.end).to_string();
             operation.custom(None, bounds, &mut content);
         }
 
@@ -733,7 +795,8 @@ where
         _layout: Layout<'_>,
         _renderer: &Renderer,
         translation: Vector,
-    ) -> Option<iced::advanced::overlay::Element<'b, Message, Theme, Renderer>> {
+    ) -> Option<iced::advanced::overlay::Element<'b, Message, Theme, Renderer>>
+    {
         let state = tree
             .state
             .downcast_mut::<State<Link, Renderer::Paragraph>>();
@@ -814,8 +877,9 @@ where
                 }
             }
 
-            state.paragraph =
-                Renderer::Paragraph::with_spans(text_with_spans(state.spans.as_slice()));
+            state.paragraph = Renderer::Paragraph::with_spans(text_with_spans(
+                state.spans.as_slice(),
+            ));
         } else {
             match state.paragraph.compare(Text {
                 content: (),
@@ -833,7 +897,8 @@ where
                     state.paragraph.resize(bounds);
                 }
                 text::Difference::Shape => {
-                    state.spans = spans.iter().cloned().map(Span::to_static).collect();
+                    state.spans =
+                        spans.iter().cloned().map(Span::to_static).collect();
 
                     // Apply shown spoiler
                     if let Some((index, _, _)) = state.shown_spoiler {
@@ -843,8 +908,9 @@ where
                         }
                     }
 
-                    state.paragraph =
-                        Renderer::Paragraph::with_spans(text_with_spans(state.spans.as_slice()));
+                    state.paragraph = Renderer::Paragraph::with_spans(
+                        text_with_spans(state.spans.as_slice()),
+                    );
                 }
             }
         }
@@ -853,14 +919,17 @@ where
     })
 }
 
-impl<'a, Message, Link, Entry, Theme, Renderer> FromIterator<Span<'a, Link, Renderer::Font>>
+impl<'a, Message, Link, Entry, Theme, Renderer>
+    FromIterator<Span<'a, Link, Renderer::Font>>
     for Rich<'a, Message, Link, Entry, Theme, Renderer>
 where
     Link: self::Link + 'static,
     Theme: Catalog,
     Renderer: text::Renderer,
 {
-    fn from_iter<T: IntoIterator<Item = Span<'a, Link, Renderer::Font>>>(spans: T) -> Self {
+    fn from_iter<T: IntoIterator<Item = Span<'a, Link, Renderer::Font>>>(
+        spans: T,
+    ) -> Self {
         Self {
             spans: spans.into_iter().collect(),
             ..Self::new()
@@ -869,13 +938,15 @@ where
 }
 
 impl<'a, Message, Link, Entry, Theme, Renderer>
-    From<Rich<'a, Message, Link, Entry, Theme, Renderer>> for Element<'a, Message, Theme, Renderer>
+    From<Rich<'a, Message, Link, Entry, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
     Link: self::Link + 'static,
     Entry: Copy + 'a,
     Theme: 'a + container::Catalog + context_menu::Catalog + Catalog,
-    <Theme as container::Catalog>::Class<'a>: From<container::StyleFn<'a, Theme>>,
+    <Theme as container::Catalog>::Class<'a>:
+        From<container::StyleFn<'a, Theme>>,
     Renderer: text::Renderer + 'a,
 {
     fn from(

--- a/src/widget/selectable_text.rs
+++ b/src/widget/selectable_text.rs
@@ -5,7 +5,8 @@ use iced::advanced::{Layout, Widget, layout, mouse, renderer, text, widget};
 use iced::widget::text::{Fragment, IntoFragment, Wrapping};
 use iced::widget::text_input::Value;
 use iced::{
-    Border, Color, Element, Length, Pixels, Point, Rectangle, Shadow, Size, Task, alignment, touch,
+    Border, Color, Element, Length, Pixels, Point, Rectangle, Shadow, Size,
+    Task, alignment, touch,
 };
 
 pub use self::selection::selection;
@@ -119,7 +120,8 @@ where
     }
 }
 
-impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer> for Text<'_, Theme, Renderer>
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Text<'_, Theme, Renderer>
 where
     Renderer: text::Renderer,
     Theme: Catalog,
@@ -189,18 +191,23 @@ where
         state.hovered = cursor.is_over(bounds);
 
         match event {
-            iced::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
+            iced::Event::Mouse(mouse::Event::ButtonPressed(
+                mouse::Button::Left,
+            ))
             | iced::Event::Touch(touch::Event::FingerPressed { .. }) => {
                 if let Some(cursor) = cursor.position() {
-                    state.interaction = Interaction::Selecting(selection::Raw {
-                        start: cursor,
-                        end: cursor,
-                    });
+                    state.interaction =
+                        Interaction::Selecting(selection::Raw {
+                            start: cursor,
+                            end: cursor,
+                        });
                 } else {
                     state.interaction = Interaction::Idle;
                 }
             }
-            iced::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
+            iced::Event::Mouse(mouse::Event::ButtonReleased(
+                mouse::Button::Left,
+            ))
             | iced::Event::Touch(touch::Event::FingerLifted { .. })
             | iced::Event::Touch(touch::Event::FingerLost { .. }) => {
                 if let Interaction::Selecting(raw) = state.interaction {
@@ -212,7 +219,8 @@ where
             iced::Event::Mouse(mouse::Event::CursorMoved { .. })
             | iced::Event::Touch(touch::Event::FingerMoved { .. }) => {
                 if let Some(cursor) = cursor.position() {
-                    if let Interaction::Selecting(raw) = &mut state.interaction {
+                    if let Interaction::Selecting(raw) = &mut state.interaction
+                    {
                         raw.end = cursor;
                     }
                 }
@@ -220,7 +228,9 @@ where
             _ => {}
         }
 
-        if prev_hovered != state.hovered || prev_interaction != state.interaction {
+        if prev_hovered != state.hovered
+            || prev_interaction != state.interaction
+        {
             shell.request_redraw();
         }
     }
@@ -250,13 +260,13 @@ where
             .selection()
             .and_then(|raw| raw.resolve(bounds))
         {
-            let line_height = f32::from(
-                self.line_height
-                    .to_absolute(self.size.unwrap_or_else(|| renderer.default_size())),
-            );
+            let line_height = f32::from(self.line_height.to_absolute(
+                self.size.unwrap_or_else(|| renderer.default_size()),
+            ));
 
-            let baseline_y =
-                bounds.y + ((selection.start.y - bounds.y) / line_height).floor() * line_height;
+            let baseline_y = bounds.y
+                + ((selection.start.y - bounds.y) / line_height).floor()
+                    * line_height;
 
             let height = selection.end.y - baseline_y - 0.5;
             let rows = (height / line_height).ceil() as usize;
@@ -266,7 +276,8 @@ where
                     (
                         selection.start.x,
                         if rows == 1 {
-                            f32::min(selection.end.x, bounds.x + bounds.width) - selection.start.x
+                            f32::min(selection.end.x, bounds.x + bounds.width)
+                                - selection.start.x
                         } else {
                             bounds.x + bounds.width - selection.start.x
                         },
@@ -280,7 +291,10 @@ where
 
                 renderer.fill_quad(
                     Quad {
-                        bounds: Rectangle::new(Point::new(x, y), Size::new(width, line_height)),
+                        bounds: Rectangle::new(
+                            Point::new(x, y),
+                            Size::new(width, line_height),
+                        ),
                         border: Border {
                             radius: 0.0.into(),
                             width: 0.0,
@@ -392,12 +406,11 @@ where
 
         let bounds = layout.bounds();
         let value = Value::new(&self.fragment);
-        if let Some(selection) = state
-            .interaction
-            .selection()
-            .and_then(|raw| selection(raw, bounds, state.paragraph.raw(), &value))
-        {
-            let mut content = value.select(selection.start, selection.end).to_string();
+        if let Some(selection) = state.interaction.selection().and_then(|raw| {
+            selection(raw, bounds, state.paragraph.raw(), &value)
+        }) {
+            let mut content =
+                value.select(selection.start, selection.end).to_string();
             operation.custom(None, bounds, &mut content);
         }
     }
@@ -417,7 +430,9 @@ fn draw<Renderer>(
     let bounds = layout.bounds();
 
     let x = match paragraph.align_x() {
-        text::Alignment::Default | text::Alignment::Left | text::Alignment::Justified => bounds.x,
+        text::Alignment::Default
+        | text::Alignment::Left
+        | text::Alignment::Justified => bounds.x,
         text::Alignment::Center => bounds.center_x(),
         text::Alignment::Right => bounds.x + bounds.width,
     };
@@ -442,7 +457,9 @@ where
     Renderer: text::Renderer + 'a,
     Theme: Catalog + 'a,
 {
-    fn from(text: Text<'a, Theme, Renderer>) -> Element<'a, Message, Theme, Renderer> {
+    fn from(
+        text: Text<'a, Theme, Renderer>,
+    ) -> Element<'a, Message, Theme, Renderer> {
         Element::new(text)
     }
 }
@@ -466,7 +483,9 @@ impl Interaction {
     pub fn selection(self) -> Option<selection::Raw> {
         match &self {
             Interaction::Idle => None,
-            Interaction::Selecting(raw) | Interaction::Selected(raw) => Some(*raw),
+            Interaction::Selecting(raw) | Interaction::Selected(raw) => {
+                Some(*raw)
+            }
         }
     }
 }
@@ -486,7 +505,9 @@ impl Interaction {
 //     renderer.measure_width(&value.to_string(), size, font, text::Shaping::Advanced)
 // }
 
-pub fn selected<Message: Send + 'static>(f: fn(Vec<(f32, String)>) -> Message) -> Task<Message> {
+pub fn selected<Message: Send + 'static>(
+    f: fn(Vec<(f32, String)>) -> Message,
+) -> Task<Message> {
     struct Selected<T> {
         contents: Vec<(f32, String)>,
         f: fn(Vec<(f32, String)>) -> T,

--- a/src/widget/selectable_text/selection.rs
+++ b/src/widget/selectable_text/selection.rs
@@ -12,7 +12,10 @@ pub struct Raw {
 impl Raw {
     pub fn resolve(&self, bounds: Rectangle) -> Option<Resolved> {
         if f32::max(f32::min(self.start.y, self.end.y), bounds.y)
-            <= f32::min(f32::max(self.start.y, self.end.y), bounds.y + bounds.height)
+            <= f32::min(
+                f32::max(self.start.y, self.end.y),
+                bounds.y + bounds.height,
+            )
         {
             let (mut start, mut end) = if self.start.y < self.end.y
                 || self.start.y == self.end.y && self.start.x < self.end.x
@@ -85,9 +88,16 @@ pub fn find_cursor_position<P: text::Paragraph>(
 ) -> Option<usize> {
     let value = value.to_string();
 
-    let char_offset = paragraph.hit_test(cursor_position).map(text::Hit::cursor)?;
+    let char_offset =
+        paragraph.hit_test(cursor_position).map(text::Hit::cursor)?;
 
-    Some(unicode_segmentation::UnicodeSegmentation::graphemes(&value[..char_offset], true).count())
+    Some(
+        unicode_segmentation::UnicodeSegmentation::graphemes(
+            &value[..char_offset],
+            true,
+        )
+        .count(),
+    )
 }
 
 fn relative(point: Point, bounds: Rectangle) -> Point {

--- a/src/widget/shortcut.rs
+++ b/src/widget/shortcut.rs
@@ -1,11 +1,10 @@
 use data::shortcut;
+pub use data::shortcut::Command;
 use iced::advanced::widget::Tree;
 use iced::advanced::{Clipboard, Layout, Shell};
-use iced::{keyboard, mouse, Event};
+use iced::{Event, keyboard, mouse};
 
-pub use data::shortcut::Command;
-
-use super::{decorate, Element, Renderer};
+use super::{Element, Renderer, decorate};
 
 pub fn shortcut<'a, Message>(
     base: impl Into<Element<'a, Message>>,
@@ -28,8 +27,13 @@ where
                   shell: &mut Shell<'_, Message>,
                   viewport: &iced::Rectangle| {
                 match &event {
-                    Event::Keyboard(keyboard::Event::KeyPressed { key, modifiers, .. }) => {
-                        let key_bind = shortcut::KeyBind::from((key.clone(), *modifiers));
+                    Event::Keyboard(keyboard::Event::KeyPressed {
+                        key,
+                        modifiers,
+                        ..
+                    }) => {
+                        let key_bind =
+                            shortcut::KeyBind::from((key.clone(), *modifiers));
 
                         if let Some(command) = shortcuts
                             .iter()
@@ -40,14 +44,17 @@ where
                             return;
                         }
                     }
-                    Event::Keyboard(keyboard::Event::ModifiersChanged(new_modifiers)) => {
+                    Event::Keyboard(keyboard::Event::ModifiersChanged(
+                        new_modifiers,
+                    )) => {
                         *modifiers = (*new_modifiers).into();
                     }
                     _ => {}
                 }
 
                 inner.as_widget_mut().update(
-                    tree, event, layout, cursor, renderer, clipboard, shell, viewport,
+                    tree, event, layout, cursor, renderer, clipboard, shell,
+                    viewport,
                 );
             },
         )

--- a/src/widget/tooltip.rs
+++ b/src/widget/tooltip.rs
@@ -1,10 +1,8 @@
+pub use iced::widget::tooltip::Position;
 use iced::widget::{container, text};
 
-use crate::theme;
-
-pub use iced::widget::tooltip::Position;
-
 use super::Element;
+use crate::theme;
 
 pub fn tooltip<'a, Message: 'a>(
     content: impl Into<Element<'a, Message>>,

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,8 +1,11 @@
-use futures::{stream::BoxStream, Stream, StreamExt};
-use iced::{advanced::graphics::futures::subscription, Point, Size, Subscription, Task};
-
 pub use data::window::{Error, MIN_SIZE};
-pub use iced::window::{close, gain_focus, get_latest, open, Id, Position, Settings};
+use futures::stream::BoxStream;
+use futures::{Stream, StreamExt};
+use iced::advanced::graphics::futures::subscription;
+pub use iced::window::{
+    Id, Position, Settings, close, gain_focus, get_latest, open,
+};
+use iced::{Point, Size, Subscription, Task};
 
 #[derive(Debug, Clone, Copy)]
 pub struct Window {
@@ -44,8 +47,12 @@ pub fn toggle_fullscreen<Message: 'static + Send>() -> Task<Message> {
             iced::window::set_mode(
                 window,
                 match mode {
-                    iced::window::Mode::Windowed => iced::window::Mode::Fullscreen,
-                    iced::window::Mode::Fullscreen => iced::window::Mode::Windowed,
+                    iced::window::Mode::Windowed => {
+                        iced::window::Mode::Fullscreen
+                    }
+                    iced::window::Mode::Fullscreen => {
+                        iced::window::Mode::Windowed
+                    }
                     // Do nothing.
                     iced::window::Mode::Hidden => iced::window::Mode::Hidden,
                 },
@@ -64,7 +71,11 @@ pub enum Event {
     CloseRequested,
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+#[cfg(not(any(
+    target_os = "macos",
+    target_os = "linux",
+    target_os = "windows"
+)))]
 pub fn settings() -> Settings {
     Settings::default()
 }
@@ -168,8 +179,10 @@ impl subscription::Recipe for Events {
     ) -> BoxStream<'static, Self::Output> {
         use futures::stream;
 
-        const TIMEOUT: std::time::Duration = std::time::Duration::from_millis(500);
-        const INITIAL_SKIP_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(2);
+        const TIMEOUT: std::time::Duration =
+            std::time::Duration::from_millis(500);
+        const INITIAL_SKIP_THRESHOLD: std::time::Duration =
+            std::time::Duration::from_secs(2);
 
         let start_time = std::time::Instant::now();
 
@@ -183,10 +196,12 @@ impl subscription::Recipe for Events {
                     status: _,
                 } => match window_event {
                     iced::window::Event::Moved(point) => {
-                        let point_is_positive =
-                            point.x.is_sign_positive() && point.y.is_sign_positive();
+                        let point_is_positive = point.x.is_sign_positive()
+                            && point.y.is_sign_positive();
 
-                        if point_is_positive && elapsed >= INITIAL_SKIP_THRESHOLD {
+                        if point_is_positive
+                            && elapsed >= INITIAL_SKIP_THRESHOLD
+                        {
                             Some((
                                 id,
                                 Event::Moved(Point {
@@ -199,21 +214,28 @@ impl subscription::Recipe for Events {
                         }
                     }
                     iced::window::Event::Resized(size) => {
-                        let is_bigger_than_min_allowed =
-                            size.width >= MIN_SIZE.width && size.height >= MIN_SIZE.height;
+                        let is_bigger_than_min_allowed = size.width
+                            >= MIN_SIZE.width
+                            && size.height >= MIN_SIZE.height;
 
-                        if is_bigger_than_min_allowed && elapsed >= INITIAL_SKIP_THRESHOLD {
+                        if is_bigger_than_min_allowed
+                            && elapsed >= INITIAL_SKIP_THRESHOLD
+                        {
                             Some((id, Event::Resized(size.max(MIN_SIZE))))
                         } else {
                             None
                         }
                     }
                     iced::window::Event::Focused => Some((id, Event::Focused)),
-                    iced::window::Event::Unfocused => Some((id, Event::Unfocused)),
+                    iced::window::Event::Unfocused => {
+                        Some((id, Event::Unfocused))
+                    }
                     iced::window::Event::Opened { position, size } => {
                         Some((id, Event::Opened { position, size }))
                     }
-                    iced::window::Event::CloseRequested => Some((id, Event::CloseRequested)),
+                    iced::window::Event::CloseRequested => {
+                        Some((id, Event::CloseRequested))
+                    }
                     _ => None,
                 },
                 _ => None,
@@ -236,18 +258,25 @@ impl subscription::Recipe for Events {
                                     position,
                                 },
                             ),
-                            Event::Resized(size) => (vec![], State::Resizing { stream, id, size }),
-                            Event::Focused => (vec![(id, Event::Focused)], State::Idle { stream }),
-                            Event::Unfocused => {
-                                (vec![(id, Event::Unfocused)], State::Idle { stream })
+                            Event::Resized(size) => {
+                                (vec![], State::Resizing { stream, id, size })
                             }
+                            Event::Focused => (
+                                vec![(id, Event::Focused)],
+                                State::Idle { stream },
+                            ),
+                            Event::Unfocused => (
+                                vec![(id, Event::Unfocused)],
+                                State::Idle { stream },
+                            ),
                             Event::Opened { position, size } => (
                                 vec![(id, Event::Opened { position, size })],
                                 State::Idle { stream },
                             ),
-                            Event::CloseRequested => {
-                                (vec![(id, Event::CloseRequested)], State::Idle { stream })
-                            }
+                            Event::CloseRequested => (
+                                vec![(id, Event::CloseRequested)],
+                                State::Idle { stream },
+                            ),
                         })
                     }
                     State::Moving {
@@ -255,27 +284,39 @@ impl subscription::Recipe for Events {
                         id,
                         position,
                     } => {
-                        let next_event = tokio::time::timeout(TIMEOUT, stream.next()).await;
+                        let next_event =
+                            tokio::time::timeout(TIMEOUT, stream.next()).await;
 
                         match next_event {
-                            Ok(Some((next_id, Event::Moved(position)))) if next_id == id => Some((
-                                vec![],
-                                State::Moving {
-                                    stream,
-                                    id,
-                                    position,
-                                },
+                            Ok(Some((next_id, Event::Moved(position))))
+                                if next_id == id =>
+                            {
+                                Some((
+                                    vec![],
+                                    State::Moving {
+                                        stream,
+                                        id,
+                                        position,
+                                    },
+                                ))
+                            }
+                            Ok(Some((next_id, Event::Resized(size))))
+                                if next_id == id =>
+                            {
+                                Some((
+                                    vec![],
+                                    State::MovingAndResizing {
+                                        stream,
+                                        id,
+                                        position,
+                                        size,
+                                    },
+                                ))
+                            }
+                            _ => Some((
+                                vec![(id, Event::Moved(position))],
+                                State::Idle { stream },
                             )),
-                            Ok(Some((next_id, Event::Resized(size)))) if next_id == id => Some((
-                                vec![],
-                                State::MovingAndResizing {
-                                    stream,
-                                    id,
-                                    position,
-                                    size,
-                                },
-                            )),
-                            _ => Some((vec![(id, Event::Moved(position))], State::Idle { stream })),
                         }
                     }
                     State::Resizing {
@@ -283,22 +324,35 @@ impl subscription::Recipe for Events {
                         id,
                         size,
                     } => {
-                        let next_event = tokio::time::timeout(TIMEOUT, stream.next()).await;
+                        let next_event =
+                            tokio::time::timeout(TIMEOUT, stream.next()).await;
 
                         match next_event {
-                            Ok(Some((next_id, Event::Resized(size)))) if next_id == id => {
-                                Some((vec![], State::Resizing { stream, id, size }))
+                            Ok(Some((next_id, Event::Resized(size))))
+                                if next_id == id =>
+                            {
+                                Some((
+                                    vec![],
+                                    State::Resizing { stream, id, size },
+                                ))
                             }
-                            Ok(Some((next_id, Event::Moved(position)))) if next_id == id => Some((
-                                vec![],
-                                State::MovingAndResizing {
-                                    stream,
-                                    id,
-                                    position,
-                                    size,
-                                },
+                            Ok(Some((next_id, Event::Moved(position))))
+                                if next_id == id =>
+                            {
+                                Some((
+                                    vec![],
+                                    State::MovingAndResizing {
+                                        stream,
+                                        id,
+                                        position,
+                                        size,
+                                    },
+                                ))
+                            }
+                            _ => Some((
+                                vec![(id, Event::Resized(size))],
+                                State::Idle { stream },
                             )),
-                            _ => Some((vec![(id, Event::Resized(size))], State::Idle { stream })),
                         }
                     }
                     State::MovingAndResizing {
@@ -307,29 +361,41 @@ impl subscription::Recipe for Events {
                         position,
                         size,
                     } => {
-                        let next_event = tokio::time::timeout(TIMEOUT, stream.next()).await;
+                        let next_event =
+                            tokio::time::timeout(TIMEOUT, stream.next()).await;
 
                         match next_event {
-                            Ok(Some((next_id, Event::Moved(position)))) if next_id == id => Some((
-                                vec![],
-                                State::MovingAndResizing {
-                                    stream,
-                                    id,
-                                    position,
-                                    size,
-                                },
-                            )),
-                            Ok(Some((next_id, Event::Resized(size)))) if next_id == id => Some((
-                                vec![],
-                                State::MovingAndResizing {
-                                    stream,
-                                    id,
-                                    position,
-                                    size,
-                                },
-                            )),
+                            Ok(Some((next_id, Event::Moved(position))))
+                                if next_id == id =>
+                            {
+                                Some((
+                                    vec![],
+                                    State::MovingAndResizing {
+                                        stream,
+                                        id,
+                                        position,
+                                        size,
+                                    },
+                                ))
+                            }
+                            Ok(Some((next_id, Event::Resized(size))))
+                                if next_id == id =>
+                            {
+                                Some((
+                                    vec![],
+                                    State::MovingAndResizing {
+                                        stream,
+                                        id,
+                                        position,
+                                        size,
+                                    },
+                                ))
+                            }
                             _ => Some((
-                                vec![(id, Event::Moved(position)), (id, Event::Resized(size))],
+                                vec![
+                                    (id, Event::Moved(position)),
+                                    (id, Event::Resized(size)),
+                                ],
                                 State::Idle { stream },
                             )),
                         }


### PR DESCRIPTION
This is a companion PR to PR #921;  intended to help facilitate styling contributions to meet style guidelines.  First commit contains all changes to `rustfmt` settings and the second the application of those settings.

- Updates `edition` to the latest stable version (`2024`) and introduces a matching `style_edition` as recommended in (`rustfmt`'s README)[https://github.com/rust-lang/rustfmt?tab=readme-ov-file#style-editions].
- Adds `max_width` as discussed in #921.
- It looks like #921 wants to check line endings as well?  I think that can be handled by `git` itself, but I may be mistaken.  If I am mistaken, then we can add `newline_style = "Unix"`.
- The unstable settings `group_imports` and `imports_granularity` were already present, so I added `unstable_features = true` to support them.  (Commented those options to make it clear why `unstable_features` has been set.)  In order to utilize those unstable features the [nightly version of rustfmt](https://github.com/rust-lang/rustfmt?tab=readme-ov-file#on-the-nightly-toolchain) is needed.

Additional settings can be found [here](https://rust-lang.github.io/rustfmt/?version=v1.8.0).