### PR TITLE
Changelog Thanks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Fixed:
 
 - Handling of RPL_NOWAWAY & RPL_UNAWAY to reflect user's own AWAY state
 
+Thanks:
+
+- Contributions: @englut, @KaiKorla, @kit-ty-kate
+- Bug reports: @awbradle
+- Feature requests: @darienm
+
 # 2025.5 (2025-05-05)
 
 Added:


### PR DESCRIPTION
Adds a thanks section to the changelog to highlight contributions (code & non-code) made by non-maintainers to a release.  The categories within the thanks section are not perfect;  was the best breakdown I could think of, but I'm open to other possibilities.  Ordering of handles was done by when the related merge was committed (just so happens to be alphabetical right now).

Edit:  I'm volunteering to be responsible for double-checking this section is up-to-date before release.