### PR TITLE
Show Content in Notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Unreleased
 
+Added:
+
+- Configuration option per toast type for showing content in toasts
+
 Thanks:
 
 - Bug reports: @darienm
+- Feature requests: @rossburton
 
 # 2025.6 (2025-06-14)
 

--- a/book/src/configuration/notifications.md
+++ b/book/src/configuration/notifications.md
@@ -15,16 +15,16 @@ exclude = ["NickServ", "#halloy"]
 
 Following notifications are available:
 
-| Name                    | Description                                        |
-| ----------------------- | -------------------------------------------------- |
-| `connected`             | Triggered when a server is connected               |
-| `direct_message`        | Triggered when a direct message is received        |
-| `disconnected`          | Triggered when a server disconnects                |
-| `file_transfer_request` | Triggered when a file transfer request is received |
-| `highlight`             | Triggered when you were highlighted in a buffer    |
-| `monitored_online`      | Triggered when a user you're monitoring is online  |
-| `monitored_offline`     | Triggered when a user you're monitoring is offline |
-| `reconnected`           | Triggered when a server reconnects                 |
+| Name                    | Description                                        | <span id="content">Content</span> |
+| ----------------------- | -------------------------------------------------- | --------------------------------- |
+| `connected`             | Triggered when a server is connected               | N/A                               |
+| `direct_message`        | Triggered when a direct message is received        | Message text                      |
+| `disconnected`          | Triggered when a server disconnects                | N/A                               |
+| `file_transfer_request` | Triggered when a file transfer request is received | File name                         |
+| `highlight`             | Triggered when you were highlighted in a buffer    | Message text                      |
+| `monitored_online`      | Triggered when a user you're monitoring is online  | N/A                               |
+| `monitored_offline`     | Triggered when a user you're monitoring is offline | N/A                               |
+| `reconnected`           | Triggered when a server reconnects                 | N/A                               |
 
 
 ## `sound`
@@ -52,6 +52,19 @@ Notification should trigger a OS toast.
 
 [notifications.<notification>]
 show_toast = true
+```
+
+## `show_content`
+
+Notification should show the content of the trigger (as described in the [table above](#content)).
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: false
+
+[notifications.<notification>]
+show_content = true
 ```
 
 ## `delay`

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -14,6 +14,7 @@ use itertools::{Either, Itertools};
 use log::error;
 use tokio::fs;
 
+pub use self::on_connect::on_connect;
 use crate::environment::{SOURCE_WEBSITE, VERSION};
 use crate::history::ReadMarker;
 use crate::isupport::{
@@ -28,8 +29,6 @@ use crate::{
     Server, User, buffer, compression, config, ctcp, dcc, environment,
     file_transfer, isupport, message, mode, server,
 };
-
-pub use self::on_connect::on_connect;
 
 pub mod on_connect;
 
@@ -112,7 +111,7 @@ pub enum Event {
     LoggedIn(DateTime<Utc>),
     ChatHistoryTargetReceived(Target, DateTime<Utc>),
     ChatHistoryTargetsReceived(DateTime<Utc>),
-    DirectMessage(User),
+    DirectMessage(message::Encoded, Nick, User),
     MonitoredOnline(Vec<User>),
     MonitoredOffline(Vec<Nick>),
     OnConnect(on_connect::Stream),
@@ -1317,7 +1316,14 @@ impl Client {
                     );
 
                     if direct_message {
-                        return Ok(vec![event, Event::DirectMessage(user)]);
+                        return Ok(vec![
+                            event,
+                            Event::DirectMessage(
+                                message,
+                                self.nickname().to_owned(),
+                                user,
+                            ),
+                        ]);
                     } else {
                         return Ok(vec![event]);
                     }

--- a/data/src/config/notification.rs
+++ b/data/src/config/notification.rs
@@ -8,6 +8,8 @@ pub type Loaded = Notification<Sound>;
 pub struct Notification<T = String> {
     #[serde(default)]
     pub show_toast: bool,
+    #[serde(default)]
+    pub show_content: bool,
     pub sound: Option<T>,
     pub delay: Option<u64>,
     #[serde(default)]
@@ -20,6 +22,7 @@ impl<T> Default for Notification<T> {
     fn default() -> Self {
         Self {
             show_toast: false,
+            show_content: false,
             sound: None,
             delay: Some(500),
             exclude: Vec::default(),
@@ -87,6 +90,7 @@ impl Notifications {
         let load = |notification: &Notification<String>| -> Result<_, audio::LoadError> {
             Ok(Notification {
                 show_toast: notification.show_toast,
+                show_content: notification.show_content,
                 sound: notification.sound.as_deref().map(Sound::load).transpose()?,
                 delay: notification.delay,
                 exclude: notification.exclude.to_owned(),

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -365,6 +365,10 @@ impl Message {
         }
     }
 
+    pub fn text(&self) -> String {
+        self.content.text().to_string()
+    }
+
     pub fn log(record: crate::log::Record) -> Self {
         let received_at = Posix::now();
         let server_time = record.timestamp;

--- a/data/src/notification.rs
+++ b/data/src/notification.rs
@@ -7,9 +7,19 @@ pub enum Notification {
     Connected,
     Disconnected,
     Reconnected,
-    DirectMessage(User),
-    Highlight { user: User, channel: Channel },
-    FileTransferRequest(Nick),
+    DirectMessage {
+        user: User,
+        message: String,
+    },
+    Highlight {
+        user: User,
+        channel: Channel,
+        message: String,
+    },
+    FileTransferRequest {
+        nick: Nick,
+        filename: String,
+    },
     MonitoredOnline(Vec<User>),
     MonitoredOffline(Vec<Nick>),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -689,6 +689,8 @@ impl Halloy {
                                             if let Some((message, channel, user)) =
                                                 message.into_highlight(server.clone())
                                             {
+                                                let message_text = message.text();
+
                                                 commands.push(
                                                     dashboard
                                                         .record_highlight(message)
@@ -698,7 +700,11 @@ impl Halloy {
                                                 if highlight_notification_enabled {
                                                     self.notifications.notify(
                                                         &self.config.notifications,
-                                                        &Notification::Highlight { user, channel },
+                                                        &Notification::Highlight {
+                                                            user,
+                                                            channel,
+                                                            message: message_text,
+                                                        },
                                                         &server,
                                                     );
                                                 }
@@ -911,22 +917,36 @@ impl Halloy {
                                             commands.push(command);
                                         }
                                     }
-                                    data::client::Event::DirectMessage(user) => {
-                                        if let Ok(query) = target::Query::parse(
-                                            user.as_str(),
+                                    data::client::Event::DirectMessage(encoded, our_nick, user) => {
+                                        if let Some(message) = data::Message::received(
+                                            encoded,
+                                            our_nick,
+                                            &self.config,
+                                            resolve_user_attributes,
+                                            channel_users,
                                             chantypes,
                                             statusmsg,
                                             casemapping,
                                         ) {
-                                            if dashboard.history().has_unread(
-                                                &history::Kind::Query(server.clone(), query),
-                                            ) || !self.main_window.focused
-                                            {
-                                                self.notifications.notify(
-                                                    &self.config.notifications,
-                                                    &Notification::DirectMessage(user),
-                                                    &server,
-                                                );
+                                            if let Ok(query) = target::Query::parse(
+                                                user.as_str(),
+                                                chantypes,
+                                                statusmsg,
+                                                casemapping,
+                                            ) {
+                                                if dashboard.history().has_unread(
+                                                    &history::Kind::Query(server.clone(), query),
+                                                ) || !self.main_window.focused
+                                                {
+                                                    self.notifications.notify(
+                                                        &self.config.notifications,
+                                                        &Notification::DirectMessage{
+                                                            user,
+                                                            message: message.text(),
+                                                        },
+                                                        &server,
+                                                    );
+                                                }
                                             }
                                         }
                                     }

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -73,49 +73,90 @@ impl Notifications {
                     );
                 });
             }
-            Notification::FileTransferRequest(nick) => {
+            Notification::FileTransferRequest { nick, filename } => {
                 if config
                     .file_transfer_request
                     .should_notify(vec![nick.to_string()])
                 {
+                    let (title, body) = if config
+                        .file_transfer_request
+                        .show_content
+                    {
+                        (
+                            &format!("File transfer from {nick} on {server}"),
+                            filename.as_ref(),
+                        )
+                    } else {
+                        (&format!("File transfer from {nick}"), server.as_ref())
+                    };
+
                     self.execute(
                         &config.file_transfer_request,
                         notification,
-                        &format!("File transfer from {nick}"),
-                        server,
+                        title,
+                        body,
                     );
                 }
             }
-            Notification::DirectMessage(user) => {
+            Notification::DirectMessage { user, message } => {
                 if config
                     .direct_message
                     .should_notify(vec![user.nickname().to_string()])
                 {
+                    let (title, body) = if config.direct_message.show_content {
+                        (
+                            &format!(
+                                "{} sent you a direct message on {server}",
+                                user.nickname()
+                            ),
+                            message.as_ref(),
+                        )
+                    } else {
+                        (
+                            &format!(
+                                "{} sent you a direct message",
+                                user.nickname()
+                            ),
+                            server.as_ref(),
+                        )
+                    };
+
                     self.execute(
                         &config.direct_message,
                         notification,
-                        "Direct message",
-                        format!(
-                            "{} sent you a direct message on {server}",
-                            user.nickname()
-                        ),
+                        title,
+                        body,
                     );
                 }
             }
-            Notification::Highlight { user, channel } => {
+            Notification::Highlight {
+                user,
+                channel,
+                message,
+            } => {
                 if config.highlight.should_notify(vec![
                     channel.to_string(),
                     user.nickname().to_string(),
                 ]) {
-                    self.execute(
-                        &config.highlight,
-                        notification,
-                        "Highlight",
-                        format!(
-                            "{} highlighted you in {channel} on {server}",
-                            user.nickname()
-                        ),
-                    );
+                    let (title, body) = if config.highlight.show_content {
+                        (
+                            &format!(
+                                "{} highlighted you in {channel} on {server}",
+                                user.nickname()
+                            ),
+                            message.as_ref(),
+                        )
+                    } else {
+                        (
+                            &format!(
+                                "{} highlighted you in {channel}",
+                                user.nickname()
+                            ),
+                            server.as_ref(),
+                        )
+                    };
+
+                    self.execute(&config.highlight, notification, title, body);
                 }
             }
         }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -2493,7 +2493,15 @@ impl Dashboard {
 
         self.notifications.notify(
             &config.notifications,
-            &Notification::FileTransferRequest(request.from.clone()),
+            &Notification::FileTransferRequest {
+                nick: request.from.clone(),
+                filename: match event {
+                    file_transfer::manager::Event::NewTransfer(
+                        ref transfer,
+                        _,
+                    ) => transfer.filename.clone(),
+                },
+            },
             server,
         );
 


### PR DESCRIPTION
Adds configuration option per notification type to show content of notification (e.g. message text or filename) when showing a toast.  For notifications that have no distinct content, such as connection notifications, the configuration option doesn't do anything.  Currently defaults to `false` since that's the more-private setting, but I think it could reasonably be switched to `true` if we think more users would expect that.