### PR TITLE
Refactor message renderer

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -27,6 +27,7 @@ pub mod query;
 mod scroll_view;
 pub mod server;
 pub mod user_context;
+mod message_view;
 
 #[derive(Clone, Debug)]
 pub enum Buffer {

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -9,7 +9,7 @@ use data::{Config, User, buffer, history, message};
 use iced::widget::{column, container, row};
 use iced::{Length, Task, padding};
 
-use super::message_view::ChannelFormat;
+use super::message_view::ChannelQueryLayout;
 use super::{input_view, scroll_view, user_context};
 use crate::widget::Element;
 use crate::Theme;
@@ -71,7 +71,7 @@ pub fn view<'a>(
         casemapping,
     ));
 
-    let message_formatter = ChannelFormat {
+    let message_formatter = ChannelQueryLayout {
         config,
         users,
         casemapping,

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -9,7 +9,7 @@ use data::{Config, User, buffer, history, message};
 use iced::widget::{column, container, row};
 use iced::{Length, Task, padding};
 
-use super::message_view::ChannelQueryLayout;
+use super::message_view::{ChannelQueryLayout, TargetInfo};
 use super::{input_view, scroll_view, user_context};
 use crate::widget::Element;
 use crate::Theme;
@@ -73,12 +73,14 @@ pub fn view<'a>(
 
     let message_formatter = ChannelQueryLayout {
         config,
-        users,
         casemapping,
         server,
-        channel: Some(channel),
-        our_user,
         theme,
+        target: TargetInfo::Channel {
+            users,
+            channel,
+            our_user,
+        },
     };
 
     let messages = container(

--- a/src/buffer/highlights.rs
+++ b/src/buffer/highlights.rs
@@ -41,7 +41,7 @@ pub fn view<'a>(
             None,
             None,
             config,
-            move |message, _, _| match &message.target {
+            move |message: &'a data::Message, _, _| match &message.target {
                 message::Target::Highlights {
                     server,
                     channel,

--- a/src/buffer/logs.rs
+++ b/src/buffer/logs.rs
@@ -38,7 +38,7 @@ pub fn view<'a>(
             None,
             None,
             config,
-            move |message, _, _| match message.target.source() {
+            move |message: &'a data::Message, _, _| match message.target.source() {
                 message::Source::Internal(message::source::Internal::Logs) => {
                     Some(
                         container(message_content(

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -6,50 +6,26 @@ use data::{Config, User, message};
 use iced::advanced::text;
 use iced::widget::{column, container, row};
 
+use super::scroll_view::LayoutMessage;
 use super::user_context;
 use crate::widget::{
     Element, message_content, message_marker, selectable_text,
 };
 use crate::{Theme, theme};
 
-pub trait MessageFormat<'a> {
-    fn format(
-        &self,
-        msg: &'a data::Message,
-        max_nick_width: Option<f32>,
-        max_prefix_width: Option<f32>,
-    ) -> Option<Element<'a, Message>>;
-}
-impl<'a, T> MessageFormat<'a> for T
-where
-    T: Fn(
-        &'a data::Message,
-        Option<f32>,
-        Option<f32>,
-    ) -> Option<Element<'a, Message>>,
-{
-    fn format(
-        &self,
-        msg: &'a data::Message,
-        max_nick_width: Option<f32>,
-        max_prefix_width: Option<f32>,
-    ) -> Option<Element<'a, Message>> {
-        self(msg, max_nick_width, max_prefix_width)
-    }
-}
-
 #[derive(Clone, Copy)]
-pub struct ChannelFormat<'a> {
+pub struct ChannelQueryLayout<'a> {
     pub config: &'a Config,
     pub users: &'a [User],
     pub casemapping: CaseMap,
     pub server: &'a Server,
+    // if we are laying out a query buffer, then this and our_user should be None
     pub channel: Option<&'a target::Channel>,
     pub our_user: Option<&'a User>,
     pub theme: &'a Theme,
 }
 
-impl<'a> ChannelFormat<'a> {
+impl<'a> ChannelQueryLayout<'a> {
     fn format_timestamp(
         &self,
         message: &'a data::Message,
@@ -229,7 +205,7 @@ impl<'a> ChannelFormat<'a> {
         )
     }
 }
-impl<'a> MessageFormat<'a> for ChannelFormat<'a> {
+impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
     fn format(
         &self,
         message: &'a data::Message,

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -1,0 +1,312 @@
+use crate::buffer::scroll_view::Message;
+use data::isupport::CaseMap;
+use data::server::Server;
+use data::target::{self};
+use data::{Config, User, message};
+use iced::advanced::text;
+use iced::widget::{column, container, row};
+
+use super::user_context;
+use crate::widget::{
+    Element, message_content, message_marker, selectable_text,
+};
+use crate::{Theme, theme};
+
+pub trait MessageFormat<'a> {
+    fn format(
+        &self,
+        msg: &'a data::Message,
+        max_nick_width: Option<f32>,
+        max_prefix_width: Option<f32>,
+    ) -> Option<Element<'a, Message>>;
+}
+impl<'a, T> MessageFormat<'a> for T
+where
+    T: Fn(
+        &'a data::Message,
+        Option<f32>,
+        Option<f32>,
+    ) -> Option<Element<'a, Message>>,
+{
+    fn format(
+        &self,
+        msg: &'a data::Message,
+        max_nick_width: Option<f32>,
+        max_prefix_width: Option<f32>,
+    ) -> Option<Element<'a, Message>> {
+        self(msg, max_nick_width, max_prefix_width)
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct ChannelFormat<'a> {
+    pub config: &'a Config,
+    pub users: &'a [User],
+    pub casemapping: CaseMap,
+    pub server: &'a Server,
+    pub channel: Option<&'a target::Channel>,
+    pub our_user: Option<&'a User>,
+    pub theme: &'a Theme,
+}
+
+impl<'a> ChannelFormat<'a> {
+    fn format_timestamp(
+        &self,
+        message: &'a data::Message,
+    ) -> Option<Element<'a, Message>> {
+        self.config
+            .buffer
+            .format_timestamp(&message.server_time)
+            .map(|timestamp| {
+                selectable_text(timestamp)
+                    .style(theme::selectable_text::timestamp)
+            })
+            .map(Element::from)
+    }
+    fn format_prefixes(
+        &self,
+        message: &'a data::Message,
+        max_nick_width: Option<f32>,
+        max_prefix_width: Option<f32>,
+    ) -> Option<Element<'a, Message>> {
+        message
+            .target
+            .prefixes()
+            .map_or(
+                max_nick_width.and_then(|_| {
+                    max_prefix_width.map(|width| {
+                        selectable_text("")
+                            .width(width)
+                            .align_x(text::Alignment::Right)
+                    })
+                }),
+                |prefixes| {
+                    let text = selectable_text(format!(
+                        "{} ",
+                        self.config
+                            .buffer
+                            .status_message_prefix
+                            .brackets
+                            .format(String::from_iter(prefixes))
+                    ))
+                    .style(theme::selectable_text::tertiary);
+
+                    if let Some(width) = max_prefix_width {
+                        Some(text.width(width).align_x(text::Alignment::Right))
+                    } else {
+                        Some(text)
+                    }
+                },
+            )
+            .map(Element::from)
+    }
+
+    fn format_user_message(
+        &self,
+        message: &'a data::Message,
+        max_nick_width: Option<f32>,
+        user: &'a User,
+    ) -> (Element<'a, Message>, Element<'a, Message>) {
+        let fm = *self;
+        let with_access_levels = self.config.buffer.nickname.show_access_levels;
+        let current_user: Option<&User> =
+            self.users.iter().find(|current_user| *current_user == user);
+
+        let mut text = selectable_text(
+            self.config
+                .buffer
+                .nickname
+                .brackets
+                .format(user.display(with_access_levels)),
+        )
+        .style(|theme| {
+            theme::selectable_text::nickname(theme, self.config, user)
+        });
+
+        if let Some(width) = max_nick_width {
+            text = text.width(width).align_x(text::Alignment::Right);
+        }
+
+        let nick = user_context::view(
+            text,
+            self.server,
+            self.casemapping,
+            self.channel,
+            user,
+            current_user,
+            self.our_user,
+            self.config,
+            &self.config.buffer.nickname.click,
+        )
+        .map(Message::UserContext);
+
+        let message_content = message_content::with_context(
+            &message.content,
+            self.casemapping,
+            self.theme,
+            Message::Link,
+            theme::selectable_text::default,
+            move |link| match link {
+                message::Link::User(_) => {
+                    user_context::Entry::list(fm.channel.is_some(), fm.our_user)
+                }
+                _ => vec![],
+            },
+            move |link, entry, length| match link {
+                message::Link::User(user) => entry
+                    .view(
+                        fm.server,
+                        fm.casemapping,
+                        fm.channel,
+                        user,
+                        current_user,
+                        length,
+                        fm.config,
+                    )
+                    .map(Message::UserContext),
+                _ => row![].into(),
+            },
+            self.config,
+        );
+
+        (nick, Element::from(container(message_content)))
+    }
+
+    fn format_server_message(
+        &self,
+        message: &'a data::Message,
+        max_nick_width: Option<f32>,
+        server: Option<&'a message::source::Server>,
+    ) -> (Element<'a, Message>, Element<'a, Message>) {
+        let message_style = move |message_theme: &Theme| {
+            theme::selectable_text::server(message_theme, server)
+        };
+        let marker = message_marker(max_nick_width, message_style);
+        let fm = *self;
+        let message_content = message_content::with_context(
+            &message.content,
+            fm.casemapping,
+            self.theme,
+            Message::Link,
+            message_style,
+            move |link| match link {
+                message::Link::User(_) => {
+                    user_context::Entry::list(fm.channel.is_some(), fm.our_user)
+                }
+                _ => vec![],
+            },
+            move |link, entry, length| match link {
+                message::Link::User(user) => entry
+                    .view(
+                        fm.server,
+                        fm.casemapping,
+                        fm.channel,
+                        user,
+                        fm.users
+                            .iter()
+                            .find(|current_user| *current_user == user),
+                        length,
+                        fm.config,
+                    )
+                    .map(Message::UserContext),
+                _ => row![].into(),
+            },
+            self.config,
+        );
+
+        (marker, container(message_content).into())
+    }
+
+    fn content_on_new_line(&self, message: &data::Message) -> bool {
+        use data::buffer::Alignment;
+        use message::Source;
+        matches!(
+            (
+                message.target.source(),
+                self.config.buffer.nickname.alignment,
+            ),
+            (Source::User(_), Alignment::Top)
+        )
+    }
+}
+impl<'a> MessageFormat<'a> for ChannelFormat<'a> {
+    fn format(
+        &self,
+        message: &'a data::Message,
+        max_nick_width: Option<f32>,
+        max_prefix_width: Option<f32>,
+    ) -> Option<Element<'a, Message>> {
+        //let fm = *self;
+        let timestamp = self.format_timestamp(message);
+        let prefixes =
+            self.format_prefixes(message, max_nick_width, max_prefix_width);
+
+        let space = selectable_text(" ");
+
+        let row = row![].push_maybe(timestamp).push_maybe(prefixes);
+
+        let (middle, content): (Element<'a, Message>, Element<'a, Message>) =
+            match message.target.source() {
+                message::Source::User(user) => Some(self.format_user_message(
+                    message,
+                    max_nick_width,
+                    user,
+                )),
+                message::Source::Server(server_message) => {
+                    Some(self.format_server_message(
+                        message,
+                        max_nick_width,
+                        server_message.as_ref(),
+                    ))
+                }
+                message::Source::Action(_) => {
+                    let marker = message_marker(
+                        max_nick_width,
+                        theme::selectable_text::action,
+                    );
+
+                    let message_content = message_content(
+                        &message.content,
+                        self.casemapping,
+                        self.theme,
+                        Message::Link,
+                        theme::selectable_text::action,
+                        self.config,
+                    );
+
+                    let text_container = container(message_content);
+
+                    Some((marker, text_container.into()))
+                }
+                message::Source::Internal(
+                    message::source::Internal::Status(status),
+                ) => {
+                    let message_style = move |message_theme: &Theme| {
+                        theme::selectable_text::status(message_theme, *status)
+                    };
+
+                    let marker = message_marker(max_nick_width, message_style);
+
+                    let message = message_content(
+                        &message.content,
+                        self.casemapping,
+                        self.theme,
+                        Message::Link,
+                        message_style,
+                        self.config,
+                    );
+
+                    Some((marker, message))
+                }
+                message::Source::Internal(message::source::Internal::Logs) => {
+                    None
+                }
+            }?;
+        let row = row.push(middle).push(space);
+        if self.content_on_new_line(message) {
+            Some(container(column![row, content]).into())
+        } else {
+            Some(container(row![row, content]).into())
+        }
+    }
+}

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -7,7 +7,7 @@ use data::{Config, Server, buffer, history, message};
 use iced::widget::{column, container, vertical_space};
 use iced::{Length, Task};
 
-use super::message_view::ChannelFormat;
+use super::message_view::ChannelQueryLayout;
 use super::{input_view, scroll_view, user_context};
 use crate::widget::Element;
 use crate::Theme;
@@ -56,7 +56,7 @@ pub fn view<'a>(
         casemapping,
     ));
 
-    let message_formatter = ChannelFormat {
+    let message_formatter = ChannelQueryLayout {
         config,
         users: &[],
         casemapping,

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -4,15 +4,13 @@ use data::dashboard::BufferAction;
 use data::preview::{self, Previews};
 use data::target::{self, Target};
 use data::{Config, Server, buffer, history, message};
-use iced::advanced::text;
-use iced::widget::{column, container, row, vertical_space};
+use iced::widget::{column, container, vertical_space};
 use iced::{Length, Task};
 
+use super::message_view::ChannelFormat;
 use super::{input_view, scroll_view, user_context};
-use crate::widget::{
-    Element, message_content, message_marker, selectable_text,
-};
-use crate::{Theme, theme};
+use crate::widget::Element;
+use crate::Theme;
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -58,6 +56,16 @@ pub fn view<'a>(
         casemapping,
     ));
 
+    let message_formatter = ChannelFormat {
+        config,
+        users: &[],
+        casemapping,
+        server,
+        channel: None,
+        our_user: None,
+        theme,
+    };
+
     let messages = container(
         scroll_view::view(
             &state.scroll_view,
@@ -66,200 +74,7 @@ pub fn view<'a>(
             previews,
             chathistory_state,
             config,
-            move |message, max_nick_width, _| {
-                let timestamp = config
-                    .buffer
-                    .format_timestamp(&message.server_time)
-                    .map(|timestamp| {
-                        selectable_text(timestamp)
-                            .style(theme::selectable_text::timestamp)
-                    });
-
-                let space = selectable_text(" ");
-
-                match message.target.source() {
-                    message::Source::User(user) => {
-                        let with_access_levels =
-                            config.buffer.nickname.show_access_levels;
-                        let mut text = selectable_text(
-                            config
-                                .buffer
-                                .nickname
-                                .brackets
-                                .format(user.display(with_access_levels)),
-                        )
-                        .style(|theme| {
-                            theme::selectable_text::nickname(
-                                theme, config, user,
-                            )
-                        });
-
-                        if let Some(width) = max_nick_width {
-                            text = text
-                                .width(width)
-                                .align_x(text::Alignment::Right);
-                        }
-
-                        let nick = user_context::view(
-                            text,
-                            server,
-                            casemapping,
-                            None,
-                            user,
-                            None,
-                            None,
-                            config,
-                            &config.buffer.nickname.click,
-                        )
-                        .map(scroll_view::Message::UserContext);
-
-                        let message_content = message_content::with_context(
-                            &message.content,
-                            casemapping,
-                            theme,
-                            scroll_view::Message::Link,
-                            theme::selectable_text::default,
-                            move |link| match link {
-                                message::Link::User(_) => {
-                                    user_context::Entry::list(false, None)
-                                }
-                                _ => vec![],
-                            },
-                            move |link, entry, length| match link {
-                                message::Link::User(user) => entry
-                                    .view(
-                                        server,
-                                        casemapping,
-                                        None,
-                                        user,
-                                        None,
-                                        length,
-                                        config,
-                                    )
-                                    .map(scroll_view::Message::UserContext),
-                                _ => row![].into(),
-                            },
-                            config,
-                        );
-
-                        let timestamp_nickname_row =
-                            row![].push_maybe(timestamp).push(nick).push(space);
-
-                        let text_container = container(message_content);
-
-                        match &config.buffer.nickname.alignment {
-                            data::buffer::Alignment::Left
-                            | data::buffer::Alignment::Right => Some(
-                                row![]
-                                    .push(timestamp_nickname_row)
-                                    .push(text_container)
-                                    .into(),
-                            ),
-                            data::buffer::Alignment::Top => Some(
-                                column![]
-                                    .push(timestamp_nickname_row)
-                                    .push(text_container)
-                                    .into(),
-                            ),
-                        }
-                    }
-                    message::Source::Server(server) => {
-                        let message_style = move |message_theme: &Theme| {
-                            theme::selectable_text::server(
-                                message_theme,
-                                server.as_ref(),
-                            )
-                        };
-
-                        let marker =
-                            message_marker(max_nick_width, message_style);
-
-                        let message = message_content(
-                            &message.content,
-                            casemapping,
-                            theme,
-                            scroll_view::Message::Link,
-                            message_style,
-                            config,
-                        );
-
-                        Some(
-                            container(
-                                row![]
-                                    .push_maybe(timestamp)
-                                    .push(marker)
-                                    .push(space)
-                                    .push(message),
-                            )
-                            .into(),
-                        )
-                    }
-                    message::Source::Action(_) => {
-                        let marker = message_marker(
-                            max_nick_width,
-                            theme::selectable_text::action,
-                        );
-
-                        let message_content = message_content(
-                            &message.content,
-                            casemapping,
-                            theme,
-                            scroll_view::Message::Link,
-                            theme::selectable_text::action,
-                            config,
-                        );
-
-                        let text_container = container(message_content);
-
-                        Some(
-                            container(
-                                row![]
-                                    .push_maybe(timestamp)
-                                    .push(marker)
-                                    .push(space)
-                                    .push(text_container),
-                            )
-                            .into(),
-                        )
-                    }
-                    message::Source::Internal(
-                        message::source::Internal::Status(status),
-                    ) => {
-                        let message_style = move |message_theme: &Theme| {
-                            theme::selectable_text::status(
-                                message_theme,
-                                *status,
-                            )
-                        };
-
-                        let marker =
-                            message_marker(max_nick_width, message_style);
-
-                        let message = message_content(
-                            &message.content,
-                            casemapping,
-                            theme,
-                            scroll_view::Message::Link,
-                            message_style,
-                            config,
-                        );
-
-                        Some(
-                            container(
-                                row![]
-                                    .push_maybe(timestamp)
-                                    .push(marker)
-                                    .push(space)
-                                    .push(message),
-                            )
-                            .into(),
-                        )
-                    }
-                    message::Source::Internal(
-                        message::source::Internal::Logs,
-                    ) => None,
-                }
-            },
+            message_formatter,
         )
         .map(Message::ScrollView),
     )

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -7,7 +7,7 @@ use data::{Config, Server, buffer, history, message};
 use iced::widget::{column, container, vertical_space};
 use iced::{Length, Task};
 
-use super::message_view::ChannelQueryLayout;
+use super::message_view::{ChannelQueryLayout, TargetInfo};
 use super::{input_view, scroll_view, user_context};
 use crate::widget::Element;
 use crate::Theme;
@@ -58,12 +58,10 @@ pub fn view<'a>(
 
     let message_formatter = ChannelQueryLayout {
         config,
-        users: &[],
         casemapping,
         server,
-        channel: None,
-        our_user: None,
         theme,
+        target: TargetInfo::Query,
     };
 
     let messages = container(

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -17,6 +17,7 @@ use iced::{ContentFit, Length, Task, alignment, padding};
 
 use self::correct_viewport::correct_viewport;
 use self::keyed::keyed;
+use super::message_view::MessageFormat;
 use super::user_context;
 use crate::widget::{
     Element, MESSAGE_MARKER_TEXT, notify_visibility, selectable_text,
@@ -102,12 +103,7 @@ pub fn view<'a>(
     previews: Option<Previews<'a>>,
     chathistory_state: Option<ChatHistoryState>,
     config: &'a Config,
-    format: impl Fn(
-        &'a data::Message,
-        Option<f32>,
-        Option<f32>,
-    ) -> Option<Element<'a, Message>>
-    + 'a,
+    formatter: impl MessageFormat<'a> + 'a
 ) -> Element<'a, Message> {
     let divider_font_size =
         config.font.size.map_or(theme::TEXT_SIZE, f32::from) - 1.0;
@@ -177,7 +173,7 @@ pub fn view<'a>(
         messages
             .iter()
             .filter_map(|message| {
-                format(message, max_nick_width, max_prefix_width).map(
+                formatter.format(message, max_nick_width, max_prefix_width).map(
                     |element| {
                         (message, keyed(keyed::Key::message(message), element))
                     },

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -46,7 +46,7 @@ pub fn view<'a>(
             None,
             None,
             config,
-            move |message, _, _| {
+            move |message: &'a data::Message, _, _| {
                 let timestamp = config
                     .buffer
                     .format_timestamp(&message.server_time)


### PR DESCRIPTION
This refactor moves message rendering primarily into one place. Previously every kind of buffer had its own message renderer, and now `query` and `channel` buffers share a renderer.

This is in preparation for the react changes, which should preferably all take place in one location.

needed for #550 