### PR TITLE
Eliminate common deep clones

### DIFF
--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -50,7 +50,7 @@ path = "../irc"
 
 [dependencies.serde]
 version = "1.0"
-features = ["derive"]
+features = ["derive", "rc"]
 
 [lints]
 workspace = true

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -21,6 +21,7 @@ use crate::isupport::{
     WhoXPollParameters,
 };
 use crate::message::{message_id, server_time, source};
+use crate::server::ServerConfig;
 use crate::target::{self, Target};
 use crate::time::Posix;
 use crate::user::{Nick, NickRef};
@@ -122,7 +123,7 @@ struct ChatHistoryRequest {
 
 pub struct Client {
     server: Server,
-    config: config::Server,
+    config: ServerConfig,
     handle: server::Handle,
     alt_nick: Option<usize>,
     resolved_nick: Option<String>,
@@ -161,7 +162,7 @@ impl fmt::Debug for Client {
 impl Client {
     pub fn new(
         server: Server,
-        config: config::Server,
+        config: ServerConfig,
         sender: mpsc::Sender<proto::Message>,
     ) -> Self {
         Self {

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::{fmt, io};
 
@@ -21,7 +22,6 @@ use crate::isupport::{
     WhoXPollParameters,
 };
 use crate::message::{message_id, server_time, source};
-use crate::server::ServerConfig;
 use crate::target::{self, Target};
 use crate::time::Posix;
 use crate::user::{Nick, NickRef};
@@ -123,7 +123,7 @@ struct ChatHistoryRequest {
 
 pub struct Client {
     server: Server,
-    config: ServerConfig,
+    config: Arc<config::Server>,
     handle: server::Handle,
     alt_nick: Option<usize>,
     resolved_nick: Option<String>,
@@ -162,7 +162,7 @@ impl fmt::Debug for Client {
 impl Client {
     pub fn new(
         server: Server,
-        config: ServerConfig,
+        config: Arc<config::Server>,
         sender: mpsc::Sender<proto::Message>,
     ) -> Self {
         Self {
@@ -2761,7 +2761,9 @@ impl Client {
     }
 
     fn mode<'a>(&'a self, channel: &target::Channel) -> Option<&'a String> {
-        self.chanmap.get(channel).and_then(|channel| channel.mode.as_ref())
+        self.chanmap
+            .get(channel)
+            .and_then(|channel| channel.mode.as_ref())
     }
 
     fn resolve_user_attributes<'a>(

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::{str, string};
 
@@ -25,7 +26,7 @@ use crate::appearance::theme::Colors;
 use crate::appearance::{self, Appearance};
 use crate::audio::{self, Sound};
 use crate::environment::config_dir;
-use crate::server::Map as ServerMap;
+use crate::server::{Map as ServerMap, Server as ServerName};
 use crate::{Theme, environment};
 
 pub mod actions;
@@ -216,7 +217,7 @@ impl Config {
         pub struct Configuration {
             #[serde(default)]
             pub theme: ThemeKeys,
-            pub servers: ServerMap,
+            pub servers: BTreeMap<ServerName, Server>,
             pub proxy: Option<Proxy>,
             #[serde(default)]
             pub font: Font,
@@ -258,7 +259,7 @@ impl Config {
 
         let Configuration {
             theme,
-            mut servers,
+            servers,
             font,
             proxy,
             scale_factor,
@@ -276,7 +277,7 @@ impl Config {
         } = toml::from_str(content.as_ref())
             .map_err(|e| Error::Parse(e.to_string()))?;
 
-        servers.read_passwords().await?;
+        let servers = ServerMap::new(servers).await?;
 
         let loaded_notifications = notifications.load_sounds()?;
 

--- a/data/src/stream.rs
+++ b/data/src/stream.rs
@@ -9,7 +9,7 @@ use irc::{Connection, codec, connection};
 use tokio::time::{self, Instant, Interval};
 
 use crate::client::Client;
-use crate::server::Server;
+use crate::server::{Server, ServerConfig};
 use crate::time::Posix;
 use crate::{config, message, server};
 
@@ -301,7 +301,7 @@ async fn _run(
 
 async fn connect(
     server: Server,
-    config: config::Server,
+    config: ServerConfig,
     proxy: Option<config::Proxy>,
 ) -> Result<(Stream, Client), connection::Error> {
     let connection =

--- a/data/src/stream.rs
+++ b/data/src/stream.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
@@ -9,7 +10,7 @@ use irc::{Connection, codec, connection};
 use tokio::time::{self, Instant, Interval};
 
 use crate::client::Client;
-use crate::server::{Server, ServerConfig};
+use crate::server::Server;
 use crate::time::Posix;
 use crate::{config, message, server};
 
@@ -301,7 +302,7 @@ async fn _run(
 
 async fn connect(
     server: Server,
-    config: ServerConfig,
+    config: Arc<config::Server>,
     proxy: Option<config::Proxy>,
 ) -> Result<(Stream, Client), connection::Error> {
     let connection =

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ use chrono::Utc;
 use data::config::{self, Config};
 use data::history::manager::Broadcast;
 use data::history::{self};
+use data::server::ServerConfig;
 use data::target::{self, Target};
 use data::version::Version;
 use data::{Notification, Server, Url, User, environment, server, version};
@@ -1088,7 +1089,7 @@ impl Halloy {
                                             .collect::<Vec<_>>(),
                                     );
                                 } else {
-                                    self.servers.insert(server, config);
+                                    self.servers.insert(server, ServerConfig::from(config));
                                 }
                             }
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,6 @@ use chrono::Utc;
 use data::config::{self, Config};
 use data::history::manager::Broadcast;
 use data::history::{self};
-use data::server::ServerConfig;
 use data::target::{self, Target};
 use data::version::Version;
 use data::{Notification, Server, Url, User, environment, server, version};
@@ -1089,7 +1088,7 @@ impl Halloy {
                                             .collect::<Vec<_>>(),
                                     );
                                 } else {
-                                    self.servers.insert(server, ServerConfig::from(config));
+                                    self.servers.insert(server, config);
                                 }
                             }
                         }


### PR DESCRIPTION
This commit changes several structures, primarily `Server`, `Target` and `config::Server` to be wrapped in an Arc. There should be little change to existing code, but this should dramatically reduce the number of deep copies of these structs. This is rather important since `Server` needs to be cloned on every message received from the network to be sent across threads.