### PR TITLE
Fix handling of RPL_NOWAWAY & RPL_UNAWAY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+Fixed:
+
+- Handling of RPL_NOWAWAY & RPL_UNAWAY to reflect users own AWAY state
+
 # 2025.5 (2025-05-05)
 
 Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Fixed:
 
-- Handling of RPL_NOWAWAY & RPL_UNAWAY to reflect users own AWAY state
+- Handling of RPL_NOWAWAY & RPL_UNAWAY to reflect user's own AWAY state
 
 # 2025.5 (2025-05-05)
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1777,8 +1777,10 @@ impl Client {
                     }
                 }
             }
+            // RPL_UNAWAY is a reply to "/AWAY" from the server
+            // for the client/user itself.
             Command::Numeric(RPL_UNAWAY, _) => {
-                let user = User::try_from(self.nickname().as_ref())?;
+                let user = User::from(self.nickname().to_owned());
 
                 for channel in self.chanmap.values_mut() {
                     if let Some(mut user) = channel.users.take(&user) {
@@ -1787,8 +1789,10 @@ impl Client {
                     }
                 }
             }
+            // RPL_UNAWAY is a reply to "/AWAY <msg>" from the server
+            // for the client/user itself.
             Command::Numeric(RPL_NOWAWAY, _) => {
-                let user = User::try_from(self.nickname().as_ref())?;
+                let user = User::from(self.nickname().to_owned());
 
                 for channel in self.chanmap.values_mut() {
                     if let Some(mut user) = channel.users.take(&user) {

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1777,29 +1777,23 @@ impl Client {
                     }
                 }
             }
-            Command::Numeric(RPL_UNAWAY, args) => {
-                let nick = ok!(args.first()).as_str();
-                let user = User::try_from(nick)?;
+            Command::Numeric(RPL_UNAWAY, _) => {
+                let user = User::try_from(self.nickname().as_ref())?;
 
-                if user.nickname() == self.nickname() {
-                    for channel in self.chanmap.values_mut() {
-                        if let Some(mut user) = channel.users.take(&user) {
-                            user.update_away(false);
-                            channel.users.insert(user);
-                        }
+                for channel in self.chanmap.values_mut() {
+                    if let Some(mut user) = channel.users.take(&user) {
+                        user.update_away(false);
+                        channel.users.insert(user);
                     }
                 }
             }
-            Command::Numeric(RPL_NOWAWAY, args) => {
-                let nick = ok!(args.first()).as_str();
-                let user = User::try_from(nick)?;
+            Command::Numeric(RPL_NOWAWAY, _) => {
+                let user = User::try_from(self.nickname().as_ref())?;
 
-                if user.nickname() == self.nickname() {
-                    for channel in self.chanmap.values_mut() {
-                        if let Some(mut user) = channel.users.take(&user) {
-                            user.update_away(true);
-                            channel.users.insert(user);
-                        }
+                for channel in self.chanmap.values_mut() {
+                    if let Some(mut user) = channel.users.take(&user) {
+                        user.update_away(true);
+                        channel.users.insert(user);
                     }
                 }
             }


### PR DESCRIPTION
RPL_NOWAWAY & RPL_UNAWAY are no sending the nickname back. There is just a custom message attached by the server, for example "You have been marked as being away" or "You are no longer marked as being away".