### PR TITLE
Remove `Client::sync`

### DIFF
--- a/data/src/file_transfer.rs
+++ b/data/src/file_transfer.rs
@@ -61,7 +61,7 @@ impl Ord for FileTransfer {
             .cmp(&other.created_at)
             .reverse()
             .then_with(|| self.direction.cmp(&other.direction))
-            .then_with(|| self.remote_user.cmp(&other.remote_user))
+            .then_with(|| self.remote_user.nickname().cmp(&other.remote_user.nickname()))
             .then_with(|| self.filename.cmp(&other.filename))
     }
 }

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -8,7 +8,7 @@ use tokio::time::Instant;
 use crate::history::{self, History, MessageReferences, ReadMarker};
 use crate::message::{self, Limit};
 use crate::target::{self, Target};
-use crate::user::Nick;
+use crate::user::{ChannelUsers, Nick};
 use crate::{
     Config, Input, Server, User, buffer, config, input, isupport, server,
 };
@@ -216,7 +216,7 @@ impl Manager {
         &mut self,
         input: Input,
         user: User,
-        channel_users: &[User],
+        channel_users: Option<&ChannelUsers>,
         chantypes: &[char],
         statusmsg: &[char],
         casemapping: isupport::CaseMap,

--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -6,6 +6,7 @@ use irc::proto::format;
 use crate::buffer::{self, AutoFormat};
 use crate::message::formatting;
 use crate::target::Target;
+use crate::user::ChannelUsers;
 use crate::{
     Command, Config, Message, Server, User, command, isupport, message,
 };
@@ -71,7 +72,7 @@ impl Input {
     pub fn messages(
         &self,
         user: User,
-        channel_users: &[User],
+        channel_users: Option<&ChannelUsers>,
         chantypes: &[char],
         statusmsg: &[char],
         casemapping: isupport::CaseMap,

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -21,7 +21,7 @@ use crate::config::buffer::UsernameFormat;
 use crate::serde::fail_as_none;
 use crate::target::Channel;
 use crate::time::Posix;
-use crate::user::{Nick, NickRef};
+use crate::user::{ChannelUsers, Nick, NickRef};
 use crate::{Config, Server, User, ctcp, isupport, target};
 
 // References:
@@ -241,7 +241,7 @@ impl Message {
         our_nick: Nick,
         config: &'a Config,
         resolve_attributes: impl Fn(&User, &target::Channel) -> Option<User>,
-        channel_users: impl Fn(&target::Channel) -> &'a [User],
+        channel_users: impl Fn(&target::Channel) -> Option<&'a ChannelUsers>,
         chantypes: &[char],
         statusmsg: &[char],
         casemapping: isupport::CaseMap,
@@ -566,7 +566,7 @@ pub fn plain(text: String) -> Content {
 
 pub fn parse_fragments_with_highlights(
     text: String,
-    channel_users: &[User],
+    channel_users: Option<&ChannelUsers>,
     target: &str,
     our_nick: Option<&Nick>,
     highlights: &Highlights,
@@ -618,13 +618,16 @@ pub fn parse_fragments_with_highlights(
 }
 
 pub fn parse_fragments_with_user(text: String, user: &User) -> Content {
-    let users: &[User] = std::slice::from_ref(user);
-    parse_fragments_with_users(text, users)
+    // XXX(pounce) annoying clone. Cow somewhere?
+    parse_fragments_with_users(
+        text,
+        Some(&[user.clone()].into_iter().collect()),
+    )
 }
 
 pub fn parse_fragments_with_users(
     text: String,
-    channel_users: &[User],
+    channel_users: Option<&ChannelUsers>,
 ) -> Content {
     let fragments = parse_fragments_with_users_inner(text, channel_users)
         .collect::<Vec<_>>();
@@ -656,20 +659,15 @@ pub fn parse_fragments(text: String) -> Content {
 
 fn parse_fragments_with_users_inner(
     text: String,
-    channel_users: &[User],
+    channel_users: Option<&ChannelUsers>,
 ) -> impl Iterator<Item = Fragment> + use<'_> {
     parse_fragments_inner(text).flat_map(move |fragment| {
         if let Fragment::Text(text) = &fragment {
             return Either::Left(
                 parse_regex_fragments(&USER_REGEX, text, |text| {
-                    channel_users
-                        .iter()
-                        .find(|user| {
-                            text.eq_ignore_ascii_case(user.nickname().as_ref())
-                        })
-                        .map(|user| {
-                            Fragment::User(user.clone(), text.to_owned())
-                        })
+                    channel_users?.get_by_nick(text.into()).map(|user| {
+                        Fragment::User(user.clone(), text.to_owned())
+                    })
                 })
                 .into_iter(),
             );
@@ -1168,7 +1166,7 @@ fn content<'a>(
     our_nick: &Nick,
     config: &Config,
     resolve_attributes: &dyn Fn(&User, &target::Channel) -> Option<User>,
-    channel_users: &dyn Fn(&target::Channel) -> &'a [User],
+    channel_users: impl Fn(&target::Channel) -> Option<&'a ChannelUsers>,
     chantypes: &[char],
     statusmsg: &[char],
     casemapping: isupport::CaseMap,
@@ -1285,7 +1283,7 @@ fn content<'a>(
                     "⟵ {target} been kicked by {}{comment}",
                     user.nickname()
                 ),
-                vec![user, victim].as_slice(),
+                Some(&[user, victim].into_iter().collect()),
             ))
         }
         Command::MODE(target, modes, args) => {
@@ -1316,8 +1314,8 @@ fn content<'a>(
                         statusmsg,
                         casemapping,
                     )
-                    .map(|channel| channel_users(&channel))
-                    .unwrap_or_default();
+                    .ok()
+                    .and_then(|channel| channel_users(&channel));
 
                     parse_fragments_with_users(
                         format!("{} sets mode {modes} {args}", user.nickname()),
@@ -1332,8 +1330,8 @@ fn content<'a>(
                 statusmsg,
                 casemapping,
             )
-            .map(|channel| channel_users(&channel))
-            .unwrap_or_default();
+            .ok()
+            .and_then(|channel| channel_users(&channel));
 
             // Check if a synthetic action message
 
@@ -1641,7 +1639,7 @@ pub fn is_action(text: &str) -> bool {
 fn parse_action(
     nick: NickRef,
     text: &str,
-    channel_users: &[User],
+    channel_users: Option<&ChannelUsers>,
     target: &str,
     our_nick: Option<&Nick>,
     highlights: &Highlights,
@@ -1665,7 +1663,7 @@ fn parse_action(
 pub fn action_text(
     nick: NickRef,
     action: Option<&str>,
-    channel_users: &[User],
+    channel_users: Option<&ChannelUsers>,
     target: &str,
     our_nick: Option<&Nick>,
     highlights: &Highlights,
@@ -1768,7 +1766,7 @@ mod tests {
     use crate::config::highlights::Nickname;
     use crate::message::formatting::Color;
     use crate::message::{Content, Formatting, Fragment};
-    use crate::user::Nick;
+    use crate::user::{ChannelUsers, Nick};
 
     #[test]
     fn fragment_parsing() {
@@ -1918,13 +1916,13 @@ mod tests {
             (
                 (
                     "Bob: I'm in #interesting with Greg, George_, &`Bill`. I hope @Dave doesn't notice.".to_string(),
-                    &Vec::from([
-                        User::try_from("Greg").unwrap(),
-                        User::try_from("Dave").unwrap(),
-                        User::try_from("Bob").unwrap(),
-                        User::try_from("George_").unwrap(),
-                        User::try_from("`Bill`").unwrap(),
-                    ]),
+                    [
+                        "Greg",
+                        "Dave",
+                        "Bob",
+                        "George_",
+                        "`Bill`",
+                    ].into_iter().map(User::try_from).map(Result::unwrap).collect::<ChannelUsers>(),
                     "#interesting",
                     Some(Nick::from("Bob")),
                     &Highlights {
@@ -1950,10 +1948,10 @@ mod tests {
             (
                 (
                     "\u{3}14<\u{3}\u{3}04lurk_\u{3}\u{3}14/rx>\u{3} f_~oftc: > A��\u{1f}qj\u{14}��L�5�g���5�P��yn_?�i3g�1\u{7f}mE�\\X��� Xe�\u{5fa}{d�+�`@�^��NK��~~ޏ\u{7}\u{8}\u{15}\\�\u{4}A� \u{f}\u{1c}�N\u{11}6�r�\u{4}t��Q��\u{1c}�m\u{19}��".to_string(),
-                    &Vec::from([
-                        User::try_from("f_").unwrap(),
-                        User::try_from("rx").unwrap(),
-                    ]),
+                    [
+                        "f_",
+                        "rx",
+                    ].into_iter().map(User::try_from).map(Result::unwrap).collect(),
                     "#funderscore-sucks",
                     Some(Nick::from("f_")),
                     &Highlights {
@@ -1973,7 +1971,7 @@ mod tests {
         {
             if let Content::Fragments(actual) = parse_fragments_with_highlights(
                 text,
-                channel_users,
+                Some(&channel_users),
                 target,
                 our_nick.as_ref(),
                 highlights,

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -205,7 +205,7 @@ pub fn nickname(
     } else {
         parse_fragments_with_users(
             format!("{old_nick} is now known as {new_nick}"),
-            &[old_user, new_user.clone()],
+            Some(&[old_user, new_user.clone()].into_iter().collect()),
         )
     };
 

--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Local, Utc};
+use data::user::ChannelUsers;
 use data::{Config, Server, User, isupport, message, target};
 use iced::Length;
 use iced::widget::{
@@ -47,7 +48,7 @@ pub fn view<'a>(
     who: Option<&'a str>,
     time: Option<&'a DateTime<Utc>>,
     max_lines: u16,
-    users: &'a [User],
+    users: Option<&'a ChannelUsers>,
     our_user: Option<&'a User>,
     config: &'a Config,
     theme: &'a Theme,
@@ -55,7 +56,7 @@ pub fn view<'a>(
     let set_by =
         who.and_then(|who| User::try_from(who).ok())
             .and_then(|user| {
-                let channel_user = users.iter().find(|u| **u == user);
+                let channel_user = users.and_then(|users| users.resolve(&user));
 
                 // If user is in channel, we return user_context component.
                 // Otherwise selectable_text component.

--- a/src/buffer/highlights.rs
+++ b/src/buffer/highlights.rs
@@ -87,7 +87,7 @@ pub fn view<'a>(
                         config.buffer.nickname.show_access_levels;
 
                     let current_user =
-                        users.iter().find(|current_user| *current_user == user);
+                        users.and_then(|users| users.resolve(user));
 
                     let text = selectable_text(
                         config

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -166,20 +166,21 @@ impl State {
                 // Reset selected history
                 self.selected_history = None;
 
-                let users = buffer
-                    .channel()
-                    .map(|channel| {
-                        clients.get_channel_users(buffer.server(), channel)
-                    })
-                    .unwrap_or_default();
-                let channels = clients.get_channels(buffer.server());
+                let users = buffer.channel().and_then(|channel| {
+                    clients.get_channel_users(buffer.server(), channel)
+                });
+                // TODO(pounce) eliminate clones
+                let channels = clients
+                    .get_channels(buffer.server())
+                    .cloned()
+                    .collect::<Vec<_>>();
                 let isupport = clients.get_isupport(buffer.server());
 
                 self.completion.process(
                     &input,
                     users,
                     &history.get_last_seen(buffer),
-                    channels,
+                    &channels,
                     current_channel,
                     &isupport,
                     config,
@@ -466,7 +467,7 @@ impl State {
 
                     if let Some(nick) = clients.nickname(buffer.server()) {
                         let mut user = nick.to_owned().into();
-                        let mut channel_users = &[][..];
+                        let mut channel_users = None;
 
                         let chantypes = clients.get_chantypes(buffer.server());
                         let statusmsg = clients.get_statusmsg(buffer.server());
@@ -545,19 +546,20 @@ impl State {
 
                     let users = buffer
                         .channel()
-                        .map(|channel| {
+                        .and_then(|channel| {
                             clients.get_channel_users(buffer.server(), channel)
-                        })
-                        .unwrap_or_default();
-                    let channels = clients.get_channels(buffer.server());
-
+                        });
+                    let channels = clients
+                        .get_channels(buffer.server())
+                        .cloned()
+                        .collect::<Vec<_>>();
                     let isupport = clients.get_isupport(buffer.server());
 
                     self.completion.process(
                         &new_input,
                         users,
                         &history.get_last_seen(buffer),
-                        channels,
+                        &channels,
                         current_channel,
                         &isupport,
                         config,
@@ -587,21 +589,20 @@ impl State {
                         let new_input =
                             cache.history.get(*index).unwrap().clone();
 
-                        let users = buffer
-                            .channel()
-                            .map(|channel| {
-                                clients
-                                    .get_channel_users(buffer.server(), channel)
-                            })
-                            .unwrap_or_default();
-                        let channels = clients.get_channels(buffer.server());
+                        let users = buffer.channel().and_then(|channel| {
+                            clients.get_channel_users(buffer.server(), channel)
+                        });
+                        let channels = clients
+                            .get_channels(buffer.server())
+                            .cloned()
+                            .collect::<Vec<_>>();
                         let isupport = clients.get_isupport(buffer.server());
 
                         self.completion.process(
                             &new_input,
                             users,
                             &history.get_last_seen(buffer),
-                            channels,
+                            &channels,
                             current_channel,
                             &isupport,
                             config,

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -7,7 +7,7 @@ use chrono::{DateTime, Utc};
 use const_format::concatcp;
 use data::buffer::{OrderBy, SkinTone, SortDirection};
 use data::isupport::{self, find_target_limit};
-use data::user::{Nick, User};
+use data::user::{ChannelUsers, Nick};
 use data::{Config, mode, target};
 use iced::Length;
 use iced::widget::{column, container, row, text, tooltip};
@@ -38,7 +38,7 @@ impl Completion {
     pub fn process(
         &mut self,
         input: &str,
-        users: &[User],
+        users: Option<&ChannelUsers>,
         last_seen: &HashMap<Nick, DateTime<Utc>>,
         channels: &[target::Channel],
         current_channel: Option<&target::Channel>,
@@ -1077,7 +1077,7 @@ impl Text {
         &mut self,
         input: &str,
         casemapping: isupport::CaseMap,
-        users: &[User],
+        users: Option<&ChannelUsers>,
         last_seen: &HashMap<Nick, DateTime<Utc>>,
         channels: &[target::Channel],
         current_channel: Option<&target::Channel>,
@@ -1098,7 +1098,7 @@ impl Text {
         &mut self,
         input: &str,
         casemapping: isupport::CaseMap,
-        users: &[User],
+        users: Option<&ChannelUsers>,
         last_seen: &HashMap<Nick, DateTime<Utc>>,
         config: &Config,
     ) {
@@ -1115,7 +1115,8 @@ impl Text {
         self.selected = None;
         self.prompt = rest.to_string();
         self.filtered = users
-            .iter()
+            .into_iter()
+            .flatten()
             .sorted_by(|a, b| {
                 if matches!(autocomplete.order_by, OrderBy::Recent) {
                     if let Some(a_last_seen) =

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -237,7 +237,7 @@ impl Dashboard {
 
                                             if let Some(nick) = clients.nickname(buffer.server()) {
                                                 let mut user = nick.to_owned().into();
-                                                let mut channel_users = &[][..];
+                                                let mut channel_users = None;
                                                 let chantypes =
                                                     clients.get_chantypes(buffer.server());
                                                 let statusmsg =
@@ -2754,7 +2754,7 @@ impl Dashboard {
         let buffer = buffer::Upstream::Channel(server.clone(), channel.clone());
 
         // Need to join channel
-        if !clients.get_channels(&server).contains(&channel) {
+        if !clients.contains_channel(&server, &channel) {
             clients.join(&server, slice::from_ref(&channel));
         }
 
@@ -2970,7 +2970,7 @@ fn all_buffers(
         .connected_servers()
         .flat_map(|server| {
             std::iter::once(buffer::Upstream::Server(server.clone()))
-                .chain(clients.get_channels(server).iter().map(|channel| {
+                .chain(clients.get_channels(server).map(|channel| {
                     buffer::Upstream::Channel(server.clone(), channel.clone())
                 }))
                 .chain(history.get_unique_queries(server).into_iter().map(
@@ -2993,7 +2993,7 @@ fn all_buffers_with_has_unread(
                 buffer::Upstream::Server(server.clone()),
                 history.has_unread(&history::Kind::Server(server.clone())),
             ))
-            .chain(clients.get_channels(server).iter().map(|channel| {
+            .chain(clients.get_channels(server).map(|channel| {
                 (
                     buffer::Upstream::Channel(server.clone(), channel.clone()),
                     history.has_unread(&history::Kind::Channel(

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -1,3 +1,4 @@
+use data::user::ChannelUsers;
 use data::{Config, file_transfer, history, preview};
 use iced::widget::{button, center, container, pane_grid, row, text};
 
@@ -63,7 +64,8 @@ impl Pane {
                 let server = &state.server;
                 let users = clients
                     .get_channel_users(&state.server, &state.target)
-                    .len();
+                    .map(ChannelUsers::len)
+                    .unwrap_or_default();
 
                 let mode = clients
                     .get_channel_mode(&state.server, &state.target)


### PR DESCRIPTION
`Client::sync` sorts the channel list, and every single userlist for every single channel on every message received. This is a huge performance sink for halloy, and my tests reported halloy spends ~30% of its CPU time in this function alone.

This function exists to keep several "views" into the client structures in sync (sorted correctly) with the client structures themselves. However, I think `chanmap` and the user list already have all the information that we would want, in the right order.

This commit includes much refactoring because the client no longer returns slice views to its channels and users. Instead, I've elected to return a channel iterator, and a `ChannelUsers` view for users. This `ChannelUsers` view satisfies a set API, which can actually make many view operations more efficient.

There is a bit of magic here to avoid needless `clone()`s, and I needed to switch from an ordinary `BTreeMap` to an `IndexMap` for `chanmap`, since the order is dependent on runtime information (it was either this, or keeping a global mutex of chantypes, which can lead to UB if modified during operation).

Before: 
![Image](https://github.com/user-attachments/assets/c7110ba8-c0cd-4428-898f-0505509fe127)

After:
![image](https://github.com/user-attachments/assets/d92e0edd-742a-40f1-9e9c-31026f17ede0)


Resolves squidowl/halloy#1050