### PR TITLE
Attempt to Parse Invalid UTF-8

### DIFF
--- a/irc/proto/src/parse.rs
+++ b/irc/proto/src/parse.rs
@@ -259,7 +259,7 @@ mod test {
     fn message() {
         let tests = [
             (
-                ":irc.example.com CAP LS * :multi-prefix extended-join sasl\r\n",
+                Vec::from(b":irc.example.com CAP LS * :multi-prefix extended-join sasl\r\n"),
                 Message {
                     tags: vec![],
                     source: Some(Source::Server("irc.example.com".to_string())),
@@ -272,7 +272,7 @@ mod test {
                 },
             ),
             (
-                "@id=234AB :dan!d@localhost PRIVMSG #chan :Hey what's up! \r\n",
+                Vec::from(b"@id=234AB :dan!d@localhost PRIVMSG #chan :Hey what's up! \r\n"),
                 Message {
                     tags: vec![Tag {
                         key: "id".to_string(),
@@ -290,7 +290,7 @@ mod test {
                 },
             ),
             (
-                "CAP REQ :sasl\r\n",
+                Vec::from(b"CAP REQ :sasl\r\n"),
                 Message {
                     tags: vec![],
                     source: None,
@@ -303,7 +303,7 @@ mod test {
                 },
             ),
             (
-                "@tag=as\\\\\\:\\sdf\\z\\ UNKNOWN\r\n",
+                Vec::from(b"@tag=as\\\\\\:\\sdf\\z\\ UNKNOWN\r\n"),
                 Message {
                     tags: vec![Tag {
                         key: "tag".to_string(),
@@ -314,7 +314,7 @@ mod test {
                 },
             ),
             (
-                "@+1.1.1.1/wi2-asef-1=as\\\\\\:\\sdf\\z\\ UNKNOWN\r\n",
+                Vec::from(b"@+1.1.1.1/wi2-asef-1=as\\\\\\:\\sdf\\z\\ UNKNOWN\r\n"),
                 Message {
                     tags: vec![Tag {
                         key: "+1.1.1.1/wi2-asef-1".to_string(),
@@ -325,7 +325,7 @@ mod test {
                 },
             ),
             (
-                ":test!test@5555:5555:0:55:5555:5555:5555:5555 396 test user/test :is now your visible host\r\n",
+                Vec::from(b":test!test@5555:5555:0:55:5555:5555:5555:5555 396 test user/test :is now your visible host\r\n"),
                 Message {
                     tags: vec![],
                     source: Some(Source::User(User {
@@ -346,7 +346,7 @@ mod test {
                 },
             ),
             (
-                ":atw.hu.quakenet.org 001 test :Welcome to the QuakeNet IRC Network, test\r\n",
+                Vec::from(b":atw.hu.quakenet.org 001 test :Welcome to the QuakeNet IRC Network, test\r\n"),
                 Message {
                     tags: vec![],
                     source: Some(Source::Server(
@@ -363,7 +363,7 @@ mod test {
                 },
             ),
             (
-                "@time=2023-07-20T21:19:11.000Z :chat!test@user/test/bot/chat PRIVMSG ##chat :\\_o< quack!\r\n",
+                Vec::from(b"@time=2023-07-20T21:19:11.000Z :chat!test@user/test/bot/chat PRIVMSG ##chat :\\_o< quack!\r\n"),
                 Message {
                     tags: vec![Tag {
                         key: "time".to_string(),
@@ -382,7 +382,7 @@ mod test {
             ),
             // Extra \r sent by digitalirc
             (
-                "@batch=JQlhpjWY7SYaBPQtXAfUQh;msgid=UGnor4DBoafs6ge0UgsHF7-aVdnYMbjbdTf9eEHQmPKWA;time=2024-11-07T12:04:28.361Z :foo!~foo@F3FF3610.5A633F24.29800D3F.IP JOIN #pixelcove * :foo\r\r\n",
+                Vec::from(b"@batch=JQlhpjWY7SYaBPQtXAfUQh;msgid=UGnor4DBoafs6ge0UgsHF7-aVdnYMbjbdTf9eEHQmPKWA;time=2024-11-07T12:04:28.361Z :foo!~foo@F3FF3610.5A633F24.29800D3F.IP JOIN #pixelcove * :foo\r\r\n"),
                 Message {
                     tags: vec![
                         Tag {
@@ -414,7 +414,7 @@ mod test {
             ),
             // Space between message and crlf sent by DejaToons
             (
-                "@batch=AhaatzFmHPzct87cyiyxk4;time=2025-01-15T22:54:02.123Z;msgid=pgON6bxXjG7unoKIYwC3aV-KPRYjZhmCa3ZReibvMIrgw :atarians.dejatoons.net MODE #test +nt \r\n",
+                Vec::from(b"@batch=AhaatzFmHPzct87cyiyxk4;time=2025-01-15T22:54:02.123Z;msgid=pgON6bxXjG7unoKIYwC3aV-KPRYjZhmCa3ZReibvMIrgw :atarians.dejatoons.net MODE #test +nt \r\n"),
                 Message {
                     tags: vec![
                         Tag {
@@ -444,7 +444,7 @@ mod test {
                 },
             ),
             (
-                ":soju.bouncer FAIL * ACCOUNT_REQUIRED :Authentication required\r\n",
+                Vec::from(b":soju.bouncer FAIL * ACCOUNT_REQUIRED :Authentication required\r\n"),
                 Message {
                     tags: vec![],
                     source: Some(Source::Server("soju.bouncer".to_string())),
@@ -456,10 +456,43 @@ mod test {
                     ),
                 },
             ),
+            (
+                Vec::from(b"@id=invalid\x80utf8 :dan!d@localhost PRIVMSG #chan :Hello \xF0\x90\x80World\r\n"),
+                Message {
+                    tags: vec![Tag {
+                        key: "id".to_string(),
+                        value: Some("invalid�utf8".to_string()),
+                    }],
+                    source: Some(Source::User(User {
+                        nickname: "dan".into(),
+                        username: Some("d".into()),
+                        hostname: Some("localhost".into()),
+                    })),
+                    command: Command::PRIVMSG(
+                        "#chan".to_string(),
+                        "Hello �World".to_string(),
+                    ),
+                },
+            ),
+            (
+                Vec::from(b":dan!d@localhost PART #halloy :My utf8 is br\xF4\x91\x87ken\r\n"),
+                Message {
+                    tags: vec![],
+                    source: Some(Source::User(User {
+                        nickname: "dan".into(),
+                        username: Some("d".into()),
+                        hostname: Some("localhost".into()),
+                    })),
+                    command: Command::PART(
+                        "#halloy".to_string(),
+                        Some("My utf8 is br���ken".to_string()),
+                    ),
+                },
+            ),
         ];
 
         for (test, expected) in tests {
-            let message = super::message(test).unwrap();
+            let message = super::message_bytes(test).unwrap();
             assert_eq!(message, expected);
         }
     }

--- a/irc/proto/src/parse.rs
+++ b/irc/proto/src/parse.rs
@@ -1,5 +1,3 @@
-use std::string::FromUtf8Error;
-
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::{alpha1, char, crlf, none_of, one_of, satisfy};
@@ -13,7 +11,7 @@ use nom::{Finish, IResult};
 use crate::{Command, Message, Source, Tag, User};
 
 pub fn message_bytes(bytes: Vec<u8>) -> Result<Message, Error> {
-    let input = String::from_utf8(bytes)?;
+    let input = String::from_utf8_lossy(&bytes);
     message(&input)
 }
 
@@ -180,8 +178,6 @@ fn user(input: &str) -> IResult<&str, User> {
 pub enum Error {
     #[error("parsing failed: {:?}", input)]
     Parse { input: String, nom: String },
-    #[error("invalid utf-8 encoding")]
-    InvalidUtf8(#[from] FromUtf8Error),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Minor change to still attempt to parse a message even if it's invalid utf-8 via `String::from_utf8_lossy`.  That way there's a chance the message could make it in front of the user, even if malformed, rather than only being present in the logs where it may go unnoticed.