### PR TITLE
Font Weight Configuration Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Added:
 - `/hop` command. `/hop` parts the current channel and joins a new one
 - Settings to limit passwords read from a file to the first line of the file only (on by default)
 - Receive `WALLOPS` messages in the server buffer (color configurable in themes)
+- Configuration option for font weight
 
 Changed:
 - Clicking to insert a username will now use same suffixes specified for autocomplete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Added:
 - `/hop` command. `/hop` parts the current channel and joins a new one
 - Settings to limit passwords read from a file to the first line of the file only (on by default)
 - Receive `WALLOPS` messages in the server buffer (color configurable in themes)
-- Configuration option for font weight
+- Configuration options for font weight and bold weight
 
 Changed:
 - Clicking to insert a username will now use same suffixes specified for autocomplete

--- a/book/src/configuration/font.md
+++ b/book/src/configuration/font.md
@@ -46,3 +46,16 @@ Font weight.
 [font]
 weight = "light"
 ```
+
+## `size`
+
+Bold font weight.  If not set, then the font weight three steps above the regular font weight (e.g. font weight `"light"` → bold font weight `"semibold"`).
+
+```toml
+# Type: string
+# Values: "thin", "extra-light", "light", "normal", "medium", "semibold", "bold", "extra-bold", and "black"
+# Default: not set
+
+[font]
+bold-weight = "semibold"
+```

--- a/book/src/configuration/font.md
+++ b/book/src/configuration/font.md
@@ -4,6 +4,8 @@ Application wide font settings.
 
 > ⚠️  Changes to font settings require an application restart to take effect.
 
+> 💡  If Halloy is unable to load the specified font & weight, an fallback font may be used.  If the font looks wrong, double-check the family name and that the font family has the specified weight.
+
 ## `family`
 
 Monospaced font family to use.
@@ -30,4 +32,17 @@ Font size.
 
 [font]
 size = 13
+```
+
+## `size`
+
+Font weight.
+
+```toml
+# Type: string
+# Values: "thin", "extra-light", "light", "normal", "medium", "semibold", "bold", "extra-bold", and "black"
+# Default: "normal"
+
+[font]
+weight = "light"
 ```

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -86,14 +86,20 @@ impl From<ScaleFactor> for f64 {
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct Font {
     pub family: Option<String>,
     pub size: Option<u8>,
     #[serde(
-        deserialize_with = "deserialize_font_weight_from_string",
-        default = "default_font_weight"
+        default = "default_font_weight",
+        deserialize_with = "deserialize_font_weight_from_string"
     )]
     pub weight: font::Weight,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_font_weight_from_string"
+    )]
+    pub bold_weight: Option<font::Weight>,
 }
 
 fn deserialize_font_weight_from_string<'de, D>(
@@ -128,6 +134,15 @@ where
               \"black\"",
         )),
     }
+}
+
+fn deserialize_optional_font_weight_from_string<'de, D>(
+    deserializer: D,
+) -> Result<Option<font::Weight>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(Some(deserialize_font_weight_from_string(deserializer)?))
 }
 
 fn default_font_weight() -> font::Weight {

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -1,9 +1,10 @@
 use std::path::PathBuf;
 use std::{str, string};
 
+use iced_core::font;
 use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use thiserror::Error;
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::ReadDirStream;
@@ -88,6 +89,49 @@ impl From<ScaleFactor> for f64 {
 pub struct Font {
     pub family: Option<String>,
     pub size: Option<u8>,
+    #[serde(
+        deserialize_with = "deserialize_font_weight_from_string",
+        default = "default_font_weight"
+    )]
+    pub weight: font::Weight,
+}
+
+fn deserialize_font_weight_from_string<'de, D>(
+    deserializer: D,
+) -> Result<font::Weight, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let string = String::deserialize(deserializer)?;
+
+    match string.as_ref() {
+        "thin" => Ok(font::Weight::Thin),
+        "extra-light" => Ok(font::Weight::ExtraLight),
+        "light" => Ok(font::Weight::Light),
+        "normal" => Ok(font::Weight::Normal),
+        "medium" => Ok(font::Weight::Medium),
+        "semibold" => Ok(font::Weight::Semibold),
+        "bold" => Ok(font::Weight::Bold),
+        "extra-bold" => Ok(font::Weight::ExtraBold),
+        "black" => Ok(font::Weight::Black),
+        _ => Err(serde::de::Error::invalid_value(
+            serde::de::Unexpected::Str(&string),
+            &"expected one of font weight names: \
+              \"thin\", \
+              \"extra-light\", \
+              \"light\", \
+              \"normal\", \
+              \"medium\", \
+              \"semibold\", \
+              \"bold\", \
+              \"extra-bold\", and \
+              \"black\"",
+        )),
+    }
+}
+
+fn default_font_weight() -> font::Weight {
+    font::Weight::Normal
 }
 
 impl Config {

--- a/src/font.rs
+++ b/src/font.rs
@@ -26,12 +26,22 @@ impl Font {
         }
     }
 
-    fn set(&self, name: String) {
+    fn set(&self, name: String, weight: font::Weight) {
         let name = Box::leak(name.into_boxed_str());
         let weight = if self.bold {
-            font::Weight::Bold
+            match weight {
+                font::Weight::Thin => font::Weight::Normal,
+                font::Weight::ExtraLight => font::Weight::Medium,
+                font::Weight::Light => font::Weight::Semibold,
+                font::Weight::Normal => font::Weight::Bold,
+                font::Weight::Medium => font::Weight::ExtraBold,
+                font::Weight::Semibold
+                | font::Weight::Bold
+                | font::Weight::ExtraBold
+                | font::Weight::Black => font::Weight::Black,
+            }
         } else {
-            font::Weight::Normal
+            weight
         };
         let style = if self.italics {
             font::Style::Italic
@@ -57,11 +67,13 @@ pub fn set(config: Option<&Config>) {
     let family = config
         .and_then(|config| config.font.family.clone())
         .unwrap_or_else(|| String::from("Iosevka Term"));
+    let weight =
+        config.map_or(font::Weight::Normal, |config| config.font.weight);
 
-    MONO.set(family.clone());
-    MONO_BOLD.set(family.clone());
-    MONO_ITALICS.set(family.clone());
-    MONO_BOLD_ITALICS.set(family);
+    MONO.set(family.clone(), weight);
+    MONO_BOLD.set(family.clone(), weight);
+    MONO_ITALICS.set(family.clone(), weight);
+    MONO_BOLD_ITALICS.set(family, weight);
 }
 
 pub fn load() -> Vec<Cow<'static, [u8]>> {

--- a/src/font.rs
+++ b/src/font.rs
@@ -26,23 +26,14 @@ impl Font {
         }
     }
 
-    fn set(&self, name: String, weight: font::Weight) {
+    fn set(
+        &self,
+        name: String,
+        weight: font::Weight,
+        bold_weight: font::Weight,
+    ) {
         let name = Box::leak(name.into_boxed_str());
-        let weight = if self.bold {
-            match weight {
-                font::Weight::Thin => font::Weight::Normal,
-                font::Weight::ExtraLight => font::Weight::Medium,
-                font::Weight::Light => font::Weight::Semibold,
-                font::Weight::Normal => font::Weight::Bold,
-                font::Weight::Medium => font::Weight::ExtraBold,
-                font::Weight::Semibold
-                | font::Weight::Bold
-                | font::Weight::ExtraBold
-                | font::Weight::Black => font::Weight::Black,
-            }
-        } else {
-            weight
-        };
+        let weight = if self.bold { bold_weight } else { weight };
         let style = if self.italics {
             font::Style::Italic
         } else {
@@ -69,11 +60,24 @@ pub fn set(config: Option<&Config>) {
         .unwrap_or_else(|| String::from("Iosevka Term"));
     let weight =
         config.map_or(font::Weight::Normal, |config| config.font.weight);
+    let bold_weight = config
+        .and_then(|config| config.font.bold_weight)
+        .unwrap_or(match weight {
+            font::Weight::Thin => font::Weight::Normal,
+            font::Weight::ExtraLight => font::Weight::Medium,
+            font::Weight::Light => font::Weight::Semibold,
+            font::Weight::Normal => font::Weight::Bold,
+            font::Weight::Medium => font::Weight::ExtraBold,
+            font::Weight::Semibold
+            | font::Weight::Bold
+            | font::Weight::ExtraBold
+            | font::Weight::Black => font::Weight::Black,
+        });
 
-    MONO.set(family.clone(), weight);
-    MONO_BOLD.set(family.clone(), weight);
-    MONO_ITALICS.set(family.clone(), weight);
-    MONO_BOLD_ITALICS.set(family, weight);
+    MONO.set(family.clone(), weight, bold_weight);
+    MONO_BOLD.set(family.clone(), weight, bold_weight);
+    MONO_ITALICS.set(family.clone(), weight, bold_weight);
+    MONO_BOLD_ITALICS.set(family, weight, bold_weight);
 }
 
 pub fn load() -> Vec<Cow<'static, [u8]>> {


### PR DESCRIPTION
Adds the ability to specify font weights, for variable weight fonts.  A configuration for the user to have some control of the perceived font weight outside of scaling tricks, to help with issues like #929 (which otherwise I believe Halloy has little control over).  E.g. for Source Code Pro normal:
![Screenshot from 2025-05-03 11-35-22](https://github.com/user-attachments/assets/6d8e60e4-3a24-43dd-ae1a-2139d3abb08c)
Light:
![Screenshot from 2025-05-03 11-35-49](https://github.com/user-attachments/assets/04088d42-7c3a-461b-890c-18ab2caf9855)
And Medium:
![Screenshot from 2025-05-03 11-34-52](https://github.com/user-attachments/assets/eabbd46d-3517-41ae-a6e9-f16e281913b8)
Currently it takes the font weight 3 steps higher than the configured weight as the bold font weight.  And, not all fonts have a good range of weights unfortunately ~~(e.g. extra-bold in Source Code Pro apparently is automatically condensed?)~~.

Edit: After double-checking, it looks like the Source Code Pro repository does not have an extra-bold variant, which is why the text looks condensed in the Medium example.