### PR TITLE
Clippy Allowance

### DIFF
--- a/irc/src/lib.rs
+++ b/irc/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::large_enum_variant)]
+
 pub use tokio_util::codec::BytesCodec;
 
 pub use self::codec::Codec;


### PR DESCRIPTION
Allow large size difference between variants in the IRC sub-crate for clippy.