### PR TITLE
Remove Superfluous Focus Tasks

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1148,7 +1148,7 @@ impl Halloy {
                     {
                         tasks.push(
                             dashboard
-                                .focus_window(self.main_window.id)
+                                .focus_window_pane(self.main_window.id)
                                 .map(Message::Dashboard),
                         );
                     }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -2187,8 +2187,10 @@ impl Dashboard {
         pane.map_or(Task::none(), |pane| self.focus_pane(window, pane))
     }
 
-    pub fn focus_window(&mut self, window: window::Id) -> Task<Message> {
-        let task = if let Some(pane) = self
+    pub fn focus_window_pane(&mut self, window: window::Id) -> Task<Message> {
+        if self.focus.window == window {
+            Task::none()
+        } else if let Some(pane) = self
             .focus_history
             .front()
             .filter(|_| window == self.main_window())
@@ -2196,7 +2198,11 @@ impl Dashboard {
             self.focus_pane(window, *pane)
         } else {
             self.focus_first_pane(window)
-        };
+        }
+    }
+
+    pub fn focus_window(&mut self, window: window::Id) -> Task<Message> {
+        let task = self.focus_window_pane(window);
 
         window::gain_focus(window).chain(task)
     }
@@ -2657,7 +2663,7 @@ impl Dashboard {
                     return window::close(id);
                 }
                 window::Event::Focused => {
-                    return self.focus_window(id);
+                    return self.focus_window_pane(id);
                 }
                 window::Event::Moved(_)
                 | window::Event::Resized(_)


### PR DESCRIPTION
Removes unnecessary `window::gain_focus` calls.  Under X11 this could cause a re-focus loop when launching with multiple windows (may be related to #861, but I have not been able to reproduce that behavior in order to properly test).  Also fixes an intermittent issue where focused pane and input could be out of sync, caused by selecting a new pane when re-focusing a Halloy window (i.e. clicking on an unfocused pane when the Halloy window does not have focus).

Tested under Wayland as well, but not on macOS or Windows. 