### PR TITLE
Wait for Server-Ack/Timeout After Quit

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -221,6 +221,13 @@ impl Client {
     }
 
     fn quit(&mut self, reason: Option<String>) {
+        self.who_polls.retain(|who_poll| {
+            matches!(
+                who_poll.status,
+                WhoStatus::Requested(_, _, _) | WhoStatus::Receiving(_, _)
+            )
+        });
+
         if let Err(e) = if let Some(reason) = reason {
             self.handle.try_send(command!("QUIT", reason))
         } else {

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -1575,7 +1575,7 @@ mod correct_viewport {
 
                     // Flip offset
                     if matches!(self.anchor, Anchor::End) {
-                        offset.y = (offset.y * -1.0)
+                        offset.y = (-offset.y)
                             .clamp(0.0, content_bounds.height - bounds.height);
                     } else {
                         let min_offset = 0.0 - translation.y;

--- a/src/widget/context_menu.rs
+++ b/src/widget/context_menu.rs
@@ -236,10 +236,11 @@ where
         _viewport: &Rectangle,
         _renderer: &Renderer,
     ) -> mouse::Interaction {
-        cursor
-            .is_over(layout.bounds())
-            .then_some(mouse::Interaction::Pointer)
-            .unwrap_or_default()
+        if cursor.is_over(layout.bounds()) {
+            mouse::Interaction::Pointer
+        } else {
+            mouse::Interaction::default()
+        }
     }
 
     fn overlay<'b>(


### PR DESCRIPTION
When quitting the final `MARKREAD` messages (and `QUIT` message) are ignored by my soju instance with the error log "ignoring message on closed connection".  These changes are to not immediately send the `Update::Quit` and enter `State::Quit` after sending the `QUIT` message, but to wait for either the server to respond with an `ERROR` message (which [horsedocs says is a valid acknowledgement of a `QUIT` command](https://modern.ircdocs.horse/#quit-message)) or for a timeout (tentatively set at 1 second).