### PR TITLE
Fix buffer.channel.topic documentation

### DIFF
--- a/book/src/configuration/buffer.md
+++ b/book/src/configuration/buffer.md
@@ -174,7 +174,7 @@ Control if topic should be shown or not by default.
 ```toml
 # Type: boolean
 # Values: true, false
-# Default: true
+# Default: false
 
 [buffer.channel.topic]
 enabled = true
@@ -187,7 +187,7 @@ Amount of visible lines before you have to scroll in topic banner.
 ```toml
 # Type: integer
 # Values: any positive integer
-# Default: 2z
+# Default: 2
 
 [buffer.channel.topic]
 max_lines = 2


### PR DESCRIPTION
The default values shown for those two variables were not matching reality (as of 2025.5). The topic banner isn’t shown by default and 2z isn’t a number (i’m guessing this was a typo)