### PR TITLE
Fallback to Glyph Wrapping for Messages in Buffers

### DIFF
--- a/src/widget/selectable_rich_text.rs
+++ b/src/widget/selectable_rich_text.rs
@@ -452,7 +452,7 @@ where
                     align_x: self.align_x,
                     align_y: self.align_y,
                     shaping: Shaping::Advanced,
-                    wrapping: text::Wrapping::default(),
+                    wrapping: text::Wrapping::WordOrGlyph,
                 };
 
                 // Check spoiler
@@ -863,7 +863,7 @@ where
             align_x,
             align_y,
             shaping: Shaping::Advanced,
-            wrapping: text::Wrapping::default(),
+            wrapping: text::Wrapping::WordOrGlyph,
         };
 
         if state.spans != spans {
@@ -890,7 +890,7 @@ where
                 align_x,
                 align_y,
                 shaping: Shaping::Advanced,
-                wrapping: text::Wrapping::default(),
+                wrapping: text::Wrapping::WordOrGlyph,
             }) {
                 text::Difference::None => {}
                 text::Difference::Bounds => {

--- a/src/widget/selectable_text.rs
+++ b/src/widget/selectable_text.rs
@@ -61,7 +61,7 @@ where
             shaping: Shaping::Basic,
             #[cfg(not(debug_assertions))]
             shaping: Shaping::Advanced,
-            wrapping: Wrapping::default(),
+            wrapping: Wrapping::WordOrGlyph,
             class: Theme::default(),
         }
     }


### PR DESCRIPTION
Long messages without word breaks can run outside the bounds of the scroll view.  For example:
![Screenshot from 2025-05-02 20-42-49](https://github.com/user-attachments/assets/04878ed0-1741-4a56-810e-14b1d4eb968b)
This PR switches the wrapping settings for buffer messages to allow for fallback to glyph wrapping when there are no word breaks, like so:
![Screenshot from 2025-05-02 18-14-14](https://github.com/user-attachments/assets/a56b8da9-2180-4731-a1e2-e8233c3a548f)

I think it would be nice if we could prevent links from wrapping at words, and have URLs specifically wrap at glyphs (like is done in the prompt to okay opening a URL), but I couldn't find any way to give spans their own wrapping.  Planning to leave that for later.