### PR TITLE
Add `/query` as Alias for `/msg`

### DIFF
--- a/book/src/commands.md
+++ b/book/src/commands.md
@@ -17,7 +17,7 @@ Halloy will first try to run below commands, and lastly send it directly to the 
 | `me`      | `describe` | Send an action message to the channel                         |
 | `mode`    | `m`        | Set mode(s) on a channel or retrieve the current mode(s) set  |
 | `monitor` |            | System to notify when users become online/offline             |
-| `msg`     |            | Open a query with a nickname and send an optional message     |
+| `msg`     | `query`    | Open a query with a nickname and send an optional message     |
 | `nick`    |            | Change your nickname on the current server                    |
 | `part`    | `leave`    | Leave channel(s) with an optional reason                      |
 | `quit`    |            | Disconnect from the server with an optional reason            |

--- a/data/src/command.rs
+++ b/data/src/command.rs
@@ -5,12 +5,10 @@ use fancy_regex::Regex;
 use irc::proto;
 use itertools::Itertools;
 
+use crate::buffer::{self, Upstream};
+use crate::ctcp;
 use crate::isupport::{self, find_target_limit};
 use crate::message::formatting;
-use crate::{
-    buffer::{self, Upstream},
-    ctcp,
-};
 
 #[derive(Debug, Clone)]
 pub enum Command {
@@ -80,7 +78,7 @@ impl FromStr for Kind {
             "motd" => Ok(Kind::Motd),
             "nick" => Ok(Kind::Nick),
             "quit" => Ok(Kind::Quit),
-            "msg" => Ok(Kind::Msg),
+            "msg" | "query" => Ok(Kind::Msg),
             "me" | "describe" => Ok(Kind::Me),
             "whois" => Ok(Kind::Whois),
             "part" | "leave" => Ok(Kind::Part),

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -841,7 +841,7 @@ impl Command {
             "join" => vec!["j"],
             "me" => vec!["describe"],
             "mode" => vec!["m"],
-            "msg" => vec![],
+            "msg" => vec!["query"],
             "nick" => vec![],
             "part" => vec!["leave"],
             "quit" => vec![""],


### PR DESCRIPTION
Add `/query` as an alias for `/msg` for users that might be familiar with that name from other clients.