### PR TITLE
Display Received WALLOPS Messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Added:
 - Mark as Read settings to control when buffers are automatically marked as read
 - `/hop` command. `/hop` parts the current channel and joins a new one
 - Settings to limit passwords read from a file to the first line of the file only (on by default)
+- Receive `WALLOPS` messages in the server buffer (color configurable in themes)
 
 Changed:
 - Clicking to insert a username will now use same suffixes specified for autocomplete

--- a/book/src/configuration/themes/README.md
+++ b/book/src/configuration/themes/README.md
@@ -95,6 +95,7 @@ url = "<string>"
 # standard_reply_fail = "<string>"
 # standard_reply_warn = "<string>"
 # standard_reply_note = "<string>"
+# wallops = "<string>"
 default = "<string>"
 ```
 > 💡  The default Ferra theme toml file can be viewed [here](https://github.com/squidowl/halloy/blob/main/assets/themes/ferra.toml).

--- a/data/src/appearance/theme.rs
+++ b/data/src/appearance/theme.rs
@@ -168,6 +168,8 @@ pub struct ServerMessages {
     pub standard_reply_warn: Option<Color>,
     #[serde(default, with = "color_serde_maybe")]
     pub standard_reply_note: Option<Color>,
+    #[serde(default, with = "color_serde_maybe")]
+    pub wallops: Option<Color>,
     #[serde(default = "default_transparent", with = "color_serde")]
     pub default: Color,
 }
@@ -476,6 +478,7 @@ mod binary {
         BufferServerMessagesStandardReplyFail = 38,
         BufferServerMessagesStandardReplyWarn = 39,
         BufferServerMessagesStandardReplyNote = 40,
+        BufferServerMessagesWallops = 41,
     }
 
     impl Tag {
@@ -536,6 +539,9 @@ mod binary {
                 }
                 Tag::BufferServerMessagesStandardReplyNote => {
                     colors.buffer.server_messages.standard_reply_note?
+                }
+                Tag::BufferServerMessagesWallops => {
+                    colors.buffer.server_messages.wallops?
                 }
                 Tag::BufferServerMessagesDefault => {
                     colors.buffer.server_messages.default
@@ -637,6 +643,9 @@ mod binary {
                 Tag::BufferServerMessagesStandardReplyNote => {
                     colors.buffer.server_messages.standard_reply_note =
                         Some(color);
+                }
+                Tag::BufferServerMessagesWallops => {
+                    colors.buffer.server_messages.wallops = Some(color);
                 }
                 Tag::BufferServerMessagesDefault => {
                     colors.buffer.server_messages.default = color;

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -140,6 +140,8 @@ pub struct ServerMessages {
     pub standard_reply_warn: ServerMessage,
     #[serde(default)]
     pub standard_reply_note: ServerMessage,
+    #[serde(default)]
+    pub wallops: ServerMessage,
 }
 
 impl ServerMessages {
@@ -165,6 +167,7 @@ impl ServerMessages {
             source::server::Kind::StandardReply(
                 source::server::StandardReply::Note,
             ) => Some(&self.standard_reply_note),
+            source::server::Kind::Wallops => Some(&self.wallops),
         }
     }
 }

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -767,7 +767,8 @@ fn has_matching_content(
                 | message::source::server::Kind::ChangeHost
                 | message::source::server::Kind::MonitoredOnline
                 | message::source::server::Kind::MonitoredOffline
-                | message::source::server::Kind::StandardReply(_) => (),
+                | message::source::server::Kind::StandardReply(_)
+                | message::source::server::Kind::Wallops => (),
             }
         }
 

--- a/data/src/message/source.rs
+++ b/data/src/message/source.rs
@@ -70,6 +70,7 @@ pub mod server {
         MonitoredOnline,
         MonitoredOffline,
         StandardReply(StandardReply),
+        Wallops,
     }
 
     #[derive(

--- a/src/appearance/theme/selectable_text.rs
+++ b/src/appearance/theme/selectable_text.rs
@@ -85,6 +85,7 @@ pub fn server(
             Kind::StandardReply(StandardReply::Note) => {
                 colors.standard_reply_note
             }
+            Kind::Wallops => colors.wallops,
         })
         .or(Some(colors.default));
 

--- a/src/screen/dashboard/theme_editor.rs
+++ b/src/screen/dashboard/theme_editor.rs
@@ -611,6 +611,7 @@ pub enum ServerMessages {
     StandardReplyFail,
     StandardReplyWarn,
     StandardReplyNote,
+    Wallops,
     Default,
 }
 
@@ -627,6 +628,7 @@ impl ServerMessages {
             ServerMessages::StandardReplyFail => colors.standard_reply_fail,
             ServerMessages::StandardReplyWarn => colors.standard_reply_warn,
             ServerMessages::StandardReplyNote => colors.standard_reply_note,
+            ServerMessages::Wallops => colors.wallops,
             ServerMessages::Default => Some(colors.default),
         }
     }
@@ -651,6 +653,7 @@ impl ServerMessages {
             ServerMessages::StandardReplyNote => {
                 colors.standard_reply_note = color;
             }
+            ServerMessages::Wallops => colors.wallops = color,
             ServerMessages::Default => {
                 colors.default = color.unwrap_or(Color::TRANSPARENT);
             }


### PR DESCRIPTION
Displays received WALLOPS messages in the server buffer in the format:
```
WALLOPS from nickname: message text here
```

I left `WALLOPS` in all caps to try to signal it's an IRC command to those who might not be familiar (rather than the English word "wallop"), but I'm open to different styling.

Gets its own color under the `server_messages` colors table, and takes on the default server message coloring if not specified.

It will trigger the unread status for the server buffer (similar to standard replies and monitor online/offline messages).  I.e. receiving a WALLOPS will color the server globe icon to indicate unread.

Tested on a local inspircd instance.