### PR TITLE
Extended Theme Settings

### DIFF
--- a/data/src/appearance/theme.rs
+++ b/data/src/appearance/theme.rs
@@ -6,7 +6,7 @@ use palette::rgb::{Rgb, Rgba};
 use palette::{FromColor, Hsva, Okhsl, Srgba};
 use rand::prelude::*;
 use rand_chacha::ChaChaRng;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 use tokio::fs;
 
@@ -17,28 +17,28 @@ const DEFAULT_THEME_CONTENT: &str =
 #[derive(Debug, Clone)]
 pub struct Theme {
     pub name: String,
-    pub colors: Colors,
+    pub styles: Styles,
 }
 
 impl Default for Theme {
     fn default() -> Self {
         Self {
             name: DEFAULT_THEME_NAME.to_string(),
-            colors: Colors::default(),
+            styles: Styles::default(),
         }
     }
 }
 
 impl Theme {
-    pub fn new(name: String, colors: Colors) -> Self {
-        Theme { name, colors }
+    pub fn new(name: String, styles: Styles) -> Self {
+        Theme { name, styles }
     }
 }
 
 // IMPORTANT: Make sure any new components are added to the theme editor
 // and `binary` representation
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct Colors {
+pub struct Styles {
     #[serde(default)]
     pub general: General,
     #[serde(default)]
@@ -49,7 +49,7 @@ pub struct Colors {
     pub buttons: Buttons,
 }
 
-impl Colors {
+impl Styles {
     pub async fn save(self, path: PathBuf) -> Result<(), Error> {
         let content = toml::to_string(&self)?;
 
@@ -116,8 +116,8 @@ pub struct General {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
 pub struct Buffer {
-    #[serde(default = "default_transparent", with = "color_serde")]
-    pub action: Color,
+    #[serde(default)]
+    pub action: TextStyle,
     #[serde(default = "default_transparent", with = "color_serde")]
     pub background: Color,
     #[serde(default = "default_transparent", with = "color_serde")]
@@ -128,69 +128,184 @@ pub struct Buffer {
     pub border: Color,
     #[serde(default = "default_transparent", with = "color_serde")]
     pub border_selected: Color,
-    #[serde(default = "default_transparent", with = "color_serde")]
-    pub code: Color,
+    #[serde(default)]
+    pub code: TextStyle,
     #[serde(default = "default_transparent", with = "color_serde")]
     pub highlight: Color,
-    #[serde(default = "default_transparent", with = "color_serde")]
-    pub nickname: Color,
+    #[serde(default)]
+    pub nickname: TextStyle,
     #[serde(default = "default_transparent", with = "color_serde")]
     pub selection: Color,
     #[serde(default)]
     pub server_messages: ServerMessages,
-    #[serde(default = "default_transparent", with = "color_serde")]
-    pub timestamp: Color,
-    #[serde(default = "default_transparent", with = "color_serde")]
-    pub topic: Color,
-    #[serde(default = "default_transparent", with = "color_serde")]
-    pub url: Color,
+    #[serde(default)]
+    pub timestamp: TextStyle,
+    #[serde(default)]
+    pub topic: TextStyle,
+    #[serde(default)]
+    pub url: TextStyle,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
 pub struct ServerMessages {
-    #[serde(default, with = "color_serde_maybe")]
-    pub join: Option<Color>,
-    #[serde(default, with = "color_serde_maybe")]
-    pub part: Option<Color>,
-    #[serde(default, with = "color_serde_maybe")]
-    pub quit: Option<Color>,
-    #[serde(default, with = "color_serde_maybe")]
-    pub reply_topic: Option<Color>,
-    #[serde(default, with = "color_serde_maybe")]
-    pub change_host: Option<Color>,
-    #[serde(default, with = "color_serde_maybe")]
-    pub monitored_online: Option<Color>,
-    #[serde(default, with = "color_serde_maybe")]
-    pub monitored_offline: Option<Color>,
-    #[serde(default, with = "color_serde_maybe")]
-    pub standard_reply_fail: Option<Color>,
-    #[serde(default, with = "color_serde_maybe")]
-    pub standard_reply_warn: Option<Color>,
-    #[serde(default, with = "color_serde_maybe")]
-    pub standard_reply_note: Option<Color>,
-    #[serde(default, with = "color_serde_maybe")]
-    pub wallops: Option<Color>,
-    #[serde(default = "default_transparent", with = "color_serde")]
-    pub default: Color,
+    #[serde(default)]
+    pub join: Option<TextStyle>,
+    #[serde(default)]
+    pub part: Option<TextStyle>,
+    #[serde(default)]
+    pub quit: Option<TextStyle>,
+    #[serde(default)]
+    pub reply_topic: Option<TextStyle>,
+    #[serde(default)]
+    pub change_host: Option<TextStyle>,
+    #[serde(default)]
+    pub monitored_online: Option<TextStyle>,
+    #[serde(default)]
+    pub monitored_offline: Option<TextStyle>,
+    #[serde(default)]
+    pub standard_reply_fail: Option<TextStyle>,
+    #[serde(default)]
+    pub standard_reply_warn: Option<TextStyle>,
+    #[serde(default)]
+    pub standard_reply_note: Option<TextStyle>,
+    #[serde(default)]
+    pub wallops: Option<TextStyle>,
+    #[serde(default)]
+    pub default: TextStyle,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
 pub struct Text {
-    #[serde(default = "default_transparent", with = "color_serde")]
-    pub primary: Color,
-    #[serde(default = "default_transparent", with = "color_serde")]
-    pub secondary: Color,
-    #[serde(default = "default_transparent", with = "color_serde")]
-    pub tertiary: Color,
-    #[serde(default = "default_transparent", with = "color_serde")]
-    pub success: Color,
-    #[serde(default = "default_transparent", with = "color_serde")]
-    pub error: Color,
+    #[serde(default)]
+    pub primary: TextStyle,
+    #[serde(default)]
+    pub secondary: TextStyle,
+    #[serde(default)]
+    pub tertiary: TextStyle,
+    #[serde(default)]
+    pub success: TextStyle,
+    #[serde(default)]
+    pub error: TextStyle,
 }
 
-impl Default for Colors {
+impl Default for Styles {
     fn default() -> Self {
         toml::from_str(DEFAULT_THEME_CONTENT).expect("parse default theme")
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct TextStyle {
+    pub color: Color,
+    pub font_style: FontStyle,
+}
+
+impl Default for TextStyle {
+    fn default() -> Self {
+        Self {
+            color: Color::TRANSPARENT,
+            font_style: FontStyle::Normal,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for TextStyle {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Data {
+            Basic(String),
+            #[serde(rename_all = "kebab-case")]
+            Extended {
+                color: String,
+                font_style: FontStyle,
+            },
+        }
+
+        let data = Data::deserialize(deserializer)?;
+
+        let (hex, font_style) = match data {
+            Data::Basic(color) => (color, FontStyle::Normal),
+            Data::Extended { color, font_style } => (color, font_style),
+        };
+
+        Ok(TextStyle {
+            color: hex_to_color(&hex).unwrap_or(Color::TRANSPARENT),
+            font_style,
+        })
+    }
+}
+
+impl Serialize for TextStyle {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        #[derive(Serialize)]
+        #[serde(rename_all = "kebab-case")]
+        struct Data {
+            color: String,
+            font_style: FontStyle,
+        }
+
+        let hex = color_to_hex(self.color);
+
+        if matches!(self.font_style, FontStyle::Normal) {
+            hex.serialize(serializer)
+        } else {
+            Data {
+                color: hex,
+                font_style: self.font_style,
+            }
+            .serialize(serializer)
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum FontStyle {
+    #[default]
+    Normal,
+    Bold,
+    Italic,
+    #[serde(alias = "bold-italic")]
+    ItalicBold,
+}
+
+impl FontStyle {
+    pub fn new(bold: bool, italic: bool) -> Self {
+        match (bold, italic) {
+            (false, false) => FontStyle::Normal,
+            (false, true) => FontStyle::Italic,
+            (true, false) => FontStyle::Bold,
+            (true, true) => FontStyle::ItalicBold,
+        }
+    }
+}
+impl std::ops::Add<FontStyle> for FontStyle {
+    type Output = FontStyle;
+
+    fn add(self, rhs: FontStyle) -> FontStyle {
+        match self {
+            FontStyle::Normal => rhs,
+            FontStyle::Italic => match rhs {
+                FontStyle::Normal | FontStyle::Italic => FontStyle::Italic,
+                FontStyle::Bold | FontStyle::ItalicBold => {
+                    FontStyle::ItalicBold
+                }
+            },
+            FontStyle::Bold => match rhs {
+                FontStyle::Normal | FontStyle::Bold => FontStyle::Bold,
+                FontStyle::Italic | FontStyle::ItalicBold => {
+                    FontStyle::ItalicBold
+                }
+            },
+            FontStyle::ItalicBold => self,
+        }
     }
 }
 
@@ -354,28 +469,25 @@ mod color_serde {
     }
 }
 
-mod color_serde_maybe {
-    use iced_core::Color;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-    pub fn deserialize<'de, D>(
-        deserializer: D,
-    ) -> Result<Option<Color>, D::Error>
-    where
-        D: Deserializer<'de>,
+pub fn set_optional_text_style_color(
+    style: &mut Option<TextStyle>,
+    color: Option<Color>,
+) {
+    if let Some(color) = color {
+        if let Some(style) = style {
+            style.color = color;
+        } else {
+            *style = Some(TextStyle {
+                color,
+                ..TextStyle::default()
+            });
+        }
+    } else if style
+        .is_some_and(|style| style.font_style == FontStyle::default())
     {
-        Ok(Option::<String>::deserialize(deserializer)?
-            .and_then(|hex| super::hex_to_color(&hex)))
-    }
-
-    pub fn serialize<S>(
-        color: &Option<Color>,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        color.map(super::color_to_hex).serialize(serializer)
+        *style = None;
+    } else if let Some(style) = style {
+        style.color = Color::TRANSPARENT;
     }
 }
 
@@ -383,13 +495,15 @@ mod binary {
     use iced_core::Color;
     use strum::{IntoEnumIterator, VariantArray};
 
-    use super::{Buffer, Buttons, Colors, General, Text};
+    use super::{
+        Buffer, Buttons, General, Styles, Text, set_optional_text_style_color,
+    };
 
-    pub fn encode(colors: &Colors) -> Vec<u8> {
+    pub fn encode(styles: &Styles) -> Vec<u8> {
         let mut bytes = Vec::with_capacity(Tag::VARIANTS.len() * (1 + 4));
 
         for tag in Tag::iter() {
-            if let Some(color) = tag.encode(colors) {
+            if let Some(color) = tag.encode(styles) {
                 bytes.push(tag as u8);
                 bytes.extend(color);
             }
@@ -398,8 +512,8 @@ mod binary {
         bytes
     }
 
-    pub fn decode(bytes: &[u8]) -> Colors {
-        let mut colors = Colors {
+    pub fn decode(bytes: &[u8]) -> Styles {
+        let mut styles = Styles {
             general: General::default(),
             text: Text::default(),
             buffer: Buffer::default(),
@@ -416,12 +530,12 @@ mod binary {
                         chunk[4] as f32 / 255.0,
                     );
 
-                    tag.update_colors(&mut colors, color);
+                    tag.update_color(&mut styles, color);
                 }
             }
         }
 
-        colors
+        styles
     }
 
     // IMPORTANT: Tags cannot be rearranged or deleted to preserve
@@ -482,197 +596,227 @@ mod binary {
     }
 
     impl Tag {
-        pub fn encode(&self, colors: &Colors) -> Option<[u8; 4]> {
+        pub fn encode(&self, styles: &Styles) -> Option<[u8; 4]> {
             let color = match self {
-                Tag::GeneralBackground => colors.general.background,
-                Tag::GeneralBorder => colors.general.border,
-                Tag::GeneralHorizontalRule => colors.general.horizontal_rule,
-                Tag::GeneralUnreadIndicator => colors.general.unread_indicator,
-                Tag::TextPrimary => colors.text.primary,
-                Tag::TextSecondary => colors.text.secondary,
-                Tag::TextTertiary => colors.text.tertiary,
-                Tag::TextSuccess => colors.text.success,
-                Tag::TextError => colors.text.error,
-                Tag::BufferAction => colors.buffer.action,
-                Tag::BufferBackground => colors.buffer.background,
+                Tag::GeneralBackground => styles.general.background,
+                Tag::GeneralBorder => styles.general.border,
+                Tag::GeneralHorizontalRule => styles.general.horizontal_rule,
+                Tag::GeneralUnreadIndicator => styles.general.unread_indicator,
+                Tag::TextPrimary => styles.text.primary.color,
+                Tag::TextSecondary => styles.text.secondary.color,
+                Tag::TextTertiary => styles.text.tertiary.color,
+                Tag::TextSuccess => styles.text.success.color,
+                Tag::TextError => styles.text.error.color,
+                Tag::BufferAction => styles.buffer.action.color,
+                Tag::BufferBackground => styles.buffer.background,
                 Tag::BufferBackgroundTextInput => {
-                    colors.buffer.background_text_input
+                    styles.buffer.background_text_input
                 }
                 Tag::BufferBackgroundTitleBar => {
-                    colors.buffer.background_title_bar
+                    styles.buffer.background_title_bar
                 }
-                Tag::BufferBorder => colors.buffer.border,
-                Tag::BufferBorderSelected => colors.buffer.border_selected,
-                Tag::BufferCode => colors.buffer.code,
-                Tag::BufferHighlight => colors.buffer.highlight,
-                Tag::BufferNickname => colors.buffer.nickname,
-                Tag::BufferSelection => colors.buffer.selection,
-                Tag::BufferTimestamp => colors.buffer.timestamp,
-                Tag::BufferTopic => colors.buffer.topic,
-                Tag::BufferUrl => colors.buffer.url,
+                Tag::BufferBorder => styles.buffer.border,
+                Tag::BufferBorderSelected => styles.buffer.border_selected,
+                Tag::BufferCode => styles.buffer.code.color,
+                Tag::BufferHighlight => styles.buffer.highlight,
+                Tag::BufferNickname => styles.buffer.nickname.color,
+                Tag::BufferSelection => styles.buffer.selection,
+                Tag::BufferTimestamp => styles.buffer.timestamp.color,
+                Tag::BufferTopic => styles.buffer.topic.color,
+                Tag::BufferUrl => styles.buffer.url.color,
                 Tag::BufferServerMessagesJoin => {
-                    colors.buffer.server_messages.join?
+                    styles.buffer.server_messages.join?.color
                 }
                 Tag::BufferServerMessagesPart => {
-                    colors.buffer.server_messages.part?
+                    styles.buffer.server_messages.part?.color
                 }
                 Tag::BufferServerMessagesQuit => {
-                    colors.buffer.server_messages.quit?
+                    styles.buffer.server_messages.quit?.color
                 }
                 Tag::BufferServerMessagesReplyTopic => {
-                    colors.buffer.server_messages.reply_topic?
+                    styles.buffer.server_messages.reply_topic?.color
                 }
                 Tag::BufferServerMessagesChangeHost => {
-                    colors.buffer.server_messages.change_host?
+                    styles.buffer.server_messages.change_host?.color
                 }
                 Tag::BufferServerMessagesMonitoredOnline => {
-                    colors.buffer.server_messages.monitored_online?
+                    styles.buffer.server_messages.monitored_online?.color
                 }
                 Tag::BufferServerMessagesMonitoredOffline => {
-                    colors.buffer.server_messages.monitored_offline?
+                    styles.buffer.server_messages.monitored_offline?.color
                 }
                 Tag::BufferServerMessagesStandardReplyFail => {
-                    colors.buffer.server_messages.standard_reply_fail?
+                    styles.buffer.server_messages.standard_reply_fail?.color
                 }
                 Tag::BufferServerMessagesStandardReplyWarn => {
-                    colors.buffer.server_messages.standard_reply_warn?
+                    styles.buffer.server_messages.standard_reply_warn?.color
                 }
                 Tag::BufferServerMessagesStandardReplyNote => {
-                    colors.buffer.server_messages.standard_reply_note?
+                    styles.buffer.server_messages.standard_reply_note?.color
                 }
                 Tag::BufferServerMessagesWallops => {
-                    colors.buffer.server_messages.wallops?
+                    styles.buffer.server_messages.wallops?.color
                 }
                 Tag::BufferServerMessagesDefault => {
-                    colors.buffer.server_messages.default
+                    styles.buffer.server_messages.default.color
                 }
                 Tag::ButtonsPrimaryBackground => {
-                    colors.buttons.primary.background
+                    styles.buttons.primary.background
                 }
                 Tag::ButtonsPrimaryBackgroundHover => {
-                    colors.buttons.primary.background_hover
+                    styles.buttons.primary.background_hover
                 }
                 Tag::ButtonsPrimaryBackgroundSelected => {
-                    colors.buttons.primary.background_selected
+                    styles.buttons.primary.background_selected
                 }
                 Tag::ButtonsPrimaryBackgroundSelectedHover => {
-                    colors.buttons.primary.background_selected_hover
+                    styles.buttons.primary.background_selected_hover
                 }
                 Tag::ButtonsSecondaryBackground => {
-                    colors.buttons.secondary.background
+                    styles.buttons.secondary.background
                 }
                 Tag::ButtonsSecondaryBackgroundHover => {
-                    colors.buttons.secondary.background_hover
+                    styles.buttons.secondary.background_hover
                 }
                 Tag::ButtonsSecondaryBackgroundSelected => {
-                    colors.buttons.secondary.background_selected
+                    styles.buttons.secondary.background_selected
                 }
                 Tag::ButtonsSecondaryBackgroundSelectedHover => {
-                    colors.buttons.secondary.background_selected_hover
+                    styles.buttons.secondary.background_selected_hover
                 }
             };
 
             Some(color.into_rgba8())
         }
 
-        pub fn update_colors(&self, colors: &mut Colors, color: Color) {
+        pub fn update_color(&self, styles: &mut Styles, color: Color) {
             match self {
-                Tag::GeneralBackground => colors.general.background = color,
-                Tag::GeneralBorder => colors.general.border = color,
+                Tag::GeneralBackground => {
+                    styles.general.background = color;
+                }
+                Tag::GeneralBorder => styles.general.border = color,
                 Tag::GeneralHorizontalRule => {
-                    colors.general.horizontal_rule = color;
+                    styles.general.horizontal_rule = color;
                 }
                 Tag::GeneralUnreadIndicator => {
-                    colors.general.unread_indicator = color;
+                    styles.general.unread_indicator = color;
                 }
-                Tag::TextPrimary => colors.text.primary = color,
-                Tag::TextSecondary => colors.text.secondary = color,
-                Tag::TextTertiary => colors.text.tertiary = color,
-                Tag::TextSuccess => colors.text.success = color,
-                Tag::TextError => colors.text.error = color,
-                Tag::BufferAction => colors.buffer.action = color,
-                Tag::BufferBackground => colors.buffer.background = color,
+                Tag::TextPrimary => styles.text.primary.color = color,
+                Tag::TextSecondary => styles.text.secondary.color = color,
+                Tag::TextTertiary => styles.text.tertiary.color = color,
+                Tag::TextSuccess => styles.text.success.color = color,
+                Tag::TextError => styles.text.error.color = color,
+                Tag::BufferAction => styles.buffer.action.color = color,
+                Tag::BufferBackground => styles.buffer.background = color,
                 Tag::BufferBackgroundTextInput => {
-                    colors.buffer.background_text_input = color;
+                    styles.buffer.background_text_input = color;
                 }
                 Tag::BufferBackgroundTitleBar => {
-                    colors.buffer.background_title_bar = color;
+                    styles.buffer.background_title_bar = color;
                 }
-                Tag::BufferBorder => colors.buffer.border = color,
+                Tag::BufferBorder => styles.buffer.border = color,
                 Tag::BufferBorderSelected => {
-                    colors.buffer.border_selected = color;
+                    styles.buffer.border_selected = color;
                 }
-                Tag::BufferCode => colors.buffer.code = color,
-                Tag::BufferHighlight => colors.buffer.highlight = color,
-                Tag::BufferNickname => colors.buffer.nickname = color,
-                Tag::BufferSelection => colors.buffer.selection = color,
-                Tag::BufferTimestamp => colors.buffer.timestamp = color,
-                Tag::BufferTopic => colors.buffer.topic = color,
-                Tag::BufferUrl => colors.buffer.url = color,
+                Tag::BufferCode => styles.buffer.code.color = color,
+                Tag::BufferHighlight => styles.buffer.highlight = color,
+                Tag::BufferNickname => styles.buffer.nickname.color = color,
+                Tag::BufferSelection => styles.buffer.selection = color,
+                Tag::BufferTimestamp => styles.buffer.timestamp.color = color,
+                Tag::BufferTopic => styles.buffer.topic.color = color,
+                Tag::BufferUrl => styles.buffer.url.color = color,
                 Tag::BufferServerMessagesJoin => {
-                    colors.buffer.server_messages.join = Some(color);
+                    set_optional_text_style_color(
+                        &mut styles.buffer.server_messages.join,
+                        Some(color),
+                    );
                 }
                 Tag::BufferServerMessagesPart => {
-                    colors.buffer.server_messages.part = Some(color);
+                    set_optional_text_style_color(
+                        &mut styles.buffer.server_messages.part,
+                        Some(color),
+                    );
                 }
                 Tag::BufferServerMessagesQuit => {
-                    colors.buffer.server_messages.quit = Some(color);
+                    set_optional_text_style_color(
+                        &mut styles.buffer.server_messages.quit,
+                        Some(color),
+                    );
                 }
                 Tag::BufferServerMessagesReplyTopic => {
-                    colors.buffer.server_messages.reply_topic = Some(color);
+                    set_optional_text_style_color(
+                        &mut styles.buffer.server_messages.reply_topic,
+                        Some(color),
+                    );
                 }
                 Tag::BufferServerMessagesChangeHost => {
-                    colors.buffer.server_messages.change_host = Some(color);
+                    set_optional_text_style_color(
+                        &mut styles.buffer.server_messages.change_host,
+                        Some(color),
+                    );
                 }
                 Tag::BufferServerMessagesMonitoredOnline => {
-                    colors.buffer.server_messages.monitored_online =
-                        Some(color);
+                    set_optional_text_style_color(
+                        &mut styles.buffer.server_messages.monitored_online,
+                        Some(color),
+                    );
                 }
                 Tag::BufferServerMessagesMonitoredOffline => {
-                    colors.buffer.server_messages.monitored_offline =
-                        Some(color);
+                    set_optional_text_style_color(
+                        &mut styles.buffer.server_messages.monitored_offline,
+                        Some(color),
+                    );
                 }
                 Tag::BufferServerMessagesStandardReplyFail => {
-                    colors.buffer.server_messages.standard_reply_fail =
-                        Some(color);
+                    set_optional_text_style_color(
+                        &mut styles.buffer.server_messages.standard_reply_fail,
+                        Some(color),
+                    );
                 }
                 Tag::BufferServerMessagesStandardReplyWarn => {
-                    colors.buffer.server_messages.standard_reply_warn =
-                        Some(color);
+                    set_optional_text_style_color(
+                        &mut styles.buffer.server_messages.standard_reply_warn,
+                        Some(color),
+                    );
                 }
                 Tag::BufferServerMessagesStandardReplyNote => {
-                    colors.buffer.server_messages.standard_reply_note =
-                        Some(color);
+                    set_optional_text_style_color(
+                        &mut styles.buffer.server_messages.standard_reply_note,
+                        Some(color),
+                    );
                 }
                 Tag::BufferServerMessagesWallops => {
-                    colors.buffer.server_messages.wallops = Some(color);
+                    set_optional_text_style_color(
+                        &mut styles.buffer.server_messages.wallops,
+                        Some(color),
+                    );
                 }
                 Tag::BufferServerMessagesDefault => {
-                    colors.buffer.server_messages.default = color;
+                    styles.buffer.server_messages.default.color = color;
                 }
                 Tag::ButtonsPrimaryBackground => {
-                    colors.buttons.primary.background = color;
+                    styles.buttons.primary.background = color;
                 }
                 Tag::ButtonsPrimaryBackgroundHover => {
-                    colors.buttons.primary.background_hover = color;
+                    styles.buttons.primary.background_hover = color;
                 }
                 Tag::ButtonsPrimaryBackgroundSelected => {
-                    colors.buttons.primary.background_selected = color;
+                    styles.buttons.primary.background_selected = color;
                 }
                 Tag::ButtonsPrimaryBackgroundSelectedHover => {
-                    colors.buttons.primary.background_selected_hover = color;
+                    styles.buttons.primary.background_selected_hover = color;
                 }
                 Tag::ButtonsSecondaryBackground => {
-                    colors.buttons.secondary.background = color;
+                    styles.buttons.secondary.background = color;
                 }
                 Tag::ButtonsSecondaryBackgroundHover => {
-                    colors.buttons.secondary.background_hover = color;
+                    styles.buttons.secondary.background_hover = color;
                 }
                 Tag::ButtonsSecondaryBackgroundSelected => {
-                    colors.buttons.secondary.background_selected = color;
+                    styles.buttons.secondary.background_selected = color;
                 }
                 Tag::ButtonsSecondaryBackgroundSelectedHover => {
-                    colors.buttons.secondary.background_selected_hover = color;
+                    styles.buttons.secondary.background_selected_hover = color;
                 }
             }
         }

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -21,7 +21,7 @@ pub use self::preview::Preview;
 pub use self::proxy::Proxy;
 pub use self::server::Server;
 pub use self::sidebar::Sidebar;
-use crate::appearance::theme::Colors;
+use crate::appearance::theme::Styles;
 use crate::appearance::{self, Appearance};
 use crate::audio::{self, Sound};
 use crate::environment::config_dir;
@@ -316,7 +316,7 @@ impl Config {
                 #[serde(rename = "name")]
                 _name: String,
             },
-            V2(Colors),
+            V2(Styles),
         }
 
         let read_entry = |entry: fs::DirEntry| async move {

--- a/data/src/message/formatting.rs
+++ b/data/src/message/formatting.rs
@@ -597,7 +597,7 @@ impl Color {
 
     pub fn into_iced(
         self,
-        _colors: &theme::Colors,
+        _styles: &theme::Styles,
     ) -> Option<iced_core::Color> {
         // TODO: Theme aware 0 - 15 colors
         match self {

--- a/data/src/url.rs
+++ b/data/src/url.rs
@@ -15,7 +15,7 @@ pub enum Url {
     },
     Theme {
         url: String,
-        colors: theme::Colors,
+        styles: theme::Styles,
     },
     Unknown(String),
 }
@@ -34,11 +34,11 @@ impl std::fmt::Display for Url {
     }
 }
 
-pub fn theme(colors: &theme::Colors) -> String {
+pub fn theme(colors: &theme::Styles) -> String {
     format!("halloy:///theme?e={}", colors.encode_base64())
 }
 
-pub fn theme_submit(colors: &theme::Colors) -> String {
+pub fn theme_submit(colors: &theme::Styles) -> String {
     format!(
         "https://themes.halloy.chat/submit?e={}",
         colors.encode_base64()
@@ -86,11 +86,11 @@ fn parse(url: url::Url) -> Result<Url, Error> {
                 .find(|(key, _)| key == "e")
                 .ok_or(Error::MissingQueryPair)?;
 
-            let colors = theme::Colors::decode_base64(&encoded)?;
+            let styles = theme::Styles::decode_base64(&encoded)?;
 
             Ok(Url::Theme {
                 url: url.into(),
-                colors,
+                styles,
             })
         }
         _ => Err(Error::Unknown),

--- a/src/appearance/theme.rs
+++ b/src/appearance/theme.rs
@@ -1,5 +1,5 @@
 pub use data::appearance::theme::{
-    Buffer, Button, Buttons, Colors, General, ServerMessages, Text,
+    Buffer, Button, Buttons, General, ServerMessages, Styles, Text,
     color_to_hex, hex_to_color,
 };
 
@@ -9,6 +9,8 @@ pub mod button;
 pub mod checkbox;
 pub mod container;
 pub mod context_menu;
+pub mod font_style;
+pub mod image;
 pub mod menu;
 pub mod pane_grid;
 pub mod progress_bar;
@@ -17,7 +19,6 @@ pub mod scrollable;
 pub mod selectable_text;
 pub mod text;
 pub mod text_input;
-pub mod image;
 
 // TODO: If we use non-standard font sizes, we should consider
 // Config.font.size since it's user configurable
@@ -53,10 +54,10 @@ impl Theme {
         }
     }
 
-    pub fn colors(&self) -> &Colors {
+    pub fn styles(&self) -> &Styles {
         match self {
-            Theme::Selected(selected) => &selected.colors,
-            Theme::Preview { preview, .. } => &preview.colors,
+            Theme::Selected(selected) => &selected.styles,
+            Theme::Preview { preview, .. } => &preview.styles,
         }
     }
 }
@@ -76,11 +77,11 @@ impl Default for Theme {
 impl iced::theme::Base for Theme {
     fn base(&self) -> iced::theme::Style {
         iced::theme::Style {
-            background_color: self.colors().general.background,
-            text_color: self.colors().text.primary,
+            background_color: self.styles().general.background,
+            text_color: self.styles().text.primary.color,
         }
     }
-    
+
     fn palette(&self) -> Option<iced::theme::Palette> {
         None
     }

--- a/src/appearance/theme/button.rs
+++ b/src/appearance/theme/button.rs
@@ -69,8 +69,8 @@ pub fn sidebar_buffer(
     is_focused: bool,
     is_open: bool,
 ) -> Style {
-    let foreground = theme.colors().text.primary;
-    let button_colors = theme.colors().buttons.primary;
+    let foreground = theme.styles().text.primary.color;
+    let button_colors = theme.styles().buttons.primary;
 
     let background = match (is_focused, is_open) {
         (true, true) => button_colors.background_selected,
@@ -88,8 +88,8 @@ pub fn sidebar_buffer(
 }
 
 pub fn primary(theme: &Theme, status: Status, selected: bool) -> Style {
-    let foreground = theme.colors().text.primary;
-    let button_colors = theme.colors().buttons.primary;
+    let foreground = theme.styles().text.primary.color;
+    let button_colors = theme.styles().buttons.primary;
 
     let background = if selected {
         button_colors.background_selected
@@ -107,8 +107,8 @@ pub fn primary(theme: &Theme, status: Status, selected: bool) -> Style {
 }
 
 pub fn secondary(theme: &Theme, status: Status, selected: bool) -> Style {
-    let foreground = theme.colors().text.primary;
-    let button_colors = theme.colors().buttons.secondary;
+    let foreground = theme.styles().text.primary.color;
+    let button_colors = theme.styles().buttons.secondary;
 
     let background = if selected {
         button_colors.background_selected

--- a/src/appearance/theme/checkbox.rs
+++ b/src/appearance/theme/checkbox.rs
@@ -20,36 +20,36 @@ impl Catalog for Theme {
 }
 
 pub fn primary(theme: &Theme, status: Status) -> Style {
-    let general = theme.colors().general;
-    let text = theme.colors().text;
+    let general = theme.styles().general;
+    let text = theme.styles().text;
 
     match status {
         Status::Active { .. } => Style {
             background: iced::Background::Color(general.background),
-            icon_color: text.primary,
+            icon_color: text.primary.color,
             border: Border {
                 color: general.border,
                 width: 1.0,
                 radius: 4.0.into(),
             },
-            text_color: Some(text.primary),
+            text_color: Some(text.primary.color),
         },
         Status::Hovered { .. } => Style {
             background: iced::Background::Color(general.background),
-            icon_color: text.primary,
+            icon_color: text.primary.color,
             border: Border {
                 color: general.border,
                 width: 1.0,
                 radius: 4.0.into(),
             },
-            text_color: Some(text.primary),
+            text_color: Some(text.primary.color),
         },
         Status::Disabled { .. } => Style {
             background: iced::Background::Color(general.background),
 
             icon_color: Color {
                 a: 0.2,
-                ..text.primary
+                ..text.primary.color
             },
             border: Border {
                 color: Color::TRANSPARENT,
@@ -58,7 +58,7 @@ pub fn primary(theme: &Theme, status: Status) -> Style {
             },
             text_color: Some(Color {
                 a: 0.2,
-                ..text.primary
+                ..text.primary.color
             }),
         },
     }

--- a/src/appearance/theme/container.rs
+++ b/src/appearance/theme/container.rs
@@ -16,7 +16,7 @@ impl Catalog for Theme {
 }
 
 pub fn buffer(theme: &Theme, selected: bool) -> Style {
-    let buffer = theme.colors().buffer;
+    let buffer = theme.styles().buffer;
 
     Style {
         background: Some(Background::Color(buffer.background)),
@@ -34,11 +34,11 @@ pub fn buffer(theme: &Theme, selected: bool) -> Style {
 }
 
 pub fn buffer_title_bar(theme: &Theme) -> Style {
-    let colors = theme.colors().buffer;
+    let styles = theme.styles().buffer;
 
     Style {
-        background: Some(Background::Color(colors.background_title_bar)),
-        text_color: Some(theme.colors().text.secondary),
+        background: Some(Background::Color(styles.background_title_bar)),
+        text_color: Some(theme.styles().text.secondary.color),
         border: Border {
             radius: border::top_left(4).top_right(4),
             width: 1.0,
@@ -49,8 +49,8 @@ pub fn buffer_title_bar(theme: &Theme) -> Style {
 }
 
 pub fn table(theme: &Theme, idx: usize) -> Style {
-    let general = theme.colors().general;
-    let buffer = theme.colors().buffer;
+    let general = theme.styles().general;
+    let buffer = theme.styles().buffer;
 
     let background = if idx % 2 != 0 {
         general.background
@@ -60,7 +60,7 @@ pub fn table(theme: &Theme, idx: usize) -> Style {
 
     Style {
         background: Some(Background::Color(background)),
-        text_color: Some(theme.colors().text.primary),
+        text_color: Some(theme.styles().text.primary.color),
         ..Default::default()
     }
 }
@@ -75,7 +75,7 @@ pub fn none(_theme: &Theme) -> Style {
 pub fn primary_background_hover(theme: &Theme) -> Style {
     Style {
         background: Some(Background::Color(
-            theme.colors().buttons.primary.background_hover,
+            theme.styles().buttons.primary.background_hover,
         )),
         border: Border {
             radius: 4.0.into(),
@@ -87,14 +87,14 @@ pub fn primary_background_hover(theme: &Theme) -> Style {
 
 pub fn general(theme: &Theme) -> Style {
     Style {
-        background: Some(Background::Color(theme.colors().general.background)),
-        text_color: Some(theme.colors().text.primary),
+        background: Some(Background::Color(theme.styles().general.background)),
+        text_color: Some(theme.styles().text.primary.color),
         ..Default::default()
     }
 }
 
 pub fn image_card(theme: &Theme) -> Style {
-    let general = theme.colors().general;
+    let general = theme.styles().general;
 
     Style {
         background: Some(Background::Color(general.background)),
@@ -108,7 +108,7 @@ pub fn image_card(theme: &Theme) -> Style {
 }
 
 pub fn tooltip(theme: &Theme) -> Style {
-    let general = theme.colors().general;
+    let general = theme.styles().general;
 
     Style {
         background: Some(Background::Color(general.background)),
@@ -122,22 +122,22 @@ pub fn tooltip(theme: &Theme) -> Style {
 }
 
 pub fn error_tooltip(theme: &Theme) -> Style {
-    let general = theme.colors().general;
-    let text = theme.colors().text;
+    let general = theme.styles().general;
+    let text = theme.styles().text;
 
     Style {
         background: Some(Background::Color(general.background)),
         border: Border {
             radius: 4.0.into(),
             width: 1.0,
-            color: text.error,
+            color: text.error.color,
         },
         ..Default::default()
     }
 }
 
 pub fn transparent_overlay(theme: &Theme) -> Style {
-    let general = theme.colors().general;
+    let general = theme.styles().general;
 
     Style {
         //TODO: Blur background when possible?

--- a/src/appearance/theme/font_style.rs
+++ b/src/appearance/theme/font_style.rs
@@ -1,0 +1,72 @@
+use data::appearance::theme::FontStyle;
+use data::message;
+use data::message::source::server::{Kind, StandardReply};
+
+use super::Theme;
+
+pub fn default(_theme: &Theme) -> FontStyle {
+    FontStyle::default()
+}
+
+pub fn tertiary(theme: &Theme) -> FontStyle {
+    theme.styles().text.tertiary.font_style
+}
+
+pub fn action(theme: &Theme) -> FontStyle {
+    theme.styles().buffer.action.font_style
+}
+
+pub fn nickname(theme: &Theme) -> FontStyle {
+    theme.styles().buffer.nickname.font_style
+}
+
+pub fn server(
+    theme: &Theme,
+    server: Option<&message::source::Server>,
+) -> FontStyle {
+    let styles = theme.styles().buffer.server_messages;
+    server
+        .and_then(|server| match server.kind() {
+            Kind::Join => styles.join,
+            Kind::Part => styles.part,
+            Kind::Quit => styles.quit,
+            Kind::ReplyTopic => styles.reply_topic,
+            Kind::ChangeHost => styles.change_host,
+            Kind::MonitoredOnline => styles.monitored_online,
+            Kind::MonitoredOffline => styles.monitored_offline,
+            Kind::StandardReply(StandardReply::Fail) => styles
+                .standard_reply_fail
+                .or(Some(theme.styles().text.error)),
+            Kind::StandardReply(StandardReply::Warn) => styles
+                .standard_reply_warn
+                .or(Some(theme.styles().text.error)),
+            Kind::StandardReply(StandardReply::Note) => {
+                styles.standard_reply_note
+            }
+            Kind::Wallops => styles.wallops,
+        })
+        .map_or(styles.default.font_style, |style| style.font_style)
+}
+
+pub fn status(theme: &Theme, status: message::source::Status) -> FontStyle {
+    match status {
+        message::source::Status::Success => success(theme),
+        message::source::Status::Error => error(theme),
+    }
+}
+
+pub fn error(theme: &Theme) -> FontStyle {
+    theme.styles().text.error.font_style
+}
+
+pub fn success(theme: &Theme) -> FontStyle {
+    theme.styles().text.success.font_style
+}
+
+pub fn timestamp(theme: &Theme) -> FontStyle {
+    theme.styles().buffer.timestamp.font_style
+}
+
+pub fn topic(theme: &Theme) -> FontStyle {
+    theme.styles().buffer.topic.font_style
+}

--- a/src/appearance/theme/menu.rs
+++ b/src/appearance/theme/menu.rs
@@ -17,19 +17,19 @@ impl Catalog for Theme {
 }
 
 pub fn primary(theme: &Theme) -> Style {
-    let buttons = theme.colors().buttons;
-    let general = theme.colors().general;
-    let text = theme.colors().text;
+    let buttons = theme.styles().buttons;
+    let general = theme.styles().general;
+    let text = theme.styles().text;
 
     Style {
-        text_color: text.primary,
+        text_color: text.primary.color,
         background: Background::Color(general.background),
         border: Border {
             width: 1.0,
             radius: 4.0.into(),
             color: general.border,
         },
-        selected_text_color: text.primary,
+        selected_text_color: text.primary.color,
         selected_background: Background::Color(
             buttons.primary.background_hover,
         ),

--- a/src/appearance/theme/pane_grid.rs
+++ b/src/appearance/theme/pane_grid.rs
@@ -16,7 +16,7 @@ impl Catalog for Theme {
 }
 
 pub fn primary(theme: &Theme) -> Style {
-    let general = theme.colors().general;
+    let general = theme.styles().general;
 
     Style {
         hovered_region: Highlight {

--- a/src/appearance/theme/progress_bar.rs
+++ b/src/appearance/theme/progress_bar.rs
@@ -15,12 +15,12 @@ impl Catalog for Theme {
 }
 
 pub fn primary(theme: &Theme) -> Style {
-    let general = theme.colors().general;
-    let text = theme.colors().text;
+    let general = theme.styles().general;
+    let text = theme.styles().text;
 
     Style {
         background: iced::Background::Color(general.background),
-        bar: iced::Background::Color(text.tertiary),
+        bar: iced::Background::Color(text.tertiary.color),
         border: iced::Border {
             color: iced::Color::TRANSPARENT,
             width: 0.0,

--- a/src/appearance/theme/rule.rs
+++ b/src/appearance/theme/rule.rs
@@ -16,7 +16,7 @@ impl Catalog for Theme {
 
 pub fn primary(theme: &Theme) -> Style {
     Style {
-        color: theme.colors().general.horizontal_rule,
+        color: theme.styles().general.horizontal_rule,
         width: 1,
         radius: 0.0.into(),
         fill_mode: FillMode::Full,

--- a/src/appearance/theme/scrollable.rs
+++ b/src/appearance/theme/scrollable.rs
@@ -23,7 +23,7 @@ pub fn primary(theme: &Theme, status: Status) -> Style {
         background: None,
         border: Border::default(),
         scroller: Scroller {
-            color: theme.colors().general.horizontal_rule,
+            color: theme.styles().general.horizontal_rule,
             border: Border {
                 radius: 8.0.into(),
                 width: 0.0,

--- a/src/appearance/theme/selectable_text.rs
+++ b/src/appearance/theme/selectable_text.rs
@@ -1,7 +1,6 @@
 use data::config::buffer::away;
 use data::message::source::server::{Kind, StandardReply};
-use data::message::{self};
-use data::{Config, User};
+use data::{Config, User, message};
 
 use super::{Theme, text};
 use crate::widget::selectable_rich_text;
@@ -22,7 +21,7 @@ impl Catalog for Theme {
 pub fn default(theme: &Theme) -> Style {
     Style {
         color: None,
-        selection_color: theme.colors().buffer.selection,
+        selection_color: theme.styles().buffer.selection,
     }
 }
 
@@ -31,7 +30,7 @@ pub fn action(theme: &Theme) -> Style {
 
     Style {
         color,
-        selection_color: theme.colors().buffer.selection,
+        selection_color: theme.styles().buffer.selection,
     }
 }
 
@@ -40,7 +39,7 @@ pub fn tertiary(theme: &Theme) -> Style {
 
     Style {
         color,
-        selection_color: theme.colors().buffer.selection,
+        selection_color: theme.styles().buffer.selection,
     }
 }
 
@@ -49,7 +48,7 @@ pub fn timestamp(theme: &Theme) -> Style {
 
     Style {
         color,
-        selection_color: theme.colors().buffer.selection,
+        selection_color: theme.styles().buffer.selection,
     }
 }
 
@@ -58,7 +57,7 @@ pub fn topic(theme: &Theme) -> Style {
 
     Style {
         color,
-        selection_color: theme.colors().buffer.selection,
+        selection_color: theme.styles().buffer.selection,
     }
 }
 
@@ -66,32 +65,33 @@ pub fn server(
     theme: &Theme,
     server: Option<&message::source::Server>,
 ) -> Style {
-    let colors = theme.colors().buffer.server_messages;
+    let styles = theme.styles().buffer.server_messages;
     let color = server
         .and_then(|server| match server.kind() {
-            Kind::Join => colors.join,
-            Kind::Part => colors.part,
-            Kind::Quit => colors.quit,
-            Kind::ReplyTopic => colors.reply_topic,
-            Kind::ChangeHost => colors.change_host,
-            Kind::MonitoredOnline => colors.monitored_online,
-            Kind::MonitoredOffline => colors.monitored_offline,
-            Kind::StandardReply(StandardReply::Fail) => colors
+            Kind::Join => styles.join,
+            Kind::Part => styles.part,
+            Kind::Quit => styles.quit,
+            Kind::ReplyTopic => styles.reply_topic,
+            Kind::ChangeHost => styles.change_host,
+            Kind::MonitoredOnline => styles.monitored_online,
+            Kind::MonitoredOffline => styles.monitored_offline,
+            Kind::StandardReply(StandardReply::Fail) => styles
                 .standard_reply_fail
-                .or(Some(theme.colors().text.error)),
-            Kind::StandardReply(StandardReply::Warn) => colors
+                .or(Some(theme.styles().text.error)),
+            Kind::StandardReply(StandardReply::Warn) => styles
                 .standard_reply_warn
-                .or(Some(theme.colors().text.error)),
+                .or(Some(theme.styles().text.error)),
             Kind::StandardReply(StandardReply::Note) => {
-                colors.standard_reply_note
+                styles.standard_reply_note
             }
-            Kind::Wallops => colors.wallops,
+            Kind::Wallops => styles.wallops,
         })
-        .or(Some(colors.default));
+        .or(Some(styles.default))
+        .map(|style| style.color);
 
     Style {
         color,
-        selection_color: theme.colors().buffer.selection,
+        selection_color: theme.styles().buffer.selection,
     }
 }
 
@@ -137,7 +137,7 @@ fn nickname_style(
 
     Style {
         color,
-        selection_color: theme.colors().buffer.selection,
+        selection_color: theme.styles().buffer.selection,
     }
 }
 
@@ -149,7 +149,7 @@ pub fn status(theme: &Theme, status: message::source::Status) -> Style {
 
     Style {
         color,
-        selection_color: theme.colors().buffer.selection,
+        selection_color: theme.styles().buffer.selection,
     }
 }
 

--- a/src/appearance/theme/text.rs
+++ b/src/appearance/theme/text.rs
@@ -24,67 +24,67 @@ pub fn none(_theme: &Theme) -> Style {
 
 pub fn primary(theme: &Theme) -> Style {
     Style {
-        color: Some(theme.colors().text.primary),
+        color: Some(theme.styles().text.primary.color),
     }
 }
 
 pub fn secondary(theme: &Theme) -> Style {
     Style {
-        color: Some(theme.colors().text.secondary),
+        color: Some(theme.styles().text.secondary.color),
     }
 }
 
 pub fn tertiary(theme: &Theme) -> Style {
     Style {
-        color: Some(theme.colors().text.tertiary),
+        color: Some(theme.styles().text.tertiary.color),
     }
 }
 
 pub fn error(theme: &Theme) -> Style {
     Style {
-        color: Some(theme.colors().text.error),
+        color: Some(theme.styles().text.error.color),
     }
 }
 
 pub fn success(theme: &Theme) -> Style {
     Style {
-        color: Some(theme.colors().text.success),
+        color: Some(theme.styles().text.success.color),
     }
 }
 
 pub fn action(theme: &Theme) -> Style {
     Style {
-        color: Some(theme.colors().buffer.action),
+        color: Some(theme.styles().buffer.action.color),
     }
 }
 
 pub fn timestamp(theme: &Theme) -> Style {
     Style {
-        color: Some(theme.colors().buffer.timestamp),
+        color: Some(theme.styles().buffer.timestamp.color),
     }
 }
 
 pub fn topic(theme: &Theme) -> Style {
     Style {
-        color: Some(theme.colors().buffer.topic),
+        color: Some(theme.styles().buffer.topic.color),
     }
 }
 
 pub fn buffer_title_bar(theme: &Theme) -> Style {
     Style {
-        color: Some(theme.colors().buffer.topic),
+        color: Some(theme.styles().buffer.topic.color),
     }
 }
 
 pub fn unread_indicator(theme: &Theme) -> Style {
     Style {
-        color: Some(theme.colors().general.unread_indicator),
+        color: Some(theme.styles().general.unread_indicator),
     }
 }
 
 pub fn url(theme: &Theme) -> Style {
     Style {
-        color: Some(theme.colors().buffer.url),
+        color: Some(theme.styles().buffer.url.color),
     }
 }
 
@@ -93,7 +93,7 @@ pub fn nickname<T: AsRef<str>>(
     seed: Option<T>,
     away_appearance: Option<away::Appearance>,
 ) -> Style {
-    let nickname = theme.colors().buffer.nickname;
+    let nickname = theme.styles().buffer.nickname;
     let calculate_alpha_color = |color| {
         if let Some(away::Appearance::Dimmed(alpha)) = away_appearance {
             match alpha {
@@ -101,7 +101,7 @@ pub fn nickname<T: AsRef<str>>(
                 None => alpha_color_calculate(
                     0.20,
                     0.61,
-                    theme.colors().buffer.background,
+                    theme.styles().buffer.background,
                     color,
                 ),
                 // Calculate alpha based on user defined alpha value.
@@ -114,10 +114,11 @@ pub fn nickname<T: AsRef<str>>(
 
     // If we have a seed we randomize the color based on the seed before adding any alpha value.
     let color = match seed {
-        Some(seed) => {
-            calculate_alpha_color(randomize_color(nickname, seed.as_ref()))
-        }
-        None => calculate_alpha_color(nickname),
+        Some(seed) => calculate_alpha_color(randomize_color(
+            nickname.color,
+            seed.as_ref(),
+        )),
+        None => calculate_alpha_color(nickname.color),
     };
 
     Style { color: Some(color) }

--- a/src/appearance/theme/text_input.rs
+++ b/src/appearance/theme/text_input.rs
@@ -18,7 +18,7 @@ impl Catalog for Theme {
 pub fn primary(theme: &Theme, status: Status) -> Style {
     let active = Style {
         background: Background::Color(
-            theme.colors().buffer.background_text_input,
+            theme.styles().buffer.background_text_input,
         ),
         border: Border {
             radius: 4.0.into(),
@@ -26,21 +26,21 @@ pub fn primary(theme: &Theme, status: Status) -> Style {
             color: Color::TRANSPARENT,
             // XXX Not currently displayed in application.
         },
-        icon: theme.colors().text.primary,
-        placeholder: theme.colors().text.secondary,
-        value: theme.colors().text.primary,
-        selection: theme.colors().buffer.selection,
+        icon: theme.styles().text.primary.color,
+        placeholder: theme.styles().text.secondary.color,
+        value: theme.styles().text.primary.color,
+        selection: theme.styles().buffer.selection,
     };
 
     match status {
         Status::Active | Status::Hovered | Status::Focused { .. } => active,
         Status::Disabled => Style {
             background: Background::Color(
-                theme.colors().buffer.background_text_input,
+                theme.styles().buffer.background_text_input,
             ),
             placeholder: Color {
                 a: 0.2,
-                ..theme.colors().text.secondary
+                ..theme.styles().text.secondary.color
             },
             border: Border {
                 radius: 4.0.into(),
@@ -61,7 +61,7 @@ pub fn error(theme: &Theme, status: Status) -> Style {
             border: Border {
                 radius: 4.0.into(),
                 width: 1.0,
-                color: theme.colors().text.error,
+                color: theme.styles().text.error.color,
             },
             ..primary
         },

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -14,7 +14,7 @@ use super::{input_view, scroll_view, user_context};
 use crate::widget::{
     Element, message_content, message_marker, selectable_text,
 };
-use crate::{Theme, theme};
+use crate::{Theme, font, theme};
 
 mod topic;
 
@@ -87,6 +87,9 @@ pub fn view<'a>(
                     .format_timestamp(&message.server_time)
                     .map(|timestamp| {
                         selectable_text(timestamp)
+                            .font_maybe(font::get(
+                                theme::font_style::timestamp(theme),
+                            ))
                             .style(theme::selectable_text::timestamp)
                     });
 
@@ -107,6 +110,9 @@ pub fn view<'a>(
                                 .brackets
                                 .format(String::from_iter(prefixes))
                         ))
+                        .font_maybe(font::get(theme::font_style::tertiary(
+                            theme,
+                        )))
                         .style(theme::selectable_text::tertiary);
 
                         if let Some(width) = max_prefix_width {
@@ -137,6 +143,9 @@ pub fn view<'a>(
                                 .brackets
                                 .format(user.display(with_access_levels)),
                         )
+                        .font_maybe(font::get(theme::font_style::nickname(
+                            theme,
+                        )))
                         .style(|theme| {
                             theme::selectable_text::nickname(
                                 theme, config, user,
@@ -158,6 +167,7 @@ pub fn view<'a>(
                             current_user,
                             our_user,
                             config,
+                            theme,
                             &config.buffer.nickname.click,
                         )
                         .map(scroll_view::Message::UserContext);
@@ -168,6 +178,7 @@ pub fn view<'a>(
                             theme,
                             scroll_view::Message::Link,
                             theme::selectable_text::default,
+                            theme::font_style::default,
                             move |link| match link {
                                 message::Link::User(_) => {
                                     user_context::Entry::list(true, our_user)
@@ -184,6 +195,7 @@ pub fn view<'a>(
                                         current_user,
                                         length,
                                         config,
+                                        theme,
                                     )
                                     .map(scroll_view::Message::UserContext),
                                 _ => row![].into(),
@@ -232,6 +244,12 @@ pub fn view<'a>(
                             theme,
                             scroll_view::Message::Link,
                             message_style,
+                            move |message_theme: &Theme| {
+                                theme::font_style::server(
+                                    message_theme,
+                                    server_message.as_ref(),
+                                )
+                            },
                             move |link| match link {
                                 message::Link::User(_) => {
                                     user_context::Entry::list(true, our_user)
@@ -250,6 +268,7 @@ pub fn view<'a>(
                                         }),
                                         length,
                                         config,
+                                        theme,
                                     )
                                     .map(scroll_view::Message::UserContext),
                                 _ => row![].into(),
@@ -283,6 +302,7 @@ pub fn view<'a>(
                             theme,
                             scroll_view::Message::Link,
                             theme::selectable_text::action,
+                            theme::font_style::action,
                             config,
                         );
 
@@ -319,6 +339,12 @@ pub fn view<'a>(
                             theme,
                             scroll_view::Message::Link,
                             message_style,
+                            move |message_theme: &Theme| {
+                                theme::font_style::status(
+                                    message_theme,
+                                    *status,
+                                )
+                            },
                             config,
                         );
 
@@ -345,9 +371,16 @@ pub fn view<'a>(
     .width(Length::FillPortion(2))
     .height(Length::Fill);
 
-    let nick_list =
-        nick_list::view(server, casemapping, channel, users, our_user, config)
-            .map(Message::UserContext);
+    let nick_list = nick_list::view(
+        server,
+        casemapping,
+        channel,
+        users,
+        our_user,
+        config,
+        theme,
+    )
+    .map(Message::UserContext);
 
     // If topic toggles from None to Some then it messes with messages' scroll state,
     // so produce a zero-height placeholder when topic is None.
@@ -579,7 +612,7 @@ mod nick_list {
 
     use crate::buffer::user_context;
     use crate::widget::{Element, selectable_text};
-    use crate::{font, theme};
+    use crate::{Theme, font, theme};
 
     pub fn view<'a>(
         server: &'a Server,
@@ -588,6 +621,7 @@ mod nick_list {
         users: &'a [User],
         our_user: Option<&'a User>,
         config: &'a Config,
+        theme: &'a Theme,
     ) -> Element<'a, Message> {
         let nicklist_config = &config.buffer.channel.nicklist;
 
@@ -612,6 +646,7 @@ mod nick_list {
             let content = selectable_text(
                 user.display(nicklist_config.show_access_levels),
             )
+            .font_maybe(font::get(theme::font_style::nickname(theme)))
             .style(|theme| {
                 theme::selectable_text::nicklist_nickname(theme, config, user)
             })
@@ -634,6 +669,7 @@ mod nick_list {
                 Some(user),
                 our_user,
                 config,
+                theme,
                 &config.buffer.channel.nicklist.click,
             )
         }));

--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -7,7 +7,7 @@ use iced::widget::{
 
 use super::user_context;
 use crate::widget::{Element, double_pass, message_content, selectable_text};
-use crate::{Theme, theme};
+use crate::{Theme, font, theme};
 
 #[derive(Debug, Clone)]
 pub enum Event {
@@ -60,13 +60,15 @@ pub fn view<'a>(
                 // Otherwise selectable_text component.
                 let content = if let Some(user) = channel_user {
                     user_context::view(
-                        selectable_text(user.nickname().to_string()).style(
-                            |theme| {
+                        selectable_text(user.nickname().to_string())
+                            .font_maybe(font::get(theme::font_style::nickname(
+                                theme,
+                            )))
+                            .style(|theme| {
                                 theme::selectable_text::topic_nickname(
                                     theme, config, user,
                                 )
-                            },
-                        ),
+                            }),
                         server,
                         casemapping,
                         Some(channel),
@@ -74,10 +76,14 @@ pub fn view<'a>(
                         Some(user),
                         our_user,
                         config,
+                        theme,
                         &config.buffer.nickname.click,
                     )
                 } else {
                     selectable_text(user.display(false))
+                        .font_maybe(font::get(theme::font_style::nickname(
+                            theme,
+                        )))
                         .style(move |theme| {
                             theme::selectable_text::topic_nickname(
                                 theme, config, &user,
@@ -89,9 +95,15 @@ pub fn view<'a>(
                 Some(
                     Element::new(row![
                         selectable_text("set by ")
+                            .font_maybe(font::get(theme::font_style::topic(
+                                theme
+                            ),))
                             .style(theme::selectable_text::topic),
                         content,
                         selectable_text(format!(" at {}", time?.to_rfc2822()))
+                            .font_maybe(font::get(theme::font_style::topic(
+                                theme
+                            ),))
                             .style(theme::selectable_text::topic),
                     ])
                     .map(Message::UserContext),
@@ -104,6 +116,7 @@ pub fn view<'a>(
         theme,
         Message::Link,
         theme::selectable_text::topic,
+        theme::font_style::topic,
         config,
     )]
     .push_maybe(set_by);

--- a/src/buffer/highlights.rs
+++ b/src/buffer/highlights.rs
@@ -10,7 +10,7 @@ use super::{scroll_view, user_context};
 use crate::widget::{
     Element, message_content, selectable_rich_text, selectable_text,
 };
-use crate::{Theme, theme};
+use crate::{Theme, font, theme};
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -54,13 +54,19 @@ pub fn view<'a>(
                         .format_timestamp(&message.server_time)
                         .map(|timestamp| {
                             selectable_text(timestamp)
+                                .font_maybe(font::get(
+                                    theme::font_style::timestamp(theme),
+                                ))
                                 .style(theme::selectable_text::timestamp)
                         });
 
                     let channel_text =
                         selectable_rich_text::<_, _, (), _, _>(vec![
                             span(channel.as_str())
-                                .color(theme.colors().buffer.url)
+                                .font_maybe(font::get(
+                                    theme.styles().buffer.url.font_style,
+                                ))
+                                .color(theme.styles().buffer.url.color)
                                 .link(message::Link::GoToMessage(
                                     server.clone(),
                                     channel.clone(),
@@ -83,6 +89,7 @@ pub fn view<'a>(
                             .brackets
                             .format(user.display(with_access_levels)),
                     )
+                    .font_maybe(font::get(theme::font_style::nickname(theme)))
                     .style(|theme| {
                         theme::selectable_text::nickname(theme, config, user)
                     });
@@ -98,6 +105,7 @@ pub fn view<'a>(
                         current_user,
                         None,
                         config,
+                        theme,
                         &config.buffer.nickname.click,
                     )
                     .map(scroll_view::Message::UserContext);
@@ -108,6 +116,7 @@ pub fn view<'a>(
                         theme,
                         scroll_view::Message::Link,
                         theme::selectable_text::default,
+                        theme::font_style::default,
                         move |link| match link {
                             message::Link::User(_) => {
                                 user_context::Entry::list(true, None)
@@ -124,6 +133,7 @@ pub fn view<'a>(
                                     current_user,
                                     length,
                                     config,
+                                    theme,
                                 )
                                 .map(scroll_view::Message::UserContext),
                             _ => row![].into(),
@@ -153,13 +163,16 @@ pub fn view<'a>(
                         .format_timestamp(&message.server_time)
                         .map(|timestamp| {
                             selectable_text(timestamp)
+                                .font_maybe(font::get(
+                                    theme::font_style::timestamp(theme),
+                                ))
                                 .style(theme::selectable_text::timestamp)
                         });
 
                     let channel_text =
                         selectable_rich_text::<_, _, (), _, _>(vec![
                             span(channel.as_str())
-                                .color(theme.colors().buffer.url)
+                                .color(theme.styles().buffer.url.color)
                                 .link(message::Link::GoToMessage(
                                     server.clone(),
                                     channel.clone(),
@@ -177,6 +190,7 @@ pub fn view<'a>(
                         theme,
                         scroll_view::Message::Link,
                         theme::selectable_text::action,
+                        theme::font_style::action,
                         config,
                     );
 

--- a/src/buffer/logs.rs
+++ b/src/buffer/logs.rs
@@ -47,6 +47,7 @@ pub fn view<'a>(
                             theme,
                             scroll_view::Message::Link,
                             theme::selectable_text::default,
+                            theme::font_style::default,
                             config,
                         ))
                         .into(),

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -12,7 +12,7 @@ use super::{input_view, scroll_view, user_context};
 use crate::widget::{
     Element, message_content, message_marker, selectable_text,
 };
-use crate::{Theme, theme};
+use crate::{Theme, font, theme};
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -72,6 +72,9 @@ pub fn view<'a>(
                     .format_timestamp(&message.server_time)
                     .map(|timestamp| {
                         selectable_text(timestamp)
+                            .font_maybe(font::get(
+                                theme::font_style::timestamp(theme),
+                            ))
                             .style(theme::selectable_text::timestamp)
                     });
 
@@ -88,6 +91,9 @@ pub fn view<'a>(
                                 .brackets
                                 .format(user.display(with_access_levels)),
                         )
+                        .font_maybe(font::get(theme::font_style::nickname(
+                            theme,
+                        )))
                         .style(|theme| {
                             theme::selectable_text::nickname(
                                 theme, config, user,
@@ -109,6 +115,7 @@ pub fn view<'a>(
                             None,
                             None,
                             config,
+                            theme,
                             &config.buffer.nickname.click,
                         )
                         .map(scroll_view::Message::UserContext);
@@ -119,6 +126,7 @@ pub fn view<'a>(
                             theme,
                             scroll_view::Message::Link,
                             theme::selectable_text::default,
+                            theme::font_style::default,
                             move |link| match link {
                                 message::Link::User(_) => {
                                     user_context::Entry::list(false, None)
@@ -135,6 +143,7 @@ pub fn view<'a>(
                                         None,
                                         length,
                                         config,
+                                        theme,
                                     )
                                     .map(scroll_view::Message::UserContext),
                                 _ => row![].into(),
@@ -180,6 +189,12 @@ pub fn view<'a>(
                             theme,
                             scroll_view::Message::Link,
                             message_style,
+                            move |message_theme: &Theme| {
+                                theme::font_style::server(
+                                    message_theme,
+                                    server.as_ref(),
+                                )
+                            },
                             config,
                         );
 
@@ -206,6 +221,7 @@ pub fn view<'a>(
                             theme,
                             scroll_view::Message::Link,
                             theme::selectable_text::action,
+                            theme::font_style::action,
                             config,
                         );
 
@@ -241,6 +257,12 @@ pub fn view<'a>(
                             theme,
                             scroll_view::Message::Link,
                             message_style,
+                            move |message_theme: &Theme| {
+                                theme::font_style::status(
+                                    message_theme,
+                                    *status,
+                                )
+                            },
                             config,
                         );
 

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -8,7 +8,7 @@ use iced::{Length, Task};
 
 use super::{input_view, scroll_view, user_context};
 use crate::widget::{Element, message_content, selectable_text};
-use crate::{Theme, theme};
+use crate::{Theme, font, theme};
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -52,6 +52,9 @@ pub fn view<'a>(
                     .format_timestamp(&message.server_time)
                     .map(|timestamp| {
                         selectable_text(timestamp)
+                            .font_maybe(font::get(
+                                theme::font_style::timestamp(theme),
+                            ))
                             .style(theme::selectable_text::timestamp)
                     });
 
@@ -64,6 +67,12 @@ pub fn view<'a>(
                             scroll_view::Message::Link,
                             move |theme| {
                                 theme::selectable_text::server(
+                                    theme,
+                                    server.as_ref(),
+                                )
+                            },
+                            move |theme| {
+                                theme::font_style::server(
                                     theme,
                                     server.as_ref(),
                                 )
@@ -88,6 +97,9 @@ pub fn view<'a>(
                             scroll_view::Message::Link,
                             move |theme| {
                                 theme::selectable_text::status(theme, *status)
+                            },
+                            move |theme| {
+                                theme::font_style::status(theme, *status)
                             },
                             config,
                         );

--- a/src/buffer/user_context.rs
+++ b/src/buffer/user_context.rs
@@ -7,7 +7,7 @@ use iced::widget::{
 use iced::{Length, Padding, padding};
 
 use crate::widget::{Element, context_menu, double_pass};
-use crate::{theme, widget};
+use crate::{Theme, font, theme, widget};
 
 #[derive(Debug, Clone, Copy)]
 pub enum Entry {
@@ -67,6 +67,7 @@ impl Entry {
         current_user: Option<&User>,
         length: Length,
         config: &Config,
+        theme: &Theme,
     ) -> Element<'a, Message> {
         let nickname = user.nickname().to_owned();
 
@@ -149,7 +150,7 @@ impl Entry {
                 length,
             ),
             Entry::UserInfo => {
-                user_info(current_user, nickname, length, config)
+                user_info(current_user, nickname, length, config, theme)
             }
             Entry::HorizontalRule => match length {
                 Length::Fill => {
@@ -227,6 +228,7 @@ pub fn view<'a>(
     current_user: Option<&'a User>,
     our_user: Option<&'a User>,
     config: &'a Config,
+    theme: &'a Theme,
     click: &'a config::buffer::NicknameClickAction,
 ) -> Element<'a, Message> {
     let entries = Entry::list(channel.is_some(), our_user);
@@ -257,6 +259,7 @@ pub fn view<'a>(
                 current_user,
                 length,
                 config,
+                theme,
             )
         },
     )
@@ -284,6 +287,7 @@ fn user_info<'a>(
     nickname: Nick,
     length: Length,
     config: &Config,
+    theme: &Theme,
 ) -> Element<'a, Message> {
     let state = match current_user {
         Some(user) => {
@@ -306,18 +310,19 @@ fn user_info<'a>(
         data::buffer::Color::Unique => Some(nickname.to_string()),
     };
 
-    column![
-        container(
-            text(nickname.to_string())
-                .style(move |theme| theme::text::nickname(
-                    theme,
-                    seed.clone(),
-                    away_appearance
-                ))
-                .width(length)
+    let mut nickname = text(nickname.to_string())
+        .style(move |theme| {
+            theme::text::nickname(theme, seed.clone(), away_appearance)
+        })
+        .width(length);
+
+    if let Some(font) = font::get(theme::font_style::nickname(theme)) {
+        nickname = nickname.font(font);
+    }
+
+    column![container(nickname).padding(right_justified_padding()),]
+        .push_maybe(
+            state.map(|s| container(s).padding(right_justified_padding())),
         )
-        .padding(right_justified_padding()),
-    ]
-    .push_maybe(state.map(|s| container(s).padding(right_justified_padding())))
-    .into()
+        .into()
 }

--- a/src/font.rs
+++ b/src/font.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::sync::OnceLock;
 
+use data::appearance::theme::FontStyle;
 use data::{Config, config};
 use iced::font;
 
@@ -118,4 +119,13 @@ pub fn width_from_chars(len: usize, config: &config::Font) -> f32 {
     .min_bounds()
     .expand(Size::new(1.0, 0.0))
     .width
+}
+
+pub fn get(font_style: FontStyle) -> Option<Font> {
+    match font_style {
+        FontStyle::Normal => None,
+        FontStyle::Bold => Some(MONO_BOLD.clone()),
+        FontStyle::Italic => Some(MONO_ITALICS.clone()),
+        FontStyle::ItalicBold => Some(MONO_BOLD_ITALICS.clone()),
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -303,11 +303,11 @@ impl Halloy {
                     config,
                 });
             }
-            data::Url::Theme { colors, .. } => {
+            data::Url::Theme { styles, .. } => {
                 if let Screen::Dashboard(dashboard) = &mut self.screen {
                     return dashboard
                         .preview_theme_in_editor(
-                            colors,
+                            styles,
                             &self.main_window,
                             &mut self.theme,
                         )

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -2685,11 +2685,11 @@ impl Dashboard {
 
     pub fn preview_theme_in_editor(
         &mut self,
-        colors: theme::Colors,
+        styles: theme::Styles,
         main_window: &Window,
         theme: &mut Theme,
     ) -> Task<Message> {
-        *theme = theme.preview(data::Theme::new("Custom Theme".into(), colors));
+        *theme = theme.preview(data::Theme::new("Custom Theme".into(), styles));
 
         if let Some(editor) = &self.theme_editor {
             window::gain_focus(editor.window)

--- a/src/screen/dashboard/theme_editor.rs
+++ b/src/screen/dashboard/theme_editor.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+use data::appearance::theme::set_optional_text_style_color;
 use data::{Config, url};
 use futures::TryFutureExt;
 use iced::Length::*;
@@ -11,7 +12,7 @@ use iced::{Color, Length, Task, Vector, alignment, clipboard};
 use strum::IntoEnumIterator;
 use tokio::time;
 
-use crate::theme::{self, Colors, Theme};
+use crate::theme::{self, Styles, Theme};
 use crate::widget::{Element, color_picker, combo_box, tooltip};
 use crate::window::{self, Window};
 use crate::{icon, widget};
@@ -92,12 +93,12 @@ impl ThemeEditor {
             Message::Color(color) => {
                 self.hex_input = None;
 
-                let mut colors = *theme.colors();
+                let mut styles = *theme.styles();
 
-                self.component.update(&mut colors, Some(color));
+                self.component.update(&mut styles, Some(color));
 
                 *theme = theme
-                    .preview(data::Theme::new("Custom Theme".into(), colors));
+                    .preview(data::Theme::new("Custom Theme".into(), styles));
             }
             Message::Component(component) => {
                 self.hex_input = None;
@@ -107,13 +108,13 @@ impl ThemeEditor {
             }
             Message::HexInput(input) => {
                 if let Some(color) = theme::hex_to_color(&input) {
-                    let mut colors = *theme.colors();
+                    let mut styles = *theme.styles();
 
-                    self.component.update(&mut colors, Some(color));
+                    self.component.update(&mut styles, Some(color));
 
                     *theme = theme.preview(data::Theme::new(
                         "Custom Theme".into(),
-                        colors,
+                        styles,
                     ));
                 }
 
@@ -145,28 +146,28 @@ impl ThemeEditor {
             Message::Revert => {
                 self.hex_input = None;
 
-                let mut colors = *theme.selected().colors();
-                let original = self.component.color(&colors);
+                let mut styles = *theme.selected().styles();
+                let original = self.component.color(&styles);
 
-                self.component.update(&mut colors, original);
+                self.component.update(&mut styles, original);
 
                 *theme = theme
-                    .preview(data::Theme::new("Custom Theme".into(), colors));
+                    .preview(data::Theme::new("Custom Theme".into(), styles));
             }
             Message::Clear => {
                 self.hex_input = None;
 
-                let mut colors = *theme.colors();
+                let mut styles = *theme.styles();
 
-                self.component.update(&mut colors, None);
+                self.component.update(&mut styles, None);
 
                 *theme = theme
-                    .preview(data::Theme::new("Custom Theme".into(), colors));
+                    .preview(data::Theme::new("Custom Theme".into(), styles));
             }
             Message::Copy => {
                 self.copied = true;
 
-                let url = url::theme(theme.colors());
+                let url = url::theme(theme.styles());
 
                 return (
                     Task::batch(vec![
@@ -180,7 +181,7 @@ impl ThemeEditor {
                 );
             }
             Message::Share => {
-                let url = url::theme_submit(theme.colors());
+                let url = url::theme_submit(theme.styles());
                 let _ = open::that_detached(url);
 
                 return (Task::none(), None);
@@ -189,11 +190,11 @@ impl ThemeEditor {
             Message::SavePath(Some(path)) => {
                 log::debug!("Saving theme to {path:?}");
 
-                let colors = *theme.colors();
+                let styles = *theme.styles();
 
                 return (
                     Task::perform(
-                        colors.save(path).map_err(|e| e.to_string()),
+                        styles.save(path).map_err(|e| e.to_string()),
                         Message::Saved,
                     ),
                     None,
@@ -235,7 +236,7 @@ impl ThemeEditor {
     pub fn view<'a>(&'a self, theme: &'a Theme) -> Element<'a, Message> {
         let color = self
             .component
-            .color(theme.colors())
+            .color(theme.styles())
             .unwrap_or(Color::TRANSPARENT);
 
         let component = combo_box(
@@ -401,26 +402,26 @@ pub enum Component {
 }
 
 impl Component {
-    fn color(&self, colors: &Colors) -> Option<Color> {
+    fn color(&self, styles: &Styles) -> Option<Color> {
         match self {
-            Component::General(general) => Some(general.color(&colors.general)),
-            Component::Text(text) => Some(text.color(&colors.text)),
-            Component::Buffer(buffer) => buffer.color(&colors.buffer),
-            Component::Buttons(buttons) => Some(buttons.color(&colors.buttons)),
+            Component::General(general) => Some(general.color(&styles.general)),
+            Component::Text(text) => Some(text.color(&styles.text)),
+            Component::Buffer(buffer) => buffer.color(&styles.buffer),
+            Component::Buttons(buttons) => Some(buttons.color(&styles.buttons)),
         }
     }
 
-    fn update(&self, colors: &mut Colors, color: Option<Color>) {
+    fn update(&self, styles: &mut Styles, color: Option<Color>) {
         match self {
             Component::General(general) => {
-                general.update(&mut colors.general, color);
+                general.update(&mut styles.general, color);
             }
-            Component::Text(text) => text.update(&mut colors.text, color),
+            Component::Text(text) => text.update(&mut styles.text, color),
             Component::Buffer(buffer) => {
-                buffer.update(&mut colors.buffer, color);
+                buffer.update(&mut styles.buffer, color);
             }
             Component::Buttons(buttons) => {
-                buttons.update(&mut colors.buttons, color);
+                buttons.update(&mut styles.buttons, color);
             }
         }
     }
@@ -438,28 +439,28 @@ pub enum General {
 }
 
 impl General {
-    fn color(&self, colors: &theme::General) -> Color {
+    fn color(&self, styles: &theme::General) -> Color {
         match self {
-            General::Background => colors.background,
-            General::Border => colors.border,
-            General::HorizontalRule => colors.horizontal_rule,
-            General::UnreadIndicator => colors.unread_indicator,
+            General::Background => styles.background,
+            General::Border => styles.border,
+            General::HorizontalRule => styles.horizontal_rule,
+            General::UnreadIndicator => styles.unread_indicator,
         }
     }
 
-    fn update(&self, colors: &mut theme::General, color: Option<Color>) {
+    fn update(&self, styles: &mut theme::General, color: Option<Color>) {
         match self {
             General::Background => {
-                colors.background = color.unwrap_or(Color::TRANSPARENT);
+                styles.background = color.unwrap_or(Color::TRANSPARENT);
             }
             General::Border => {
-                colors.border = color.unwrap_or(Color::TRANSPARENT);
+                styles.border = color.unwrap_or(Color::TRANSPARENT);
             }
             General::HorizontalRule => {
-                colors.horizontal_rule = color.unwrap_or(Color::TRANSPARENT);
+                styles.horizontal_rule = color.unwrap_or(Color::TRANSPARENT);
             }
             General::UnreadIndicator => {
-                colors.unread_indicator = color.unwrap_or(Color::TRANSPARENT);
+                styles.unread_indicator = color.unwrap_or(Color::TRANSPARENT);
             }
         }
     }
@@ -478,31 +479,33 @@ pub enum Text {
 }
 
 impl Text {
-    fn color(&self, colors: &theme::Text) -> Color {
+    fn color(&self, styles: &theme::Text) -> Color {
         match self {
-            Text::Primary => colors.primary,
-            Text::Secondary => colors.secondary,
-            Text::Tertiary => colors.tertiary,
-            Text::Success => colors.success,
-            Text::Error => colors.error,
+            Text::Primary => styles.primary.color,
+            Text::Secondary => styles.secondary.color,
+            Text::Tertiary => styles.tertiary.color,
+            Text::Success => styles.success.color,
+            Text::Error => styles.error.color,
         }
     }
 
-    fn update(&self, colors: &mut theme::Text, color: Option<Color>) {
+    fn update(&self, styles: &mut theme::Text, color: Option<Color>) {
         match self {
             Text::Primary => {
-                colors.primary = color.unwrap_or(Color::TRANSPARENT);
+                styles.primary.color = color.unwrap_or(Color::TRANSPARENT);
             }
             Text::Secondary => {
-                colors.secondary = color.unwrap_or(Color::TRANSPARENT);
+                styles.secondary.color = color.unwrap_or(Color::TRANSPARENT);
             }
             Text::Tertiary => {
-                colors.tertiary = color.unwrap_or(Color::TRANSPARENT);
+                styles.tertiary.color = color.unwrap_or(Color::TRANSPARENT);
             }
             Text::Success => {
-                colors.success = color.unwrap_or(Color::TRANSPARENT);
+                styles.success.color = color.unwrap_or(Color::TRANSPARENT);
             }
-            Text::Error => colors.error = color.unwrap_or(Color::TRANSPARENT),
+            Text::Error => {
+                styles.error.color = color.unwrap_or(Color::TRANSPARENT);
+            }
         }
     }
 }
@@ -530,67 +533,73 @@ pub enum Buffer {
 }
 
 impl Buffer {
-    fn color(&self, colors: &theme::Buffer) -> Option<Color> {
+    fn color(&self, styles: &theme::Buffer) -> Option<Color> {
         match self {
-            Buffer::Action => Some(colors.action),
-            Buffer::Background => Some(colors.background),
-            Buffer::BackgroundTextInput => Some(colors.background_text_input),
-            Buffer::BackgroundTitleBar => Some(colors.background_title_bar),
-            Buffer::Border => Some(colors.border),
-            Buffer::BorderSelected => Some(colors.border_selected),
-            Buffer::Code => Some(colors.code),
-            Buffer::Highlight => Some(colors.highlight),
-            Buffer::Nickname => Some(colors.nickname),
-            Buffer::Selection => Some(colors.selection),
+            Buffer::Action => Some(styles.action.color),
+            Buffer::Background => Some(styles.background),
+            Buffer::BackgroundTextInput => Some(styles.background_text_input),
+            Buffer::BackgroundTitleBar => Some(styles.background_title_bar),
+            Buffer::Border => Some(styles.border),
+            Buffer::BorderSelected => Some(styles.border_selected),
+            Buffer::Code => Some(styles.code.color),
+            Buffer::Highlight => Some(styles.highlight),
+            Buffer::Nickname => Some(styles.nickname.color),
+            Buffer::Selection => Some(styles.selection),
             Buffer::ServerMessages(server_messages) => {
-                server_messages.color(&colors.server_messages)
+                server_messages.color(&styles.server_messages)
             }
-            Buffer::Timestamp => Some(colors.timestamp),
-            Buffer::Topic => Some(colors.topic),
-            Buffer::Url => Some(colors.url),
+            Buffer::Timestamp => Some(styles.timestamp.color),
+            Buffer::Topic => Some(styles.topic.color),
+            Buffer::Url => Some(styles.url.color),
         }
     }
 
-    fn update(&self, colors: &mut theme::Buffer, color: Option<Color>) {
+    fn update(&self, styles: &mut theme::Buffer, color: Option<Color>) {
         match self {
             Buffer::Action => {
-                colors.action = color.unwrap_or(Color::TRANSPARENT);
+                styles.action.color = color.unwrap_or(Color::TRANSPARENT);
             }
             Buffer::Background => {
-                colors.background = color.unwrap_or(Color::TRANSPARENT);
+                styles.background = color.unwrap_or(Color::TRANSPARENT);
             }
             Buffer::BackgroundTextInput => {
-                colors.background_text_input =
+                styles.background_text_input =
                     color.unwrap_or(Color::TRANSPARENT);
             }
             Buffer::BackgroundTitleBar => {
-                colors.background_title_bar =
+                styles.background_title_bar =
                     color.unwrap_or(Color::TRANSPARENT);
             }
             Buffer::Border => {
-                colors.border = color.unwrap_or(Color::TRANSPARENT);
+                styles.border = color.unwrap_or(Color::TRANSPARENT);
             }
             Buffer::BorderSelected => {
-                colors.border_selected = color.unwrap_or(Color::TRANSPARENT);
+                styles.border_selected = color.unwrap_or(Color::TRANSPARENT);
             }
-            Buffer::Code => colors.code = color.unwrap_or(Color::TRANSPARENT),
+            Buffer::Code => {
+                styles.code.color = color.unwrap_or(Color::TRANSPARENT);
+            }
             Buffer::Highlight => {
-                colors.highlight = color.unwrap_or(Color::TRANSPARENT);
+                styles.highlight = color.unwrap_or(Color::TRANSPARENT);
             }
             Buffer::Nickname => {
-                colors.nickname = color.unwrap_or(Color::TRANSPARENT);
+                styles.nickname.color = color.unwrap_or(Color::TRANSPARENT);
             }
             Buffer::Selection => {
-                colors.selection = color.unwrap_or(Color::TRANSPARENT);
+                styles.selection = color.unwrap_or(Color::TRANSPARENT);
             }
             Buffer::ServerMessages(server_messages) => {
-                server_messages.update(&mut colors.server_messages, color);
+                server_messages.update(&mut styles.server_messages, color);
             }
             Buffer::Timestamp => {
-                colors.timestamp = color.unwrap_or(Color::TRANSPARENT);
+                styles.timestamp.color = color.unwrap_or(Color::TRANSPARENT);
             }
-            Buffer::Topic => colors.topic = color.unwrap_or(Color::TRANSPARENT),
-            Buffer::Url => colors.url = color.unwrap_or(Color::TRANSPARENT),
+            Buffer::Topic => {
+                styles.topic.color = color.unwrap_or(Color::TRANSPARENT);
+            }
+            Buffer::Url => {
+                styles.url.color = color.unwrap_or(Color::TRANSPARENT);
+            }
         }
     }
 }
@@ -616,46 +625,87 @@ pub enum ServerMessages {
 }
 
 impl ServerMessages {
-    fn color(&self, colors: &theme::ServerMessages) -> Option<Color> {
+    fn color(&self, styles: &theme::ServerMessages) -> Option<Color> {
         match self {
-            ServerMessages::Join => colors.join,
-            ServerMessages::Part => colors.part,
-            ServerMessages::Quit => colors.quit,
-            ServerMessages::ReplyTopic => colors.reply_topic,
-            ServerMessages::ChangeHost => colors.change_host,
-            ServerMessages::MonitoredOnline => colors.monitored_online,
-            ServerMessages::MonitoredOffline => colors.monitored_offline,
-            ServerMessages::StandardReplyFail => colors.standard_reply_fail,
-            ServerMessages::StandardReplyWarn => colors.standard_reply_warn,
-            ServerMessages::StandardReplyNote => colors.standard_reply_note,
-            ServerMessages::Wallops => colors.wallops,
-            ServerMessages::Default => Some(colors.default),
+            ServerMessages::Join => styles.join.map(|style| style.color),
+            ServerMessages::Part => styles.part.map(|style| style.color),
+            ServerMessages::Quit => styles.quit.map(|style| style.color),
+            ServerMessages::ReplyTopic => {
+                styles.reply_topic.map(|style| style.color)
+            }
+            ServerMessages::ChangeHost => {
+                styles.change_host.map(|style| style.color)
+            }
+            ServerMessages::MonitoredOnline => {
+                styles.monitored_online.map(|style| style.color)
+            }
+            ServerMessages::MonitoredOffline => {
+                styles.monitored_offline.map(|style| style.color)
+            }
+            ServerMessages::StandardReplyFail => {
+                styles.standard_reply_fail.map(|style| style.color)
+            }
+            ServerMessages::StandardReplyWarn => {
+                styles.standard_reply_warn.map(|style| style.color)
+            }
+            ServerMessages::StandardReplyNote => {
+                styles.standard_reply_note.map(|style| style.color)
+            }
+            ServerMessages::Wallops => styles.wallops.map(|style| style.color),
+            ServerMessages::Default => Some(styles.default.color),
         }
     }
 
-    fn update(&self, colors: &mut theme::ServerMessages, color: Option<Color>) {
+    fn update(&self, styles: &mut theme::ServerMessages, color: Option<Color>) {
         match self {
-            ServerMessages::Join => colors.join = color,
-            ServerMessages::Part => colors.part = color,
-            ServerMessages::Quit => colors.quit = color,
-            ServerMessages::ReplyTopic => colors.reply_topic = color,
-            ServerMessages::ChangeHost => colors.change_host = color,
-            ServerMessages::MonitoredOnline => colors.monitored_online = color,
+            ServerMessages::Join => {
+                set_optional_text_style_color(&mut styles.join, color);
+            }
+            ServerMessages::Part => {
+                set_optional_text_style_color(&mut styles.part, color);
+            }
+            ServerMessages::Quit => {
+                set_optional_text_style_color(&mut styles.quit, color);
+            }
+            ServerMessages::ReplyTopic => {
+                set_optional_text_style_color(&mut styles.reply_topic, color);
+            }
+            ServerMessages::ChangeHost => {
+                set_optional_text_style_color(&mut styles.change_host, color);
+            }
+            ServerMessages::MonitoredOnline => set_optional_text_style_color(
+                &mut styles.monitored_online,
+                color,
+            ),
             ServerMessages::MonitoredOffline => {
-                colors.monitored_offline = color;
+                set_optional_text_style_color(
+                    &mut styles.monitored_offline,
+                    color,
+                );
             }
             ServerMessages::StandardReplyFail => {
-                colors.standard_reply_fail = color;
+                set_optional_text_style_color(
+                    &mut styles.standard_reply_fail,
+                    color,
+                );
             }
             ServerMessages::StandardReplyWarn => {
-                colors.standard_reply_warn = color;
+                set_optional_text_style_color(
+                    &mut styles.standard_reply_warn,
+                    color,
+                );
             }
             ServerMessages::StandardReplyNote => {
-                colors.standard_reply_note = color;
+                set_optional_text_style_color(
+                    &mut styles.standard_reply_note,
+                    color,
+                );
             }
-            ServerMessages::Wallops => colors.wallops = color,
+            ServerMessages::Wallops => {
+                set_optional_text_style_color(&mut styles.wallops, color);
+            }
             ServerMessages::Default => {
-                colors.default = color.unwrap_or(Color::TRANSPARENT);
+                styles.default.color = color.unwrap_or(Color::TRANSPARENT);
             }
         }
     }
@@ -672,20 +722,20 @@ pub enum Buttons {
 }
 
 impl Buttons {
-    fn color(&self, colors: &theme::Buttons) -> Color {
+    fn color(&self, styles: &theme::Buttons) -> Color {
         match self {
-            Buttons::Primary(button) => button.color(&colors.primary),
-            Buttons::Secondary(button) => button.color(&colors.secondary),
+            Buttons::Primary(button) => button.color(&styles.primary),
+            Buttons::Secondary(button) => button.color(&styles.secondary),
         }
     }
 
-    fn update(&self, colors: &mut theme::Buttons, color: Option<Color>) {
+    fn update(&self, styles: &mut theme::Buttons, color: Option<Color>) {
         match self {
             Buttons::Primary(button) => {
-                button.update(&mut colors.primary, color);
+                button.update(&mut styles.primary, color);
             }
             Buttons::Secondary(button) => {
-                button.update(&mut colors.secondary, color);
+                button.update(&mut styles.secondary, color);
             }
         }
     }
@@ -704,29 +754,29 @@ pub enum Button {
 }
 
 impl Button {
-    fn color(&self, colors: &theme::Button) -> Color {
+    fn color(&self, styles: &theme::Button) -> Color {
         match self {
-            Button::Background => colors.background,
-            Button::BackgroundHover => colors.background_hover,
-            Button::BackgroundSelected => colors.background_selected,
-            Button::BackgroundSelectedHover => colors.background_selected_hover,
+            Button::Background => styles.background,
+            Button::BackgroundHover => styles.background_hover,
+            Button::BackgroundSelected => styles.background_selected,
+            Button::BackgroundSelectedHover => styles.background_selected_hover,
         }
     }
 
-    fn update(&self, colors: &mut theme::Button, color: Option<Color>) {
+    fn update(&self, styles: &mut theme::Button, color: Option<Color>) {
         match self {
             Button::Background => {
-                colors.background = color.unwrap_or(Color::TRANSPARENT);
+                styles.background = color.unwrap_or(Color::TRANSPARENT);
             }
             Button::BackgroundHover => {
-                colors.background_hover = color.unwrap_or(Color::TRANSPARENT);
+                styles.background_hover = color.unwrap_or(Color::TRANSPARENT);
             }
             Button::BackgroundSelected => {
-                colors.background_selected =
+                styles.background_selected =
                     color.unwrap_or(Color::TRANSPARENT);
             }
             Button::BackgroundSelectedHover => {
-                colors.background_selected_hover =
+                styles.background_selected_hover =
                     color.unwrap_or(Color::TRANSPARENT);
             }
         }

--- a/src/widget/color_picker.rs
+++ b/src/widget/color_picker.rs
@@ -59,7 +59,7 @@ fn bordered<'a, Message: 'a>(
             background: None,
             border: border::rounded(2)
                 .width(1)
-                .color(theme.colors().general.border),
+                .color(theme.styles().general.border),
             shadow: iced::Shadow::default(),
         })
 }

--- a/src/widget/message_content.rs
+++ b/src/widget/message_content.rs
@@ -1,4 +1,4 @@
-use data::appearance::theme::randomize_color;
+use data::appearance::theme::{FontStyle, randomize_color};
 use data::{Config, isupport, message, target};
 use iced::widget::span;
 use iced::widget::text::Span;
@@ -13,6 +13,7 @@ pub fn message_content<'a, M: 'a>(
     theme: &'a Theme,
     on_link: impl Fn(message::Link) -> M + 'a,
     style: impl Fn(&Theme) -> selectable_text::Style + 'a,
+    font_style: impl Fn(&Theme) -> FontStyle,
     config: &Config,
 ) -> Element<'a, M> {
     message_content_impl::<(), M>(
@@ -21,6 +22,7 @@ pub fn message_content<'a, M: 'a>(
         theme,
         on_link,
         style,
+        font_style,
         Option::<(fn(&message::Link) -> _, fn(&message::Link, _, _) -> _)>::None,
         config,
     )
@@ -32,6 +34,7 @@ pub fn with_context<'a, T: Copy + 'a, M: 'a>(
     theme: &'a Theme,
     on_link: impl Fn(message::Link) -> M + 'a,
     style: impl Fn(&Theme) -> selectable_text::Style + 'a,
+    font_style: impl Fn(&Theme) -> FontStyle,
     link_entries: impl Fn(&message::Link) -> Vec<T> + 'a,
     entry: impl Fn(&message::Link, T, Length) -> Element<'a, M> + 'a,
     config: &Config,
@@ -42,6 +45,7 @@ pub fn with_context<'a, T: Copy + 'a, M: 'a>(
         theme,
         on_link,
         style,
+        font_style,
         Some((link_entries, entry)),
         config,
     )
@@ -54,6 +58,7 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
     theme: &'a Theme,
     on_link: impl Fn(message::Link) -> M + 'a,
     style: impl Fn(&Theme) -> selectable_text::Style + 'a,
+    font_style: impl Fn(&Theme) -> FontStyle,
     context_menu: Option<(
         impl Fn(&message::Link) -> Vec<T> + 'a,
         impl Fn(&message::Link, T, Length) -> Element<'a, M> + 'a,
@@ -61,9 +66,10 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
     config: &Config,
 ) -> Element<'a, M> {
     match content {
-        data::message::Content::Plain(text) => {
-            selectable_text(text).style(style).into()
-        }
+        data::message::Content::Plain(text) => selectable_text(text)
+            .font_maybe(font::get(font_style(theme)))
+            .style(style)
+            .into(),
         data::message::Content::Fragments(fragments) => {
             let mut text = selectable_rich_text::<
                 M,
@@ -77,7 +83,10 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
                     .map(|fragment| match fragment {
                         data::message::Fragment::Text(s) => span(s),
                         data::message::Fragment::Channel(s) => span(s.as_str())
-                            .color(theme.colors().buffer.url)
+                            .font_maybe(font::get(
+                                theme.styles().buffer.url.font_style,
+                            ))
+                            .color(theme.styles().buffer.url.color)
                             .link(message::Link::Channel(
                                 target::Channel::from_str(
                                     s.as_str(),
@@ -85,7 +94,7 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
                                 ),
                             )),
                         data::message::Fragment::User(user, text) => {
-                            let color = theme.colors().buffer.nickname;
+                            let color = theme.styles().buffer.nickname.color;
                             let seed = match &config
                                 .buffer
                                 .channel
@@ -100,15 +109,18 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
 
                             let color = match seed {
                                 Some(seed) => randomize_color(color, seed),
-                                None => theme.colors().text.primary,
+                                None => theme.styles().text.primary.color,
                             };
 
                             span(text)
+                                .font_maybe(font::get(
+                                    theme.styles().buffer.nickname.font_style,
+                                ))
                                 .color(color)
                                 .link(message::Link::User(user.clone()))
                         }
                         data::message::Fragment::HighlightNick(user, text) => {
-                            let color = theme.colors().buffer.nickname;
+                            let color = theme.styles().buffer.nickname.color;
                             let seed = match &config
                                 .buffer
                                 .channel
@@ -123,21 +135,30 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
 
                             let color = match seed {
                                 Some(seed) => randomize_color(color, seed),
-                                None => theme.colors().text.primary,
+                                None => theme.styles().text.primary.color,
                             };
 
                             span(text)
+                                .font_maybe(font::get(
+                                    theme.styles().buffer.nickname.font_style,
+                                ))
                                 .color(color)
-                                .background(theme.colors().buffer.highlight)
+                                .background(theme.styles().buffer.highlight)
                                 .link(message::Link::User(user.clone()))
                         }
                         data::message::Fragment::HighlightMatch(text) => {
                             span(text.as_str())
-                                .color(theme.colors().text.primary)
-                                .background(theme.colors().buffer.highlight)
+                                .font_maybe(font::get(
+                                    theme.styles().text.primary.font_style,
+                                ))
+                                .color(theme.styles().text.primary.color)
+                                .background(theme.styles().buffer.highlight)
                         }
                         data::message::Fragment::Url(s) => span(s.as_str())
-                            .color(theme.colors().buffer.url)
+                            .font_maybe(font::get(
+                                theme.styles().buffer.url.font_style,
+                            ))
+                            .color(theme.styles().buffer.url.color)
                             .link(message::Link::Url(s.as_str().to_string())),
                         data::message::Fragment::Formatted {
                             text,
@@ -145,48 +166,45 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
                         } => {
                             let mut span = span(text)
                                 .color_maybe(formatting.fg.and_then(|color| {
-                                    color.into_iced(theme.colors())
+                                    color.into_iced(theme.styles())
                                 }))
                                 .background_maybe(formatting.bg.and_then(
-                                    |color| color.into_iced(theme.colors()),
+                                    |color| color.into_iced(theme.styles()),
                                 ))
                                 .underline(formatting.underline)
                                 .strikethrough(formatting.strikethrough);
 
+                            let mut formatted_style = FontStyle::new(
+                                formatting.bold,
+                                formatting.italics,
+                            );
+
                             if formatting.monospace {
                                 span = span
                                     .padding([0, 4])
-                                    .color(theme.colors().buffer.code)
+                                    .color(theme.styles().buffer.code.color)
                                     .border(
                                         border::rounded(3)
                                             .color(
-                                                theme.colors().general.border,
+                                                theme.styles().general.border,
                                             )
                                             .width(1),
                                     );
+
+                                formatted_style = formatted_style
+                                    + theme.styles().buffer.code.font_style;
+                            } else {
+                                formatted_style =
+                                    formatted_style + font_style(theme);
                             }
 
-                            match (formatting.bold, formatting.italics) {
-                                (true, true) => {
-                                    span = span
-                                        .font(font::MONO_BOLD_ITALICS.clone());
-                                }
-                                (true, false) => {
-                                    span = span.font(font::MONO_BOLD.clone());
-                                }
-                                (false, true) => {
-                                    span =
-                                        span.font(font::MONO_ITALICS.clone());
-                                }
-                                (false, false) => {}
-                            }
-
-                            span
+                            span.font_maybe(font::get(formatted_style))
                         }
                     })
                     .collect::<Vec<_>>(),
             )
             .on_link(on_link)
+            .font_maybe(font::get(font_style(theme)))
             .style(style);
 
             if let Some((link_entries, view)) = context_menu {
@@ -199,15 +217,21 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
             let mut spans: Vec<Span<'a, message::Link, _>> = vec![];
 
             spans.extend(
-                config
-                    .buffer
-                    .format_timestamp(&record.timestamp)
-                    .map(|ts| span(ts).color(theme.colors().buffer.timestamp)),
+                config.buffer.format_timestamp(&record.timestamp).map(|ts| {
+                    span(ts)
+                        .font_maybe(font::get(
+                            theme.styles().buffer.timestamp.font_style,
+                        ))
+                        .color(theme.styles().buffer.timestamp.color)
+                }),
             );
 
             spans.extend([
                 span(format!("{: <5}", record.level))
-                    .color(theme.colors().text.secondary),
+                    .font_maybe(font::get(
+                        theme.styles().text.secondary.font_style,
+                    ))
+                    .color(theme.styles().text.secondary.color),
                 span(" "),
                 span(&record.message),
             ]);

--- a/src/widget/selectable_rich_text.rs
+++ b/src/widget/selectable_rich_text.rs
@@ -127,6 +127,15 @@ where
         self
     }
 
+    /// Sets the default font of the [`Rich`] text, if any.
+    pub fn font_maybe(
+        mut self,
+        font: Option<impl Into<Renderer::Font>>,
+    ) -> Self {
+        self.font = font.map(Into::into);
+        self
+    }
+
     /// Sets the width of the [`Rich`] text boundaries.
     pub fn width(mut self, width: impl Into<Length>) -> Self {
         self.width = width.into();
@@ -187,7 +196,7 @@ where
 
         self.style(move |_theme| Style {
             color,
-            selection_color: Color::WHITE,
+            ..Style::default()
         })
     }
 

--- a/src/widget/selectable_text.rs
+++ b/src/widget/selectable_text.rs
@@ -81,6 +81,14 @@ where
         self
     }
 
+    pub fn font_maybe(
+        mut self,
+        font: Option<impl Into<Renderer::Font>>,
+    ) -> Self {
+        self.font = font.map(Into::into);
+        self
+    }
+
     pub fn style(mut self, style: impl Fn(&Theme) -> Style + 'a) -> Self
     where
         Theme::Class<'a>: From<StyleFn<'a, Theme>>,


### PR DESCRIPTION
This PR draft is for adding the ability to specify font style for some theme settings.  For example, if you wanted to display nicknames in italic you could have in your theme TOML:
```toml
nickname = { color = "#F6B6C9", font-style = "italic" }
topic = { color = "#AB8A79", font-style = "bold-italic" }
```

With the result potentially looking like this:
![Screenshot from 2025-05-11 21-30-14](https://github.com/user-attachments/assets/92c8acf1-9940-4634-b5ce-89ad52effbeb)

There is more work that would need to be done, but I wanted to get feedback before progressing further.

A lot of the changes are due to changing names (e.g. `Colors` to `Styles`) since theme settings can include font-style as well as color.  The main changes are in:
- `data/src/appearance/theme.rs`
- `src/appearance/theme/font_style.rs`
- `src/font.rs`
- `src/widget/selectable_rich_text.rs` 
- `src/widget/selectable_text.rs`

Changes to apply font styles in:
- `src/widget/message_content.rs`
- `src/buffer/channel.rs`
- `src/buffer/channel/topic.rs`
- `src/buffer/highlights.rs`
- `src/buffer/logs.rs`
- `src/buffer/query.rs`
- `src/buffer/server.rs`
- `src/buffer/user_context.rs`

And the rest are just name changes.