### PR TITLE
WHOIS command now accept optional server parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Added:
 
 - Ability to show a modal prompt before opening a URL
+- WHOIS command now accepts optional server parameter
 - Title bar button and keyboard shortcut to mark a buffer as read (will update the read marker as well, if the `read-marker` capability is available)
 - Mark as Read settings to control when buffers are automatically marked as read
 

--- a/book/src/guides/getting-started.md
+++ b/book/src/guides/getting-started.md
@@ -8,13 +8,13 @@ Once connected to a server, you can join channels. This can be done automaticall
 
 Here are a few useful IRC commands for a new user[^2]
 
-| Command          | Example                                             | Description |
-|--------------|---------------------------------------------------------|---------|
-| `/join` | `/join #halloy` | Join a new channel        |
-| `/part` | `/part #halloy` | Part a channel        |
-| `/nick` | `/nick halloyisgreat` | Change your nickname        |
-| `/whois nickname` | `/whois halloyisgreat` | Displays information of nickname requested       |
-| `/list *keyword*` | `/list *linux*` | List channels. Keyword is optional        |
+| Command           | Example                | Description                                |
+| ----------------- | ---------------------- | ------------------------------------------ |
+| `/join`           | `/join #halloy`        | Join a new channel                         |
+| `/part`           | `/part #halloy`        | Part a channel                             |
+| `/nick`           | `/nick halloyisgreat`  | Change your nickname                       |
+| `/whois nickname` | `/whois halloyisgreat` | Displays information of nickname requested |
+| `/list *keyword*` | `/list *linux*`        | List channels. Keyword is optional         |
 
 
 [^1]: Channel names always start with a `#` symbol and do not contain spaces.


### PR DESCRIPTION
Fixes https://github.com/squidowl/halloy/issues/564.
WHOIS command now accepts optional server parameter. See: https://modern.ircdocs.horse/#whois-message.

I also re-did the command-list. I didn't like how we essentially had two of each, it was very error prone.