### PR TITLE
Setting to Mark as Read when Sending a Message

### DIFF
--- a/book/src/configuration/buffer.md
+++ b/book/src/configuration/buffer.md
@@ -434,6 +434,19 @@ When scrolling to the bottom of a buffer.
 on_scroll_to_bottom = true
 ```
 
+### `on_message_sent`
+
+When sending a message to the buffer.
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: true
+
+[buffer.mark_as_read]
+on_message_sent = true
+```
+
 ## `[buffer.nickname]`
 
 Customize how nicknames are displayed within a buffer.

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -2392,19 +2392,16 @@ impl Client {
         Ok(vec![Event::Single(message, self.nickname().to_owned())])
     }
 
-    pub fn send_markread(
-        &mut self,
-        target: Target,
-        read_marker: ReadMarker,
-    ) -> Result<()> {
+    pub fn send_markread(&mut self, target: Target, read_marker: ReadMarker) {
         if self.supports_read_marker {
-            self.handle.try_send(command!(
+            if let Err(e) = self.handle.try_send(command!(
                 "MARKREAD",
                 target.as_str().to_string(),
                 format!("timestamp={read_marker}"),
-            ))?;
+            )) {
+                log::warn!("Error sending markread: {e}");
+            }
         }
-        Ok(())
     }
 
     fn user_who_request(&self, channel: &target::Channel) -> bool {
@@ -3101,11 +3098,10 @@ impl Map {
         server: &Server,
         target: Target,
         read_marker: ReadMarker,
-    ) -> Result<()> {
+    ) {
         if let Some(client) = self.client_mut(server) {
-            client.send_markread(target, read_marker)?;
+            client.send_markread(target, read_marker);
         }
-        Ok(())
     }
 
     pub fn join(&mut self, server: &Server, channels: &[target::Channel]) {

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -92,6 +92,8 @@ pub struct MarkAsRead {
     pub on_buffer_close: bool,
     #[serde(default = "default_bool_true")]
     pub on_scroll_to_bottom: bool,
+    #[serde(default = "default_bool_true")]
+    pub on_message_sent: bool,
 }
 
 impl Default for MarkAsRead {
@@ -100,6 +102,7 @@ impl Default for MarkAsRead {
             on_application_exit: bool::default(),
             on_buffer_close: default_bool_true(),
             on_scroll_to_bottom: default_bool_true(),
+            on_message_sent: default_bool_true(),
         }
     }
 }

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -52,12 +52,14 @@ pub enum Message {
             Result<Option<history::ReadMarker>, history::Error>,
         )>,
     ),
+    SentMessageUpdated(history::Kind, history::ReadMarker),
 }
 
 pub enum Event {
     Loaded(history::Kind),
     Closed(history::Kind, Option<history::ReadMarker>),
     Exited(Vec<(history::Kind, Option<history::ReadMarker>)>),
+    SentMessageUpdated(history::Kind, history::ReadMarker),
 }
 
 #[derive(Debug, Default)]
@@ -162,6 +164,9 @@ impl Manager {
 
                 return Some(Event::Exited(output));
             }
+            Message::SentMessageUpdated(kind, read_marker) => {
+                return Some(Event::SentMessageUpdated(kind, read_marker));
+            }
         }
 
         None
@@ -216,8 +221,12 @@ impl Manager {
         statusmsg: &[char],
         casemapping: isupport::CaseMap,
         config: &Config,
-    ) -> Vec<impl Future<Output = Message> + use<>> {
-        let mut tasks = vec![];
+    ) -> (
+        Vec<impl Future<Output = Message> + use<>>,
+        Vec<impl Future<Output = Message> + use<>>,
+    ) {
+        let mut record_message_tasks = vec![];
+        let mut update_read_marker_tasks = vec![];
 
         if let Some(messages) = input.messages(
             user,
@@ -228,11 +237,28 @@ impl Manager {
             config,
         ) {
             for message in messages {
-                tasks.extend(self.record_message(input.server(), message));
+                if config.buffer.mark_as_read.on_message_sent {
+                    if let Some(kind) = history::Kind::from_server_message(
+                        input.server().clone(),
+                        &message,
+                    ) {
+                        update_read_marker_tasks.extend(
+                            self.update_read_marker(
+                                kind,
+                                history::ReadMarker::from_date_time(
+                                    message.server_time,
+                                ),
+                            ),
+                        );
+                    }
+                }
+
+                record_message_tasks
+                    .extend(self.record_message(input.server(), message));
             }
         }
 
-        tasks
+        (record_message_tasks, update_read_marker_tasks)
     }
 
     pub fn record_input_history(
@@ -827,12 +853,17 @@ impl Data {
 
         match self.map.entry(kind.clone()) {
             hash_map::Entry::Occupied(mut entry) => {
-                entry.get_mut().add_message(message);
+                let read_marker = entry.get_mut().add_message(message);
 
-                None
+                read_marker.map(|read_marker| {
+                    async move {
+                        Message::SentMessageUpdated(kind.clone(), read_marker)
+                    }
+                    .boxed()
+                })
             }
             hash_map::Entry::Vacant(entry) => {
-                entry
+                let _ = entry
                     .insert(History::partial(kind.clone()))
                     .add_message(message);
 

--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -128,6 +128,34 @@ impl Input {
         }
     }
 
+    pub fn targets(
+        &self,
+        chantypes: &[char],
+        statusmsg: &[char],
+        casemapping: isupport::CaseMap,
+    ) -> Option<Vec<Target>> {
+        let command = self.content.command(&self.buffer)?;
+
+        match command {
+            command::Irc::Msg(targets, _)
+            | command::Irc::Notice(targets, _) => Some(
+                targets
+                    .split(',')
+                    .map(|target| {
+                        Target::parse(target, chantypes, statusmsg, casemapping)
+                    })
+                    .collect(),
+            ),
+            command::Irc::Me(target, _) => Some(vec![Target::parse(
+                &target,
+                chantypes,
+                statusmsg,
+                casemapping,
+            )]),
+            _ => None,
+        }
+    }
+
     pub fn encoded(&self) -> Option<message::Encoded> {
         self.content.proto(&self.buffer).map(message::Encoded::from)
     }

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -1,7 +1,6 @@
-use data::buffer::{self, Autocomplete};
 use std::time::Duration;
 
-use data::buffer::Upstream;
+use data::buffer::{self, Autocomplete, Upstream};
 use data::dashboard::BufferAction;
 use data::history::{self, ReadMarker};
 use data::input::{self, Cache, Draft};
@@ -472,26 +471,19 @@ impl State {
                             }
                         }
 
-                        let (record_message_tasks, update_read_marker_tasks) =
-                            history.record_input_message(
-                                input,
-                                user,
-                                channel_users,
-                                chantypes,
-                                statusmsg,
-                                casemapping,
-                                config,
-                            );
-
                         history_task = Task::batch(
-                            record_message_tasks
+                            history
+                                .record_input_message(
+                                    input,
+                                    user,
+                                    channel_users,
+                                    chantypes,
+                                    statusmsg,
+                                    casemapping,
+                                    config,
+                                )
                                 .into_iter()
-                                .map(Task::future)
-                                .chain(
-                                    update_read_marker_tasks
-                                        .into_iter()
-                                        .map(Task::future),
-                                ),
+                                .map(Task::future),
                         );
                     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -636,7 +636,10 @@ impl Halloy {
                                         ) {
                                             commands.push(
                                                 dashboard
-                                                    .record_message(&server, message)
+                                                    .record_message(
+                                                        &server,
+                                                        message,
+                                                    )
                                                     .map(Message::Dashboard),
                                             );
                                         }
@@ -676,7 +679,10 @@ impl Halloy {
 
                                             commands.push(
                                                 dashboard
-                                                    .record_message(&server, message)
+                                                    .record_message(
+                                                        &server,
+                                                        message,
+                                                    )
                                                     .map(Message::Dashboard),
                                             );
                                         }


### PR DESCRIPTION
Adds an option to mark a buffer as read when sending a message.  Required a bit more plumbing than I was hoping for, but seems to work in my testing.