### PR TITLE
Tor support is now an optional feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Added:
 - Context menu item to server buffers to mark all messages on the server as read
 - Auto-accept file transfer option with support for nick and mask filtering
 
+Changed:
+
+- Tor is now an optional feature. Build with `--features tor` to enable Tor proxy support.
+
 Thanks:
 
 - Bug reports: @darienm, @mercster

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,8 @@ dependencies = [
  "tor-dirmgr",
  "tor-error",
  "tor-guardmgr",
+ "tor-hsclient",
+ "tor-hscrypto",
  "tor-keymgr",
  "tor-linkspec",
  "tor-llcrypto",
@@ -7123,6 +7125,7 @@ dependencies = [
  "tor-bytes",
  "tor-cert",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-memquota",
@@ -7319,6 +7322,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tor-circmgr",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-netdoc",
@@ -7451,12 +7455,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "tor-hsclient"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f31d16e217827a6846502b87b507d7d47da42446306c3d6ebbd681e8a73d8f8"
+dependencies = [
+ "async-trait",
+ "derive-deftly",
+ "derive_more 1.0.0",
+ "educe",
+ "either",
+ "futures",
+ "itertools 0.14.0",
+ "oneshot-fused-workaround",
+ "postage",
+ "rand 0.8.5",
+ "retry-error",
+ "safelog",
+ "slotmap-careful",
+ "strum 0.26.3",
+ "thiserror 2.0.12",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-bytes",
+ "tor-cell",
+ "tor-checkable",
+ "tor-circmgr",
+ "tor-config",
+ "tor-dirclient",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-keymgr",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-memquota",
+ "tor-netdir",
+ "tor-netdoc",
+ "tor-persist",
+ "tor-proto",
+ "tor-rtcompat",
+ "tracing",
+]
+
+[[package]]
 name = "tor-hscrypto"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b86a73a511b16c23b25175f30c31b241004de410be400603a8e980355dc2bf1"
 dependencies = [
  "data-encoding",
+ "derive-deftly",
  "derive_more 1.0.0",
  "digest",
  "itertools 0.14.0",
@@ -7471,6 +7519,7 @@ dependencies = [
  "tor-error",
  "tor-key-forge",
  "tor-llcrypto",
+ "tor-memquota",
  "tor-units",
  "void",
 ]
@@ -7645,7 +7694,9 @@ dependencies = [
  "async-trait",
  "bitflags 2.7.0",
  "derive_more 1.0.0",
+ "digest",
  "futures",
+ "hex",
  "humantime",
  "itertools 0.14.0",
  "num_enum",
@@ -7654,8 +7705,10 @@ dependencies = [
  "static_assertions",
  "strum 0.26.3",
  "thiserror 2.0.12",
+ "time",
  "tor-basic-utils",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-netdoc",
@@ -7684,6 +7737,7 @@ dependencies = [
  "itertools 0.14.0",
  "once_cell",
  "phf 0.11.3",
+ "rand 0.8.5",
  "serde",
  "serde_with",
  "signature",
@@ -7698,8 +7752,11 @@ dependencies = [
  "tor-cert",
  "tor-checkable",
  "tor-error",
+ "tor-hscrypto",
+ "tor-linkspec",
  "tor-llcrypto",
  "tor-protover",
+ "tor-units",
  "void",
  "weak-table",
  "zeroize",
@@ -7769,6 +7826,7 @@ dependencies = [
  "tor-checkable",
  "tor-config",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-log-ratelim",
@@ -7778,6 +7836,7 @@ dependencies = [
  "tor-units",
  "tracing",
  "typenum",
+ "visibility",
  "void",
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ edition.workspace = true
 default = []
 debug = ["iced/debug"]
 dev = ["debug", "data/dev"]
+tor = ["data/tor"]
 
 [workspace]
 members = ["data", "ipc", "irc", "irc/proto"]

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -10,6 +10,7 @@
 
 - [Connect with soju](guides/connect-with-soju.md)
 - [Connect with ZNC](guides/connect-with-znc.md)
+- [Optional Features](guides/optional-features.md)
 - [Portable mode](guides/portable-mode.md)
 - [Multiple servers](guides/multiple-servers.md)
 - [Storing passwords in a File](guides/password-file.md)

--- a/book/src/configuration/proxy.md
+++ b/book/src/configuration/proxy.md
@@ -159,6 +159,8 @@ password = "password"
 Tor proxy settings. Utilizes the [arti](https://arti.torproject.org/) to integrate Tor natively.
 It accepts no further configuration.
 
+**Note:** Tor support is **not included by default**. You must build Halloy with the `tor` feature to use this proxy type. See [Optional Features](../guides/optional-features.md) for build instructions.
+
 ## Example
 
 ```toml

--- a/book/src/configuration/proxy.md
+++ b/book/src/configuration/proxy.md
@@ -156,10 +156,12 @@ password = "password"
 
 ## `[proxy.tor]`
 
-Tor proxy settings. Utilizes the [arti](https://arti.torproject.org/) to integrate Tor natively.
+Tor proxy settings. Utilizes [Arti](https://arti.torproject.org/) to integrate Tor support directly into Halloy.
 It accepts no further configuration.
 
-**Note:** Tor support is **not included by default**. You must build Halloy with the `tor` feature to use this proxy type. See [Optional Features](../guides/optional-features.md) for build instructions.
+**Note:**
+- Does not integrate into a pre-existing Tor setup.  To utilize an existing Tor daemon, use [`[proxy.socks5]`](#proxysocks5) instead.
+- Tor support is **not included by default**. You must build Halloy with the `tor` feature to use this proxy type. See [Optional Features](../guides/optional-features.md) for build instructions.
 
 ## Example
 

--- a/book/src/guides/optional-features.md
+++ b/book/src/guides/optional-features.md
@@ -1,0 +1,24 @@
+# Optional Features
+
+Halloy supports optional features that can be enabled during compilation to add additional functionality. These features are not included by default to keep the binary size small and compilation fast.
+
+## Building with features
+
+To build Halloy with specific features, use the `--features` flag:
+
+```bash
+# Build with a feature
+cargo build --features tor
+
+# Build release with features
+cargo build --release --features tor
+```
+
+## Available features
+
+### `tor`
+
+Enables Tor network support for anonymous IRC connections. 
+Not enabled by default. 
+
+See [Proxy Configuration](../configuration/proxy.md#proxytor) for usage details.

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 
 [features]
 dev = []
+tor = ["irc/tor"]
 
 [dependencies]
 thiserror = { workspace = true }

--- a/data/src/config/proxy.rs
+++ b/data/src/config/proxy.rs
@@ -15,6 +15,7 @@ pub enum Proxy {
         username: Option<String>,
         password: Option<String>,
     },
+    #[cfg(feature = "tor")]
     Tor,
 }
 
@@ -43,6 +44,7 @@ impl From<Proxy> for irc::connection::Proxy {
                 username,
                 password,
             },
+            #[cfg(feature = "tor")]
             Proxy::Tor => irc::connection::Proxy::Tor,
         }
     }

--- a/irc/Cargo.toml
+++ b/irc/Cargo.toml
@@ -5,16 +5,31 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 
+[features]
+default = []
+tor = ["arti-client"]
+
 [dependencies]
 thiserror = { workspace = true }
 futures = { workspace = true }
-tokio = { workspace = true,  features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 bytes = { workspace = true }
 
-arti-client = { version = "0.26", default-features = false, features = ["rustls", "compression", "tokio", "static-sqlite"] }
-async-http-proxy = { version = "1.2.5", features = ["runtime-tokio", "basic-auth"] }
+arti-client = { version = "0.26", default-features = false, features = [
+    "rustls",
+    "compression",
+    "tokio",
+    "static-sqlite",
+], optional = true }
+async-http-proxy = { version = "1.2.5", features = [
+    "runtime-tokio",
+    "basic-auth",
+] }
 fast-socks5 = "0.10.0"
-tokio-rustls = { version = "0.26.0", default-features = false, features = ["tls12", "ring"] }
+tokio-rustls = { version = "0.26.0", default-features = false, features = [
+    "tls12",
+    "ring",
+] }
 tokio-util = { version = "0.7", features = ["codec"] }
 rustls-native-certs = "0.8.1"
 rustls-pemfile = "2.1.1"

--- a/irc/Cargo.toml
+++ b/irc/Cargo.toml
@@ -20,6 +20,7 @@ arti-client = { version = "0.26", default-features = false, features = [
     "compression",
     "tokio",
     "static-sqlite",
+    "onion-service-client",
 ], optional = true }
 async-http-proxy = { version = "1.2.5", features = [
     "runtime-tokio",

--- a/irc/src/connection.rs
+++ b/irc/src/connection.rs
@@ -2,6 +2,7 @@ use std::net::IpAddr;
 use std::path::PathBuf;
 use std::pin::Pin;
 
+#[cfg(feature = "tor")]
 use arti_client::DataStream as TorStream;
 use futures::{Sink, SinkExt, Stream, StreamExt};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
@@ -17,6 +18,7 @@ mod tls;
 
 pub enum IrcStream {
     Tcp(TcpStream),
+    #[cfg(feature = "tor")]
     Tor(TorStream),
 }
 
@@ -188,6 +190,7 @@ impl AsyncRead for IrcStream {
     ) -> std::task::Poll<std::io::Result<()>> {
         match self.get_mut() {
             IrcStream::Tcp(s) => Pin::new(s).poll_read(cx, buf),
+            #[cfg(feature = "tor")]
             IrcStream::Tor(s) => Pin::new(s).poll_read(cx, buf),
         }
     }
@@ -197,6 +200,7 @@ impl AsyncWrite for IrcStream {
     fn is_write_vectored(&self) -> bool {
         match self {
             IrcStream::Tcp(s) => s.is_write_vectored(),
+            #[cfg(feature = "tor")]
             IrcStream::Tor(s) => s.is_write_vectored(),
         }
     }
@@ -206,6 +210,7 @@ impl AsyncWrite for IrcStream {
     ) -> std::task::Poll<Result<(), std::io::Error>> {
         match self.get_mut() {
             IrcStream::Tcp(s) => Pin::new(s).poll_flush(cx),
+            #[cfg(feature = "tor")]
             IrcStream::Tor(s) => Pin::new(s).poll_flush(cx),
         }
     }
@@ -215,6 +220,7 @@ impl AsyncWrite for IrcStream {
     ) -> std::task::Poll<Result<(), std::io::Error>> {
         match self.get_mut() {
             IrcStream::Tcp(s) => Pin::new(s).poll_shutdown(cx),
+            #[cfg(feature = "tor")]
             IrcStream::Tor(s) => Pin::new(s).poll_shutdown(cx),
         }
     }
@@ -225,6 +231,7 @@ impl AsyncWrite for IrcStream {
     ) -> std::task::Poll<Result<usize, std::io::Error>> {
         match self.get_mut() {
             IrcStream::Tcp(s) => Pin::new(s).poll_write(cx, buf),
+            #[cfg(feature = "tor")]
             IrcStream::Tor(s) => Pin::new(s).poll_write(cx, buf),
         }
     }
@@ -235,6 +242,7 @@ impl AsyncWrite for IrcStream {
     ) -> std::task::Poll<Result<usize, std::io::Error>> {
         match self.get_mut() {
             IrcStream::Tcp(s) => Pin::new(s).poll_write_vectored(cx, bufs),
+            #[cfg(feature = "tor")]
             IrcStream::Tor(s) => Pin::new(s).poll_write_vectored(cx, bufs),
         }
     }

--- a/irc/src/connection/proxy.rs
+++ b/irc/src/connection/proxy.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "tor")]
 use arti_client::{TorClient, TorClientConfig};
 use async_http_proxy::{
     http_connect_tokio, http_connect_tokio_with_basic_auth,
@@ -22,6 +23,7 @@ pub enum Proxy {
         username: Option<String>,
         password: Option<String>,
     },
+    #[cfg(feature = "tor")]
     Tor,
 }
 
@@ -64,6 +66,7 @@ impl Proxy {
                 )
                 .await
             }
+            #[cfg(feature = "tor")]
             Proxy::Tor => {
                 connect_tor(target_server.to_string(), target_port).await
             }
@@ -128,6 +131,7 @@ pub async fn connect_socks5(
     Ok(IrcStream::Tcp(stream))
 }
 
+#[cfg(feature = "tor")]
 pub async fn connect_tor(
     target_server: String,
     target_port: u16,
@@ -148,6 +152,7 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error("socks5 error: {0}")]
     Socks5(#[from] fast_socks5::SocksError),
+    #[cfg(feature = "tor")]
     #[error("tor error: {0}")]
     Tor(#[from] arti_client::Error),
 }


### PR DESCRIPTION
After a few discussions on IRC we have agreed that the best approach forward is to move `tor` support to a optional feature. 
This way we also reduce the binary size by almost 20%.