### PR TITLE
Settings to Only Read First Line of Password Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Added:
 - Title bar button and keyboard shortcut to mark a buffer as read (will update the read marker as well, if the `read-marker` capability is available)
 - Mark as Read settings to control when buffers are automatically marked as read
 - `/hop` command. `/hop` parts the current channel and joins a new one
+- Settings to limit passwords read from a file to the first line of the file only (on by default)
 
 Changed:
 - Clicking to insert a username will now use same suffixes specified for autocomplete

--- a/book/src/configuration/servers.md
+++ b/book/src/configuration/servers.md
@@ -39,7 +39,7 @@ nick_password = ""
 
 ## `nick_password_file`
 
-Read nick_password from the file at the given path.[^1] [^2]
+Read `nick_password` from the file at the given path.[^1] [^2]
 
 ```toml
 # Type: string
@@ -48,6 +48,19 @@ Read nick_password from the file at the given path.[^1] [^2]
 
 [servers.<name>]
 nick_password_file = ""
+```
+
+## `nick_password_file_first_line_only`
+
+Read `nick_password` from the first line of `nick_password_file` only.
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: true
+
+[servers.<name>]
+nick_password_file_first_line_only = true
 ```
 
 ## `nick_password_command`
@@ -166,6 +179,19 @@ Read password from the file at the given path.[^1] [^2]
 
 [servers.<name>]
 password_file = ""
+```
+
+## `password_file_first_line_only`
+
+Read `password` from the first line of `password_file` only.
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: true
+
+[servers.<name>]
+password_file_first_line_only = true
 ```
 
 ## `password_command`
@@ -433,6 +459,19 @@ Read `password` from the file at the given path.[^1] [^2]
 
 [servers.<name>.sasl.plain]
 password_file = ""
+```
+
+## `password_file_first_line_only`
+
+Read `password` from the first line of `password_file` only.
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: true
+
+[servers.<name>]
+password_file_first_line_only = true
 ```
 
 ### `password_command`

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -6,6 +6,7 @@ use irc::connection;
 use serde::{Deserialize, Deserializer};
 
 use crate::config;
+use crate::serde::default_bool_true;
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct Server {
@@ -15,6 +16,9 @@ pub struct Server {
     pub nick_password: Option<String>,
     /// The client's NICKSERV password file.
     pub nick_password_file: Option<String>,
+    /// Truncate read from NICKSERV password file to first newline
+    #[serde(default = "default_bool_true")]
+    pub nick_password_file_first_line_only: bool,
     /// The client's NICKSERV password command.
     pub nick_password_command: Option<String>,
     /// The server's NICKSERV IDENTIFY syntax.
@@ -35,6 +39,9 @@ pub struct Server {
     pub password: Option<String>,
     /// The file with the password to connect to the server.
     pub password_file: Option<String>,
+    /// Truncate read from password file to first newline
+    #[serde(default = "default_bool_true")]
+    pub password_file_first_line_only: bool,
     /// The command which outputs a password to connect to the server.
     pub password_command: Option<String>,
     /// A list of channels to join on connection.
@@ -153,6 +160,7 @@ impl Default for Server {
             nickname: String::default(),
             nick_password: Option::default(),
             nick_password_file: Option::default(),
+            nick_password_file_first_line_only: default_bool_true(),
             nick_password_command: Option::default(),
             nick_identify_syntax: Option::default(),
             alt_nicks: Vec::default(),
@@ -162,6 +170,7 @@ impl Default for Server {
             port: default_tls_port(),
             password: Option::default(),
             password_file: Option::default(),
+            password_file_first_line_only: default_bool_true(),
             password_command: Option::default(),
             channels: Vec::default(),
             channel_keys: HashMap::default(),
@@ -201,6 +210,8 @@ pub enum Sasl {
         password: Option<String>,
         /// Account password file
         password_file: Option<String>,
+        /// Truncate read from password file to first newline
+        password_file_first_line_only: Option<bool>,
         /// Account password command
         password_command: Option<String>,
     },

--- a/data/src/server.rs
+++ b/data/src/server.rs
@@ -108,7 +108,14 @@ impl Map {
                 {
                     return Err(Error::DuplicatePassword);
                 }
-                let pass = fs::read_to_string(pass_file).await?;
+                let mut pass = fs::read_to_string(pass_file).await?;
+                if config.password_file_first_line_only {
+                    pass = pass
+                        .lines()
+                        .next()
+                        .map(String::from)
+                        .unwrap_or_default();
+                }
                 config.password = Some(pass);
             }
             if let Some(pass_command) = &config.password_command {
@@ -123,7 +130,14 @@ impl Map {
                 {
                     return Err(Error::DuplicateNickPassword);
                 }
-                let nick_pass = fs::read_to_string(nick_pass_file).await?;
+                let mut nick_pass = fs::read_to_string(nick_pass_file).await?;
+                if config.nick_password_file_first_line_only {
+                    nick_pass = nick_pass
+                        .lines()
+                        .next()
+                        .map(String::from)
+                        .unwrap_or_default();
+                }
                 config.nick_password = Some(nick_pass);
             }
             if let Some(nick_pass_command) = &config.nick_password_command {
@@ -144,10 +158,21 @@ impl Map {
                     Sasl::Plain {
                         password: password @ None,
                         password_file: Some(pass_file),
+                        password_file_first_line_only,
                         password_command: None,
                         ..
                     } => {
-                        let pass = fs::read_to_string(pass_file).await?;
+                        let mut pass = fs::read_to_string(pass_file).await?;
+                        if password_file_first_line_only
+                            .is_none_or(|first_line_only| first_line_only)
+                        {
+                            pass = pass
+                                .lines()
+                                .next()
+                                .map(String::from)
+                                .unwrap_or_default();
+                        }
+
                         *password = Some(pass);
                     }
                     Sasl::Plain {


### PR DESCRIPTION
Adds a setting to read the first line of a password file only (ignoring the first newline and everything past it).  On by default since many text editors will automatically insert a trailing newline (and very few passwords tend to include a newline, as far as I know).