### PR TITLE
Use `BTreeMap` for tags instead of a vector

### DIFF
--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -1140,20 +1140,14 @@ fn target(
 }
 
 pub fn message_id(message: &Encoded) -> Option<String> {
-    message
-        .tags
-        .iter()
-        .find(|tag| &tag.key == "msgid")
-        .and_then(|tag| tag.value.clone())
+    message.tags.get("msgid").cloned()
 }
 
 pub fn server_time(message: &Encoded) -> DateTime<Utc> {
     message
         .tags
-        .iter()
-        .find(|tag| &tag.key == "time")
-        .and_then(|tag| tag.value.clone())
-        .and_then(|rfc3339| DateTime::parse_from_rfc3339(&rfc3339).ok())
+        .get("time")
+        .and_then(|rfc3339| DateTime::parse_from_rfc3339(rfc3339).ok())
         .map_or_else(Utc::now, |dt| dt.with_timezone(&Utc))
 }
 

--- a/irc/proto/src/lib.rs
+++ b/irc/proto/src/lib.rs
@@ -1,4 +1,17 @@
+use std::collections::BTreeMap;
+
 pub use self::command::Command;
+
+pub type Tags = BTreeMap<String, String>;
+
+#[macro_export]
+macro_rules! tags {
+    () => { ::std::collections::BTreeMap::new() };
+    ($x:expr) => { $crate::parse::tagstr($x).unwrap() };
+    ($($key:expr => $value:expr),+ $(,)?) => {
+        ::std::collections::BTreeMap::from([ $((::std::string::String::from($key), ::std::string::String::from($value))),* ])
+    };
+}
 
 pub mod command;
 pub mod format;
@@ -6,7 +19,7 @@ pub mod parse;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Message {
-    pub tags: Vec<Tag>,
+    pub tags: Tags,
     pub source: Option<Source>,
     pub command: Command,
 }
@@ -14,17 +27,11 @@ pub struct Message {
 impl From<Command> for Message {
     fn from(command: Command) -> Self {
         Self {
-            tags: vec![],
+            tags: tags![],
             source: None,
             command,
         }
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Tag {
-    pub key: String,
-    pub value: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -42,7 +49,7 @@ pub struct User {
 
 pub fn command(command: &str, parameters: Vec<String>) -> Message {
     Message {
-        tags: vec![],
+        tags: tags![],
         source: None,
         command: Command::new(command, parameters),
     }


### PR DESCRIPTION
This commit is a minor convenience, and removes a minor footgun (two possible values for an empty tag, which the ircv3 spec forbids discriminating).

`BTreeMap` should have equivalent (that is, pretty fast) performance for <= B (6) tags which is pretty common. For more tags it should most likely give better performance. It also guarentees that we don't care about tag order and duplication.

There is a minor refactor in `format.rs` that allows for paring tag-escaped key-value strings for squidowl/halloy#77.