### PR TITLE
Correctly wrap urls if they are too long

### DIFF
--- a/src/modal/prompt_before_open_url.rs
+++ b/src/modal/prompt_before_open_url.rs
@@ -1,6 +1,5 @@
 use iced::{
-    Length,
-    alignment::{self, Horizontal::Left},
+    Length, alignment,
     widget::{button, column, container, text, vertical_space},
 };
 

--- a/src/modal/prompt_before_open_url.rs
+++ b/src/modal/prompt_before_open_url.rs
@@ -1,5 +1,6 @@
 use iced::{
-    Length, alignment,
+    Length,
+    alignment::{self, Horizontal::Left},
     widget::{button, column, container, text, vertical_space},
 };
 
@@ -11,7 +12,10 @@ pub fn view(payload: &str) -> Element<Message> {
         column![
             column![
                 text("This hyperlink will take you to"),
-                text(payload).style(theme::text::url),
+                text(payload)
+                    .style(theme::text::url)
+                    .wrapping(text::Wrapping::Glyph)
+                    .width(Length::Shrink),
                 vertical_space().height(8),
                 text("Are you sure you want to go there?"),
             ]
@@ -25,7 +29,9 @@ pub fn view(payload: &str) -> Element<Message> {
                 )
                 .padding(5)
                 .width(Length::Fixed(250.0))
-                .style(|theme, status| theme::button::secondary(theme, status, false))
+                .style(|theme, status| theme::button::secondary(
+                    theme, status, false
+                ))
                 .on_press(Message::OpenURL(payload.to_string())),
                 button(
                     container(text("Close"))
@@ -34,7 +40,9 @@ pub fn view(payload: &str) -> Element<Message> {
                 )
                 .padding(5)
                 .width(Length::Fixed(250.0))
-                .style(|theme, status| theme::button::secondary(theme, status, false))
+                .style(|theme, status| theme::button::secondary(
+                    theme, status, false
+                ))
                 .on_press(Message::Cancel),
             ]
             .spacing(4),


### PR DESCRIPTION
There was a problem with my recent PR which adds URL prompt. If the URL was too long, it would clip the view.
This is now fixed with word breaking.

<img width="464" alt="Screenshot 2025-04-18 at 21 27 08" src="https://github.com/user-attachments/assets/984be417-a654-402a-a2f5-88fce678c700" />


