### PR TITLE
docs: fix scroll keybinds and add highlight keybind

### DIFF
--- a/book/src/configuration/keyboard.md
+++ b/book/src/configuration/keyboard.md
@@ -40,4 +40,5 @@ move_right = "alt+l"
 | `file_transfers`               | Toggle File Transfers Buffer | <kbd>⌘</kbd> + <kbd>j</kbd>                         | <kbd>ctrl</kbd> + <kbd>j</kbd>                      |
 | `logs`                         | Toggle Logs Buffer           | <kbd>⌘</kbd> + <kbd>l</kbd>                         | <kbd>ctrl</kbd> + <kbd>l</kbd>                      |
 | `theme_editor`                 | Toggle Theme Editor Window   | <kbd>⌘</kbd> + <kbd>t</kbd>                         | <kbd>ctrl</kbd> + <kbd>t</kbd>                      |
+| `highlight`                    | Toggle Highlight Window      | <kbd>⌘</kbd> + <kbd>i</kbd>                         | <kbd>ctrl</kbd> + <kbd>i</kbd>                      |
 | `quit_application`             | Quit Halloy                  | Not set                                             | Not set                                             |


### PR DESCRIPTION
Based on https://github.com/squidowl/halloy/blob/main/data/src/config/keys.rs#L47-L50, the correct key for `scroll-page-{down|up}` is `scroll-{down|up}-page`.

Based on https://github.com/squidowl/halloy/blob/main/data/src/shortcut.rs#L156, the default keybind for highlight is `cmd+i` or `ctrl+i`
