### PR TITLE
initial scroll view page size of height / line_height

### DIFF
--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -1615,19 +1615,6 @@ pub enum Limit {
     Since(DateTime<Utc>),
 }
 
-impl Limit {
-    pub const DEFAULT_STEP: usize = 50;
-    pub const DEFAULT_COUNT: usize = 500;
-
-    pub fn top() -> Self {
-        Self::Top(Self::DEFAULT_COUNT)
-    }
-
-    pub fn bottom() -> Self {
-        Self::Bottom(Self::DEFAULT_COUNT)
-    }
-}
-
 pub fn is_action(text: &str) -> bool {
     if let Some(query) = ctcp::parse_query(text) {
         matches!(query.command, ctcp::Command::Action)

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -23,11 +23,11 @@ pub mod file_transfers;
 pub mod highlights;
 mod input_view;
 pub mod logs;
+mod message_view;
 pub mod query;
 mod scroll_view;
 pub mod server;
 pub mod user_context;
-mod message_view;
 
 #[derive(Clone, Debug)]
 pub enum Buffer {
@@ -456,64 +456,65 @@ impl Buffer {
         }
     }
 
-    pub fn scroll_to_start(&mut self) -> Task<Message> {
+    pub fn scroll_to_start(&mut self, config: &Config) -> Task<Message> {
         match self {
             Buffer::Empty | Buffer::FileTransfers(_) => Task::none(),
             Buffer::Channel(channel) => {
-                channel.scroll_view.scroll_to_start().map(|message| {
+                channel.scroll_view.scroll_to_start(config).map(|message| {
                     Message::Channel(channel::Message::ScrollView(message))
                 })
             }
             Buffer::Server(server) => {
-                server.scroll_view.scroll_to_start().map(|message| {
+                server.scroll_view.scroll_to_start(config).map(|message| {
                     Message::Server(server::Message::ScrollView(message))
                 })
             }
             Buffer::Query(query) => {
-                query.scroll_view.scroll_to_start().map(|message| {
+                query.scroll_view.scroll_to_start(config).map(|message| {
                     Message::Query(query::Message::ScrollView(message))
                 })
             }
             Buffer::Logs(log) => {
-                log.scroll_view.scroll_to_start().map(|message| {
+                log.scroll_view.scroll_to_start(config).map(|message| {
                     Message::Logs(logs::Message::ScrollView(message))
                 })
             }
-            Buffer::Highlights(highlights) => {
-                highlights.scroll_view.scroll_to_start().map(|message| {
+            Buffer::Highlights(highlights) => highlights
+                .scroll_view
+                .scroll_to_start(config)
+                .map(|message| {
                     Message::Highlights(highlights::Message::ScrollView(
                         message,
                     ))
-                })
-            }
+                }),
         }
     }
 
-    pub fn scroll_to_end(&mut self) -> Task<Message> {
+    pub fn scroll_to_end(&mut self, config: &Config) -> Task<Message> {
         match self {
             Buffer::Empty | Buffer::FileTransfers(_) => Task::none(),
             Buffer::Channel(channel) => {
-                channel.scroll_view.scroll_to_end().map(|message| {
+                channel.scroll_view.scroll_to_end(config).map(|message| {
                     Message::Channel(channel::Message::ScrollView(message))
                 })
             }
             Buffer::Server(server) => {
-                server.scroll_view.scroll_to_end().map(|message| {
+                server.scroll_view.scroll_to_end(config).map(|message| {
                     Message::Server(server::Message::ScrollView(message))
                 })
             }
             Buffer::Query(query) => {
-                query.scroll_view.scroll_to_end().map(|message| {
+                query.scroll_view.scroll_to_end(config).map(|message| {
                     Message::Query(query::Message::ScrollView(message))
                 })
             }
             Buffer::Logs(log) => {
-                log.scroll_view.scroll_to_end().map(|message| {
+                log.scroll_view.scroll_to_end(config).map(|message| {
                     Message::Logs(logs::Message::ScrollView(message))
                 })
             }
             Buffer::Highlights(highlights) => {
-                highlights.scroll_view.scroll_to_end().map(|message| {
+                highlights.scroll_view.scroll_to_end(config).map(|message| {
                     Message::Highlights(highlights::Message::ScrollView(
                         message,
                     ))

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -252,7 +252,7 @@ impl Channel {
                         let command = Task::batch(vec![
                             command,
                             self.scroll_view
-                                .scroll_to_end()
+                                .scroll_to_end(config)
                                 .map(Message::ScrollView),
                         ]);
 

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -199,7 +199,7 @@ impl Query {
                         let command = Task::batch(vec![
                             command,
                             self.scroll_view
-                                .scroll_to_end()
+                                .scroll_to_end(config)
                                 .map(Message::ScrollView),
                         ]);
 

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -231,7 +231,7 @@ impl Server {
                         Task::batch(vec![
                             command,
                             self.scroll_view
-                                .scroll_to_end()
+                                .scroll_to_end(config)
                                 .map(Message::ScrollView),
                         ]),
                         Some(Event::History(history_task)),

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -586,14 +586,15 @@ impl Dashboard {
                         let Focus { window, pane } = self.focus;
 
                         if let Some(state) = self.panes.get_mut(window, pane) {
-                            let mut task = state.buffer.scroll_to_end().map(
-                                move |message| {
+                            let mut task = state
+                                .buffer
+                                .scroll_to_end(config)
+                                .map(move |message| {
                                     Message::Pane(
                                         window,
                                         pane::Message::Buffer(pane, message),
                                     )
-                                },
-                            );
+                                });
 
                             if config.buffer.mark_as_read.on_scroll_to_bottom {
                                 task = task.chain(Task::done(Message::Pane(
@@ -611,9 +612,9 @@ impl Dashboard {
                                 .buffer
                                 .data()
                                 .and_then(history::Kind::from_buffer)
-                            {
-                                self.mark_as_read(kind, clients);
-                            }
+                        {
+                            self.mark_as_read(kind, clients);
+                        }
                     }
                 }
             }
@@ -807,13 +808,13 @@ impl Dashboard {
                             if config.buffer.mark_as_read.on_message_sent
                                 && let (Some(server), Some(target)) =
                                     (kind.server(), kind.target())
-                                {
-                                    clients.send_markread(
-                                        server,
-                                        target,
-                                        read_marker,
-                                    );
-                                }
+                            {
+                                clients.send_markread(
+                                    server,
+                                    target,
+                                    read_marker,
+                                );
+                            }
                         }
                     }
                 }
@@ -969,9 +970,9 @@ impl Dashboard {
                     if window == self.main_window()
                         && let Some(adjacent) =
                             self.panes.main.adjacent(pane, direction)
-                        {
-                            return self.focus_pane(window, adjacent);
-                        }
+                    {
+                        return self.focus_pane(window, adjacent);
+                    }
 
                     Task::none()
                 };
@@ -1013,13 +1014,13 @@ impl Dashboard {
                                 state.buffer.upstream(),
                                 all_buffers,
                                 &open_buffers,
-                            ) {
-                                state.buffer = Buffer::from(
-                                    data::Buffer::Upstream(buffer),
-                                );
-                                self.last_changed = Some(Instant::now());
-                                return (self.focus_pane(window, pane), None);
-                            }
+                            )
+                        {
+                            state.buffer =
+                                Buffer::from(data::Buffer::Upstream(buffer));
+                            self.last_changed = Some(Instant::now());
+                            return (self.focus_pane(window, pane), None);
+                        }
                     }
                     CyclePreviousBuffer => {
                         let all_buffers = all_buffers(clients, &self.history);
@@ -1031,25 +1032,25 @@ impl Dashboard {
                                 state.buffer.upstream(),
                                 all_buffers,
                                 &open_buffers,
-                            ) {
-                                state.buffer = Buffer::from(
-                                    data::Buffer::Upstream(buffer),
-                                );
-                                self.last_changed = Some(Instant::now());
-                                return (self.focus_pane(window, pane), None);
-                            }
+                            )
+                        {
+                            state.buffer =
+                                Buffer::from(data::Buffer::Upstream(buffer));
+                            self.last_changed = Some(Instant::now());
+                            return (self.focus_pane(window, pane), None);
+                        }
                     }
                     LeaveBuffer => {
                         if let Some((_, _, state)) = self.get_focused_mut()
                             && let Some(buffer) =
                                 state.buffer.upstream().cloned()
-                            {
-                                return self.leave_buffer(
-                                    clients,
-                                    buffer,
-                                    config.buffer.mark_as_read.on_buffer_close,
-                                );
-                            }
+                        {
+                            return self.leave_buffer(
+                                clients,
+                                buffer,
+                                config.buffer.mark_as_read.on_buffer_close,
+                            );
+                        }
                     }
                     ToggleNicklist => {
                         if let Some((_, _, pane)) = self.get_focused_mut() {
@@ -1182,17 +1183,16 @@ impl Dashboard {
                     ScrollToTop => {
                         if config.buffer.chathistory.infinite_scroll
                             && let Some((_, _, state)) = self.get_focused()
-                                && let Some(buffer) = state.buffer.data() {
-                                    self.request_older_chathistory(
-                                        clients, &buffer,
-                                    );
-                                }
+                            && let Some(buffer) = state.buffer.data()
+                        {
+                            self.request_older_chathistory(clients, &buffer);
+                        }
 
                         return (
                             self.get_focused_mut().map_or_else(
                                 Task::none,
                                 |(window, id, pane)| {
-                                    pane.buffer.scroll_to_start().map(
+                                    pane.buffer.scroll_to_start(config).map(
                                         move |message| {
                                             Message::Pane(
                                                 window,
@@ -1213,7 +1213,7 @@ impl Dashboard {
                             |(window, pane, state)| {
                                 let mut task = state
                                     .buffer
-                                    .scroll_to_end()
+                                    .scroll_to_end(config)
                                     .map(move |message| {
                                         Message::Pane(
                                             window,
@@ -1252,13 +1252,13 @@ impl Dashboard {
                                 state.buffer.upstream(),
                                 all_buffers,
                                 &open_buffers,
-                            ) {
-                                state.buffer = Buffer::from(
-                                    data::Buffer::Upstream(buffer),
-                                );
-                                self.last_changed = Some(Instant::now());
-                                return (self.focus_pane(window, pane), None);
-                            }
+                            )
+                        {
+                            state.buffer =
+                                Buffer::from(data::Buffer::Upstream(buffer));
+                            self.last_changed = Some(Instant::now());
+                            return (self.focus_pane(window, pane), None);
+                        }
                     }
                     CyclePreviousUnreadBuffer => {
                         let all_buffers =
@@ -1271,13 +1271,13 @@ impl Dashboard {
                                 state.buffer.upstream(),
                                 all_buffers,
                                 &open_buffers,
-                            ) {
-                                state.buffer = Buffer::from(
-                                    data::Buffer::Upstream(buffer),
-                                );
-                                self.last_changed = Some(Instant::now());
-                                return (self.focus_pane(window, pane), None);
-                            }
+                            )
+                        {
+                            state.buffer =
+                                Buffer::from(data::Buffer::Upstream(buffer));
+                            self.last_changed = Some(Instant::now());
+                            return (self.focus_pane(window, pane), None);
+                        }
                     }
                     MarkAsRead => {
                         if let Some((_, _, pane)) = self.get_focused_mut()
@@ -1285,9 +1285,9 @@ impl Dashboard {
                                 .buffer
                                 .data()
                                 .and_then(history::Kind::from_buffer)
-                            {
-                                self.mark_as_read(kind, clients);
-                            }
+                        {
+                            self.mark_as_read(kind, clients);
+                        }
                     }
                 }
             }
@@ -1297,35 +1297,35 @@ impl Dashboard {
             Message::SendFileSelected(server, to, path) => {
                 if let Some(server_handle) = clients.get_server_handle(&server)
                     && let Some(path) = path
-                        && let Ok(query) = target::Query::parse(
-                            to.nickname().as_ref(),
-                            clients.get_chantypes(&server),
-                            clients.get_statusmsg(&server),
-                            clients.get_casemapping(&server),
-                        )
-                            && let Some(event) = self.file_transfers.send(
-                                file_transfer::SendRequest {
-                                    to,
-                                    path,
-                                    server: server.clone(),
-                                    server_handle: server_handle.clone(),
-                                },
-                                config,
-                            ) {
-                                return (
-                                    self.handle_file_transfer_event(
-                                        &server, &query, event,
-                                    ),
-                                    None,
-                                );
-                            }
+                    && let Ok(query) = target::Query::parse(
+                        to.nickname().as_ref(),
+                        clients.get_chantypes(&server),
+                        clients.get_statusmsg(&server),
+                        clients.get_casemapping(&server),
+                    )
+                    && let Some(event) = self.file_transfers.send(
+                        file_transfer::SendRequest {
+                            to,
+                            path,
+                            server: server.clone(),
+                            server_handle: server_handle.clone(),
+                        },
+                        config,
+                    )
+                {
+                    return (
+                        self.handle_file_transfer_event(&server, &query, event),
+                        None,
+                    );
+                }
             }
             Message::CloseContextMenu(window, any_closed) => {
                 if !any_closed {
                     if let Some((_, _, state)) = self.get_focused_mut()
-                        && state.buffer.close_picker() {
-                            return (Task::none(), None);
-                        }
+                        && state.buffer.close_picker()
+                    {
+                        return (Task::none(), None);
+                    }
 
                     if self.is_pane_maximized() && window == self.main_window()
                     {
@@ -1510,9 +1510,10 @@ impl Dashboard {
             return Element::new(content)
                 .map(move |message| Message::Pane(window, message));
         } else if let Some(editor) = self.theme_editor.as_ref()
-            && editor.window == window {
-                return editor.view(theme).map(Message::ThemeEditor);
-            }
+            && editor.window == window
+        {
+            return editor.view(theme).map(Message::ThemeEditor);
+        }
 
         column![].into()
     }
@@ -1979,37 +1980,38 @@ impl Dashboard {
         let server = upstream.server();
 
         if clients.get_server_supports_chathistory(server)
-            && let Some(target) = upstream.target() {
-                if clients.get_chathistory_exhausted(server, &target) {
-                    return;
-                }
-
-                let message_reference_types = clients
-                    .get_server_chathistory_message_reference_types(server);
-
-                let first_can_reference = self.get_oldest_message_reference(
-                    server,
-                    target.clone(),
-                    &message_reference_types,
-                );
-
-                let subcommand =
-                    if matches!(first_can_reference, MessageReference::None) {
-                        ChatHistorySubcommand::Latest(
-                            target,
-                            first_can_reference,
-                            clients.get_server_chathistory_limit(server),
-                        )
-                    } else {
-                        ChatHistorySubcommand::Before(
-                            target,
-                            first_can_reference,
-                            clients.get_server_chathistory_limit(server),
-                        )
-                    };
-
-                clients.send_chathistory_request(server, subcommand);
+            && let Some(target) = upstream.target()
+        {
+            if clients.get_chathistory_exhausted(server, &target) {
+                return;
             }
+
+            let message_reference_types =
+                clients.get_server_chathistory_message_reference_types(server);
+
+            let first_can_reference = self.get_oldest_message_reference(
+                server,
+                target.clone(),
+                &message_reference_types,
+            );
+
+            let subcommand =
+                if matches!(first_can_reference, MessageReference::None) {
+                    ChatHistorySubcommand::Latest(
+                        target,
+                        first_can_reference,
+                        clients.get_server_chathistory_limit(server),
+                    )
+                } else {
+                    ChatHistorySubcommand::Before(
+                        target,
+                        first_can_reference,
+                        clients.get_server_chathistory_limit(server),
+                    )
+                };
+
+            clients.send_chathistory_request(server, subcommand);
+        }
     }
 
     pub fn broadcast(
@@ -2298,13 +2300,10 @@ impl Dashboard {
             .collect();
 
         if let Some((pane, _)) = self.panes.main.close(pane)
-            && let Some(buffer) = pane.buffer.data() {
-                return self.open_buffer(
-                    buffer,
-                    BufferAction::NewWindow,
-                    config,
-                );
-            }
+            && let Some(buffer) = pane.buffer.data()
+        {
+            return self.open_buffer(buffer, BufferAction::NewWindow, config);
+        }
 
         Task::none()
     }
@@ -2393,16 +2392,17 @@ impl Dashboard {
         );
 
         if let Some(last_changed) = self.last_changed
-            && now.duration_since(last_changed) >= SAVE_AFTER {
-                let dashboard = data::Dashboard::from(&*self);
+            && now.duration_since(last_changed) >= SAVE_AFTER
+        {
+            let dashboard = data::Dashboard::from(&*self);
 
-                self.last_changed = None;
+            self.last_changed = None;
 
-                return Task::batch(vec![
-                    Task::perform(dashboard.save(), Message::DashboardSaved),
-                    history,
-                ]);
-            }
+            return Task::batch(vec![
+                Task::perform(dashboard.save(), Message::DashboardSaved),
+                history,
+            ]);
+        }
 
         history
     }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -2,6 +2,8 @@
 use data::appearance::theme::FontStyle;
 use iced::advanced::text;
 
+use crate::{Theme, font};
+
 pub use self::anchored_overlay::anchored_overlay;
 pub use self::color_picker::color_picker;
 pub use self::combo_box::combo_box;
@@ -13,11 +15,11 @@ pub use self::key_press::key_press;
 pub use self::message_content::message_content;
 pub use self::modal::modal;
 pub use self::notify_visibility::notify_visibility;
+pub use self::on_resize::on_resize;
 pub use self::selectable_rich_text::selectable_rich_text;
 pub use self::selectable_text::selectable_text;
 pub use self::shortcut::shortcut;
 pub use self::tooltip::tooltip;
-use crate::{Theme, font};
 
 pub mod anchored_overlay;
 pub mod collection;
@@ -32,6 +34,7 @@ pub mod key_press;
 pub mod message_content;
 pub mod modal;
 pub mod notify_visibility;
+pub mod on_resize;
 pub mod pick_list;
 pub mod selectable_rich_text;
 pub mod selectable_text;

--- a/src/widget/on_resize.rs
+++ b/src/widget/on_resize.rs
@@ -1,0 +1,45 @@
+use iced::advanced::widget::Tree;
+use iced::advanced::{Clipboard, Layout, Shell};
+use iced::{Size, mouse};
+
+use super::{Element, Renderer, decorate};
+
+pub fn on_resize<'a, Message>(
+    base: impl Into<Element<'a, Message>>,
+    on_resize: impl Fn(Size) -> Message + 'a,
+) -> Element<'a, Message>
+where
+    Message: 'a,
+{
+    #[derive(Default)]
+    struct State {
+        last_size: Option<Size>,
+    }
+
+    decorate(base)
+        .update(
+            move |state: &mut State,
+                  inner: &mut Element<'a, Message>,
+                  tree: &mut Tree,
+                  event: &iced::Event,
+                  layout: Layout<'_>,
+                  cursor: mouse::Cursor,
+                  renderer: &Renderer,
+                  clipboard: &mut dyn Clipboard,
+                  shell: &mut Shell<'_, Message>,
+                  viewport: &iced::Rectangle| {
+                let new_size = viewport.size();
+
+                if state.last_size.is_none_or(|size| size != new_size) {
+                    state.last_size = Some(new_size);
+                    shell.publish(on_resize(new_size));
+                }
+
+                inner.as_widget_mut().update(
+                    tree, event, layout, cursor, renderer, clipboard, shell,
+                    viewport,
+                );
+            },
+        )
+        .into()
+}


### PR DESCRIPTION
Instead of always loading 500+ messages, we now initially only load however many messages fit on the y axis and then lazily grow the scrollable from there.

Also fixes a bug where going the start of message history and then scrolling down, it was loading all messages vs anchoring to top + step count (lazy loading).

This should massively improve performance by reducing number of messages being loaded in view & layout & text caching by `open_buffers * (500 - (buffer_height  / line_height))` so say you have 2 side-by-side buffers open with a window height of ~768px and default line height of ~`(1.3 * 13)=16.9` we'd reduce the number of messages impacting view from `500 * 2 = 1000` to `2 * (500 - (768 / 16.9)) = 909` 909 messages! Each buffer will only have to load 45 messages in view vs 500 each. This should massively reduce CPU time spent on text caching / layout. 

Now users really only incur increasing cost when scrolling up quite a ways into the history, which is something that shouldn't happen often and typically only would happen one buffer at a time.

Edit: A picture speaks a thousand words. This shows me profiling this branch vs main w/ 4 buffers open in _debug_ mode:

| fix | before |
| - | - |
| <img width="800" height="629" alt="image" src="https://github.com/user-attachments/assets/a3e3ba14-cc0a-4175-8cf0-af948901596a" />| <img width="800" height="629" alt="image" src="https://github.com/user-attachments/assets/39e91190-2950-4a28-b387-1abbf1736f9a" /> |

