### PR TITLE
Case-Insensitive Sort in Nick List

### DIFF
--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -151,8 +151,11 @@ impl From<Nick> for User {
 }
 
 impl User {
-    fn key(&self) -> (Reverse<AccessLevel>, &str) {
-        (Reverse(self.highest_access_level()), self.nickname.as_ref())
+    fn key(&self) -> (Reverse<AccessLevel>, NickRef) {
+        (
+            Reverse(self.highest_access_level()),
+            self.nickname.as_nickref(),
+        )
     }
 
     pub fn seed(&self) -> &str {


### PR DESCRIPTION
Use `NickRef` for `User::key` so we get case-insensitive sorting in nick lists.