### PR TITLE
Update flatpak build manifest

### DIFF
--- a/assets/flatpak/org.squidowl.halloy.json
+++ b/assets/flatpak/org.squidowl.halloy.json
@@ -1,18 +1,20 @@
 {
     "app-id": "org.squidowl.halloy",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "23.08",
+    "runtime-version": "24.08",
     "sdk": "org.freedesktop.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"
     ],
     "command": "halloy",
     "finish-args": [
-        "--share=ipc",
-        "--socket=fallback-x11",
-        "--socket=wayland",
         "--device=dri",
-        "--share=network"
+        "--share=ipc",
+        "--share=network",
+        "--socket=fallback-x11",
+        "--socket=pulseaudio",
+        "--socket=wayland",
+        "--talk-name=org.freedesktop.Notifications"
     ],
     "build-options": {
         "append-path" : "/usr/lib/sdk/rust-stable/bin"


### PR DESCRIPTION
The flatpak build manifest has deviated a little bit, so I'm bringing it in line with the flathub repo's [manifest](https://github.com/flathub/org.squidowl.halloy/blob/master/org.squidowl.halloy.json).