### PR TITLE
Autocomplete by Last Seen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Added:
 Changed:
 - Clicking to insert a username will now use same suffixes specified for autocomplete
 - Emoji picker will only show once there are two characters after `:` (by default, configurable)
+- Autocomplete will match users based on how recently they were seen in the channel (by default, configurable)
 
 # 2025.4 (2025-04-07)
 

--- a/book/src/configuration/buffer.md
+++ b/book/src/configuration/buffer.md
@@ -658,9 +658,28 @@ auto_format = "markdown"
 
 Customize autocomplete.
 
+#### `order_by`
+
+Ordering that autocomplete uses to select from matching users.
+
+- `"recent"`: Autocomplete users by their last message in the channel;  the user with most recent message autocompletes first, then increasingly older messages.  Users with no seen messages are matched last, in the order specified by `sort_direction`.
+- `"alpha"`: Autocomplete users based on alphabetical ordering of potential matches.  Ordering is asecnding/descinding based on `sort_direction`.
+
+```toml
+# Type: string
+# Values: "alpha", "recent"
+# Default: "recent"
+
+[buffer.text_input.autocomplete]
+order_by = "recent"
+```
+
 #### `sort_direction`
 
-Sort direction when autocompleting.
+Sort direction when autocompleting alphabetically.
+
+- `"asc"`: ascending alphabetical (a→z)
+- `"desc"`: descending alphabetical (z→a)
 
 ```toml
 # Type: string
@@ -682,19 +701,6 @@ Sets what suffix is added after autocompleting. The first option is for when a n
 
 [buffer.text_input.autocomplete]
 completion_suffixes = [": ", " "]
-```
-
-#### `order_by_recency`
-
-Autocomplete users by their last message in the channel;  the user with most recent message autocompletes first, then increasing older messages.  Users with no seen messages are matched last, in the order specified by `sort_direction`.
-
-```toml
-# Type: bool
-# Values: true, false
-# Default: true
-
-[buffer.text_input.autocomplete]
-order_by_recency = true
 ```
 
 ## `[buffer.timestamp]`

--- a/book/src/configuration/buffer.md
+++ b/book/src/configuration/buffer.md
@@ -684,6 +684,19 @@ Sets what suffix is added after autocompleting. The first option is for when a n
 completion_suffixes = [": ", " "]
 ```
 
+#### `order_by_recency`
+
+Autocomplete users by their last message in the channel;  the user with most recent message autocompletes first, then increasing older messages.  Users with no seen messages are matched last, in the order specified by `sort_direction`.
+
+```toml
+# Type: bool
+# Values: true, false
+# Default: true
+
+[buffer.text_input.autocomplete]
+order_by_recency = true
+```
+
 ## `[buffer.timestamp]`
 
 Customize how timestamps are displayed within a buffer.

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -171,6 +171,8 @@ pub struct Autocomplete {
     pub sort_direction: SortDirection,
     #[serde(default = "default_completion_suffixes")]
     pub completion_suffixes: [String; 2],
+    #[serde(default = "default_bool_true")]
+    pub order_by_recency: bool,
 }
 
 impl Default for Autocomplete {
@@ -178,6 +180,7 @@ impl Default for Autocomplete {
         Self {
             sort_direction: SortDirection::default(),
             completion_suffixes: default_completion_suffixes(),
+            order_by_recency: default_bool_true(),
         }
     }
 }

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -159,6 +159,14 @@ pub struct TextInput {
 
 #[derive(Debug, Clone, Copy, Default, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+pub enum OrderBy {
+    Alpha,
+    #[default]
+    Recent,
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum SortDirection {
     #[default]
     Asc,
@@ -168,19 +176,19 @@ pub enum SortDirection {
 #[derive(Debug, Clone, Deserialize)]
 pub struct Autocomplete {
     #[serde(default)]
+    pub order_by: OrderBy,
+    #[serde(default)]
     pub sort_direction: SortDirection,
     #[serde(default = "default_completion_suffixes")]
     pub completion_suffixes: [String; 2],
-    #[serde(default = "default_bool_true")]
-    pub order_by_recency: bool,
 }
 
 impl Default for Autocomplete {
     fn default() -> Self {
         Self {
+            order_by: OrderBy::default(),
             sort_direction: SortDirection::default(),
             completion_suffixes: default_completion_suffixes(),
-            order_by_recency: default_bool_true(),
         }
     }
 }

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -151,8 +151,14 @@ impl State {
                 let channels = clients.get_channels(buffer.server());
                 let isupport = clients.get_isupport(buffer.server());
 
-                self.completion
-                    .process(&input, users, channels, &isupport, config);
+                self.completion.process(
+                    &input,
+                    users,
+                    &history.get_last_seen(buffer),
+                    channels,
+                    &isupport,
+                    config,
+                );
 
                 let input =
                     self.completion.complete_emoji(&input).unwrap_or(input);
@@ -376,7 +382,12 @@ impl State {
                     let isupport = clients.get_isupport(buffer.server());
 
                     self.completion.process(
-                        &new_input, users, channels, &isupport, config,
+                        &new_input,
+                        users,
+                        &history.get_last_seen(buffer),
+                        channels,
+                        &isupport,
+                        config,
                     );
 
                     return self.on_completion(buffer, history, new_input);
@@ -413,7 +424,12 @@ impl State {
                         let isupport = clients.get_isupport(buffer.server());
 
                         self.completion.process(
-                            &new_input, users, channels, &isupport, config,
+                            &new_input,
+                            users,
+                            &history.get_last_seen(buffer),
+                            channels,
+                            &isupport,
+                            config,
                         );
                         new_input
                     };

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::sync::LazyLock;
 
 use chrono::{DateTime, Utc};
-use data::buffer::{SkinTone, SortDirection};
+use data::buffer::{OrderBy, SkinTone, SortDirection};
 use data::isupport::{self, find_target_limit};
 use data::user::{Nick, User};
 use data::{Config, target};
@@ -1010,7 +1010,7 @@ impl Text {
         self.filtered = users
             .iter()
             .sorted_by(|a, b| {
-                if autocomplete.order_by_recency {
+                if matches!(autocomplete.order_by, OrderBy::Recent) {
                     if let Some(a_last_seen) =
                         last_seen.get(&a.nickname().to_owned())
                     {


### PR DESCRIPTION
Adds `order_by_recency` setting (`true` by default) that makes autocomplete match users based first on how recently they were last seen in the channel (first, then alphabetically ascending/descending based on `sort_direction` for users that have not been seen in the channel).

Also changes matching to use server normalization (rather than Unicode case insensitivity).