### PR TITLE
Highlights Buffer Naming Consistency

### DIFF
--- a/book/src/configuration/keyboard.md
+++ b/book/src/configuration/keyboard.md
@@ -40,5 +40,5 @@ move_right = "alt+l"
 | `file_transfers`               | Toggle File Transfers Buffer | <kbd>⌘</kbd> + <kbd>j</kbd>                         | <kbd>ctrl</kbd> + <kbd>j</kbd>                      |
 | `logs`                         | Toggle Logs Buffer           | <kbd>⌘</kbd> + <kbd>l</kbd>                         | <kbd>ctrl</kbd> + <kbd>l</kbd>                      |
 | `theme_editor`                 | Toggle Theme Editor Window   | <kbd>⌘</kbd> + <kbd>t</kbd>                         | <kbd>ctrl</kbd> + <kbd>t</kbd>                      |
-| `highlight`                    | Toggle Highlight Window      | <kbd>⌘</kbd> + <kbd>i</kbd>                         | <kbd>ctrl</kbd> + <kbd>i</kbd>                      |
+| `highlights`                   | Toggle Highlights Window     | <kbd>⌘</kbd> + <kbd>i</kbd>                         | <kbd>ctrl</kbd> + <kbd>i</kbd>                      |
 | `quit_application`             | Quit Halloy                  | Not set                                             | Not set                                             |

--- a/data/src/config/keys.rs
+++ b/data/src/config/keys.rs
@@ -42,8 +42,9 @@ pub struct Keyboard {
     pub logs: KeyBind,
     #[serde(default = "KeyBind::theme_editor")]
     pub theme_editor: KeyBind,
-    #[serde(default = "KeyBind::highlight")]
-    pub highlight: KeyBind,
+    // Keep highlight as alias for backwards compatibility
+    #[serde(default = "KeyBind::highlights", alias = "highlight")]
+    pub highlights: KeyBind,
     #[serde(default = "KeyBind::scroll_up_page")]
     pub scroll_up_page: KeyBind,
     #[serde(default = "KeyBind::scroll_down_page")]
@@ -84,7 +85,7 @@ impl Default for Keyboard {
             file_transfers: KeyBind::file_transfers(),
             logs: KeyBind::logs(),
             theme_editor: KeyBind::theme_editor(),
-            highlight: KeyBind::highlight(),
+            highlights: KeyBind::highlights(),
             scroll_up_page: KeyBind::scroll_up_page(),
             scroll_down_page: KeyBind::scroll_down_page(),
             scroll_to_top: KeyBind::scroll_to_top(),
@@ -126,7 +127,7 @@ impl Keyboard {
             shortcut(self.scroll_down_page.clone(), ScrollDownPage),
             shortcut(self.scroll_to_top.clone(), ScrollToTop),
             shortcut(self.scroll_to_bottom.clone(), ScrollToBottom),
-            shortcut(self.highlight.clone(), Highlight),
+            shortcut(self.highlights.clone(), Highlights),
             shortcut(
                 self.cycle_next_unread_buffer.clone(),
                 CycleNextUnreadBuffer,

--- a/data/src/shortcut.rs
+++ b/data/src/shortcut.rs
@@ -42,7 +42,7 @@ pub enum Command {
     FileTransfers,
     Logs,
     ThemeEditor,
-    Highlight,
+    Highlights,
     QuitApplication,
     ScrollUpPage,
     ScrollDownPage,
@@ -153,7 +153,7 @@ impl KeyBind {
     default!(file_transfers, "j", COMMAND);
     default!(logs, "l", COMMAND);
     default!(theme_editor, "t", COMMAND);
-    default!(highlight, "i", COMMAND);
+    default!(highlights, "i", COMMAND);
     default!(scroll_up_page, PageUp);
     default!(scroll_down_page, PageDown);
     // Don't use HOME / END since text input is always focused

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1132,7 +1132,7 @@ impl Dashboard {
                             None,
                         );
                     }
-                    Highlight => {
+                    Highlights => {
                         return (
                             self.toggle_internal_buffer(
                                 config,

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -218,7 +218,7 @@ impl Sidebar {
                         ),
                         Menu::Highlights => context_button(
                             text("Highlights"),
-                            Some(&keyboard.highlight),
+                            Some(&keyboard.highlights),
                             icon::highlights(),
                             Message::ToggleInternalBuffer(
                                 buffer::Internal::Highlights,


### PR DESCRIPTION
Make the Highlights buffer naming consistent between menu and keyboard shortcut.  Keeps `highlight` as an alias for the new `highlights` key binding, for backwards compatibility.