### PR TITLE
Option to hide `nick` and `mode` change server messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Added:
 
 - Configuration option per toast type for showing content in toasts
+- Configuration option to hide `nick` and `mode` change server messages
 - Context menu item to server buffers to mark all messages on the server as read
 
 Thanks:

--- a/book/src/configuration/buffer.md
+++ b/book/src/configuration/buffer.md
@@ -523,16 +523,20 @@ click = "open-query"
 
 Server messages are messages sent from an IRC server.
 
-- **change_host** - Message is sent when a user changes host  
-- **join** - Message is sent when a user joins a channel  
-- **monitored_offline** - Message is sent when a monitored user goes offline  
-- **monitored_online** - Message is sent when a monitored user goes online  
-- **part** - Message is sent when a user leaves a channel  
-- **quit** - Message is sent when a user closes the connection to a channel or server  
-- **standard_reply_fail** - Message is sent when a command/function fails or an error with the session  
-- **standard_reply_note** - Message is sent when there is information about a command/function or session  
-- **standard_reply_warn** - Message is sent when there is feedback about a command/function or session  
-- **topic** - Message is sent when the client joins a channel to inform them of the current topic
+| **Event Type**            | **Description**                                                                 |
+|---------------------------|---------------------------------------------------------------------------------|
+| `change_host`             | Message is sent when a user changes host                                       |
+| `change_mode`             | Message is sent when a mode is set                                             |
+| `change_nick`             | Message is sent when a user changes nick                                       |
+| `join`                    | Message is sent when a user joins a channel                                    |
+| `monitored_offline`       | Message is sent when a monitored user goes offline                             |
+| `monitored_online`        | Message is sent when a monitored user goes online                              |
+| `part`                    | Message is sent when a user leaves a channel                                   |
+| `quit`                    | Message is sent when a user closes the connection to a channel or server       |
+| `standard_reply_fail`     | Message is sent when a command/function fails or an error with the session     |
+| `standard_reply_note`     | Message is sent when there is information about a command/function or session  |
+| `standard_reply_warn`     | Message is sent when there is feedback about a command/function or session     |
+| `topic`                   | Message is sent when the client joins a channel to inform them of the topic    |
 
 Example
 

--- a/data/src/appearance/theme.rs
+++ b/data/src/appearance/theme.rs
@@ -159,6 +159,10 @@ pub struct ServerMessages {
     #[serde(default, with = "color_serde_maybe")]
     pub change_host: Option<Color>,
     #[serde(default, with = "color_serde_maybe")]
+    pub change_mode: Option<Color>,
+    #[serde(default, with = "color_serde_maybe")]
+    pub change_nick: Option<Color>,
+    #[serde(default, with = "color_serde_maybe")]
     pub monitored_online: Option<Color>,
     #[serde(default, with = "color_serde_maybe")]
     pub monitored_offline: Option<Color>,

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -134,6 +134,10 @@ pub struct ServerMessages {
     #[serde(default)]
     pub change_host: ServerMessage,
     #[serde(default)]
+    pub change_mode: ServerMessage,
+    #[serde(default)]
+    pub change_nick: ServerMessage,
+    #[serde(default)]
     pub monitored_online: ServerMessage,
     #[serde(default)]
     pub monitored_offline: ServerMessage,
@@ -155,6 +159,8 @@ impl ServerMessages {
             source::server::Kind::Part => Some(&self.part),
             source::server::Kind::Quit => Some(&self.quit),
             source::server::Kind::ChangeHost => Some(&self.change_host),
+            source::server::Kind::ChangeMode => Some(&self.change_mode),
+            source::server::Kind::ChangeNick => Some(&self.change_nick),
             source::server::Kind::MonitoredOnline => {
                 Some(&self.monitored_online)
             }

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -790,6 +790,8 @@ fn has_matching_content(
                 }
                 message::source::server::Kind::ReplyTopic
                 | message::source::server::Kind::ChangeHost
+                | message::source::server::Kind::ChangeNick
+                | message::source::server::Kind::ChangeMode
                 | message::source::server::Kind::MonitoredOnline
                 | message::source::server::Kind::MonitoredOffline
                 | message::source::server::Kind::StandardReply(_)

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -883,7 +883,10 @@ fn target(
 
             Some(Target::Channel {
                 channel,
-                source: Source::Server(None),
+                source: Source::Server(Some(source::Server::new(
+                    Kind::ChangeMode,
+                    Some(user?.nickname().to_owned()),
+                ))),
             })
         }
         Command::TOPIC(channel, _) | Command::KICK(channel, _, _) => {

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -205,7 +205,7 @@ pub fn nickname(
     } else {
         parse_fragments_with_users(
             format!("{old_nick} is now known as {new_nick}"),
-            &[old_user, new_user],
+            &[old_user, new_user.clone()],
         )
     };
 
@@ -213,7 +213,10 @@ pub fn nickname(
         channels,
         queries,
         false,
-        Cause::Server(None),
+        Cause::Server(Some(source::Server::new(
+            source::server::Kind::ChangeNick,
+            Some(new_user.nickname().to_owned()),
+        ))),
         content,
         sent_time,
     )

--- a/data/src/message/source.rs
+++ b/data/src/message/source.rs
@@ -67,6 +67,8 @@ pub mod server {
         Quit,
         ReplyTopic,
         ChangeHost,
+        ChangeMode,
+        ChangeNick,
         MonitoredOnline,
         MonitoredOffline,
         StandardReply(StandardReply),

--- a/src/appearance/theme/selectable_text.rs
+++ b/src/appearance/theme/selectable_text.rs
@@ -74,6 +74,8 @@ pub fn server(
             Kind::Quit => colors.quit,
             Kind::ReplyTopic => colors.reply_topic,
             Kind::ChangeHost => colors.change_host,
+            Kind::ChangeMode => colors.change_mode,
+            Kind::ChangeNick => colors.change_nick,
             Kind::MonitoredOnline => colors.monitored_online,
             Kind::MonitoredOffline => colors.monitored_offline,
             Kind::StandardReply(StandardReply::Fail) => colors

--- a/src/window.rs
+++ b/src/window.rs
@@ -128,7 +128,7 @@ pub fn settings() -> Settings {
                 .ok(),
                 ..Default::default()
             },
-            None => Default::default(),
+            None => Settings::default(),
         },
         Err(_) => Settings {
             ..Default::default()


### PR DESCRIPTION
Ability to hide mode and nick changes:

```toml
[buffer.server_messages.change_mode]
exclude = ["*"]
include = ["#foobar"]

[buffer.server_messages.change_nick]
exclude = ["*"]
```