### PR TITLE
Add Typos Check to Build Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  Check-Clippy-Test:
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: "-C linker=clang -C link-arg=-fuse-ld=mold"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,8 @@ jobs:
     env:
       RUSTFLAGS: "-C linker=clang -C link-arg=-fuse-ld=mold"
     steps:
-    - uses: actions/checkout@v3
-    - name: Install deps
+    - uses: actions/checkout@v4
+    - name: Install Dependencies
       run: |
         sudo apt update
         sudo apt install \
@@ -58,3 +58,11 @@ jobs:
       run: cargo clippy --profile ci --workspace --all-targets -- -D warnings
     - name: Test
       run: cargo test --profile ci --workspace --all-targets
+  spelling:
+    name: Spell Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions Repository
+        uses: actions/checkout@v4
+      - name: Spell Check Repository
+        uses: crate-ci/typos@v1.32.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -326,7 +326,7 @@ Changed:
 
 # 2024.5 (2024-03-21)
 
-**BREAKING** Configuration file format has switched from `YAML` to `TOML`. Please vist the migration guide here: [halloy.squidowl.org/guides/migrating-from-yaml](https://halloy.squidowl.org/guides/migrating-from-yaml.html).
+**BREAKING** Configuration file format has switched from `YAML` to `TOML`. Please visit the migration guide here: [halloy.squidowl.org/guides/migrating-from-yaml](https://halloy.squidowl.org/guides/migrating-from-yaml.html).
 
 Added:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,3 +134,12 @@ redundant_closure_for_method_calls = "deny"
 semicolon_if_nothing_returned = "deny"
 uninlined_format_args = "deny"
 unnecessary_wraps = "deny"
+
+[workspace.metadata.typos.default]
+extend-ignore-re = [
+    "(?Rm)^.*(#|//)\\s*spellchecker:disable-line$", # Ignore lines with trailing spellchecker:disable-line
+]
+extend-ignore-identifiers-re = [
+    "ERR_[A-Z]+", # IRC Error Numeric
+    "RPL_[A-Z]+", # IRC Reply Numeric
+]

--- a/data/src/appearance/theme.rs
+++ b/data/src/appearance/theme.rs
@@ -425,7 +425,7 @@ mod binary {
     }
 
     // IMPORTANT: Tags cannot be rearranged or deleted to preserve
-    // backwards compatability. Only append new items in the future
+    // backwards compatibility. Only append new items in the future
     #[derive(
         Debug,
         Clone,

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1284,7 +1284,7 @@ impl Client {
                                     }
                                     ctcp::Command::Unknown(command) => {
                                         log::debug!(
-                                            "Ignorning CTCP command {command}: Unknown command"
+                                            "Ignoring CTCP command {command}: Unknown command"
                                         );
                                     }
                                 }
@@ -2420,7 +2420,7 @@ impl Client {
 
     // TODO allow configuring the "sorting method"
     // this function sorts channels together which have similar names when the chantype prefix
-    // (sometimes multipled) is removed
+    // (sometimes multiplied) is removed
     // e.g. '#chat', '##chat-offtopic' and '&chat-local' all get sorted together instead of in
     // wildly different places.
     fn compare_channels(&self, a: &str, b: &str) -> Ordering {

--- a/data/src/config/preview.rs
+++ b/data/src/config/preview.rs
@@ -32,7 +32,7 @@ pub struct Request {
     ///
     /// Some servers will only send opengraph metadata to
     /// browser-like user agents. We default to `WhatsApp/2`
-    /// for wide compatability
+    /// for wide compatibility
     #[serde(default = "default_user_agent")]
     pub user_agent: String,
     /// Request timeout in millisceonds
@@ -54,7 +54,7 @@ pub struct Request {
     /// Reduce this to prevent rate-limiting
     #[serde(default = "default_concurrency")]
     pub concurrency: usize,
-    /// Numer of milliseconds to wait before requesting another preview
+    /// Number of milliseconds to wait before requesting another preview
     /// when number of requested previews > `concurrency`
     #[serde(default = "default_delay_ms")]
     pub delay_ms: u64,

--- a/data/src/dcc.rs
+++ b/data/src/dcc.rs
@@ -74,7 +74,7 @@ impl Send {
         }
 
         // Host will always be 3rd or 4th arg in reverse order
-        // The last arg to succesfully decode as host will be host
+        // The last arg to successfully decode as host will be host
         let host_pos = args.len()
             - 1
             - args

--- a/data/src/file_transfer.rs
+++ b/data/src/file_transfer.rs
@@ -75,7 +75,7 @@ pub enum Direction {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Status {
-    /// Pending appoval
+    /// Pending approval
     PendingApproval,
     /// Pending reverse confirmation
     PendingReverseConfirmation,
@@ -87,7 +87,7 @@ pub enum Status {
     Active { transferred: u64, elapsed: Duration },
     /// Transfer is complete
     Completed { elapsed: Duration, sha256: String },
-    /// An error occured
+    /// An error occurred
     Failed { error: String },
 }
 

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -450,7 +450,7 @@ impl Serialize for Message {
             content: &'a Content,
             id: &'a Option<String>,
             // Old field before we had fragments,
-            // added for downgrade compatability
+            // added for downgrade compatibility
             text: Cow<'a, str>,
             hidden_urls: &'a HashSet<url::Url>,
             is_echo: &'a bool,
@@ -482,7 +482,7 @@ impl<'de> Deserialize<'de> for Message {
             server_time: DateTime<Utc>,
             direction: Direction,
             target: Target,
-            // New field, optional for upgrade compatability
+            // New field, optional for upgrade compatibility
             #[serde(default, deserialize_with = "fail_as_none")]
             content: Option<Content>,
             // Old field before we had fragments
@@ -490,7 +490,7 @@ impl<'de> Deserialize<'de> for Message {
             id: Option<String>,
             #[serde(default)]
             hidden_urls: HashSet<url::Url>,
-            // New field, optional for upgrade compatability
+            // New field, optional for upgrade compatibility
             #[serde(default, deserialize_with = "fail_as_none")]
             is_echo: Option<bool>,
         }
@@ -1827,9 +1827,9 @@ mod tests {
                 ],
             ),
             (
-                "https://www.reddit.com/r/witze/comments/1fcoz5a/ein_vampir_auf_einem_tandem_gerät_in_eine/",
+                "https://www.reddit.com/r/witze/comments/1fcoz5a/ein_vampir_auf_einem_tandem_gerät_in_eine/", // spellchecker:disable-line
                 vec![Fragment::Url(
-                    "https://www.reddit.com/r/witze/comments/1fcoz5a/ein_vampir_auf_einem_tandem_gerät_in_eine/"
+                    "https://www.reddit.com/r/witze/comments/1fcoz5a/ein_vampir_auf_einem_tandem_gerät_in_eine/" // spellchecker:disable-line
                     .parse()
                     .unwrap()
                 )],

--- a/data/src/message/formatting/encode.rs
+++ b/data/src/message/formatting/encode.rs
@@ -123,7 +123,7 @@ fn markdown<'a>(
     let right_flanking = move |d, n| {
         move |i: &'a str| {
             alt((
-                // delimiter run that is not preceded by Unicode whitespace or punctutation
+                // delimiter run that is not preceded by Unicode whitespace or punctuation
                 map(
                     verify(delimiter_run(d, n), move |_: &Vec<_>| {
                         !prev_is_ws_or_punc(d, i)

--- a/data/src/preview.rs
+++ b/data/src/preview.rs
@@ -285,7 +285,7 @@ async fn fetch(
         }
     };
 
-    // Artifically wait before releasing this permit for rate limiting
+    // Artificially wait before releasing this permit for rate limiting
     time::sleep(Duration::from_millis(config.request.delay_ms)).await;
 
     Ok(fetched)

--- a/data/src/shortcut.rs
+++ b/data/src/shortcut.rs
@@ -123,7 +123,7 @@ impl Hash for KeyBind {
     }
 }
 
-// For defaults checkt the platform specific defaults:
+// For defaults check the platform specific defaults:
 // macOS: https://support.apple.com/en-us/102650
 // Windows: https://support.microsoft.com/en-us/windows/keyboard-shortcuts-in-windows-dcc61a57-8ff0-cffe-9796-cb9706c75eec
 // Linux FreeDesktop (not ready yet): https://wiki.freedesktop.org/www/Specifications/default-keys-spec/

--- a/data/src/stream.rs
+++ b/data/src/stream.rs
@@ -141,7 +141,7 @@ async fn _run(
                         let error = match e {
                             // unwrap Tls-specific error enums to access more error info
                             connection::Error::Tls(e) => {
-                                format!("a TLS error occured: {e}")
+                                format!("a TLS error occurred: {e}")
                             }
                             _ => e.to_string(),
                         };

--- a/data/src/url.rs
+++ b/data/src/url.rs
@@ -141,7 +141,7 @@ fn parse_server_config(url: &url::Url) -> Option<config::Server> {
         });
 
         if !url.path().is_empty() {
-            // We also consider path as channels seperated by ','.
+            // We also consider path as channels separated by ','.
             // Eg: [...]/channel1,channel2
             channels.extend(
                 url.path()[1..]

--- a/irc/proto/src/lib.rs
+++ b/irc/proto/src/lib.rs
@@ -73,7 +73,7 @@ pub fn parse_channel_from_target(
     chantypes: &[char],
     statusmsg_prefixes: &[char],
 ) -> Option<(Vec<char>, String)> {
-    // We parse the target by finding the first character in chantypes, and returing (even if that
+    // We parse the target by finding the first character in chantypes, and returning (even if that
     // character is in statusmsg_prefixes)
     // If the characters before the first chantypes character are all valid prefixes, then we have
     // a valid channel name with those prefixes.

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -41,6 +41,6 @@ case "$1" in
   "archive_name") archive_name;;
   "archive_path") archive_path;;
   *)
-    echo "avaiable commands: package, archive_name, archive_path"
+    echo "available commands: package, archive_name, archive_path"
     ;;
 esac

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -334,7 +334,7 @@ impl State {
                                         }
                                     };
 
-                                    // Part channel. Might not exsist if we execute on a query/server.
+                                    // Part channel. Might not exist if we execute on a query/server.
                                     let part_command =
                                         buffer.channel().and_then(|channel| {
                                             data::Input::command(

--- a/src/main.rs
+++ b/src/main.rs
@@ -514,7 +514,7 @@ impl Halloy {
                     };
 
                     if is_initial {
-                        // Intial is sent when first trying to connect
+                        // Initial is sent when first trying to connect
                         dashboard
                             .broadcast(
                                 &server,
@@ -1098,7 +1098,7 @@ impl Halloy {
                 command.map(Message::Modal)
             }
             Message::RouteReceived(route) => {
-                log::info!("RouteRecived: {:?}", route);
+                log::info!("RouteReceived: {:?}", route);
 
                 if let Ok(url) = route.parse() {
                     return self.handle_url(url);

--- a/src/widget/selectable_rich_text.rs
+++ b/src/widget/selectable_rich_text.rs
@@ -115,7 +115,7 @@ where
         self
     }
 
-    /// Sets the defualt [`LineHeight`] of the [`Rich`] text.
+    /// Sets the default [`LineHeight`] of the [`Rich`] text.
     pub fn line_height(mut self, line_height: impl Into<LineHeight>) -> Self {
         self.line_height = line_height.into();
         self


### PR DESCRIPTION
Adds a typos/spell check action to the build workflow via [typos](https://github.com/crate-ci/typos), and fixes all the typos found with its CLI.