### PR TITLE
Minor Docs Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+Thanks:
+
+- Bug reports: @darienm
+
 # 2025.6 (2025-06-14)
 
 Added:

--- a/book/src/configuration/font.md
+++ b/book/src/configuration/font.md
@@ -34,7 +34,7 @@ Font size.
 size = 13
 ```
 
-## `size`
+## `weight`
 
 Font weight.
 
@@ -47,7 +47,7 @@ Font weight.
 weight = "light"
 ```
 
-## `size`
+## `bold-weight`
 
 Bold font weight.  If not set, then the font weight three steps above the regular font weight (e.g. font weight `"light"` → bold font weight `"semibold"`).
 


### PR DESCRIPTION
Fixes two headers which were accidentally left as `size` from the original copy-paste.