### PR TITLE
Workflow Updates

### DIFF
--- a/.config/lychee.toml
+++ b/.config/lychee.toml
@@ -1,0 +1,5 @@
+verbose = "info"
+no_progress = true
+
+include_fragments = true
+exclude = [ '^https://halloy\.squidowl\.org/.*', '^irc://.*', '^ircs://.*' ]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,3 @@
+[profile.ci]
+# Do not cancel the test run on the first failure.
+fail-fast = false

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,14 +1,24 @@
-name: Github Pages
+name: Book
 
 on:
-  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'book/**.md'
+      - 'book/book.toml'
   push:
-    tags:
-      - '*'
+    branches:
+      - main
+    paths:
+      - 'book/**.md'
+      - 'book/book.toml'
+  merge_group:
+    paths:
+      - 'book/**.md'
+      - 'book/book.toml'
 
 jobs:
-  deploy:
-    name: Deploy
+  build-linkcheck:
+    name: Build & Link Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,9 +38,3 @@ jobs:
 
       - name: Build book
         run: mdbook build book
-
-      - name: Publish book
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./book/book

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,13 +23,14 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  Check-Clippy-Test:
+  build-check-clippy-test:
+    name: Build, Check, Clippy, & Test
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: "-C linker=clang -C link-arg=-fuse-ld=mold"
     steps:
     - uses: actions/checkout@v4
-    - name: Install Dependencies
+    - name: Install dependencies
       run: |
         sudo apt update
         sudo apt install \
@@ -52,17 +53,15 @@ jobs:
           ~/.cargo/git/db/
           target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
     - name: Check
       run: cargo check --profile ci
+
     - name: Clippy
       run: cargo clippy --profile ci --workspace --all-targets -- -D warnings
+
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-nextest
     - name: Test
-      run: cargo test --profile ci --workspace --all-targets
-  spelling:
-    name: Spell Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v4
-      - name: Spell Check Repository
-        uses: crate-ci/typos@v1.32.0
+      run: cargo nextest run --profile ci --workspace --all-targets

--- a/.github/workflows/checksum.yml
+++ b/.github/workflows/checksum.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   deploy:
+    name: Deploy
     runs-on: ubuntu-latest
     steps:
       - name: Download Artifacts

--- a/.github/workflows/gh-page-unstable.yml
+++ b/.github/workflows/gh-page-unstable.yml
@@ -8,23 +8,30 @@ on:
 
 jobs:
   deploy:
+    name: Deploy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Check links
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --config ./.config/lychee.toml './**/*.md'
+          fail: true
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
           mdbook-version: 'latest'
 
-      - name: Install mdbook plugins
-        run: cargo install mdbook-linkcheck
-
-      - run: mdbook build book
+      - name: Build book
+        run: mdbook build book
 
       - name: Publish book
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages-unstable
-          publish_dir: ./book/book/html
+          publish_dir: ./book/book

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,17 @@
+name: Spell Check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  merge_group:
+
+jobs:
+  typos:
+    name: Typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check spelling
+        uses: crate-ci/typos@v1.32.0

--- a/book/book.toml
+++ b/book/book.toml
@@ -8,5 +8,3 @@ src = "src"
 cname = "halloy.chat"
 git-repository-url = "https://github.com/squidowl/halloy"
 edit-url-template = "https://github.com/squidowl/halloy/edit/main/book/{path}"
-
-[output.linkcheck]

--- a/book/src/configuration/file_transfer.md
+++ b/book/src/configuration/file_transfer.md
@@ -17,7 +17,7 @@ save_directory = "/Users/halloy/Downloads"
 
 ## `passive`
 
-If true, act as the "client" for the transfer. Requires the remote user act as the [server](#file_transferserver-section).
+If true, act as the "client" for the transfer. Requires the remote user act as the [server](#file_transferserver).
 
 ```toml
 # Type: boolean


### PR DESCRIPTION
This PR was originally intended to be a collection of minor tweaks to workflows, but has unexpectedly grown to be somewhat substantial.  I can split this up if need be, or remove any part that's not desirable.  The changes:
- Since the Typos action checks many files outside of the Rust source code, I moved it out of the `build.yml` workflow into its own workflow (`spell-check.yml`) that can be triggered more generally.
- Added the `book.yml` workflow to perform checks on the documentation.  In doing so noticed that `mdbook-linkcheck` was not catching all of the broken links I created to test the workflow, so I switched the link checking to Lychee (as demonstrated in #921).  One broken anchor was found by Lychee, and fixed in this PR.
- I've been using `cargo-nextest` for testing, because I find the output more legible than `cargo test`.  So that has been tentatively swapped in.
- When I added Typos I didn't pay close enough attention to the naming style that was already in use.  Minor changes to make the new workflow additions better match the existing style.