### PR TITLE
Use Autocomplete Suffixes when Inserting Username via Click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Added:
 - Title bar button and keyboard shortcut to mark a buffer as read (will update the read marker as well, if the `read-marker` capability is available)
 - Mark as Read settings to control when buffers are automatically marked as read
 
+Changed:
+- Clicking to insert a username will now use same suffixes specified for autocomplete
+
 # 2025.4 (2025-04-07)
 
 Added:

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,4 +1,4 @@
-pub use data::buffer::{Internal, Settings, Upstream};
+pub use data::buffer::{Autocomplete, Internal, Settings, Upstream};
 use data::dashboard::BufferAction;
 use data::target::{self, Target};
 use data::user::Nick;
@@ -342,6 +342,7 @@ impl Buffer {
         &mut self,
         nick: Nick,
         history: &mut history::Manager,
+        autocomplete: &Autocomplete,
     ) -> Task<Message> {
         match self {
             Buffer::Empty
@@ -351,13 +352,13 @@ impl Buffer {
             | Buffer::Highlights(_) => Task::none(),
             Buffer::Channel(state) => state
                 .input_view
-                .insert_user(nick, state.buffer.clone(), history)
+                .insert_user(nick, state.buffer.clone(), history, autocomplete)
                 .map(|message| {
                     Message::Channel(channel::Message::InputView(message))
                 }),
             Buffer::Query(state) => state
                 .input_view
-                .insert_user(nick, state.buffer.clone(), history)
+                .insert_user(nick, state.buffer.clone(), history, autocomplete)
                 .map(|message| {
                     Message::Query(query::Message::InputView(message))
                 }),

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -1,8 +1,9 @@
+use data::buffer::{self, Autocomplete};
 use data::dashboard::BufferAction;
 use data::input::{self, Cache, Draft};
 use data::target::Target;
 use data::user::Nick;
-use data::{Config, buffer, client, command, history};
+use data::{Config, client, command, history};
 use iced::Task;
 use iced::widget::{column, container, text, text_input};
 
@@ -465,16 +466,24 @@ impl State {
         nick: Nick,
         buffer: buffer::Upstream,
         history: &mut history::Manager,
+        autocomplete: &Autocomplete,
     ) -> Task<Message> {
         let mut text = history.input(&buffer).draft.to_string();
 
-        if text.is_empty() {
-            text = format!("{nick}: ");
-        } else if text.ends_with(' ') {
-            text = format!("{text}{nick}");
+        let suffix = if text.is_empty() {
+            text = format!("{nick}");
+
+            &autocomplete.completion_suffixes[0]
         } else {
-            text = format!("{text} {nick}");
-        }
+            if text.ends_with(' ') {
+                text = format!("{text}{nick}");
+            } else {
+                text = format!("{text} {nick}");
+            }
+
+            &autocomplete.completion_suffixes[1]
+        };
+        text.push_str(suffix);
 
         history.record_draft(Draft { buffer, text });
 

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -317,7 +317,7 @@ impl Dashboard {
                                                 Task::batch(vec![
                                                     task,
                                                     pane.buffer
-                                                        .insert_user_to_input(nick, history)
+                                                        .insert_user_to_input(nick, history, &config.buffer.text_input.autocomplete)
                                                         .map(move |message| {
                                                             Message::Pane(
                                                                 window,


### PR DESCRIPTION
Addresses issue #932.  This changes the default behavior slightly by adding a space after usernames inserted into a non-empty input.