### PR TITLE
Topic Time with Local Offset

### DIFF
--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -4,7 +4,7 @@ use std::hash::{DefaultHasher, Hash as _, Hasher};
 use std::iter;
 use std::sync::LazyLock;
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Local, Utc};
 use const_format::concatcp;
 use fancy_regex::{Regex, RegexBuilder};
 use irc::proto;
@@ -1485,6 +1485,7 @@ fn content<'a>(
                 .map(Posix::from_seconds)
                 .as_ref()
                 .and_then(Posix::datetime)?
+                .with_timezone(&Local)
                 .to_rfc2822();
 
             Some(parse_fragments_with_user(

--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Local, Utc};
 use data::{Config, Server, User, isupport, message, target};
 use iced::Length;
 use iced::widget::{
@@ -101,11 +101,14 @@ pub fn view<'a>(
                             )
                             .style(theme::selectable_text::topic),
                         content,
-                        selectable_text(format!(" at {}", time?.to_rfc2822()))
-                            .font_maybe(
-                                theme::font_style::topic(theme).map(font::get)
-                            )
-                            .style(theme::selectable_text::topic),
+                        selectable_text(format!(
+                            " at {}",
+                            time?.with_timezone(&Local).to_rfc2822()
+                        ))
+                        .font_maybe(
+                            theme::font_style::topic(theme).map(font::get)
+                        )
+                        .style(theme::selectable_text::topic),
                     ])
                     .map(Message::UserContext),
                 )


### PR DESCRIPTION
Display "set at" time for topics with the local timezone offset, instead of UTC's.