### PR TITLE
"Mark entire server as read" Context Menu Entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 Added:
 
 - Configuration option per toast type for showing content in toasts
+- Context menu item to server buffers to mark all messages on the server as read
 
 Thanks:
 
 - Bug reports: @darienm, @mercster
-- Feature requests: @rossburton
+- Feature requests: @rossburton, death916
 
 # 2025.6 (2025-06-14)
 

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -377,6 +377,34 @@ impl Manager {
             .collect::<Vec<_>>()
     }
 
+    pub fn server_kinds(&self, server: Server) -> Vec<history::Kind> {
+        self.data
+            .map
+            .iter()
+            .filter_map(|(kind, _)| {
+                if kind.server().is_some_and(|s| *s == server) {
+                    Some(kind.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    pub fn server_has_unread(&self, server: Server) -> bool {
+        self.data
+            .map
+            .iter()
+            .filter_map(|(kind, history)| {
+                if kind.server().is_some_and(|s| *s == server) {
+                    Some(history)
+                } else {
+                    None
+                }
+            })
+            .any(History::has_unread)
+    }
+
     pub fn has_unread(&self, kind: &history::Kind) -> bool {
         self.data.map.get(kind).is_some_and(History::has_unread)
     }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -693,6 +693,11 @@ impl Dashboard {
                         let _ = open::that_detached(WIKI_WEBSITE);
                         (Task::none(), None)
                     }
+                    sidebar::Event::MarkServerAsRead(server) => {
+                        self.mark_server_as_read(server, clients);
+
+                        (Task::none(), None)
+                    }
                     sidebar::Event::MarkAsRead(buffer) => {
                         if let Some(kind) = history::Kind::from_buffer(
                             data::Buffer::Upstream(buffer),
@@ -2790,6 +2795,16 @@ impl Dashboard {
 
     fn main_window(&self) -> window::Id {
         self.panes.main_window
+    }
+
+    fn mark_server_as_read(
+        &mut self,
+        server: Server,
+        clients: &mut data::client::Map,
+    ) {
+        for kind in self.history.server_kinds(server) {
+            self.mark_as_read(kind, clients);
+        }
     }
 
     fn mark_as_read(


### PR DESCRIPTION
Adds a "Mark entire server as read" context menu item to server buffers that marks all messages on the server as read.