### PR TITLE
Characters Until Emojis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Added:
 
 Changed:
 - Clicking to insert a username will now use same suffixes specified for autocomplete
+- Emoji picker will only show once there are two characters after `:` (by default, configurable)
 
 # 2025.4 (2025-04-07)
 

--- a/book/src/configuration/buffer.md
+++ b/book/src/configuration/buffer.md
@@ -313,6 +313,20 @@ Automatically replace `:shortcode:` in text input with the corresponding emoji.
 auto_replace = true
 ```
 
+### `characters_to_trigger_picker`
+
+Minimum number of characters after `:` required for the emoji picker to show.
+E.g. `:D` will not show the emoji picker unless `characters_to_trigger_picker` is less than or equal to `1`.
+
+```toml
+# Type: integer
+# Values: any non-negative integer
+# Default: 2
+
+[buffer.emojis]
+characters_to_trigger_picker = 2
+```
+
 ## `[buffer.internal_messages]`
 
 Internal messages are messages sent from Halloy itself.

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -62,6 +62,8 @@ pub struct Emojis {
     pub skin_tone: SkinTone,
     #[serde(default = "default_bool_true")]
     pub auto_replace: bool,
+    #[serde(default = "default_characters_to_trigger_picker")]
+    pub characters_to_trigger_picker: usize,
 }
 
 impl Default for Emojis {
@@ -70,6 +72,8 @@ impl Default for Emojis {
             show_picker: default_bool_true(),
             skin_tone: SkinTone::default(),
             auto_replace: default_bool_true(),
+            characters_to_trigger_picker: default_characters_to_trigger_picker(
+            ),
         }
     }
 }
@@ -288,4 +292,8 @@ impl Buffer {
             )
         ))
     }
+}
+
+fn default_characters_to_trigger_picker() -> usize {
+    2
 }

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -1971,7 +1971,7 @@ impl Emojis {
     fn process(&mut self, last_word: &str, config: &Config) {
         let last_word = last_word.strip_prefix(":").unwrap_or("");
 
-        if last_word.is_empty() {
+        if last_word.len() < config.buffer.emojis.characters_to_trigger_picker {
             *self = Self::default();
             return;
         }


### PR DESCRIPTION
Adds a setting to control the number of characters until the emoji picker is shown.  Changes the previous default value from 1 to 2 to avoid showing the emoji picker for most emoticons.