### PR TITLE
servers.md: Add note about changing to plain text ports.

### DIFF
--- a/book/src/configuration/servers.md
+++ b/book/src/configuration/servers.md
@@ -144,7 +144,7 @@ server = "irc.libera.chat"
 
 ## `port`
 
-The port to connect on.	
+The port to connect on. If you want to use a plain text port like 6667 you MUST also change the `use_tls` setting.
 
 ```toml
 # Type: integer


### PR DESCRIPTION
Someone might use a plaintext port and not know or forget they need to change the ```use_tls``` setting. Add a note about.