### PR TITLE
Log Unknown Settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,6 +1509,7 @@ dependencies = [
  "reqwest",
  "seahash",
  "serde",
+ "serde_ignored",
  "serde_json",
  "sha2",
  "strum 0.27.1",

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -35,6 +35,7 @@ iced_core = "0.14.0-dev"
 indexmap = { version = "2.9", features = ["std", "serde"] }
 seahash = "4.1.0"
 serde_json = "1.0"
+serde_ignored = "0.1"
 sha2 = "0.10.8"
 toml = "0.8.11"
 reqwest = { version = "0.12", features = ["json"] }

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -257,6 +257,8 @@ impl Config {
             .await
             .map_err(|e| Error::LoadConfigFile(e.to_string()))?;
 
+        let config = toml::Deserializer::new(content.as_ref());
+
         let Configuration {
             theme,
             mut servers,
@@ -274,8 +276,10 @@ impl Config {
             highlights,
             actions,
             ctcp,
-        } = toml::from_str(content.as_ref())
-            .map_err(|e| Error::Parse(e.to_string()))?;
+        } = serde_ignored::deserialize(config, |ignored| {
+            log::warn!("[config.toml] Ignoring unknown setting: {ignored}");
+        })
+        .map_err(|e| Error::Parse(e.to_string()))?;
 
         match sidebar.order_by {
             sidebar::OrderBy::Alpha => servers.sort_keys(),


### PR DESCRIPTION
Logs unknown settings in `config.toml`, for easier debugging.  Planning on follow-up PR(s) to make the log easier to use.