### PR TITLE
Split `User::try_from` by Use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,6 +1511,7 @@ dependencies = [
  "serde",
  "serde_ignored",
  "serde_json",
+ "serde_test",
  "sha2",
  "strum 0.27.1",
  "thiserror 2.0.12",
@@ -6023,6 +6024,15 @@ name = "serde_spanned"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_test"
+version = "1.0.177"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f901ee573cab6b3060453d2d5f0bae4e6d628c23c0a962ff9b5f1d7c8d4f1ed"
 dependencies = [
  "serde",
 ]

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -36,6 +36,7 @@ indexmap = { version = "2.9", features = ["std", "serde"] }
 seahash = "4.1.0"
 serde_json = "1.0"
 serde_ignored = "0.1"
+serde_test = "1.0"
 sha2 = "0.10.8"
 toml = "0.8.11"
 reqwest = { version = "0.12", features = ["json"] }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1901,8 +1901,9 @@ impl Client {
                         self.casemapping(),
                     )))
                 {
+                    let prefix = isupport::get_prefix(&self.isupport);
                     for user in args[3].split(' ') {
-                        if let Ok(user) = User::try_from(user) {
+                        if let Ok(user) = User::parse(user, prefix) {
                             channel.users.insert(user);
                         }
                     }
@@ -1946,7 +1947,7 @@ impl Client {
                     }
 
                     channel.topic.who =
-                        message.user().map(|user| user.nickname().to_string());
+                        message.user().map(|user| user.nickname().to_owned());
                     channel.topic.time = Some(server_time(&message));
                 }
             }
@@ -1980,7 +1981,8 @@ impl Client {
                         self.casemapping(),
                     )))
                 {
-                    channel.topic.who = Some(ok!(args.get(2)).to_string());
+                    channel.topic.who =
+                        Some(Nick::from(ok!(args.get(2)).as_str()));
                     let timestamp =
                         Posix::from_seconds(ok!(args.get(3)).parse::<u64>()?);
                     channel.topic.time =
@@ -2155,7 +2157,7 @@ impl Client {
             Command::Numeric(RPL_MONONLINE, args) => {
                 let targets = ok!(args.get(1))
                     .split(',')
-                    .filter_map(|target| User::try_from(target).ok())
+                    .map(|target| User::from(Nick::from(target)))
                     .collect::<Vec<_>>();
 
                 return Ok(vec![
@@ -2859,23 +2861,23 @@ impl Client {
     }
 
     pub fn casemapping(&self) -> isupport::CaseMap {
-        isupport::get_casemapping(&self.isupport)
+        isupport::get_casemapping_or_default(&self.isupport)
     }
 
     pub fn chanmodes(&self) -> &[isupport::ModeKind] {
-        isupport::get_chanmodes(&self.isupport)
+        isupport::get_chanmodes_or_default(&self.isupport)
     }
 
     pub fn chantypes(&self) -> &[char] {
-        isupport::get_chantypes(&self.isupport)
+        isupport::get_chantypes_or_default(&self.isupport)
     }
 
     pub fn prefix(&self) -> &[isupport::PrefixMap] {
-        isupport::get_prefix(&self.isupport)
+        isupport::get_prefix_or_default(&self.isupport)
     }
 
     pub fn statusmsg(&self) -> &[char] {
-        isupport::get_statusmsg(&self.isupport)
+        isupport::get_statusmsg_or_default(&self.isupport)
     }
 
     pub fn is_channel(&self, target: &str) -> bool {
@@ -3457,7 +3459,7 @@ impl Channel {
 #[derive(Default, Debug, Clone)]
 pub struct Topic {
     pub content: Option<message::Content>,
-    pub who: Option<String>,
+    pub who: Option<Nick>,
     pub time: Option<DateTime<Utc>>,
 }
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1981,8 +1981,14 @@ impl Client {
                         self.casemapping(),
                     )))
                 {
-                    channel.topic.who =
-                        Some(Nick::from(ok!(args.get(2)).as_str()));
+                    channel.topic.who = Some(
+                        context!(User::parse(
+                            ok!(args.get(2)),
+                            isupport::get_prefix(&self.isupport),
+                        ))
+                        .nickname()
+                        .to_owned(),
+                    );
                     let timestamp =
                         Posix::from_seconds(ok!(args.get(3)).parse::<u64>()?);
                     channel.topic.time =

--- a/data/src/command.rs
+++ b/data/src/command.rs
@@ -257,9 +257,12 @@ pub fn parse(
                 if let Some(msg) = msg {
                     Ok(Command::Irc(Irc::Msg(targets, msg)))
                 } else {
-                    let casemapping = isupport::get_casemapping(isupport);
-                    let chantypes = isupport::get_chantypes(isupport);
-                    let statusmsg = isupport::get_statusmsg(isupport);
+                    let casemapping =
+                        isupport::get_casemapping_or_default(isupport);
+                    let chantypes =
+                        isupport::get_chantypes_or_default(isupport);
+                    let statusmsg =
+                        isupport::get_statusmsg_or_default(isupport);
 
                     Ok(Command::Internal(Internal::OpenBuffers(
                         targets
@@ -397,7 +400,8 @@ pub fn parse(
             Kind::Mode => validated::<1, 2, true>(
                 args,
                 |[target], [mode_string, mode_arguments]| {
-                    let mode_limit = isupport::get_mode_limit(isupport);
+                    let mode_limit =
+                        isupport::get_mode_limit_or_default(isupport);
 
                     if let Some(mode_string) = mode_string {
                         if mode_string == "+" || mode_string == "-" {
@@ -405,11 +409,14 @@ pub fn parse(
                         } else {
                             let mode_string_regex = if proto::is_channel(
                                 &target,
-                                isupport::get_chantypes(isupport),
+                                isupport::get_chantypes_or_default(isupport),
                             ) {
                                 let chanmodes =
-                                    isupport::get_chanmodes(isupport);
-                                let prefix = isupport::get_prefix(isupport);
+                                    isupport::get_chanmodes_or_default(
+                                        isupport,
+                                    );
+                                let prefix =
+                                    isupport::get_prefix_or_default(isupport);
 
                                 let mut channel_modes_regex =
                                     String::from(r"^((\+|\-)[");
@@ -543,9 +550,12 @@ pub fn parse(
                     if let Some(msg) = msg {
                         Ok(Command::Irc(Irc::Notice(targets, msg)))
                     } else {
-                        let casemapping = isupport::get_casemapping(isupport);
-                        let chantypes = isupport::get_chantypes(isupport);
-                        let statusmsg = isupport::get_statusmsg(isupport);
+                        let casemapping =
+                            isupport::get_casemapping_or_default(isupport);
+                        let chantypes =
+                            isupport::get_chantypes_or_default(isupport);
+                        let statusmsg =
+                            isupport::get_statusmsg_or_default(isupport);
 
                         Ok(Command::Internal(Internal::OpenBuffers(
                             targets

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -296,6 +296,8 @@ pub enum UsernameFormat {
     Short,
     #[default]
     Full,
+    #[serde(skip)]
+    Mask,
 }
 
 impl Buffer {

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -1194,7 +1194,9 @@ pub fn find_target_limit(
     }
 }
 
-pub fn get_casemapping(isupport: &HashMap<Kind, Parameter>) -> CaseMap {
+pub fn get_casemapping_or_default(
+    isupport: &HashMap<Kind, Parameter>,
+) -> CaseMap {
     if let Some(Parameter::CASEMAPPING(casemapping)) =
         isupport.get(&Kind::CASEMAPPING)
     {
@@ -1205,7 +1207,9 @@ pub fn get_casemapping(isupport: &HashMap<Kind, Parameter>) -> CaseMap {
 }
 
 // https://modern.ircdocs.horse/#chanmodes-parameter
-pub fn get_chanmodes(isupport: &HashMap<Kind, Parameter>) -> &[ModeKind] {
+pub fn get_chanmodes_or_default(
+    isupport: &HashMap<Kind, Parameter>,
+) -> &[ModeKind] {
     isupport
         .get(&Kind::CHANMODES)
         .and_then(|chanmodes| {
@@ -1220,7 +1224,9 @@ pub fn get_chanmodes(isupport: &HashMap<Kind, Parameter>) -> &[ModeKind] {
         .unwrap_or(DEFAULT_CHANMODES)
 }
 
-pub fn get_chantypes(isupport: &HashMap<Kind, Parameter>) -> &[char] {
+pub fn get_chantypes_or_default(
+    isupport: &HashMap<Kind, Parameter>,
+) -> &[char] {
     isupport
         .get(&Kind::CHANTYPES)
         .and_then(|chantypes| {
@@ -1236,7 +1242,9 @@ pub fn get_chantypes(isupport: &HashMap<Kind, Parameter>) -> &[char] {
 }
 
 // https://modern.ircdocs.horse/#modes-parameter
-pub fn get_mode_limit(isupport: &HashMap<Kind, Parameter>) -> Option<u16> {
+pub fn get_mode_limit_or_default(
+    isupport: &HashMap<Kind, Parameter>,
+) -> Option<u16> {
     isupport
         .get(&Kind::MODES)
         .and_then(|modes| {
@@ -1251,22 +1259,27 @@ pub fn get_mode_limit(isupport: &HashMap<Kind, Parameter>) -> Option<u16> {
         .unwrap_or(Some(3))
 }
 
-pub fn get_prefix(isupport: &HashMap<Kind, Parameter>) -> &[PrefixMap] {
-    isupport
-        .get(&Kind::PREFIX)
-        .and_then(|prefix| {
-            if let Parameter::PREFIX(prefix) = prefix {
-                Some(prefix.as_ref())
-            } else {
-                log::debug!("Corruption in isupport table.");
+pub fn get_prefix(isupport: &HashMap<Kind, Parameter>) -> Option<&[PrefixMap]> {
+    isupport.get(&Kind::PREFIX).and_then(|prefix| {
+        if let Parameter::PREFIX(prefix) = prefix {
+            Some(prefix.as_ref())
+        } else {
+            log::debug!("Corruption in isupport table.");
 
-                None
-            }
-        })
-        .unwrap_or(DEFAULT_PREFIX)
+            None
+        }
+    })
 }
 
-pub fn get_statusmsg(isupport: &HashMap<Kind, Parameter>) -> &[char] {
+pub fn get_prefix_or_default(
+    isupport: &HashMap<Kind, Parameter>,
+) -> &[PrefixMap] {
+    get_prefix(isupport).unwrap_or(DEFAULT_PREFIX)
+}
+
+pub fn get_statusmsg_or_default(
+    isupport: &HashMap<Kind, Parameter>,
+) -> &[char] {
     isupport.get(&Kind::STATUSMSG).map_or(&[], |statusmsg| {
         if let Parameter::STATUSMSG(prefixes) = statusmsg {
             prefixes.as_ref()

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -1242,6 +1242,7 @@ pub fn get_chantypes_or_default(
 }
 
 // https://modern.ircdocs.horse/#modes-parameter
+// The value itself is optional, with None signifying unlimited
 pub fn get_mode_limit_or_default(
     isupport: &HashMap<Kind, Parameter>,
 ) -> Option<u16> {

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -1245,7 +1245,7 @@ fn content<'a>(
             })
         }
         Command::KICK(channel, victim, comment) => {
-            let raw_victim_user = User::try_from(victim.as_str()).ok()?;
+            let raw_victim_user = User::from(Nick::from(victim.as_str()));
             let victim = target::Channel::parse(
                 victim,
                 chantypes,
@@ -1384,7 +1384,7 @@ fn content<'a>(
             None
         }
         Command::Numeric(RPL_WHOISIDLE, params) => {
-            let user = User::try_from(params.get(1)?.as_str()).ok()?;
+            let user = User::from(Nick::from(params.get(1)?.as_str()));
 
             let idle = params.get(2)?.parse::<u64>().ok()?;
             let sign_on = params.get(3)?.parse::<u64>().ok()?;
@@ -1408,7 +1408,7 @@ fn content<'a>(
             ))
         }
         Command::Numeric(RPL_WHOISSERVER, params) => {
-            let user = User::try_from(params.get(1)?.as_str()).ok()?;
+            let user = User::from(Nick::from(params.get(1)?.as_str()));
 
             let server = params.get(2)?;
             let region = params.get(3)?;
@@ -1422,7 +1422,7 @@ fn content<'a>(
             ))
         }
         Command::Numeric(RPL_WHOISUSER, params) => {
-            let user = User::try_from(params.get(1)?.as_str()).ok()?;
+            let user = User::from(Nick::from(params.get(1)?.as_str()));
 
             let userhost = format!("{}@{}", params.get(2)?, params.get(3)?);
             let real_name = params.get(5)?;
@@ -1436,7 +1436,7 @@ fn content<'a>(
             ))
         }
         Command::Numeric(RPL_WHOISCHANNELS, params) => {
-            let user = User::try_from(params.get(1)?.as_str()).ok()?;
+            let user = User::from(Nick::from(params.get(1)?.as_str()));
             let channels = params.get(2)?;
 
             Some(parse_fragments_with_user(
@@ -1445,7 +1445,7 @@ fn content<'a>(
             ))
         }
         Command::Numeric(RPL_WHOISACTUALLY, params) => {
-            let user: User = User::try_from(params.get(1)?.as_str()).ok()?;
+            let user: User = User::from(Nick::from(params.get(1)?.as_str()));
             let ip = params.get(2)?;
             let status_text = params.get(3)?;
 
@@ -1455,7 +1455,7 @@ fn content<'a>(
             ))
         }
         Command::Numeric(RPL_WHOISSECURE, params) => {
-            let user: User = User::try_from(params.get(1)?.as_str()).ok()?;
+            let user: User = User::from(Nick::from(params.get(1)?.as_str()));
             let status_text = params.get(2)?;
 
             Some(parse_fragments_with_user(
@@ -1464,7 +1464,7 @@ fn content<'a>(
             ))
         }
         Command::Numeric(RPL_WHOISACCOUNT, params) => {
-            let user: User = User::try_from(params.get(1)?.as_str()).ok()?;
+            let user: User = User::from(Nick::from(params.get(1)?.as_str()));
             let account = params.get(2)?;
             let status_text = params.get(3)?;
 
@@ -1474,7 +1474,7 @@ fn content<'a>(
             ))
         }
         Command::Numeric(RPL_TOPICWHOTIME, params) => {
-            let user = User::try_from(params.get(2)?.as_str()).ok()?;
+            let user = User::from(Nick::from(params.get(2)?.as_str()));
 
             let datetime = params
                 .get(3)?
@@ -1512,7 +1512,7 @@ fn content<'a>(
             Some(parse_fragments(format!("User mode is {mode}")))
         }
         Command::Numeric(RPL_AWAY, params) => {
-            let user = User::try_from(params.get(1)?.as_str()).ok()?;
+            let user = User::from(Nick::from(params.get(1)?.as_str()));
             let away_message = params
                 .get(2)
                 .map(|away| format!(" ({away})"))
@@ -1527,7 +1527,7 @@ fn content<'a>(
             let targets = params
                 .get(1)?
                 .split(',')
-                .filter_map(|target| User::try_from(target).ok())
+                .map(|target| User::from(Nick::from(target)))
                 .map(|user| user.formatted(UsernameFormat::Full))
                 .collect::<Vec<_>>();
 
@@ -1922,7 +1922,7 @@ mod tests {
                         "Bob",
                         "George_",
                         "`Bill`",
-                    ].into_iter().map(User::try_from).map(Result::unwrap).collect::<ChannelUsers>(),
+                    ].into_iter().map(|nick| User::from(Nick::from(nick))).collect::<ChannelUsers>(),
                     "#interesting",
                     Some(Nick::from("Bob")),
                     &Highlights {
@@ -1931,17 +1931,17 @@ mod tests {
                     },
                 ),
                 vec![
-                    Fragment::HighlightNick(User::try_from("Bob").unwrap(), "Bob".into()),
+                    Fragment::HighlightNick(User::from(Nick::from("Bob")), "Bob".into()),
                     Fragment::Text(": I'm in ".into()),
                     Fragment::Channel("#interesting".into()),
                     Fragment::Text(" with ".into()),
-                    Fragment::User(User::try_from("Greg").unwrap(), "Greg".into()),
+                    Fragment::User(User::from(Nick::from("Greg")), "Greg".into()),
                     Fragment::Text(", ".into()),
-                    Fragment::User(User::try_from("George_").unwrap(), "George_".into()),
+                    Fragment::User(User::from(Nick::from("George_")), "George_".into()),
                     Fragment::Text(", &".into()),
-                    Fragment::User(User::try_from("`Bill`").unwrap(), "`Bill`".into()),
+                    Fragment::User(User::from(Nick::from("`Bill`")), "`Bill`".into()),
                     Fragment::Text(". I hope @".into()),
-                    Fragment::User(User::try_from("Dave").unwrap(), "Dave".into()),
+                    Fragment::User(User::from(Nick::from("Dave")), "Dave".into()),
                     Fragment::Text(" doesn't notice.".into()),
                 ],
             ),
@@ -1951,7 +1951,7 @@ mod tests {
                     [
                         "f_",
                         "rx",
-                    ].into_iter().map(User::try_from).map(Result::unwrap).collect(),
+                    ].into_iter().map(|nick| User::from(Nick::from(nick))).collect::<ChannelUsers>(),
                     "#funderscore-sucks",
                     Some(Nick::from("f_")),
                     &Highlights {
@@ -1961,7 +1961,7 @@ mod tests {
                 ),
                 vec![
                     Fragment::Text("\u{3}14<\u{3}\u{3}04lurk_\u{3}\u{3}14/rx>\u{3} ".into()),
-                    Fragment::HighlightNick(User::try_from("f_").unwrap(), "f_".into()),
+                    Fragment::HighlightNick(User::from(Nick::from("f_")), "f_".into()),
                     Fragment::Text("~oftc: > A��\u{1f}qj\u{14}��L�5�g���5�P��yn_?�i3g�1\u{7f}mE�\\X��� Xe�\u{5fa}{d�+�`@�^��NK��~~ޏ\u{7}\u{8}\u{15}\\�\u{4}A� \u{f}\u{1c}�N\u{11}6�r�\u{4}t��Q��\u{1c}�m\u{19}��".into())
                 ],
             ),

--- a/data/src/mode.rs
+++ b/data/src/mode.rs
@@ -412,8 +412,8 @@ mod test {
             let modes = parse::<Channel>(
                 modes,
                 &args,
-                isupport::get_chanmodes(&isupport),
-                isupport::get_prefix(&isupport),
+                isupport::get_chanmodes_or_default(&isupport),
+                isupport::get_prefix_or_default(&isupport),
             );
             assert_eq!(modes, expected);
         }

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -10,11 +10,9 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::config::buffer::UsernameFormat;
-use crate::mode;
+use crate::{isupport, mode};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(into = "String")]
-#[serde(try_from = "String")]
+#[derive(Debug, Clone)]
 pub struct User {
     nickname: Nick,
     username: Option<String>,
@@ -100,98 +98,42 @@ impl ChannelUsers {
     }
 }
 
-#[derive(Error, Debug)]
-pub enum TryFromUserError {
-    #[error("nickname can't be empty")]
-    NicknameEmpty,
-    #[error("nickname must start with alphabetic or [ \\ ] ^ _ ` {{ | }} *")]
-    NicknameInvalidCharacter,
-}
-
-impl TryFrom<String> for User {
-    type Error = TryFromUserError;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::try_from(value.as_str())
-    }
-}
-
-impl<'a> TryFrom<&'a str> for User {
-    type Error = TryFromUserError;
-
-    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
-        if value.is_empty() {
-            return Err(Self::Error::NicknameEmpty);
-        }
-
-        let Some(index) = value.find(|c: char| {
-            c.is_alphabetic() || "[\\]^_`{|}*".find(c).is_some()
-        }) else {
-            return Err(Self::Error::NicknameInvalidCharacter);
-        };
-
-        let (access_levels, rest) = (&value[..index], &value[index..]);
-
-        let access_levels = access_levels
-            .chars()
-            .filter_map(|c| AccessLevel::try_from(c).ok())
-            .collect::<BTreeSet<_>>();
-
-        let (nickname, username, hostname) =
-            match (rest.find('!'), rest.find('@')) {
-                (None, None) => (rest, None, None),
-                (Some(i), None) => {
-                    (&rest[..i], Some(rest[i + 1..].to_string()), None)
-                }
-                (None, Some(i)) => {
-                    (&rest[..i], None, Some(rest[i + 1..].to_string()))
-                }
-                (Some(i), Some(j)) => {
-                    if i < j {
-                        (
-                            &rest[..i],
-                            Some(rest[i + 1..j].to_string()),
-                            Some(rest[j + 1..].to_string()),
-                        )
-                    } else if let Some(k) = rest[i + 1..].find('@') {
-                        (
-                            &rest[..i],
-                            Some(rest[i + 1..i + k + 1].to_string()),
-                            Some(rest[i + k + 2..].to_string()),
-                        )
-                    } else {
-                        (&rest[..i], Some(rest[i + 1..].to_string()), None)
-                    }
-                }
-            };
-
-        Ok(User {
-            nickname: Nick::from(nickname),
-            username,
-            hostname,
-            accountname: None,
-            access_levels,
-            away: false,
-        })
-    }
-}
-
-impl From<User> for String {
-    fn from(user: User) -> Self {
-        let access_levels: String = sorted(user.access_levels.iter())
+impl Serialize for User {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let access_levels: String = sorted(self.access_levels.iter())
             .map(ToString::to_string)
             .collect();
-        let nickname = user.nickname();
-        let username = user
+        let nickname = self.nickname();
+        let username = self
             .username()
             .map(|username| format!("!{username}"))
             .unwrap_or_default();
-        let hostname = user
+        let hostname = self
             .hostname()
             .map(|hostname| format!("@{hostname}"))
             .unwrap_or_default();
 
         format!("{access_levels}{nickname}{username}{hostname}")
+            .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for User {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+
+        User::parse(&value, None).map_err(|_| {
+            serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(&value),
+                &"{access_levels}{nickname}{username}{hostname}",
+            )
+        })
     }
 }
 
@@ -325,6 +267,16 @@ impl User {
                 (Some(user), None) => format!("{nick} ({user})"),
                 (Some(user), Some(host)) => format!("{nick} ({user}@{host})"),
             },
+            UsernameFormat::Mask => format!(
+                "{}{}{}",
+                self.nickname(),
+                self.username()
+                    .map(|username| format!("!{username}"))
+                    .unwrap_or_default(),
+                self.hostname()
+                    .map(|hostname| format!("@{hostname}"))
+                    .unwrap_or_default()
+            ),
         }
     }
 
@@ -333,7 +285,7 @@ impl User {
     pub fn matches_masks(&self, masks: &[String]) -> bool {
         use fancy_regex::Regex;
 
-        let user_mask = String::from(self.clone());
+        let user_mask = self.formatted(UsernameFormat::Mask);
 
         masks.iter().any(|mask_pattern| {
             if let Ok(regex) = Regex::new(mask_pattern) {
@@ -343,6 +295,77 @@ impl User {
             }
         })
     }
+
+    pub fn parse(
+        value: &str,
+        prefix: Option<&[isupport::PrefixMap]>,
+    ) -> Result<Self, ParseUserError> {
+        if value.is_empty() {
+            return Err(ParseUserError::NicknameEmpty);
+        }
+
+        let index = if let Some(prefix) = prefix {
+            value.find(|c: char| {
+                prefix.iter().all(|prefix_map| c != prefix_map.prefix)
+            })
+        } else {
+            value.find(|c: char| AccessLevel::try_from(c).is_err())
+        };
+
+        let Some(index) = index else {
+            return Err(ParseUserError::NicknameEmpty);
+        };
+
+        let (access_levels, rest) = (&value[..index], &value[index..]);
+
+        let access_levels = access_levels
+            .chars()
+            .filter_map(|c| AccessLevel::try_from(c).ok())
+            .collect::<BTreeSet<_>>();
+
+        let (nickname, username, hostname) =
+            match (rest.find('!'), rest.find('@')) {
+                (None, None) => (rest, None, None),
+                (Some(i), None) => {
+                    (&rest[..i], Some(rest[i + 1..].to_string()), None)
+                }
+                (None, Some(i)) => {
+                    (&rest[..i], None, Some(rest[i + 1..].to_string()))
+                }
+                (Some(i), Some(j)) => {
+                    if i < j {
+                        (
+                            &rest[..i],
+                            Some(rest[i + 1..j].to_string()),
+                            Some(rest[j + 1..].to_string()),
+                        )
+                    } else if let Some(k) = rest[i + 1..].find('@') {
+                        (
+                            &rest[..i],
+                            Some(rest[i + 1..i + k + 1].to_string()),
+                            Some(rest[i + k + 2..].to_string()),
+                        )
+                    } else {
+                        (&rest[..i], Some(rest[i + 1..].to_string()), None)
+                    }
+                }
+            };
+
+        Ok(User {
+            nickname: Nick::from(nickname),
+            username,
+            hostname,
+            accountname: None,
+            access_levels,
+            away: false,
+        })
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ParseUserError {
+    #[error("nickname can't be empty")]
+    NicknameEmpty,
 }
 
 impl From<proto::User> for User {
@@ -540,7 +563,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn string_try_from() {
+    fn user_serde() {
+        use serde_test::{Token, assert_tokens};
+
         let tests = [
             (
                 User {
@@ -554,7 +579,18 @@ mod tests {
                     ]),
                     away: false,
                 },
-                "+@dan",
+                [Token::String("+@dan")],
+            ),
+            (
+                User {
+                    nickname: "dan".into(),
+                    username: Some("d".into()),
+                    hostname: Some("localhost".into()),
+                    accountname: None,
+                    access_levels: BTreeSet::<AccessLevel>::new(),
+                    away: false,
+                },
+                [Token::String("dan!d@localhost")],
             ),
             (
                 User {
@@ -567,7 +603,7 @@ mod tests {
                     ]),
                     away: false,
                 },
-                "@d@n!d@localhost",
+                [Token::String("@d@n!d@localhost")],
             ),
             (
                 User {
@@ -578,7 +614,7 @@ mod tests {
                     access_levels: BTreeSet::<AccessLevel>::new(),
                     away: false,
                 },
-                "foobar",
+                [Token::String("foobar")],
             ),
             (
                 User {
@@ -591,7 +627,9 @@ mod tests {
                     access_levels: BTreeSet::<AccessLevel>::new(),
                     away: false,
                 },
-                "foobar!8a027a9a4a@2201:12f1:2:1162:1242:1fg:he11:abde",
+                [Token::String(
+                    "foobar!8a027a9a4a@2201:12f1:2:1162:1242:1fg:he11:abde",
+                )],
             ),
             (
                 User {
@@ -605,32 +643,9 @@ mod tests {
                     ]),
                     away: false,
                 },
-                "+@foobar!~foobar@12.521.212.521",
-            ),
-        ];
-
-        for (test, expected) in tests {
-            let user = String::from(test);
-            assert_eq!(user, expected);
-        }
-    }
-
-    #[test]
-    fn user_try_from() {
-        let tests = [
-            (
-                "dan!d@localhost",
-                User {
-                    nickname: "dan".into(),
-                    username: Some("d".into()),
-                    hostname: Some("localhost".into()),
-                    accountname: None,
-                    access_levels: BTreeSet::<AccessLevel>::new(),
-                    away: false,
-                },
+                [Token::String("+@foobar!~foobar@12.521.212.521")],
             ),
             (
-                "$@H1N5!the.flu@in.you",
                 User {
                     nickname: "H1N5".into(),
                     username: Some("the.flu".into()),
@@ -641,31 +656,9 @@ mod tests {
                     ]),
                     away: false,
                 },
+                [Token::String("@H1N5!the.flu@in.you")],
             ),
             (
-                "d@n!d@localhost",
-                User {
-                    nickname: "d@n".into(),
-                    username: Some("d".into()),
-                    hostname: Some("localhost".into()),
-                    accountname: None,
-                    access_levels: BTreeSet::<AccessLevel>::new(),
-                    away: false,
-                },
-            ),
-            (
-                "d@n!d",
-                User {
-                    nickname: "d@n".into(),
-                    username: Some("d".into()),
-                    hostname: None,
-                    accountname: None,
-                    access_levels: BTreeSet::<AccessLevel>::new(),
-                    away: false,
-                },
-            ),
-            (
-                "*status",
                 User {
                     nickname: "*status".into(),
                     username: None,
@@ -674,32 +667,25 @@ mod tests {
                     access_levels: BTreeSet::<AccessLevel>::new(),
                     away: false,
                 },
+                [Token::String("*status")],
             ),
         ];
 
-        for (test, expected) in tests {
-            let user = super::User::try_from(test).unwrap();
-
-            assert_eq!(
-                (
-                    user.nickname,
-                    user.username,
-                    user.hostname,
-                    user.access_levels
-                ),
-                (
-                    expected.nickname,
-                    expected.username,
-                    expected.hostname,
-                    expected.access_levels
-                )
-            );
+        for (user, expected) in tests {
+            assert_tokens(&user, &expected);
         }
     }
 
     #[test]
     fn matches_masks() {
-        let user = super::User::try_from("alice!alice@example.com ").unwrap();
+        let user = User {
+            nickname: "alice".into(),
+            username: Some("alice".into()),
+            hostname: Some("example.com".into()),
+            accountname: None,
+            access_levels: BTreeSet::<AccessLevel>::new(),
+            away: false,
+        };
 
         // Test exact match
         assert!(user.matches_masks(&["alice!alice@example.com".to_string()]));
@@ -736,7 +722,7 @@ mod tests {
             ("foobar", "+@foobar!~foobar@12.521.212.521"),
             ("*status", "*status"),
         ]
-        .map(|(a, b)| (NickRef::from(a), User::try_from(b).unwrap()));
+        .map(|(a, b)| (NickRef::from(a), User::parse(b, None).unwrap()));
         let channel_users: ChannelUsers =
             users.iter().map(|(_, u)| u).cloned().collect();
         for (nick, user) in users {

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -326,7 +326,7 @@ fn topic<'a>(
             prefix,
             &state.target,
             topic.content.as_ref()?,
-            topic.who.as_deref(),
+            topic.who.clone(),
             topic.time.as_ref(),
             config.buffer.channel.topic.max_lines,
             users,

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -60,8 +60,7 @@ pub fn view<'a>(
             clients.resolve_user_attributes(&state.server, channel, &user)
         });
 
-    let users = clients
-        .get_channel_users(&state.server, channel);
+    let users = clients.get_channel_users(&state.server, channel);
 
     let chathistory_state =
         clients.get_chathistory_state(server, &channel.to_target());
@@ -326,7 +325,7 @@ fn topic<'a>(
             prefix,
             &state.target,
             topic.content.as_ref()?,
-            topic.who.clone(),
+            topic.who.as_ref().map(Nick::as_nickref),
             topic.time.as_ref(),
             config.buffer.channel.topic.max_lines,
             users,

--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Local, Utc};
-use data::user::ChannelUsers;
+use data::user::{ChannelUsers, Nick};
 use data::{Config, Server, User, isupport, message, target};
 use iced::Length;
 use iced::widget::{
@@ -45,7 +45,7 @@ pub fn view<'a>(
     prefix: &'a [isupport::PrefixMap],
     channel: &'a target::Channel,
     content: &'a message::Content,
-    who: Option<&'a str>,
+    who: Option<Nick>,
     time: Option<&'a DateTime<Utc>>,
     max_lines: u16,
     users: Option<&'a ChannelUsers>,
@@ -53,69 +53,58 @@ pub fn view<'a>(
     config: &'a Config,
     theme: &'a Theme,
 ) -> Element<'a, Message> {
-    let set_by =
-        who.and_then(|who| User::try_from(who).ok())
-            .and_then(|user| {
-                let channel_user = users.and_then(|users| users.resolve(&user));
+    let set_by = who.map(User::from).and_then(|user| {
+        let channel_user = users.and_then(|users| users.resolve(&user));
 
-                // If user is in channel, we return user_context component.
-                // Otherwise selectable_text component.
-                let content = if let Some(user) = channel_user {
-                    user_context::view(
-                        selectable_text(user.nickname().to_string())
-                            .font_maybe(
-                                theme::font_style::nickname(theme)
-                                    .map(font::get),
-                            )
-                            .style(|theme| {
-                                theme::selectable_text::topic_nickname(
-                                    theme, config, user,
-                                )
-                            }),
-                        server,
-                        casemapping,
-                        prefix,
-                        Some(channel),
-                        user,
-                        Some(user),
-                        our_user,
-                        config,
-                        theme,
-                        &config.buffer.nickname.click,
+        // If user is in channel, we return user_context component.
+        // Otherwise selectable_text component.
+        let content = if let Some(user) = channel_user {
+            user_context::view(
+                selectable_text(user.nickname().to_string())
+                    .font_maybe(
+                        theme::font_style::nickname(theme).map(font::get),
                     )
-                } else {
-                    selectable_text(user.display(false))
-                        .font_maybe(
-                            theme::font_style::nickname(theme).map(font::get),
+                    .style(|theme| {
+                        theme::selectable_text::topic_nickname(
+                            theme, config, user,
                         )
-                        .style(move |theme| {
-                            theme::selectable_text::topic_nickname(
-                                theme, config, &user,
-                            )
-                        })
-                        .into()
-                };
+                    }),
+                server,
+                casemapping,
+                prefix,
+                Some(channel),
+                user,
+                Some(user),
+                our_user,
+                config,
+                theme,
+                &config.buffer.nickname.click,
+            )
+        } else {
+            selectable_text(user.display(false))
+                .font_maybe(theme::font_style::nickname(theme).map(font::get))
+                .style(move |theme| {
+                    theme::selectable_text::topic_nickname(theme, config, &user)
+                })
+                .into()
+        };
 
-                Some(
-                    Element::new(row![
-                        selectable_text("set by ")
-                            .font_maybe(
-                                theme::font_style::topic(theme).map(font::get)
-                            )
-                            .style(theme::selectable_text::topic),
-                        content,
-                        selectable_text(format!(
-                            " at {}",
-                            time?.with_timezone(&Local).to_rfc2822()
-                        ))
-                        .font_maybe(
-                            theme::font_style::topic(theme).map(font::get)
-                        )
-                        .style(theme::selectable_text::topic),
-                    ])
-                    .map(Message::UserContext),
-                )
-            });
+        Some(
+            Element::new(row![
+                selectable_text("set by ")
+                    .font_maybe(theme::font_style::topic(theme).map(font::get))
+                    .style(theme::selectable_text::topic),
+                content,
+                selectable_text(format!(
+                    " at {}",
+                    time?.with_timezone(&Local).to_rfc2822()
+                ))
+                .font_maybe(theme::font_style::topic(theme).map(font::get))
+                .style(theme::selectable_text::topic),
+            ])
+            .map(Message::UserContext),
+        )
+    });
 
     let content = column![message_content(
         content,

--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Local, Utc};
-use data::user::{ChannelUsers, Nick};
+use data::user::{ChannelUsers, NickRef};
 use data::{Config, Server, User, isupport, message, target};
 use iced::Length;
 use iced::widget::{
@@ -45,7 +45,7 @@ pub fn view<'a>(
     prefix: &'a [isupport::PrefixMap],
     channel: &'a target::Channel,
     content: &'a message::Content,
-    who: Option<Nick>,
+    who: Option<NickRef<'a>>,
     time: Option<&'a DateTime<Utc>>,
     max_lines: u16,
     users: Option<&'a ChannelUsers>,
@@ -53,7 +53,7 @@ pub fn view<'a>(
     config: &'a Config,
     theme: &'a Theme,
 ) -> Element<'a, Message> {
-    let set_by = who.map(User::from).and_then(|user| {
+    let set_by = who.map(NickRef::to_owned).map(User::from).and_then(|user| {
         let channel_user = users.and_then(|users| users.resolve(&user));
 
         // If user is in channel, we return user_context component.

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -457,9 +457,9 @@ impl Commands {
             },
             // MODE
             {
-                let chanmodes = isupport::get_chanmodes(isupport);
-                let prefix = isupport::get_prefix(isupport);
-                let mode_limit = isupport::get_mode_limit(isupport);
+                let chanmodes = isupport::get_chanmodes_or_default(isupport);
+                let prefix = isupport::get_prefix_or_default(isupport);
+                let mode_limit = isupport::get_mode_limit_or_default(isupport);
 
                 Command {
                     title: "MODE",
@@ -648,7 +648,8 @@ impl Commands {
                             (String::from(command.title) + " " + subcmd)
                                 .to_lowercase()
                         } else {
-                            let chantypes = isupport::get_chantypes(isupport);
+                            let chantypes =
+                                isupport::get_chantypes_or_default(isupport);
 
                             format!(
                                 "{} {}",


### PR DESCRIPTION
In `#libera` I saw a user renamed to a nickname that started with numbers (presumably by staff, since I think nicknames are otherwise not allowed to start with numbers on Libera).  In messages the renamed user sent in channel, the numbers were stripped from the beginning of their nickname.  In other places (the nick changed message and in the channel users list, if I recall correctly) the numbers were not stripped.  I think this might be why, but I'm having trouble reproducing the issue.

Even if it's not the fix, I think this is a benign allowance.  I believe we allow nicknames that start with numbers in the `user` function in `irc/proto/src/parse.rs`, and [horsedocs](https://modern.ircdocs.horse/#clients) does not restrict nicknames from starting with a number.

Edit:  Found a way to repro on Ergo's testnet what I have to assume is the same issue.  Initially receiving messages via chathistory on Ergo, usernames starting with numbers do appear with their numbers-prefix.  But, if I close the buffer and reopen it, then the numbers are stripped from the beginning of usernames in already-received messages.  Can confirm this fixes.