### PR TITLE
Fix for Panic in Message Parsing

### DIFF
--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -13,7 +13,7 @@ use itertools::{Either, Itertools};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-pub use self::formatting::Formatting;
+pub use self::formatting::{Color, Formatting};
 pub use self::source::Source;
 pub use self::source::server::{Kind, StandardReply};
 use crate::config::Highlights;
@@ -1878,20 +1878,20 @@ mod tests {
             assert_eq!(Content::Fragments(expected), actual);
         }
     }
+
     #[test]
     fn fragment_highlight_parsing() {
-        let nick = Nick::from("Bob");
         let tests = [
             (
                 (
                     "Bob: I'm in #interesting with Greg. I hope Dave doesn't notice.".to_string(),
-                    &[
+                    &Vec::from([
                         User::try_from("Greg").unwrap(),
                         User::try_from("Dave").unwrap(),
                         User::try_from("Bob").unwrap(),
-                    ],
+                    ]),
                     "#interesting",
-                    Some(&nick),
+                    Some(Nick::from("Bob")),
                     &Highlights {
                         nickname: Nickname {exclude: vec![], include: vec!["#interesting".into()]},
                         matches: vec![],
@@ -1908,6 +1908,24 @@ mod tests {
                     Fragment::Text(" doesn't notice.".into()),
                 ],
             ),
+            (
+                (
+                    "\u{3}14<\u{3}\u{3}04lurk_\u{3}\u{3}14/rx>\u{3} f_~oftc: > A��\u{1f}qj\u{14}��L�5�g���5�P��yn_?�i3g�1\u{7f}mE�\\X��� Xe�\u{5fa}{d�+�`@�^��NK��~~ޏ\u{7}\u{8}\u{15}\\�\u{4}A� \u{f}\u{1c}�N\u{11}6�r�\u{4}t��Q��\u{1c}�m\u{19}��".to_string(),
+                    &Vec::from([
+                        User::try_from("f_").unwrap(),
+                        User::try_from("rx").unwrap(),
+                    ]),
+                    "#funderscore-sucks",
+                    Some(Nick::from("f_")),
+                    &Highlights {
+                        nickname: Nickname {exclude: vec![], include: vec!["*".into()]},
+                        matches: vec![],
+                    },
+                ),
+                vec![
+                    Fragment::Formatted{ text: "hmm".into(), formatting: Formatting { fg: Some(Color::Grey), ..Formatting::default() }},
+                ],
+            ),
         ];
         for ((text, channel_users, target, our_nick, highlights), expected) in
             tests
@@ -1916,7 +1934,7 @@ mod tests {
                 text,
                 channel_users,
                 target,
-                our_nick,
+                our_nick.as_ref(),
                 highlights,
             ) {
                 assert_eq!(expected, actual);

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -699,6 +699,10 @@ fn parse_fragments_inner<'a>(
             if let Some(fragments) =
                 formatting::parse(text, &mut modifiers, &mut fg, &mut bg)
             {
+                if fragments.is_empty() {
+                    return Either::Right(Either::Left(iter::empty()));
+                }
+
                 if fragments.iter().any(|fragment| {
                     matches!(fragment, formatting::Fragment::Formatted(_, _))
                 }) {
@@ -722,8 +726,12 @@ fn parse_fragments_inner<'a>(
                         Fragment::Text(text),
                     )));
                 }
-            } else {
+            } else if text.is_empty() {
                 return Either::Right(Either::Left(iter::empty()));
+            } else {
+                return Either::Right(Either::Right(iter::once(
+                    Fragment::Text(text.clone()),
+                )));
             }
         }
 
@@ -1923,7 +1931,9 @@ mod tests {
                     },
                 ),
                 vec![
-                    Fragment::Formatted{ text: "hmm".into(), formatting: Formatting { fg: Some(Color::Grey), ..Formatting::default() }},
+                    Fragment::Text("\u{3}14<\u{3}\u{3}04lurk_\u{3}\u{3}14/rx>\u{3} ".into()),
+                    Fragment::HighlightNick(User::try_from("f_").unwrap(), "f_".into()),
+                    Fragment::Text("~oftc: > A��\u{1f}qj\u{14}��L�5�g���5�P��yn_?�i3g�1\u{7f}mE�\\X��� Xe�\u{5fa}{d�+�`@�^��NK��~~ޏ\u{7}\u{8}\u{15}\\�\u{4}A� \u{f}\u{1c}�N\u{11}6�r�\u{4}t��Q��\u{1c}�m\u{19}��".into())
                 ],
             ),
         ];

--- a/data/src/message/formatting.rs
+++ b/data/src/message/formatting.rs
@@ -89,14 +89,26 @@ pub fn parse(
                     if let Some(c) = iter.peeking_next(char::is_ascii_hexdigit)
                     {
                         // 6 digits (hex)
-                        let mut hex = c.to_string();
+                        let mut hex = Vec::from([c]);
                         for _ in 0..5 {
                             hex.push(iter.next()?);
                         }
 
-                        let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
-                        let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
-                        let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+                        let r = u8::from_str_radix(
+                            &hex.iter().take(2).collect::<String>(),
+                            16,
+                        )
+                        .ok()?;
+                        let g = u8::from_str_radix(
+                            &hex.iter().skip(2).take(2).collect::<String>(),
+                            16,
+                        )
+                        .ok()?;
+                        let b = u8::from_str_radix(
+                            &hex.iter().skip(4).take(2).collect::<String>(),
+                            16,
+                        )
+                        .ok()?;
 
                         *fg = Some(Color::Rgb(r, g, b));
 
@@ -106,17 +118,32 @@ pub fn parse(
                                 iter.peeking_next(char::is_ascii_hexdigit)
                             {
                                 // 6 digits (hex)
-                                let mut hex = c.to_string();
+                                let mut hex = Vec::from([c]);
                                 for _ in 0..5 {
                                     hex.push(iter.next()?);
                                 }
 
-                                let r =
-                                    u8::from_str_radix(&hex[0..2], 16).ok()?;
-                                let g =
-                                    u8::from_str_radix(&hex[2..4], 16).ok()?;
-                                let b =
-                                    u8::from_str_radix(&hex[4..6], 16).ok()?;
+                                let r = u8::from_str_radix(
+                                    &hex.iter().take(2).collect::<String>(),
+                                    16,
+                                )
+                                .ok()?;
+                                let g = u8::from_str_radix(
+                                    &hex.iter()
+                                        .skip(2)
+                                        .take(2)
+                                        .collect::<String>(),
+                                    16,
+                                )
+                                .ok()?;
+                                let b = u8::from_str_radix(
+                                    &hex.iter()
+                                        .skip(4)
+                                        .take(2)
+                                        .collect::<String>(),
+                                    16,
+                                )
+                                .ok()?;
 
                                 *bg = Some(Color::Rgb(r, g, b));
                             }
@@ -156,11 +183,9 @@ pub fn parse(
         }
     }
 
-    if fragments.is_empty() {
-        None
-    } else {
-        Some(fragments)
-    }
+    // Only return None if parsing failed; return an empty fragments if there
+    // are no non-formatting characters after parsing
+    Some(fragments)
 }
 
 #[derive(


### PR DESCRIPTION
Avoids a potential panic caused by slicing on `u8` indices instead of character indices.  The offending string has been added to the parsing test cases.  Originally implemented using `str::char_indices`, but I think this is cleaner.