### PR TITLE
Side Regression Fix Part 2

### DIFF
--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -261,7 +261,7 @@ impl Config {
 
         let Configuration {
             theme,
-            mut servers,
+            servers,
             font,
             proxy,
             scale_factor,
@@ -280,11 +280,6 @@ impl Config {
             log::warn!("[config.toml] Ignoring unknown setting: {ignored}");
         })
         .map_err(|e| Error::Parse(e.to_string()))?;
-
-        match sidebar.order_by {
-            sidebar::OrderBy::Alpha => servers.sort_keys(),
-            sidebar::OrderBy::Config => (),
-        }
 
         let servers = ServerMap::new(servers).await?;
 

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -9,6 +9,7 @@ use iced::widget::{
     vertical_space,
 };
 use iced::{Alignment, Length, Task, padding};
+use itertools::Either;
 use tokio::time;
 
 use super::{Focus, Panes, Server};
@@ -305,11 +306,18 @@ impl Sidebar {
             let mut buffers = vec![];
             let mut client_enumeration = 0;
 
-            for server in config.servers.keys().chain(
-                clients
-                    .servers()
-                    .filter(|key| !config.servers.contains(key)),
-            ) {
+            let servers = match config.sidebar.order_by {
+                sidebar::OrderBy::Alpha => Either::Left(clients.servers()),
+                sidebar::OrderBy::Config => Either::Right(
+                    config.servers.keys().chain(
+                        clients
+                            .servers()
+                            .filter(|key| !config.servers.contains(key)),
+                    ),
+                ),
+            };
+
+            for server in servers {
                 let button = |buffer: buffer::Upstream,
                               connected: bool,
                               server_has_unread: bool,


### PR DESCRIPTION
After some discussion in `#halloy`, realized that there was a second sidebar regression.  Servers joined via link would not get properly sorted into the existing sidebar (instead would be sorted at the end, as is done for order-by-config).