### PR TITLE
Save Input Draft when Navigating Input History

### DIFF
--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -268,8 +268,12 @@ impl Manager {
         self.data.input.record(buffer, text);
     }
 
-    pub fn record_draft(&mut self, draft: input::Draft) {
-        self.data.input.store_draft(draft);
+    pub fn record_draft(&mut self, raw_input: input::RawInput) {
+        self.data.input.store_draft(raw_input);
+    }
+
+    pub fn record_text(&mut self, raw_input: input::RawInput) {
+        self.data.input.store_text(raw_input);
     }
 
     pub fn record_message(


### PR DESCRIPTION
Stores the current input text as a draft separate from the current text in the input (previously the draft was also the current text in the input).  The draft is stored separately to allow users to navigate input history without losing their input text.  I.e. if the user presses up to look at their sent message history (or by accident), then pressing down will restore the text that was previously in the input.

If the user modifies the text history text, then it becomes the new draft text (overwriting the previously stored draft).

Addresses secondary comment in issue #871 (not the main feature request).