### PR TITLE
fix: New message indicator shouldn't show for suppressed message

### DIFF
--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -16,7 +16,7 @@ use crate::message::{self, MessageReferences, Source};
 use crate::target::{self, Target};
 use crate::user::Nick;
 use crate::{
-    Buffer, Message, Server, buffer, compression, environment, isupport,
+    Buffer, Message, Server, buffer, compression, config, environment, isupport,
 };
 
 pub mod manager;
@@ -320,8 +320,12 @@ impl History {
         }
     }
 
-    fn add_message(&mut self, message: Message) -> Option<ReadMarker> {
-        if message.triggers_unread() {
+    fn add_message(
+        &mut self,
+        message: Message,
+        config: &config::buffer::ServerMessages,
+    ) -> Option<ReadMarker> {
+        if !message.suppressed(config) && message.triggers_unread() {
             if let History::Partial {
                 max_triggers_unread,
                 ..

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -16,8 +16,8 @@ use url::Url;
 pub use self::formatting::{Color, Formatting};
 pub use self::source::Source;
 pub use self::source::server::{Kind, StandardReply};
-use crate::config::Highlights;
 use crate::config::buffer::UsernameFormat;
+use crate::config::{self, Highlights};
 use crate::serde::fail_as_none;
 use crate::target::Channel;
 use crate::time::Posix;
@@ -205,6 +205,14 @@ impl Message {
                 Source::Internal(source::Internal::Logs) => true,
                 _ => false,
             }
+    }
+
+    /// Server message should not be shown due to user's preferences.
+    pub fn suppressed(&self, config: &config::buffer::ServerMessages) -> bool {
+        matches!(self.target.source(),
+            Source::Server(Some(server))
+            if config.get(server).is_some_and(|kind| !kind.enabled)
+        )
     }
 
     pub fn can_reference(&self) -> bool {

--- a/src/appearance/theme.rs
+++ b/src/appearance/theme.rs
@@ -9,6 +9,7 @@ pub mod button;
 pub mod checkbox;
 pub mod container;
 pub mod context_menu;
+pub mod image;
 pub mod menu;
 pub mod pane_grid;
 pub mod progress_bar;
@@ -17,7 +18,6 @@ pub mod scrollable;
 pub mod selectable_text;
 pub mod text;
 pub mod text_input;
-pub mod image;
 
 // TODO: If we use non-standard font sizes, we should consider
 // Config.font.size since it's user configurable
@@ -80,7 +80,7 @@ impl iced::theme::Base for Theme {
             text_color: self.colors().text.primary,
         }
     }
-    
+
     fn palette(&self) -> Option<iced::theme::Palette> {
         None
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -664,6 +664,7 @@ impl Halloy {
                                                     .record_message(
                                                         &server,
                                                         message,
+                                                        &self.config
                                                     )
                                                     .map(Message::Dashboard),
                                             );
@@ -689,7 +690,7 @@ impl Halloy {
                                             {
                                                 commands.push(
                                                     dashboard
-                                                        .record_highlight(message)
+                                                        .record_highlight(message, &self.config)
                                                         .map(Message::Dashboard),
                                                 );
 
@@ -707,6 +708,7 @@ impl Halloy {
                                                     .record_message(
                                                         &server,
                                                         message,
+                                                        &self.config
                                                     )
                                                     .map(Message::Dashboard),
                                             );
@@ -727,7 +729,7 @@ impl Halloy {
                                                 dashboard
                                                     .record_message(
                                                         &server,
-                                                        message.with_target(target),
+                                                        message.with_target(target), &self.config,
                                                     )
                                                     .map(Message::Dashboard),
                                             );
@@ -1197,9 +1199,9 @@ impl Halloy {
                 }
 
                 Task::batch(
-                    records
-                        .into_iter()
-                        .map(|record| dashboard.record_log(record)),
+                    records.into_iter().map(|record| {
+                        dashboard.record_log(record, &self.config)
+                    }),
                 )
                 .map(Message::Dashboard)
             }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -280,6 +280,7 @@ impl Dashboard {
                                                             .record_message(
                                                                 input.server(),
                                                                 message,
+                                                                config
                                                         ) {
                                                             tasks.push(Task::perform(
                                                                 task,
@@ -1328,7 +1329,7 @@ impl Dashboard {
                             ) {
                                 return (
                                     self.handle_file_transfer_event(
-                                        &server, &query, event,
+                                        config, &server, &query, event,
                                     ),
                                     None,
                                 );
@@ -1929,16 +1930,22 @@ impl Dashboard {
         &mut self,
         server: &Server,
         message: data::Message,
+        config: &Config,
     ) -> Task<Message> {
-        if let Some(task) = self.history.record_message(server, message) {
+        if let Some(task) = self.history.record_message(server, message, config)
+        {
             Task::perform(task, Message::History)
         } else {
             Task::none()
         }
     }
 
-    pub fn record_log(&mut self, record: data::log::Record) -> Task<Message> {
-        if let Some(task) = self.history.record_log(record) {
+    pub fn record_log(
+        &mut self,
+        record: data::log::Record,
+        config: &Config,
+    ) -> Task<Message> {
+        if let Some(task) = self.history.record_log(record, config) {
             Task::perform(task, Message::History)
         } else {
             Task::none()
@@ -1948,8 +1955,9 @@ impl Dashboard {
     pub fn record_highlight(
         &mut self,
         message: data::Message,
+        config: &Config,
     ) -> Task<Message> {
-        if let Some(task) = self.history.record_highlight(message) {
+        if let Some(task) = self.history.record_highlight(message, config) {
             Task::perform(task, Message::History)
         } else {
             Task::none()
@@ -2505,11 +2513,12 @@ impl Dashboard {
         )
         .ok()?;
 
-        Some(self.handle_file_transfer_event(server, &query, event))
+        Some(self.handle_file_transfer_event(config, server, &query, event))
     }
 
     pub fn handle_file_transfer_event(
         &mut self,
+        config: &Config,
         server: &Server,
         query: &target::Query,
         event: file_transfer::manager::Event,
@@ -2527,6 +2536,7 @@ impl Dashboard {
                                 query,
                                 &transfer.filename,
                             ),
+                            config,
                         ));
                     }
                     file_transfer::Direction::Sent => {
@@ -2537,6 +2547,7 @@ impl Dashboard {
                                 query,
                                 &transfer.filename,
                             ),
+                            config,
                         ));
                     }
                 }

--- a/src/widget/decorate.rs
+++ b/src/widget/decorate.rs
@@ -1,8 +1,8 @@
 use std::marker::PhantomData;
 use std::slice;
 
-use iced::{Element, Rectangle};
 use iced::advanced::{self, Widget, layout};
+use iced::{Element, Rectangle};
 
 pub fn decorate<'a, Message, Theme, Renderer>(
     element: impl Into<Element<'a, Message, Theme, Renderer>>,
@@ -609,9 +609,13 @@ where
         viewport: &Rectangle,
         translation: iced::Vector,
     ) -> Option<advanced::overlay::Element<'b, Message, Theme, Renderer>> {
-        inner
-            .as_widget_mut()
-            .overlay(tree, layout, renderer, viewport, translation)
+        inner.as_widget_mut().overlay(
+            tree,
+            layout,
+            renderer,
+            viewport,
+            translation,
+        )
     }
 }
 


### PR DESCRIPTION
Closes: #979

I tested this with and without...

```toml
[buffer.server_messages.join]
enabled = false

[buffer.server_messages.quit]
enabled = false

[buffer.server_messages.part]
enabled = false
```

...in my config to check if the indicator shows.

Alsooo, there are two small, unrelated changes in `src/appearance/theme.rs` and `src/widget/decorate.rs` because of `cargo fmt`.

