### PR TITLE
Auto accept file transfers

### DIFF
--- a/book/src/configuration/file_transfer.md
+++ b/book/src/configuration/file_transfer.md
@@ -15,19 +15,6 @@ Default directory to save files in. If not set, user will see a file dialog.
 save_directory = "/Users/halloy/Downloads"
 ```
 
-## `auto_accept_files`
-
-If true, automatically accept incoming file transfers. Requires `save_directory` to be set.
-
-```toml
-# Type: boolean
-# Values: true, false
-# Default: false
-
-[file_transfer]
-auto_accept_files = false
-```
-
 ## `passive`
 
 If true, act as the "client" for the transfer. Requires the remote user act as the [server](#file_transferserver).
@@ -109,4 +96,49 @@ Last port in port range to bind to.
 
 [file_transfer.server]
 bind_port_last = "5000"
+```
+
+# `[file_transfer.auto_accept]`
+
+Configuration for automatically accepting incoming file transfers.
+
+## `enabled`
+
+If true, automatically accept incoming file transfers. Requires `save_directory` to be set.
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: false
+
+[file_transfer.auto_accept]
+enabled = false
+```
+
+## `nicks`
+
+If true, automatically accept incoming file transfers from these nicks.
+Note `auto_accept` has to be enabled.
+
+```toml
+# Type: array of strings
+# Values: array of any strings
+# Default: []
+
+[file_transfer.auto_accept]
+nicks = ["nick1", "nick2"]
+```
+
+## `masks`
+
+If true, automatically accept incoming file transfers from these nicks. 
+Note `auto_accept` has to be enabled.
+
+```toml
+# Type: array of strings
+# Values: array of any strings
+# Default: []
+
+[file_transfer.auto_accept]
+masks = ["nick!ident@example.com", ".*@foobar.com"]
 ```

--- a/book/src/configuration/file_transfer.md
+++ b/book/src/configuration/file_transfer.md
@@ -133,6 +133,15 @@ nicks = ["nick1", "nick2"]
 
 If true, automatically accept incoming file transfers from these nicks. Matches are made against the full nickname (i.e. nickname, username, and hostname in the format `nickname!username@hostname`). Note `auto_accept` has to be enabled.
 
+<div class="warning">
+
+Use toml multi-line literal strings `'''\bfoo'd\b'''` when writing a regex. This allows you to write write the regex without
+escaping. You can also use a literal string `'\bfoo\b'`, but then you can't use `'` inside the string.
+
+Without literal strings, you'd have to write the above as `"\\bfoo'd\\b"`
+
+</div>
+
 ```toml
 # Type: array of strings
 # Values: array of any strings

--- a/book/src/configuration/file_transfer.md
+++ b/book/src/configuration/file_transfer.md
@@ -15,6 +15,19 @@ Default directory to save files in. If not set, user will see a file dialog.
 save_directory = "/Users/halloy/Downloads"
 ```
 
+## `auto_accept_files`
+
+If true, automatically accept incoming file transfers. Requires `save_directory` to be set.
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: false
+
+[file_transfer]
+auto_accept_files = false
+```
+
 ## `passive`
 
 If true, act as the "client" for the transfer. Requires the remote user act as the [server](#file_transferserver).

--- a/book/src/configuration/file_transfer.md
+++ b/book/src/configuration/file_transfer.md
@@ -139,5 +139,8 @@ If true, automatically accept incoming file transfers from these nicks. Matches 
 # Default: []
 
 [file_transfer.auto_accept]
-masks = ["nick!ident@example.com", ".*@foobar.com"]
+masks = [
+    '''nick!ident@example\.com''',
+    '''.*@foobar\.com'''
+]
 ```

--- a/book/src/configuration/file_transfer.md
+++ b/book/src/configuration/file_transfer.md
@@ -82,7 +82,7 @@ First port in port range to bind to.
 # Default: not set
 
 [file_transfer.server]
-bind_port_first = "1024"
+bind_port_first = 1024
 ```
 
 ## `bind_port_last`
@@ -95,7 +95,7 @@ Last port in port range to bind to.
 # Default: not set
 
 [file_transfer.server]
-bind_port_last = "5000"
+bind_port_last = 5000
 ```
 
 # `[file_transfer.auto_accept]`
@@ -131,8 +131,7 @@ nicks = ["nick1", "nick2"]
 
 ## `masks`
 
-If true, automatically accept incoming file transfers from these nicks. 
-Note `auto_accept` has to be enabled.
+If true, automatically accept incoming file transfers from these nicks. Matches are made against the full nickname (i.e. nickname, username, and hostname in the format `nickname!username@hostname`). Note `auto_accept` has to be enabled.
 
 ```toml
 # Type: array of strings

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1188,7 +1188,7 @@ impl Client {
                                 log::trace!("DCC Send => {request:?}");
                                 return Ok(vec![Event::FileTransferRequest(
                                     file_transfer::ReceiveRequest {
-                                        from: user.nickname().to_owned(),
+                                        from: user,
                                         dcc_send: request,
                                         server: self.server.clone(),
                                         server_handle: self.handle.clone(),

--- a/data/src/config/file_transfer.rs
+++ b/data/src/config/file_transfer.rs
@@ -16,6 +16,9 @@ pub struct FileTransfer {
     /// Time in seconds to wait before timing out a transfer waiting to be accepted.
     #[serde(default = "default_timeout")]
     pub timeout: u64,
+    /// If true, automatically accept incoming file transfers. Requires save_directory to be set.
+    #[serde(default = "default_auto_accept")]
+    pub auto_accept_files: bool,
     pub server: Option<Server>,
 }
 
@@ -25,6 +28,7 @@ impl Default for FileTransfer {
             save_directory: None,
             passive: default_passive(),
             timeout: default_timeout(),
+            auto_accept_files: default_auto_accept(),
             server: None,
         }
     }
@@ -36,6 +40,10 @@ fn default_passive() -> bool {
 
 fn default_timeout() -> u64 {
     60 * 5
+}
+
+fn default_auto_accept() -> bool {
+    false
 }
 
 #[derive(Debug, Clone)]

--- a/data/src/config/file_transfer.rs
+++ b/data/src/config/file_transfer.rs
@@ -16,10 +16,23 @@ pub struct FileTransfer {
     /// Time in seconds to wait before timing out a transfer waiting to be accepted.
     #[serde(default = "default_timeout")]
     pub timeout: u64,
+    /// Auto-accept configuration for incoming file transfers.
+    #[serde(default)]
+    pub auto_accept: AutoAccept,
+    pub server: Option<Server>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AutoAccept {
     /// If true, automatically accept incoming file transfers. Requires save_directory to be set.
     #[serde(default = "default_auto_accept")]
-    pub auto_accept_files: bool,
-    pub server: Option<Server>,
+    pub enabled: bool,
+    /// Auto-accept incoming file transfers from these nicks. Requires enabled to be true.
+    #[serde(default)]
+    pub nicks: Option<Vec<String>>,
+    /// Auto-accept incoming file transfers from these masks (regex patterns). Requires enabled to be true.
+    #[serde(default)]
+    pub masks: Option<Vec<String>>,
 }
 
 impl Default for FileTransfer {
@@ -28,8 +41,18 @@ impl Default for FileTransfer {
             save_directory: None,
             passive: default_passive(),
             timeout: default_timeout(),
-            auto_accept_files: default_auto_accept(),
+            auto_accept: AutoAccept::default(),
             server: None,
+        }
+    }
+}
+
+impl Default for AutoAccept {
+    fn default() -> Self {
+        Self {
+            enabled: default_auto_accept(),
+            nicks: None,
+            masks: None,
         }
     }
 }

--- a/data/src/file_transfer.rs
+++ b/data/src/file_transfer.rs
@@ -5,8 +5,7 @@ use chrono::{DateTime, Utc};
 
 pub use self::manager::Manager;
 pub use self::task::Task;
-use crate::user::Nick;
-use crate::{Server, dcc, server};
+use crate::{Server, User, dcc, server};
 
 pub mod manager;
 pub mod task;
@@ -32,7 +31,7 @@ pub struct FileTransfer {
     pub server: Server,
     pub created_at: DateTime<Utc>,
     pub direction: Direction,
-    pub remote_user: Nick,
+    pub remote_user: User,
     pub filename: String,
     pub size: u64,
     pub status: Status,
@@ -93,7 +92,7 @@ pub enum Status {
 
 #[derive(Debug, Clone)]
 pub struct ReceiveRequest {
-    pub from: Nick,
+    pub from: User,
     pub dcc_send: dcc::Send,
     pub server: Server,
     pub server_handle: server::Handle,
@@ -101,7 +100,7 @@ pub struct ReceiveRequest {
 
 #[derive(Debug)]
 pub struct SendRequest {
-    pub to: Nick,
+    pub to: User,
     pub path: PathBuf,
     pub server: Server,
     pub server_handle: server::Handle,

--- a/data/src/file_transfer/manager.rs
+++ b/data/src/file_transfer/manager.rs
@@ -214,15 +214,12 @@ impl Manager {
                         |nicks| nicks.contains(&from.nickname().to_string()),
                     );
 
-                let mask_match =
-                    config.file_transfer.auto_accept.masks.as_ref().is_none_or(
-                        |masks| {
-                            let a = from.matches_masks(masks);
-                            println!("masks: {masks:?}");
-                            println!("matches user with mask {a}");
-                            a
-                        },
-                    );
+                let mask_match = config
+                    .file_transfer
+                    .auto_accept
+                    .masks
+                    .as_ref()
+                    .is_none_or(|masks| from.matches_masks(masks));
 
                 nickname_match && mask_match
             };

--- a/data/src/file_transfer/manager.rs
+++ b/data/src/file_transfer/manager.rs
@@ -199,35 +199,38 @@ impl Manager {
         };
 
         let task = Task::receive(id, dcc_send, from.clone(), server_handle);
-        let (handle, stream) = task.spawn(
+        let (mut handle, stream) = task.spawn(
             self.server(),
             Duration::from_secs(self.config.timeout),
             proxy.cloned(),
         );
 
-        let item = Item::Working {
-            file_transfer: file_transfer.clone(),
-            task: handle,
-        };
-
-        self.items.insert(id, item);
-
         // Auto-accept if enabled and save directory is set
         if self.config.auto_accept_files {
             if let Some(save_directory) = &self.config.save_directory {
                 let save_path = save_directory.join(&file_transfer.filename);
-                if let Some(Item::Working { task, .. }) = self.items.get_mut(&id) {
-                    log::debug!(
-                        "Auto-accepting file transfer from {} for {:?}",
-                        from,
-                        file_transfer.filename
-                    );
-                    task.approve(save_path);
-                }
+
+                log::debug!(
+                    "Auto-accepting file transfer from {} for {:?}",
+                    from,
+                    file_transfer.filename
+                );
+
+                handle.approve(save_path);
             } else {
-                log::warn!("Auto-accept is enabled but save_directory is not set. File transfer will require manual approval.");
+                log::warn!(
+                    "Auto-accept is enabled but save_directory is not set. File transfer will require manual approval."
+                );
             }
         }
+
+        self.items.insert(
+            id,
+            Item::Working {
+                file_transfer: file_transfer.clone(),
+                task: handle,
+            },
+        );
 
         Some(Event::NewTransfer(file_transfer, stream.boxed()))
     }

--- a/data/src/file_transfer/manager.rs
+++ b/data/src/file_transfer/manager.rs
@@ -13,7 +13,7 @@ use super::{
     Direction, FileTransfer, Id, ReceiveRequest, SendRequest, Status, Task,
     task,
 };
-use crate::{config, dcc};
+use crate::{Config, dcc};
 
 enum Item {
     Working {
@@ -43,8 +43,8 @@ pub enum Event {
     NewTransfer(FileTransfer, BoxStream<'static, task::Update>),
 }
 
+#[derive(Default)]
 pub struct Manager {
-    config: config::FileTransfer,
     items: HashMap<Id, Item>,
     /// Queued = waiting for port assignment
     queued: VecDeque<Id>,
@@ -52,15 +52,6 @@ pub struct Manager {
 }
 
 impl Manager {
-    pub fn new(config: config::FileTransfer) -> Self {
-        Self {
-            config,
-            items: HashMap::new(),
-            queued: VecDeque::new(),
-            used_ports: HashMap::new(),
-        }
-    }
-
     fn get_random_id(&self) -> Id {
         let mut rng = rand::rng();
 
@@ -73,17 +64,21 @@ impl Manager {
         }
     }
 
-    fn server(&self) -> Option<task::Server> {
-        self.config.server.as_ref().map(|server| task::Server {
-            public_address: server.public_address,
-            bind_address: server.bind_address,
-        })
+    fn server(&self, config: &Config) -> Option<task::Server> {
+        config
+            .file_transfer
+            .server
+            .as_ref()
+            .map(|server| task::Server {
+                public_address: server.public_address,
+                bind_address: server.bind_address,
+            })
     }
 
     pub fn send(
         &mut self,
         request: SendRequest,
-        proxy: Option<config::Proxy>,
+        config: &Config,
     ) -> Option<Event> {
         let SendRequest {
             to,
@@ -92,7 +87,7 @@ impl Manager {
             server_handle,
         } = request;
 
-        let reverse = self.config.passive;
+        let reverse = config.file_transfer.passive;
 
         let filename = path
             .file_name()
@@ -100,7 +95,10 @@ impl Manager {
             .unwrap_or_default()
             .replace(' ', "_");
 
-        log::debug!("File transfer send request to {to} for {filename:?}");
+        log::debug!(
+            "File transfer send request to {} for {filename:?}",
+            to.nickname()
+        );
 
         let id = self.get_random_id();
 
@@ -124,9 +122,9 @@ impl Manager {
 
         let task = Task::send(id, path, filename, to, reverse, server_handle);
         let (handle, stream) = task.spawn(
-            self.server(),
-            Duration::from_secs(self.config.timeout),
-            proxy,
+            self.server(config),
+            Duration::from_secs(config.file_transfer.timeout),
+            config.proxy.clone(),
         );
 
         self.items.insert(
@@ -143,7 +141,7 @@ impl Manager {
     pub fn receive(
         &mut self,
         request: ReceiveRequest,
-        proxy: Option<&config::Proxy>,
+        config: &Config,
     ) -> Option<Event> {
         let ReceiveRequest {
             from,
@@ -169,7 +167,8 @@ impl Manager {
                 {
                     if file_transfer.filename == *filename {
                         log::debug!(
-                            "File transfer received reverse confirmation from {from} for {:?}",
+                            "File transfer received reverse confirmation from {} for {:?}",
+                            from.nickname(),
                             filename,
                         );
                         task.confirm_reverse(*host, *port);
@@ -180,7 +179,8 @@ impl Manager {
         }
 
         log::debug!(
-            "File transfer request received from {from} for {:?}",
+            "File transfer request received from {} for {:?}",
+            from.nickname(),
             dcc_send.filename()
         );
 
@@ -200,27 +200,52 @@ impl Manager {
 
         let task = Task::receive(id, dcc_send, from.clone(), server_handle);
         let (mut handle, stream) = task.spawn(
-            self.server(),
-            Duration::from_secs(self.config.timeout),
-            proxy.cloned(),
+            self.server(config),
+            Duration::from_secs(config.file_transfer.timeout),
+            config.proxy.as_ref().cloned(),
         );
 
         // Auto-accept if enabled and save directory is set
-        if self.config.auto_accept_files {
-            if let Some(save_directory) = &self.config.save_directory {
-                let save_path = save_directory.join(&file_transfer.filename);
+        if config.file_transfer.auto_accept.enabled {
+            // Check if sender matches nickname or mask filters
+            let should_auto_accept = {
+                let nickname_match =
+                    config.file_transfer.auto_accept.nicks.as_ref().is_none_or(
+                        |nicks| nicks.contains(&from.nickname().to_string()),
+                    );
 
-                log::debug!(
-                    "Auto-accepting file transfer from {} for {:?}",
-                    from,
-                    file_transfer.filename
-                );
+                let mask_match =
+                    config.file_transfer.auto_accept.masks.as_ref().is_none_or(
+                        |masks| {
+                            let a = from.matches_masks(masks);
+                            println!("masks: {masks:?}");
+                            println!("matches user with mask {a}");
+                            a
+                        },
+                    );
 
-                handle.approve(save_path);
-            } else {
-                log::warn!(
-                    "Auto-accept is enabled but save_directory is not set. File transfer will require manual approval."
-                );
+                nickname_match && mask_match
+            };
+
+            if should_auto_accept {
+                if let Some(save_directory) =
+                    &config.file_transfer.save_directory
+                {
+                    let save_path =
+                        save_directory.join(&file_transfer.filename);
+
+                    log::debug!(
+                        "Auto-accepting file transfer from {} for {:?}",
+                        from.nickname(),
+                        file_transfer.filename
+                    );
+
+                    handle.approve(save_path);
+                } else {
+                    log::warn!(
+                        "Auto-accept is enabled but save_directory is not set. File transfer will require manual approval."
+                    );
+                }
             }
         }
 
@@ -235,7 +260,7 @@ impl Manager {
         Some(Event::NewTransfer(file_transfer, stream.boxed()))
     }
 
-    pub fn update(&mut self, update: task::Update) {
+    pub fn update(&mut self, update: task::Update, config: &Config) {
         match update {
             task::Update::Metadata(id, size) => {
                 if let Some(item) = self.items.get_mut(&id) {
@@ -243,7 +268,7 @@ impl Manager {
                 }
             }
             task::Update::Queued(id) => {
-                let available_port = self.get_available_port();
+                let available_port = self.get_available_port(config);
 
                 if let Some(Item::Working {
                     file_transfer,
@@ -279,7 +304,7 @@ impl Manager {
                             Direction::Sent => "to",
                             Direction::Received => "from",
                         },
-                        file_transfer.remote_user,
+                        file_transfer.remote_user.nickname(),
                         file_transfer.filename,
                         transferred as f32 / file_transfer.size as f32 * 100.0,
                     );
@@ -303,7 +328,7 @@ impl Manager {
                             Direction::Sent => "to",
                             Direction::Received => "from",
                         },
-                        &file_transfer.remote_user,
+                        &file_transfer.remote_user.nickname(),
                         &file_transfer.filename,
                         elapsed.as_secs_f32()
                     );
@@ -328,7 +353,7 @@ impl Manager {
                             Direction::Sent => "to",
                             Direction::Received => "from",
                         },
-                        &file_transfer.remote_user,
+                        &file_transfer.remote_user.nickname(),
                         &file_transfer.filename,
                     );
                     file_transfer.status = Status::Failed { error };
@@ -339,8 +364,8 @@ impl Manager {
         }
     }
 
-    fn get_available_port(&self) -> Option<NonZeroU16> {
-        let server = self.config.server.as_ref()?;
+    fn get_available_port(&self, config: &Config) -> Option<NonZeroU16> {
+        let server = config.file_transfer.server.as_ref()?;
 
         server
             .bind_ports

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -302,13 +302,16 @@ impl Message {
     }
 
     pub fn file_transfer_request_received(
-        from: &Nick,
+        from: &User,
         query: &target::Query,
         filename: &str,
     ) -> Message {
         let received_at = Posix::now();
         let server_time = Utc::now();
-        let content = plain(format!("{from} wants to send you \"{filename}\""));
+        let content = plain(format!(
+            "{} wants to send you \"{filename}\"",
+            from.nickname()
+        ));
         let hash = Hash::new(&server_time, &content);
 
         Message {
@@ -328,13 +331,14 @@ impl Message {
     }
 
     pub fn file_transfer_request_sent(
-        to: &Nick,
+        to: &User,
         query: &target::Query,
         filename: &str,
     ) -> Message {
         let received_at = Posix::now();
         let server_time = Utc::now();
-        let content = plain(format!("offering to send {to} \"{filename}\""));
+        let content =
+            plain(format!("offering to send {} \"{filename}\"", to.nickname()));
         let hash = Hash::new(&server_time, &content);
 
         Message {

--- a/src/buffer/file_transfers.rs
+++ b/src/buffer/file_transfers.rs
@@ -134,14 +134,14 @@ mod transfer_row {
                     file_transfer::Direction::Sent => container(
                         text(format!(
                             "Transfer to {}. Waiting for them to accept.",
-                            transfer.remote_user
+                            transfer.remote_user.nickname()
                         ))
                         .style(theme::text::secondary),
                     ),
                     file_transfer::Direction::Received => container(
                         text(format!(
                             "Transfer from {}. Accept to begin.",
-                            transfer.remote_user
+                            transfer.remote_user.nickname()
                         ))
                         .style(theme::text::secondary),
                     ),
@@ -156,7 +156,8 @@ mod transfer_row {
                 container(
                     text(format!(
                         "Transfer {} {}. Waiting for open port.",
-                        direction, transfer.remote_user,
+                        direction,
+                        transfer.remote_user.nickname(),
                     ))
                     .style(theme::text::secondary),
                 )
@@ -170,7 +171,8 @@ mod transfer_row {
                 container(
                     text(format!(
                         "Transfer {} {}. Waiting for remote user to connect.",
-                        direction, transfer.remote_user
+                        direction,
+                        transfer.remote_user.nickname()
                     ))
                     .style(theme::text::secondary),
                 )
@@ -242,7 +244,8 @@ mod transfer_row {
                 container(
                     text(format!(
                         "Completed {} {} in {elapsed}. sha256: {sha256}",
-                        direction, transfer.remote_user,
+                        direction,
+                        transfer.remote_user.nickname(),
                     ))
                     .style(theme::text::secondary),
                 )

--- a/src/buffer/user_context.rs
+++ b/src/buffer/user_context.rs
@@ -145,7 +145,7 @@ impl Entry {
             }
             Entry::SendFile => menu_button(
                 "Send File",
-                Message::SendFile(server.clone(), nickname),
+                Message::SendFile(server.clone(), user.clone()),
                 length,
             ),
             Entry::UserInfo => {
@@ -186,7 +186,7 @@ pub enum Message {
     Whois(Server, Nick),
     Query(Server, target::Query, BufferAction),
     ToggleAccessLevel(Server, target::Channel, Nick, String),
-    SendFile(Server, Nick),
+    SendFile(Server, User),
     InsertNickname(Nick),
     CtcpRequest(ctcp::Command, Server, Nick, Option<String>),
 }
@@ -196,7 +196,7 @@ pub enum Event {
     SendWhois(Server, Nick),
     OpenQuery(Server, target::Query, BufferAction),
     ToggleAccessLevel(Server, target::Channel, Nick, String),
-    SendFile(Server, Nick),
+    SendFile(Server, User),
     InsertNickname(Nick),
     CtcpRequest(ctcp::Command, Server, Nick, Option<String>),
 }
@@ -210,7 +210,7 @@ pub fn update(message: Message) -> Event {
         Message::ToggleAccessLevel(server, target, nick, mode) => {
             Event::ToggleAccessLevel(server, target, nick, mode)
         }
-        Message::SendFile(server, nick) => Event::SendFile(server, nick),
+        Message::SendFile(server, user) => Event::SendFile(server, user),
         Message::InsertNickname(nick) => Event::InsertNickname(nick),
         Message::CtcpRequest(command, server, nick, params) => {
             Event::CtcpRequest(command, server, nick, params)

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -10,9 +10,8 @@ use data::history::ReadMarker;
 use data::history::manager::Broadcast;
 use data::isupport::{self, ChatHistorySubcommand, MessageReference};
 use data::target::{self, Target};
-use data::user::Nick;
 use data::{
-    Config, Notification, Server, Version, client, command, config,
+    Config, Notification, Server, User, Version, client, command, config,
     environment, file_transfer, history, preview,
 };
 use iced::widget::pane_grid::{self, PaneGrid};
@@ -66,7 +65,7 @@ pub enum Message {
     Task(command_bar::Message),
     Shortcut(shortcut::Command),
     FileTransfer(file_transfer::task::Update),
-    SendFileSelected(Server, Nick, Option<PathBuf>),
+    SendFileSelected(Server, User, Option<PathBuf>),
     CloseContextMenu(window::Id, bool),
     ThemeEditor(theme_editor::Message),
     ConfigReloaded(Result<Config, config::Error>),
@@ -109,9 +108,7 @@ impl Dashboard {
             history: history::Manager::default(),
             last_changed: None,
             command_bar: None,
-            file_transfers: file_transfer::Manager::new(
-                config.file_transfer.clone(),
-            ),
+            file_transfers: file_transfer::Manager::default(),
             theme_editor: None,
             notifications: notification::Notifications::new(),
             previews: preview::Collection::default(),
@@ -1310,14 +1307,14 @@ impl Dashboard {
                 }
             }
             Message::FileTransfer(update) => {
-                self.file_transfers.update(update);
+                self.file_transfers.update(update, config);
             }
             Message::SendFileSelected(server, to, path) => {
                 if let Some(server_handle) = clients.get_server_handle(&server)
                 {
                     if let Some(path) = path {
                         if let Ok(query) = target::Query::parse(
-                            to.as_ref(),
+                            to.nickname().as_ref(),
                             clients.get_chantypes(&server),
                             clients.get_statusmsg(&server),
                             clients.get_casemapping(&server),
@@ -1329,7 +1326,7 @@ impl Dashboard {
                                     server: server.clone(),
                                     server_handle: server_handle.clone(),
                                 },
-                                config.proxy.clone(),
+                                config,
                             ) {
                                 return (
                                     self.handle_file_transfer_event(
@@ -2492,14 +2489,12 @@ impl Dashboard {
         request: file_transfer::ReceiveRequest,
         config: &Config,
     ) -> Option<Task<Message>> {
-        let event = self
-            .file_transfers
-            .receive(request.clone(), config.proxy.as_ref())?;
+        let event = self.file_transfers.receive(request.clone(), config)?;
 
         self.notifications.notify(
             &config.notifications,
             &Notification::FileTransferRequest {
-                nick: request.from.clone(),
+                nick: request.from.nickname().to_owned(),
                 filename: match event {
                     file_transfer::manager::Event::NewTransfer(
                         ref transfer,
@@ -2511,7 +2506,7 @@ impl Dashboard {
         );
 
         let query = target::Query::parse(
-            request.from.as_ref(),
+            request.from.nickname().as_ref(),
             chantypes,
             statusmsg,
             casemapping,
@@ -2627,9 +2622,7 @@ impl Dashboard {
             history: history::Manager::default(),
             last_changed: None,
             command_bar: None,
-            file_transfers: file_transfer::Manager::new(
-                config.file_transfer.clone(),
-            ),
+            file_transfers: file_transfer::Manager::default(),
             theme_editor: None,
             notifications: notification::Notifications::new(),
             previews: preview::Collection::default(),


### PR DESCRIPTION
This fixes (some of) https://github.com/squidowl/halloy/issues/856.

```toml
[file_transfer]
save_directory = "/Users/crs/Downloads"

[file_transfer.auto_accept]
enabled = true
nicks = ["boo", "slasker"]
masks = [".*!.*@example.com"]
```
You are now able to auto accept files by using `auto_accept_files` - you also have  `auto_accept_nicks` and `auto_accept_masks` if you wish to only accept certain nicks/masks.

Above would  auto accept a file if:
Their nickname is "boo" or "slasker" and their mask matches ".*@example.com"
