### PR TITLE
CTCP Tweaks

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -22,6 +22,7 @@
 - [Configuration](configuration/README.md)
   - [Actions](configuration/actions.md)
   - [Buffer](configuration/buffer.md)
+  - [CTCP](configuration/ctcp.md)
   - [File Transfer](configuration/file_transfer.md)
   - [Font](configuration/font.md)
   - [Highlights](configuration/highlights.md)

--- a/book/src/configuration/ctcp.md
+++ b/book/src/configuration/ctcp.md
@@ -1,0 +1,65 @@
+# `[ctcp]`
+
+[Client-to-Client Protocol](https://modern.ircdocs.horse/ctcp) response settings.
+
+**Example**
+
+```toml
+# Disable responses for TIME and VERSION responses
+
+[ctcp]
+time = false
+version = false
+```
+
+# `ping`
+
+Whether Halloy will respond to a [CTCP PING](https://modern.ircdocs.horse/ctcp#ping) message.
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: true
+
+[ctcp]
+ping = true
+```
+
+# `source`
+
+Whether Halloy will respond to a [CTCP TIME](https://modern.ircdocs.horse/ctcp#source) message.
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: true
+
+[ctcp]
+source = true
+```
+
+# `time`
+
+Whether Halloy will respond to a [CTCP TIME](https://modern.ircdocs.horse/ctcp#time) message.
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: true
+
+[ctcp]
+time = true
+```
+
+# `version`
+
+Whether Halloy will respond to a [CTCP VERSION](https://modern.ircdocs.horse/ctcp#version) message.
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: true
+
+[ctcp]
+version = true
+```

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1133,12 +1133,7 @@ impl Client {
                         let is_action = message::is_action(text);
 
                         // Ignore CTCP Action queries.
-                        if !is_action {
-                            // Ignore CTCP echo
-                            if is_echo {
-                                return Ok(vec![]);
-                            }
-
+                        if !is_action && !is_echo {
                             // Response to us sending a CTCP request to another client
                             if matches!(&message.command, Command::NOTICE(_, _))
                             {

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -10,6 +10,7 @@ use tokio_stream::wrappers::ReadDirStream;
 
 pub use self::actions::Actions;
 pub use self::buffer::Buffer;
+pub use self::ctcp::Ctcp;
 pub use self::file_transfer::FileTransfer;
 pub use self::highlights::Highlights;
 pub use self::keys::Keyboard;
@@ -28,6 +29,7 @@ use crate::{Theme, environment};
 
 pub mod actions;
 pub mod buffer;
+pub mod ctcp;
 pub mod file_transfer;
 pub mod highlights;
 pub mod keys;
@@ -58,6 +60,7 @@ pub struct Config {
     pub preview: Preview,
     pub highlights: Highlights,
     pub actions: Actions,
+    pub ctcp: Ctcp,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize)]
@@ -180,6 +183,8 @@ impl Config {
             pub highlights: Highlights,
             #[serde(default)]
             pub actions: Actions,
+            #[serde(default)]
+            pub ctcp: Ctcp,
         }
 
         let path = Self::path();
@@ -208,6 +213,7 @@ impl Config {
             pane,
             highlights,
             actions,
+            ctcp,
         } = toml::from_str(content.as_ref())
             .map_err(|e| Error::Parse(e.to_string()))?;
 
@@ -235,6 +241,7 @@ impl Config {
             pane,
             highlights,
             actions,
+            ctcp,
         })
     }
 

--- a/data/src/config/ctcp.rs
+++ b/data/src/config/ctcp.rs
@@ -1,0 +1,50 @@
+use serde::Deserialize;
+
+use crate::serde::default_bool_true;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Ctcp {
+    #[serde(default = "default_bool_true")]
+    pub ping: bool,
+    #[serde(default = "default_bool_true")]
+    pub source: bool,
+    #[serde(default = "default_bool_true")]
+    pub time: bool,
+    #[serde(default = "default_bool_true")]
+    pub version: bool,
+}
+
+impl Default for Ctcp {
+    fn default() -> Self {
+        Self {
+            ping: default_bool_true(),
+            source: default_bool_true(),
+            time: default_bool_true(),
+            version: default_bool_true(),
+        }
+    }
+}
+
+impl Ctcp {
+    pub fn client_info(&self) -> String {
+        let mut commands = vec!["ACTION", "CLIENTINFO", "DCC"];
+
+        if self.ping {
+            commands.push("PING");
+        }
+
+        if self.source {
+            commands.push("SOURCE");
+        }
+
+        if self.time {
+            commands.push("TIME");
+        }
+
+        if self.version {
+            commands.push("VERSION");
+        }
+
+        commands.join(" ")
+    }
+}

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -964,57 +964,11 @@ fn target(
                 source: Source::Action(None),
             })
         }
-        Command::PRIVMSG(target, text) => {
+        Command::PRIVMSG(target, text) | Command::NOTICE(target, text) => {
             let is_action = is_action(&text);
-            let source = |user| {
-                if is_action {
-                    Source::Action(Some(user))
-                } else {
-                    Source::User(user)
-                }
-            };
 
-            match (
-                target::Target::parse(
-                    &target,
-                    chantypes,
-                    statusmsg,
-                    casemapping,
-                ),
-                user,
-            ) {
-                (target::Target::Channel(channel), Some(user)) => {
-                    let source = source(
-                        resolve_attributes(&user, &channel).unwrap_or(user),
-                    );
-                    Some(Target::Channel { channel, source })
-                }
-                (target::Target::Query(query), Some(user)) => {
-                    let query = if user.nickname() == *our_nick {
-                        // Message from ourself, from another client.
-                        query
-                    } else {
-                        // Message from conversation partner.
-                        target::Query::parse(
-                            user.as_str(),
-                            chantypes,
-                            statusmsg,
-                            casemapping,
-                        )
-                        .ok()?
-                    };
-
-                    Some(Target::Query {
-                        query,
-                        source: source(user),
-                    })
-                }
-                _ => None,
-            }
-        }
-        Command::NOTICE(target, text) => {
             // CTCP Handling.
-            if ctcp::parse_query(&text).is_some() {
+            if ctcp::is_query(&text) && !is_action {
                 let user = user?;
                 let target = User::from(Nick::from(target));
 
@@ -1030,7 +984,6 @@ fn target(
                     source: Source::Server(None),
                 })
             } else {
-                let is_action = is_action(&text);
                 let source = |user| {
                     if is_action {
                         Source::Action(Some(user))
@@ -1056,10 +1009,10 @@ fn target(
                     }
                     (target::Target::Query(query), Some(user)) => {
                         let query = if user.nickname() == *our_nick {
-                            // Notice from ourself, from another client.
+                            // Message from ourself, from another client.
                             query
                         } else {
-                            // Notice from conversation partner.
+                            // Message from conversation partner.
                             target::Query::parse(
                                 user.as_str(),
                                 chantypes,
@@ -1074,9 +1027,7 @@ fn target(
                             source: source(user),
                         })
                     }
-                    _ => Some(Target::Server {
-                        source: Source::Server(None),
-                    }),
+                    _ => None,
                 }
             }
         }
@@ -1350,7 +1301,7 @@ fn content<'a>(
                     )
                 })
         }
-        Command::PRIVMSG(target, text) => {
+        Command::PRIVMSG(target, text) | Command::NOTICE(target, text) => {
             let channel_users = target::Channel::parse(
                 target,
                 chantypes,
@@ -1361,6 +1312,7 @@ fn content<'a>(
             .unwrap_or_default();
 
             // Check if a synthetic action message
+
             if let Some(nick) = message.user().as_ref().map(User::nickname) {
                 if let Some(action) = parse_action(
                     nick,
@@ -1374,34 +1326,23 @@ fn content<'a>(
                 }
             }
 
-            Some(parse_fragments_with_highlights(
-                text.clone(),
-                channel_users,
-                target,
-                Some(our_nick),
-                &config.highlights,
-            ))
-        }
-        Command::NOTICE(target, text) => {
             if let Some(query) = ctcp::parse_query(text) {
-                let command = query.command.as_ref();
-                let text = match &query.params {
-                    Some("") => "(empty)",
-                    Some(text) => text,
-                    None => return None, // Return if we don't have any params.
+                let arrow = if target == our_nick.as_ref() {
+                    "⟵"
+                } else {
+                    "⟶"
                 };
 
-                return Some(parse_fragments(format!("{command} {text}")));
-            }
+                let command = query.command.as_ref();
 
-            let channel_users = target::Channel::parse(
-                target,
-                chantypes,
-                statusmsg,
-                casemapping,
-            )
-            .map(|channel| channel_users(&channel))
-            .unwrap_or_default();
+                let text = if let Some(params) = query.params {
+                    [arrow, command, params].join(" ")
+                } else {
+                    [arrow, command].join(" ")
+                };
+
+                return Some(parse_fragments(text));
+            }
 
             Some(parse_fragments_with_highlights(
                 text.clone(),
@@ -1672,6 +1613,10 @@ fn parse_action(
     our_nick: Option<&Nick>,
     highlights: &Highlights,
 ) -> Option<Content> {
+    if !is_action(text) {
+        return None;
+    }
+
     let query = ctcp::parse_query(text)?;
 
     Some(action_text(

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -8,7 +8,7 @@ use data::user::User;
 use data::{Config, target};
 use iced::Length;
 use iced::widget::{column, container, row, text, tooltip};
-use itertools::Itertools;
+use itertools::{Either, Itertools};
 use strsim::jaro_winkler;
 
 use crate::theme;
@@ -214,10 +214,12 @@ impl Entry {
 
                 let mut new_input = words.join(" ");
 
-                // If next is not the original prompt, then append the configured suffix
+                // If next is not the original prompt, then append the
+                // configured suffix
                 if *append_suffix {
                     if words.len() == 1 && !is_channel {
-                        // If completed at the beginning of the input line and not a channel.
+                        // If completed at the beginning of the input line and
+                        // not a channel.
                         let suffix = &autocomplete.completion_suffixes[0];
                         new_input.push_str(suffix);
                     } else {
@@ -508,27 +510,36 @@ impl Commands {
                     *self = Self::Idle;
                 }
             }
-            // Command fully typed & already selected, check for subcommand if any exist
+            // Command fully typed & already selected, check for subcommand if
+            // any exist
             Self::Selected { command, .. } => {
                 if let Some(subcommands) = &command.subcommands {
-                    let subcmd =
-                        if let Some(index) = &rest[cmd.len() + 1..].find(' ') {
-                            &rest[0..cmd.len() + 1 + index]
-                        } else {
-                            rest
+                    if let Some(subcmd) = rest[cmd.len() + 1..]
+                        .split_ascii_whitespace()
+                        .nth(command.args.len() - 1)
+                    {
+                        let subcmd =
+                            (String::from(command.title) + " " + subcmd)
+                                .to_lowercase();
+
+                        let subcommand =
+                            subcommands.iter().find(|subcommand| {
+                                subcommand.title.to_lowercase() == subcmd
+                                    || subcommand.alias().iter().any(|alias| {
+                                        alias.to_lowercase() == subcmd
+                                    })
+                            });
+
+                        *self = Self::Selected {
+                            command: command.clone(),
+                            subcommand: subcommand.cloned(),
                         };
-
-                    let subcommand = subcommands.iter().find(|subcommand| {
-                        subcommand.title.to_lowercase() == subcmd.to_lowercase()
-                            || subcommand.alias().iter().any(|alias| {
-                                alias.to_lowercase() == subcmd.to_lowercase()
-                            })
-                    });
-
-                    *self = Self::Selected {
-                        command: command.clone(),
-                        subcommand: subcommand.cloned(),
-                    };
+                    } else {
+                        *self = Self::Selected {
+                            command: command.clone(),
+                            subcommand: None,
+                        };
+                    }
                 }
             }
         }
@@ -632,10 +643,7 @@ impl Commands {
                 subcommand,
             } => {
                 if config.buffer.commands.show_description {
-                    subcommand
-                        .as_ref()
-                        .map(|sub| sub.view(input))
-                        .or_else(|| Some(command.view(input)))
+                    Some(command.view(input, subcommand.as_ref()))
                 } else {
                     None
                 }
@@ -681,7 +689,22 @@ impl Command {
             "whois" => "Retrieve information about user(s)",
             "format" => "Format text using markdown or $ sequences",
             "ctcp" => "Send Client-To-Client requests",
-
+            "ctcp action" => "Display <text> as a third-person action or emote",
+            "ctcp clientinfo" => {
+                "Request a list of the CTCP messages <nick> supports"
+            }
+            "ctcp ping" => {
+                "Request a reply containing the same <info> that was sent"
+            }
+            "ctcp source" => {
+                "Request a URL where the source code for <nick>'s IRC client can be found"
+            }
+            "ctcp time" => {
+                "Request the <nick>'s local time in a human-readable format"
+            }
+            "ctcp version" => {
+                "Request the name and version of <nick>'s IRC client"
+            }
             _ => return None,
         })
     }
@@ -705,7 +728,11 @@ impl Command {
         }
     }
 
-    fn view<'a, Message: 'a>(&self, input: &str) -> Element<'a, Message> {
+    fn view<'a, Message: 'a>(
+        &self,
+        input: &str,
+        subcommand: Option<&Command>,
+    ) -> Element<'a, Message> {
         let command_prefix = format!("/{}", self.title.to_lowercase());
 
         let active_arg = [
@@ -720,11 +747,15 @@ impl Command {
         .split_ascii_whitespace()
         .count()
         .saturating_sub(2)
-        .min(self.args.len().saturating_sub(1));
+        .min(
+            (self.args.len()
+                + subcommand.map_or(0, |subcommand| subcommand.args.len()))
+            .saturating_sub(1),
+        );
 
         let title = Some(Element::from(text(self.title)));
 
-        let args = self.args.iter().enumerate().map(|(index, arg)| {
+        let arg_text = |index: usize, arg: &Arg| {
             let content = text(format!("{arg}")).style(move |theme| {
                 if index == active_arg {
                     theme::text::tertiary(theme)
@@ -766,13 +797,45 @@ impl Command {
             } else {
                 Element::from(row![text(" "), content])
             }
-        });
+        };
+
+        let args = if let Some(subcommand) = subcommand {
+            Either::Left(
+                self.args
+                    .iter()
+                    .take(self.args.len() - 1)
+                    .enumerate()
+                    .map(|(index, arg)| arg_text(index, arg))
+                    .chain(std::iter::once(Element::from(row![text(
+                        subcommand
+                            .title
+                            .strip_prefix(self.title)
+                            .unwrap_or_default()
+                    )])))
+                    .chain(subcommand.args.iter().enumerate().map(
+                        |(index, arg)| arg_text(self.args.len() + index, arg),
+                    )),
+            )
+        } else {
+            Either::Right(
+                self.args
+                    .iter()
+                    .enumerate()
+                    .map(|(index, arg)| arg_text(index, arg)),
+            )
+        };
 
         container(
             column![]
-                .push_maybe(self.description().map(|description| {
-                    text(description).style(theme::text::secondary)
-                }))
+                .push_maybe(
+                    subcommand
+                        .map_or(self.description(), |subcommand| {
+                            subcommand.description()
+                        })
+                        .map(|description| {
+                            text(description).style(theme::text::secondary)
+                        }),
+                )
                 .push(row(title.into_iter().chain(args))),
         )
         .style(theme::container::tooltip)
@@ -1152,19 +1215,73 @@ static COMMAND_LIST: LazyLock<Vec<Command>> = LazyLock::new(|| {
                     text: "command",
                     optional: false,
                     tooltip: Some(
-                        "ACTION CLIENTINFO PING SOURCE VERSION TIME"
-                            .to_string(),
+                        "    ACTION: Display <text> as a third-person action or emote\
+                       \nCLIENTINFO: Request a list of the CTCP messages <nick> supports\
+                       \n      PING: Request a reply containing the same <info> that was sent\
+                       \n    SOURCE: Request a URL where the source code for <nick>'s IRC client can be found\
+                       \n      TIME: Request the <nick>'s local time in a human-readable format\
+                       \n   VERSION: Request the name and version of <nick>'s IRC client".to_string(),
                     ),
                 },
-                Arg {
-                    text: "params",
-                    optional: true,
-                    tooltip: Some("Additional parameters".to_string()),
-                },
             ],
-            subcommands: None,
+            subcommands: Some(vec![
+                    CTCP_ACTION_COMMAND.clone(),
+                    CTCP_CLIENTINFO_COMMAND.clone(),
+                    CTCP_PING_COMMAND.clone(),
+                    CTCP_SOURCE_COMMAND.clone(),
+                    CTCP_TIME_COMMAND.clone(),
+                    CTCP_VERSION_COMMAND.clone()
+                ]),
         },
     ]
+});
+
+static CTCP_ACTION_COMMAND: LazyLock<Command> = LazyLock::new(|| Command {
+    title: "CTCP ACTION",
+    args: vec![Arg {
+        text: "text",
+        optional: false,
+        tooltip: Some(String::from(
+            "message to display as a third-person action or emote",
+        )),
+    }],
+    subcommands: None,
+});
+
+static CTCP_CLIENTINFO_COMMAND: LazyLock<Command> = LazyLock::new(|| Command {
+    title: "CTCP CLIENTINFO",
+    args: vec![],
+    subcommands: None,
+});
+
+static CTCP_PING_COMMAND: LazyLock<Command> = LazyLock::new(|| Command {
+    title: "CTCP PING",
+    args: vec![Arg {
+        text: "info",
+        optional: false,
+        tooltip: Some(String::from(
+            "text that should be exactly reproduced in the reply PING",
+        )),
+    }],
+    subcommands: None,
+});
+
+static CTCP_SOURCE_COMMAND: LazyLock<Command> = LazyLock::new(|| Command {
+    title: "CTCP SOURCE",
+    args: vec![],
+    subcommands: None,
+});
+
+static CTCP_TIME_COMMAND: LazyLock<Command> = LazyLock::new(|| Command {
+    title: "CTCP TIME",
+    args: vec![],
+    subcommands: None,
+});
+
+static CTCP_VERSION_COMMAND: LazyLock<Command> = LazyLock::new(|| Command {
+    title: "CTCP VERSION",
+    args: vec![],
+    subcommands: None,
 });
 
 fn isupport_parameter_to_command(

--- a/src/main.rs
+++ b/src/main.rs
@@ -562,6 +562,7 @@ impl Halloy {
                                 &server,
                                 message,
                                 &self.config.actions,
+                                &self.config.ctcp,
                             ) {
                                 Ok(events) => events,
                                 Err(e) => {


### PR DESCRIPTION
Three tweaks/additions to the CTCP functionality added in #922:

- Expand the tooltip information for CTCP requests.  Required reworking completion logic a bit to allow subcommands to be the second or later argument in a command.
- Adds configuration options to disable the `PING`, `SOURCE`, `TIME`, and `VERSION` automated responses.  `TIME` in particular is the one I wanted to add a configuration option for, just added the other three since they were straightforward to implement.
- Shows all sent CTCP requests.  In my testing not all targets' clients would respond, and when they didn't respond it wasn't clear if the request had been sent or not.  Added some styling to indicate whether a CTCP message is outgoing or incoming.  Completely open to changing the styling.