### PR TITLE
Fix Unintentional Documentation Overwrite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3466,6 +3466,7 @@ dependencies = [
  "data",
  "futures",
  "interprocess",
+ "log",
  "rand 0.9.0",
  "rand_chacha 0.9.0",
  "thiserror 2.0.12",

--- a/book/src/configuration/buffer.md
+++ b/book/src/configuration/buffer.md
@@ -523,16 +523,20 @@ click = "open-query"
 
 Server messages are messages sent from an IRC server.
 
-- **change_host** - Message is sent when a user changes host  
-- **join** - Message is sent when a user joins a channel  
-- **monitored_offline** - Message is sent when a monitored user goes offline  
-- **monitored_online** - Message is sent when a monitored user goes online  
-- **part** - Message is sent when a user leaves a channel  
-- **quit** - Message is sent when a user closes the connection to a channel or server  
-- **standard_reply_fail** - Message is sent when a command/function fails or an error with the session  
-- **standard_reply_note** - Message is sent when there is information about a command/function or session  
-- **standard_reply_warn** - Message is sent when there is feedback about a command/function or session  
-- **topic** - Message is sent when the client joins a channel to inform them of the current topic
+| **Event Type**            | **Description**                                                                 |
+|---------------------------|---------------------------------------------------------------------------------|
+| `change_host`             | Message is sent when a user changes host                                       |
+| `change_mode`             | Message is sent when a mode is set                                             |
+| `change_nick`             | Message is sent when a user changes nick                                       |
+| `join`                    | Message is sent when a user joins a channel                                    |
+| `monitored_offline`       | Message is sent when a monitored user goes offline                             |
+| `monitored_online`        | Message is sent when a monitored user goes online                              |
+| `part`                    | Message is sent when a user leaves a channel                                   |
+| `quit`                    | Message is sent when a user closes the connection to a channel or server       |
+| `standard_reply_fail`     | Message is sent when a command/function fails or an error with the session     |
+| `standard_reply_note`     | Message is sent when there is information about a command/function or session  |
+| `standard_reply_warn`     | Message is sent when there is feedback about a command/function or session     |
+| `topic`                   | Message is sent when the client joins a channel to inform them of the topic    |
 
 Example
 

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -281,7 +281,6 @@ impl User {
         use fancy_regex::Regex;
 
         let user_mask = String::from(self.clone());
-        println!("user_mask: {user_mask}");
 
         masks.iter().any(|mask_pattern| {
             if let Ok(regex) = Regex::new(mask_pattern) {

--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 url = { workspace = true }
 tokio = { workspace = true, features = ["rt", "fs", "process"] }
 futures = { workspace = true }
+log = { workspace = true, features = ['std'] }
 thiserror = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }

--- a/ipc/src/server.rs
+++ b/ipc/src/server.rs
@@ -66,7 +66,7 @@ pub fn listen() -> futures::stream::BoxStream<'static, String> {
             State::Uninitialized => match spawn_server().await {
                 Ok(server) => Some((None, State::Waiting(server))),
                 Err(err) => {
-                    println!("error: {err:?}");
+                    log::error!("Unable to spawn server: {err:?}");
                     None
                 }
             },

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -49,6 +49,7 @@ pub fn setup(
         .level_for("panic", log::LevelFilter::Error)
         .level_for("iced_wgpu", log::LevelFilter::Info)
         .level_for("data", file_level_filter)
+        .level_for("ipc", file_level_filter)
         .level_for("halloy", file_level_filter);
 
     let (channel_sink, receiver) = channel_logger();
@@ -59,6 +60,7 @@ pub fn setup(
         .level_for("panic", log::LevelFilter::Error)
         .level_for("iced_wgpu", log::LevelFilter::Info)
         .level_for("data", channel_level_filter)
+        .level_for("ipc", channel_level_filter)
         .level_for("halloy", channel_level_filter);
 
     fern::Dispatch::new()


### PR DESCRIPTION
Merging #1054 wound up unintentionally overwriting documentation for `server_messages`.  This reverts that overwrite, and cleans up a couple loose `println!`s.