### PR TITLE
Serde Struct Defaults

### DIFF
--- a/data/src/appearance/theme.rs
+++ b/data/src/appearance/theme.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::sync::LazyLock;
 
 use base64::Engine;
 use iced_core::Color;
@@ -13,6 +14,10 @@ use tokio::fs;
 const DEFAULT_THEME_NAME: &str = "Ferra";
 const DEFAULT_THEME_CONTENT: &str =
     include_str!("../../../assets/themes/ferra.toml");
+
+static DEFAULT_STYLES: LazyLock<Styles> = LazyLock::new(|| {
+    toml::from_str(DEFAULT_THEME_CONTENT).expect("parse default theme")
+});
 
 #[derive(Debug, Clone)]
 pub struct Theme {
@@ -37,6 +42,9 @@ impl Theme {
 
 // IMPORTANT: Make sure any new components are added to the theme editor
 // and `binary` representation
+// This struct cannot have #[serde(default)] attribute since it uses
+// deserialization in its Default implementation.  Its fields should
+// each be given the #[serde(default)] attribute instead.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct Styles {
     #[serde(default)]
@@ -47,6 +55,12 @@ pub struct Styles {
     pub buffer: Buffer,
     #[serde(default)]
     pub buttons: Buttons,
+}
+
+impl Default for Styles {
+    fn default() -> Self {
+        *DEFAULT_STYLES
+    }
 }
 
 impl Styles {
@@ -83,129 +97,141 @@ pub enum Error {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
+#[serde(default)]
 pub struct Buttons {
-    #[serde(default)]
     pub primary: Button,
-    #[serde(default)]
     pub secondary: Button,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(default)]
 pub struct Button {
-    #[serde(default = "default_transparent", with = "color_serde")]
+    #[serde(with = "color_serde")]
     pub background: Color,
-    #[serde(default = "default_transparent", with = "color_serde")]
+    #[serde(with = "color_serde")]
     pub background_hover: Color,
-    #[serde(default = "default_transparent", with = "color_serde")]
+    #[serde(with = "color_serde")]
     pub background_selected: Color,
-    #[serde(default = "default_transparent", with = "color_serde")]
+    #[serde(with = "color_serde")]
     pub background_selected_hover: Color,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
+impl Default for Button {
+    fn default() -> Self {
+        Self {
+            background: Color::TRANSPARENT,
+            background_hover: Color::TRANSPARENT,
+            background_selected: Color::TRANSPARENT,
+            background_selected_hover: Color::TRANSPARENT,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(default)]
 pub struct General {
-    #[serde(default = "default_transparent", with = "color_serde")]
+    #[serde(with = "color_serde")]
     pub background: Color,
-    #[serde(default = "default_transparent", with = "color_serde")]
+    #[serde(with = "color_serde")]
     pub border: Color,
-    #[serde(default = "default_transparent", with = "color_serde")]
+    #[serde(with = "color_serde")]
     pub horizontal_rule: Color,
-    #[serde(default, with = "color_serde_maybe")]
+    #[serde(with = "color_serde_maybe")]
     pub scrollbar: Option<Color>,
-    #[serde(default = "default_transparent", with = "color_serde")]
+    #[serde(with = "color_serde")]
     pub unread_indicator: Color,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
+impl Default for General {
+    fn default() -> Self {
+        Self {
+            background: Color::TRANSPARENT,
+            border: Color::TRANSPARENT,
+            horizontal_rule: Color::TRANSPARENT,
+            scrollbar: None,
+            unread_indicator: Color::TRANSPARENT,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(default)]
 pub struct Buffer {
-    #[serde(default)]
     pub action: TextStyle,
-    #[serde(default = "default_transparent", with = "color_serde")]
+    #[serde(with = "color_serde")]
     pub background: Color,
-    #[serde(default = "default_transparent", with = "color_serde")]
+    #[serde(with = "color_serde")]
     pub background_text_input: Color,
-    #[serde(default = "default_transparent", with = "color_serde")]
+    #[serde(with = "color_serde")]
     pub background_title_bar: Color,
-    #[serde(default = "default_transparent", with = "color_serde")]
+    #[serde(with = "color_serde")]
     pub border: Color,
-    #[serde(default = "default_transparent", with = "color_serde")]
+    #[serde(with = "color_serde")]
     pub border_selected: Color,
-    #[serde(default)]
     pub code: TextStyle,
-    #[serde(default = "default_transparent", with = "color_serde")]
+    #[serde(with = "color_serde")]
     pub highlight: Color,
-    #[serde(default)]
     pub nickname: TextStyle,
-    #[serde(default = "default_transparent", with = "color_serde")]
+    #[serde(with = "color_serde")]
     pub selection: Color,
-    #[serde(default)]
     pub server_messages: ServerMessages,
-    #[serde(default)]
     pub timestamp: TextStyle,
-    #[serde(default)]
     pub topic: TextStyle,
-    #[serde(default)]
     pub url: TextStyle,
 }
 
+impl Default for Buffer {
+    fn default() -> Self {
+        Self {
+            action: TextStyle::default(),
+            background: Color::TRANSPARENT,
+            background_text_input: Color::TRANSPARENT,
+            background_title_bar: Color::TRANSPARENT,
+            border: Color::TRANSPARENT,
+            border_selected: Color::TRANSPARENT,
+            code: TextStyle::default(),
+            highlight: Color::TRANSPARENT,
+            nickname: TextStyle::default(),
+            selection: Color::TRANSPARENT,
+            server_messages: ServerMessages::default(),
+            timestamp: TextStyle::default(),
+            topic: TextStyle::default(),
+            url: TextStyle::default(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
+#[serde(default)]
 pub struct ServerMessages {
-    #[serde(default)]
     pub join: OptionalTextStyle,
-    #[serde(default)]
     pub part: OptionalTextStyle,
-    #[serde(default)]
     pub quit: OptionalTextStyle,
-    #[serde(default)]
     pub reply_topic: OptionalTextStyle,
-    #[serde(default)]
     pub change_host: OptionalTextStyle,
-    #[serde(default)]
     pub change_mode: OptionalTextStyle,
-    #[serde(default)]
     pub change_nick: OptionalTextStyle,
-    #[serde(default)]
     pub monitored_online: OptionalTextStyle,
-    #[serde(default)]
     pub monitored_offline: OptionalTextStyle,
-    #[serde(default)]
     pub standard_reply_fail: OptionalTextStyle,
-    #[serde(default)]
     pub standard_reply_warn: OptionalTextStyle,
-    #[serde(default)]
     pub standard_reply_note: OptionalTextStyle,
-    #[serde(default)]
     pub wallops: OptionalTextStyle,
-    #[serde(default)]
     pub default: TextStyle,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
+#[serde(default)]
 pub struct Text {
-    #[serde(default)]
     pub primary: TextStyle,
-    #[serde(default)]
     pub secondary: TextStyle,
-    #[serde(default)]
     pub tertiary: TextStyle,
-    #[serde(default)]
     pub success: TextStyle,
-    #[serde(default)]
     pub error: TextStyle,
-    #[serde(default)]
     pub warning: OptionalTextStyle,
-    #[serde(default)]
     pub info: OptionalTextStyle,
-    #[serde(default)]
     pub debug: OptionalTextStyle,
-    #[serde(default)]
     pub trace: OptionalTextStyle,
-}
-
-impl Default for Styles {
-    fn default() -> Self {
-        toml::from_str(DEFAULT_THEME_CONTENT).expect("parse default theme")
-    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -494,10 +520,6 @@ pub fn alpha_color(color: Color, alpha: f32) -> Color {
     Color { a: alpha, ..color }
 }
 
-fn default_transparent() -> Color {
-    Color::TRANSPARENT
-}
-
 fn to_rgb(color: Color) -> Rgb {
     Rgb {
         red: color.r,
@@ -545,7 +567,6 @@ mod color_serde {
 }
 
 mod color_serde_maybe {
-
     use iced_core::Color;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -3,7 +3,6 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 
 use crate::config::buffer::NicknameClickAction;
-use crate::serde::default_bool_true;
 use crate::target::{self, Target};
 use crate::{Server, channel, config, message};
 
@@ -148,12 +147,10 @@ impl From<config::Buffer> for Settings {
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
 pub struct TextInput {
-    #[serde(default)]
     pub visibility: TextInputVisibility,
-    #[serde(default)]
     pub auto_format: AutoFormat,
-    #[serde(default)]
     pub autocomplete: Autocomplete,
 }
 
@@ -174,12 +171,10 @@ pub enum SortDirection {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct Autocomplete {
-    #[serde(default)]
     pub order_by: OrderBy,
-    #[serde(default)]
     pub sort_direction: SortDirection,
-    #[serde(default = "default_completion_suffixes")]
     pub completion_suffixes: [String; 2],
 }
 
@@ -188,7 +183,7 @@ impl Default for Autocomplete {
         Self {
             order_by: OrderBy::default(),
             sort_direction: SortDirection::default(),
-            completion_suffixes: default_completion_suffixes(),
+            completion_suffixes: [": ".to_string(), " ".to_string()],
         }
     }
 }
@@ -211,50 +206,44 @@ pub enum AutoFormat {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct Timestamp {
-    #[serde(default = "default_timestamp")]
     pub format: String,
-    #[serde(default)]
     pub brackets: Brackets,
 }
 
 impl Default for Timestamp {
     fn default() -> Self {
         Self {
-            format: default_timestamp(),
+            format: "%R".to_string(),
             brackets: Brackets::default(),
         }
     }
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct DateSeparators {
-    #[serde(default = "default_date_separators")]
     pub format: String,
-    #[serde(default = "default_bool_true")]
     pub show: bool,
 }
 
 impl Default for DateSeparators {
     fn default() -> Self {
         Self {
-            format: default_date_separators(),
+            format: "%A, %B %-d".to_string(),
             show: true,
         }
     }
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct Nickname {
-    #[serde(default)]
     pub color: Color,
-    #[serde(default)]
     pub brackets: Brackets,
-    #[serde(default)]
     pub alignment: Alignment,
-    #[serde(default = "default_bool_true")]
     pub show_access_levels: bool,
-    #[serde(default)]
     pub click: NicknameClickAction,
 }
 
@@ -264,15 +253,15 @@ impl Default for Nickname {
             color: Color::default(),
             brackets: Brackets::default(),
             alignment: Alignment::default(),
-            show_access_levels: default_bool_true(),
+            show_access_levels: true,
             click: NicknameClickAction::default(),
         }
     }
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
 pub struct StatusMessagePrefix {
-    #[serde(default)]
     pub brackets: Brackets,
 }
 
@@ -355,16 +344,4 @@ impl From<SkinTone> for emojis::SkinTone {
             SkinTone::Dark => emojis::SkinTone::Dark,
         }
     }
-}
-
-fn default_timestamp() -> String {
-    "%R".to_string()
-}
-
-fn default_date_separators() -> String {
-    "%A, %B %-d".to_string()
-}
-
-fn default_completion_suffixes() -> [String; 2] {
-    [": ".to_string(), " ".to_string()]
 }

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -89,39 +89,45 @@ impl From<ScaleFactor> for f64 {
     }
 }
 
-#[derive(Debug, Copy, Clone, Deserialize, Default)]
+#[derive(Debug, Copy, Clone, Deserialize)]
+#[serde(default)]
 pub struct Scrollbar {
     /// Width of the scrollbar.
-    #[serde(default = "default_scrollbar_width")]
     pub width: u32,
     /// Width of the scrollbar scroller.
-    #[serde(default = "default_scrollbar_scroller_width")]
     pub scroller_width: u32,
 }
 
-fn default_scrollbar_width() -> u32 {
-    5
+impl Default for Scrollbar {
+    fn default() -> Self {
+        Self {
+            width: 5,
+            scroller_width: 5,
+        }
+    }
 }
 
-fn default_scrollbar_scroller_width() -> u32 {
-    5
-}
-
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct Font {
     pub family: Option<String>,
     pub size: Option<u8>,
-    #[serde(
-        default = "default_font_weight",
-        deserialize_with = "deserialize_font_weight_from_string"
-    )]
+    #[serde(deserialize_with = "deserialize_font_weight_from_string")]
     pub weight: font::Weight,
-    #[serde(
-        default,
-        deserialize_with = "deserialize_optional_font_weight_from_string"
-    )]
+    #[serde(deserialize_with = "deserialize_optional_font_weight_from_string")]
     #[serde(alias = "bold-weight")] // For backwards compatibility
     pub bold_weight: Option<font::Weight>,
+}
+
+impl Default for Font {
+    fn default() -> Self {
+        Self {
+            family: None,
+            size: None,
+            weight: font::Weight::Normal,
+            bold_weight: None,
+        }
+    }
 }
 
 fn deserialize_font_weight_from_string<'de, D>(
@@ -165,10 +171,6 @@ where
     D: Deserializer<'de>,
 {
     Ok(Some(deserialize_font_weight_from_string(deserializer)?))
-}
-
-fn default_font_weight() -> font::Weight {
-    font::Weight::Normal
 }
 
 impl Config {
@@ -235,39 +237,49 @@ impl Config {
         }
 
         #[derive(Deserialize)]
+        #[serde(default)]
         pub struct Configuration {
-            #[serde(default)]
             pub theme: ThemeKeys,
             pub servers: IndexMap<ServerName, Server>,
             pub proxy: Option<Proxy>,
-            #[serde(default)]
             pub font: Font,
-            #[serde(default)]
             pub scale_factor: ScaleFactor,
-            #[serde(default)]
             pub buffer: Buffer,
-            #[serde(default)]
             pub pane: Pane,
-            #[serde(default)]
             pub sidebar: Sidebar,
-            #[serde(default)]
             pub keyboard: Keyboard,
-            #[serde(default)]
             pub notifications: Notifications,
-            #[serde(default)]
             pub file_transfer: FileTransfer,
-            #[serde(default = "default_tooltip")]
             pub tooltips: bool,
-            #[serde(default)]
             pub preview: Preview,
-            #[serde(default)]
             pub highlights: Highlights,
-            #[serde(default)]
             pub actions: Actions,
-            #[serde(default)]
             pub ctcp: Ctcp,
-            #[serde(default)]
             pub logs: Logs,
+        }
+
+        impl Default for Configuration {
+            fn default() -> Self {
+                Self {
+                    theme: ThemeKeys::default(),
+                    servers: IndexMap::<ServerName, Server>::default(),
+                    proxy: None,
+                    font: Font::default(),
+                    scale_factor: ScaleFactor::default(),
+                    buffer: Buffer::default(),
+                    pane: Pane::default(),
+                    sidebar: Sidebar::default(),
+                    keyboard: Keyboard::default(),
+                    notifications: Notifications::default(),
+                    file_transfer: FileTransfer::default(),
+                    tooltips: true,
+                    preview: Preview::default(),
+                    highlights: Highlights::default(),
+                    actions: Actions::default(),
+                    ctcp: Ctcp::default(),
+                    logs: Logs::default(),
+                }
+            }
         }
 
         let path = Self::path();
@@ -412,8 +424,8 @@ impl Config {
 
     pub fn load_logs() -> Option<Logs> {
         #[derive(Default, Deserialize)]
+        #[serde(default)]
         pub struct Configuration {
-            #[serde(default)]
             pub logs: Logs,
         }
 
@@ -462,10 +474,6 @@ pub fn random_nickname_with_seed<R: Rng>(rng: &mut R) -> String {
 /// Has YAML configuration file.
 fn has_yaml_config() -> Result<bool, Error> {
     Ok(config_dir().join("config.yaml").try_exists()?)
-}
-
-fn default_tooltip() -> bool {
-    true
 }
 
 #[derive(Debug, Error, Clone)]

--- a/data/src/config/actions.rs
+++ b/data/src/config/actions.rs
@@ -3,33 +3,26 @@ use serde::Deserialize;
 use crate::dashboard::{BufferAction, BufferFocusedAction};
 
 #[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default)]
 pub struct Actions {
-    #[serde(default)]
     pub sidebar: Sidebar,
-    #[serde(default)]
     pub buffer: Buffer,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default)]
 pub struct Buffer {
-    #[serde(default)]
     pub click_channel_name: BufferAction,
-    #[serde(default)]
     pub click_highlight: BufferAction,
-    #[serde(default)]
     pub click_username: BufferAction,
-    #[serde(default)]
     pub local: BufferAction,
-    #[serde(default)]
     pub message_channel: BufferAction,
-    #[serde(default)]
     pub message_user: BufferAction,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default)]
 pub struct Sidebar {
-    #[serde(default)]
     pub buffer: BufferAction,
-    #[serde(default)]
     pub focused_buffer: Option<BufferFocusedAction>,
 }

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -3,7 +3,6 @@ use serde::Deserialize;
 
 pub use self::away::Away;
 pub use self::channel::Channel;
-use crate::serde::default_bool_true;
 
 pub mod away;
 pub mod channel;
@@ -15,34 +14,21 @@ use crate::buffer::{
 use crate::message::source;
 
 #[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default)]
 pub struct Buffer {
-    #[serde(default)]
     pub away: Away,
-    #[serde(default)]
     pub timestamp: Timestamp,
-    #[serde(default)]
     pub nickname: Nickname,
-    #[serde(default)]
     pub text_input: TextInput,
-    #[serde(default)]
     pub channel: Channel,
-    #[serde(default)]
     pub server_messages: ServerMessages,
-    #[serde(default)]
     pub internal_messages: InternalMessages,
-    #[serde(default)]
     pub status_message_prefix: StatusMessagePrefix,
-    #[serde(default)]
     pub chathistory: ChatHistory,
-    #[serde(default)]
     pub date_separators: DateSeparators,
-    #[serde(default)]
     pub commands: Commands,
-    #[serde(default)]
     pub emojis: Emojis,
-    #[serde(default)]
     pub mark_as_read: MarkAsRead,
-    #[serde(default)]
     pub url: Url,
 }
 
@@ -55,25 +41,21 @@ pub enum NicknameClickAction {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct Emojis {
-    #[serde(default = "default_bool_true")]
     pub show_picker: bool,
-    #[serde(default)]
     pub skin_tone: SkinTone,
-    #[serde(default = "default_bool_true")]
     pub auto_replace: bool,
-    #[serde(default = "default_characters_to_trigger_picker")]
     pub characters_to_trigger_picker: usize,
 }
 
 impl Default for Emojis {
     fn default() -> Self {
         Self {
-            show_picker: default_bool_true(),
+            show_picker: true,
             skin_tone: SkinTone::default(),
-            auto_replace: default_bool_true(),
-            characters_to_trigger_picker: default_characters_to_trigger_picker(
-            ),
+            auto_replace: true,
+            characters_to_trigger_picker: 2,
         }
     }
 }
@@ -85,69 +67,54 @@ pub struct Url {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct MarkAsRead {
-    #[serde(default)]
     pub on_application_exit: bool,
-    #[serde(default = "default_bool_true")]
     pub on_buffer_close: bool,
-    #[serde(default = "default_bool_true")]
     pub on_scroll_to_bottom: bool,
-    #[serde(default = "default_bool_true")]
     pub on_message_sent: bool,
 }
 
 impl Default for MarkAsRead {
     fn default() -> Self {
         Self {
-            on_application_exit: bool::default(),
-            on_buffer_close: default_bool_true(),
-            on_scroll_to_bottom: default_bool_true(),
-            on_message_sent: default_bool_true(),
+            on_application_exit: false,
+            on_buffer_close: true,
+            on_scroll_to_bottom: true,
+            on_message_sent: true,
         }
     }
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct Commands {
-    #[serde(default = "default_bool_true")]
     pub show_description: bool,
 }
 
 impl Default for Commands {
     fn default() -> Self {
         Self {
-            show_description: default_bool_true(),
+            show_description: true,
         }
     }
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
 pub struct ServerMessages {
-    #[serde(default)]
     pub topic: ServerMessage,
-    #[serde(default)]
     pub join: ServerMessage,
-    #[serde(default)]
     pub part: ServerMessage,
-    #[serde(default)]
     pub quit: ServerMessage,
-    #[serde(default)]
     pub change_host: ServerMessage,
-    #[serde(default)]
     pub change_mode: ServerMessage,
-    #[serde(default)]
     pub change_nick: ServerMessage,
-    #[serde(default)]
     pub monitored_online: ServerMessage,
-    #[serde(default)]
     pub monitored_offline: ServerMessage,
-    #[serde(default)]
     pub standard_reply_fail: ServerMessage,
-    #[serde(default)]
     pub standard_reply_warn: ServerMessage,
-    #[serde(default)]
     pub standard_reply_note: ServerMessage,
-    #[serde(default)]
     pub wallops: ServerMessage,
 }
 
@@ -182,16 +149,12 @@ impl ServerMessages {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct ServerMessage {
-    #[serde(default = "default_bool_true")]
     pub enabled: bool,
-    #[serde(default)]
     pub smart: Option<i64>,
-    #[serde(default)]
     pub username_format: UsernameFormat,
-    #[serde(default)]
     pub exclude: Vec<String>,
-    #[serde(default)]
     pub include: Vec<String>,
 }
 
@@ -199,7 +162,7 @@ impl Default for ServerMessage {
     fn default() -> Self {
         Self {
             enabled: true,
-            smart: Option::default(),
+            smart: None,
             username_format: UsernameFormat::default(),
             exclude: Vec::default(),
             include: Vec::default(),
@@ -231,10 +194,9 @@ impl ServerMessage {
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
 pub struct InternalMessages {
-    #[serde(default)]
     pub success: InternalMessage,
-    #[serde(default)]
     pub error: InternalMessage,
 }
 
@@ -248,10 +210,9 @@ impl InternalMessages {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct InternalMessage {
-    #[serde(default = "default_bool_true")]
     pub enabled: bool,
-    #[serde(default)]
     pub smart: Option<i64>,
 }
 
@@ -259,7 +220,7 @@ impl Default for InternalMessage {
     fn default() -> Self {
         Self {
             enabled: true,
-            smart: Option::default(),
+            smart: None,
         }
     }
 }
@@ -277,8 +238,8 @@ pub enum LevelFilter {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct ChatHistory {
-    #[serde(default = "default_bool_true")]
     pub infinite_scroll: bool,
 }
 
@@ -318,8 +279,4 @@ impl Buffer {
             )
         ))
     }
-}
-
-fn default_characters_to_trigger_picker() -> usize {
-    2
 }

--- a/data/src/config/buffer/away.rs
+++ b/data/src/config/buffer/away.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Deserializer};
 
 #[derive(Debug, Clone, Copy, Default, Deserialize)]
+#[serde(default)]
 pub struct Away {
-    #[serde(default)]
     pub appearance: Appearance,
 }
 

--- a/data/src/config/buffer/channel.rs
+++ b/data/src/config/buffer/channel.rs
@@ -3,51 +3,42 @@ use serde::Deserialize;
 use super::NicknameClickAction;
 use crate::buffer::Color;
 use crate::channel::Position;
-use crate::serde::default_bool_true;
 
 #[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
 pub struct Channel {
-    #[serde(default)]
     pub nicklist: Nicklist,
-    #[serde(default)]
     pub topic: Topic,
-    #[serde(default)]
     pub message: Message,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
 pub struct Message {
-    #[serde(default)]
     pub nickname_color: Color,
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct Nicklist {
-    #[serde(default = "default_bool_true")]
     pub enabled: bool,
-    #[serde(default)]
     pub position: Position,
-    #[serde(default)]
     pub color: Color,
-    #[serde(default)]
     pub width: Option<f32>,
-    #[serde(default)]
     pub alignment: Alignment,
-    #[serde(default = "default_bool_true")]
     pub show_access_levels: bool,
-    #[serde(default)]
     pub click: NicknameClickAction,
 }
 
 impl Default for Nicklist {
     fn default() -> Self {
         Self {
-            enabled: default_bool_true(),
+            enabled: true,
             position: Position::default(),
             color: Color::default(),
-            width: Option::default(),
+            width: None,
             alignment: Alignment::default(),
-            show_access_levels: default_bool_true(),
+            show_access_levels: true,
             click: NicknameClickAction::default(),
         }
     }
@@ -62,10 +53,9 @@ pub enum Alignment {
 }
 
 #[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(default)]
 pub struct Topic {
-    #[serde(default)]
     pub enabled: bool,
-    #[serde(default = "default_topic_banner_max_lines")]
     pub max_lines: u16,
 }
 
@@ -73,11 +63,7 @@ impl Default for Topic {
     fn default() -> Self {
         Self {
             enabled: false,
-            max_lines: default_topic_banner_max_lines(),
+            max_lines: 2,
         }
     }
-}
-
-fn default_topic_banner_max_lines() -> u16 {
-    2
 }

--- a/data/src/config/ctcp.rs
+++ b/data/src/config/ctcp.rs
@@ -1,26 +1,21 @@
 use serde::Deserialize;
 
-use crate::serde::default_bool_true;
-
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct Ctcp {
-    #[serde(default = "default_bool_true")]
     pub ping: bool,
-    #[serde(default = "default_bool_true")]
     pub source: bool,
-    #[serde(default = "default_bool_true")]
     pub time: bool,
-    #[serde(default = "default_bool_true")]
     pub version: bool,
 }
 
 impl Default for Ctcp {
     fn default() -> Self {
         Self {
-            ping: default_bool_true(),
-            source: default_bool_true(),
-            time: default_bool_true(),
-            version: default_bool_true(),
+            ping: true,
+            source: true,
+            time: true,
+            version: true,
         }
     }
 }

--- a/data/src/config/file_transfer.rs
+++ b/data/src/config/file_transfer.rs
@@ -6,67 +6,40 @@ use std::path::PathBuf;
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct FileTransfer {
     /// Default directory to save files in. If not set, user will see a file dialog.
-    #[serde(default)]
     pub save_directory: Option<PathBuf>,
     /// If true, act as the "client" for the transfer. Requires the remote user act as the server.
-    #[serde(default = "default_passive")]
     pub passive: bool,
     /// Time in seconds to wait before timing out a transfer waiting to be accepted.
-    #[serde(default = "default_timeout")]
     pub timeout: u64,
     /// Auto-accept configuration for incoming file transfers.
-    #[serde(default)]
     pub auto_accept: AutoAccept,
     pub server: Option<Server>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct AutoAccept {
-    /// If true, automatically accept incoming file transfers. Requires save_directory to be set.
-    #[serde(default = "default_auto_accept")]
-    pub enabled: bool,
-    /// Auto-accept incoming file transfers from these nicks. Requires enabled to be true.
-    #[serde(default)]
-    pub nicks: Option<Vec<String>>,
-    /// Auto-accept incoming file transfers from these masks (regex patterns). Requires enabled to be true.
-    #[serde(default)]
-    pub masks: Option<Vec<String>>,
 }
 
 impl Default for FileTransfer {
     fn default() -> Self {
         Self {
             save_directory: None,
-            passive: default_passive(),
-            timeout: default_timeout(),
+            passive: true,
+            timeout: 60 * 5,
             auto_accept: AutoAccept::default(),
             server: None,
         }
     }
 }
 
-impl Default for AutoAccept {
-    fn default() -> Self {
-        Self {
-            enabled: default_auto_accept(),
-            nicks: None,
-            masks: None,
-        }
-    }
-}
-
-fn default_passive() -> bool {
-    true
-}
-
-fn default_timeout() -> u64 {
-    60 * 5
-}
-
-fn default_auto_accept() -> bool {
-    false
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct AutoAccept {
+    /// If true, automatically accept incoming file transfers. Requires save_directory to be set.
+    pub enabled: bool,
+    /// Auto-accept incoming file transfers from these nicks. Requires enabled to be true.
+    pub nicks: Option<Vec<String>>,
+    /// Auto-accept incoming file transfers from these masks (regex patterns). Requires enabled to be true.
+    pub masks: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone)]

--- a/data/src/config/highlights.rs
+++ b/data/src/config/highlights.rs
@@ -3,18 +3,17 @@ use itertools::Itertools;
 use serde::{Deserialize, Deserializer};
 
 #[derive(Debug, Clone, Deserialize, Default)]
+#[serde(default)]
 pub struct Highlights {
-    #[serde(default)]
     pub nickname: Nickname,
-    #[serde(rename = "match", default)]
+    #[serde(rename = "match")]
     pub matches: Vec<Match>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
+#[serde(default)]
 pub struct Nickname {
-    #[serde(default)]
     pub exclude: Vec<String>,
-    #[serde(default)]
     pub include: Vec<String>,
 }
 

--- a/data/src/config/keys.rs
+++ b/data/src/config/keys.rs
@@ -3,63 +3,37 @@ use serde::Deserialize;
 use crate::shortcut::{KeyBind, Shortcut, shortcut};
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct Keyboard {
-    #[serde(default = "KeyBind::move_up")]
     pub move_up: KeyBind,
-    #[serde(default = "KeyBind::move_down")]
     pub move_down: KeyBind,
-    #[serde(default = "KeyBind::move_left")]
     pub move_left: KeyBind,
-    #[serde(default = "KeyBind::move_right")]
     pub move_right: KeyBind,
-    #[serde(default = "KeyBind::close_buffer")]
     pub close_buffer: KeyBind,
-    #[serde(default = "KeyBind::maximize_buffer")]
     pub maximize_buffer: KeyBind,
-    #[serde(default = "KeyBind::restore_buffer")]
     pub restore_buffer: KeyBind,
-    #[serde(default = "KeyBind::cycle_next_buffer")]
     pub cycle_next_buffer: KeyBind,
-    #[serde(default = "KeyBind::cycle_previous_buffer")]
     pub cycle_previous_buffer: KeyBind,
-    #[serde(default = "KeyBind::leave_buffer")]
     pub leave_buffer: KeyBind,
-    #[serde(default = "KeyBind::toggle_nick_list")]
     pub toggle_nick_list: KeyBind,
-    #[serde(default = "KeyBind::toggle_topic")]
     pub toggle_topic: KeyBind,
-    #[serde(default = "KeyBind::toggle_sidebar")]
     pub toggle_sidebar: KeyBind,
-    #[serde(default = "KeyBind::toggle_fullscreen")]
     pub toggle_fullscreen: KeyBind,
-    #[serde(default = "KeyBind::command_bar")]
     pub command_bar: KeyBind,
-    #[serde(default = "KeyBind::reload_configuration")]
     pub reload_configuration: KeyBind,
-    #[serde(default = "KeyBind::file_transfers")]
     pub file_transfers: KeyBind,
-    #[serde(default = "KeyBind::logs")]
     pub logs: KeyBind,
-    #[serde(default = "KeyBind::theme_editor")]
     pub theme_editor: KeyBind,
     // Keep highlight as alias for backwards compatibility
-    #[serde(default = "KeyBind::highlights", alias = "highlight")]
+    #[serde(alias = "highlight")]
     pub highlights: KeyBind,
-    #[serde(default = "KeyBind::scroll_up_page")]
     pub scroll_up_page: KeyBind,
-    #[serde(default = "KeyBind::scroll_down_page")]
     pub scroll_down_page: KeyBind,
-    #[serde(default = "KeyBind::scroll_to_top")]
     pub scroll_to_top: KeyBind,
-    #[serde(default = "KeyBind::scroll_to_bottom")]
     pub scroll_to_bottom: KeyBind,
-    #[serde(default = "KeyBind::cycle_next_unread_buffer")]
     pub cycle_next_unread_buffer: KeyBind,
-    #[serde(default = "KeyBind::cycle_previous_unread_buffer")]
     pub cycle_previous_unread_buffer: KeyBind,
-    #[serde(default = "KeyBind::mark_as_read")]
     pub mark_as_read: KeyBind,
-    #[serde(default)]
     pub quit_application: Option<KeyBind>,
 }
 

--- a/data/src/config/logs.rs
+++ b/data/src/config/logs.rs
@@ -1,18 +1,17 @@
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct Logs {
-    #[serde(default = "default_file_level")]
     pub file_level: LevelFilter,
-    #[serde(default = "default_pane_level")]
     pub pane_level: LevelFilter,
 }
 
 impl Default for Logs {
     fn default() -> Self {
         Self {
-            file_level: default_file_level(),
-            pane_level: default_pane_level(),
+            file_level: LevelFilter::Debug,
+            pane_level: LevelFilter::Info,
         }
     }
 }
@@ -39,12 +38,4 @@ impl From<LevelFilter> for log::LevelFilter {
             LevelFilter::Trace => log::LevelFilter::Trace,
         }
     }
-}
-
-fn default_file_level() -> LevelFilter {
-    LevelFilter::Debug
-}
-
-fn default_pane_level() -> LevelFilter {
-    LevelFilter::Info
 }

--- a/data/src/config/notification.rs
+++ b/data/src/config/notification.rs
@@ -5,16 +5,13 @@ use crate::audio::{self, Sound};
 pub type Loaded = Notification<Sound>;
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct Notification<T = String> {
-    #[serde(default)]
     pub show_toast: bool,
-    #[serde(default)]
     pub show_content: bool,
     pub sound: Option<T>,
     pub delay: Option<u64>,
-    #[serde(default)]
     pub exclude: Vec<String>,
-    #[serde(default)]
     pub include: Vec<String>,
 }
 
@@ -49,22 +46,15 @@ impl<T> Notification<T> {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct Notifications<T = String> {
-    #[serde(default)]
     pub connected: Notification<T>,
-    #[serde(default)]
     pub disconnected: Notification<T>,
-    #[serde(default)]
     pub reconnected: Notification<T>,
-    #[serde(default)]
     pub direct_message: Notification<T>,
-    #[serde(default)]
     pub highlight: Notification<T>,
-    #[serde(default)]
     pub file_transfer_request: Notification<T>,
-    #[serde(default)]
     pub monitored_online: Notification<T>,
-    #[serde(default)]
     pub monitored_offline: Notification<T>,
 }
 

--- a/data/src/config/pane.rs
+++ b/data/src/config/pane.rs
@@ -3,11 +3,10 @@ use serde::Deserialize;
 use crate::config::Scrollbar;
 
 #[derive(Debug, Clone, Deserialize, Default)]
+#[serde(default)]
 pub struct Pane {
     /// Default axis used when splitting a pane.
-    #[serde(default)]
     pub split_axis: SplitAxis,
-    #[serde(default)]
     pub scrollbar: Scrollbar,
 }
 

--- a/data/src/config/preview.rs
+++ b/data/src/config/preview.rs
@@ -1,24 +1,20 @@
 use serde::Deserialize;
 
-use crate::serde::default_bool_true;
 use crate::{Target, isupport};
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct Preview {
-    #[serde(default = "default_bool_true")]
     pub enabled: bool,
-    #[serde(default)]
     pub request: Request,
-    #[serde(default)]
     pub card: Card,
-    #[serde(default)]
     pub image: Image,
 }
 
 impl Default for Preview {
     fn default() -> Self {
         Self {
-            enabled: default_bool_true(),
+            enabled: true,
             request: Request::default(),
             card: Card::default(),
             image: Image::default(),
@@ -27,59 +23,52 @@ impl Default for Preview {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct Request {
     /// Request user agent
     ///
     /// Some servers will only send opengraph metadata to
     /// browser-like user agents. We default to `WhatsApp/2`
     /// for wide compatibility
-    #[serde(default = "default_user_agent")]
     pub user_agent: String,
     /// Request timeout in millisceonds
-    #[serde(default = "default_timeout_ms")]
     pub timeout_ms: u64,
     /// Max image size in bytes
     ///
     /// This prevents downloading images that are too big
-    #[serde(default = "default_max_image_size")]
     pub max_image_size: usize,
     /// Max bytes streamed when scraping for opengraph metadata
     /// before cancelling the request
     ///
     /// This prevents downloading responses that are too big
-    #[serde(default = "default_max_scrape_size")]
     pub max_scrape_size: usize,
     /// Number of allowed concurrent requests for fetching previews
     ///
     /// Reduce this to prevent rate-limiting
-    #[serde(default = "default_concurrency")]
     pub concurrency: usize,
     /// Number of milliseconds to wait before requesting another preview
     /// when number of requested previews > `concurrency`
-    #[serde(default = "default_delay_ms")]
     pub delay_ms: u64,
 }
 
 impl Default for Request {
     fn default() -> Self {
         Self {
-            user_agent: default_user_agent(),
-            timeout_ms: default_timeout_ms(),
-            max_image_size: default_max_image_size(),
-            max_scrape_size: default_max_scrape_size(),
-            concurrency: default_concurrency(),
-            delay_ms: default_delay_ms(),
+            user_agent: "WhatsApp/2".to_string(),
+            timeout_ms: 10 * 1_000,
+            max_image_size: 10 * 1024 * 1024,
+            max_scrape_size: 500 * 1024,
+            concurrency: 4,
+            delay_ms: 500,
         }
     }
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct Card {
-    #[serde(default)]
     pub exclude: Vec<String>,
-    #[serde(default)]
     pub include: Vec<String>,
-    #[serde(default = "default_bool_true")]
     pub show_image: bool,
 }
 
@@ -104,12 +93,10 @@ impl Card {
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
+#[serde(default)]
 pub struct Image {
-    #[serde(default)]
     pub action: ImageAction,
-    #[serde(default)]
     pub exclude: Vec<String>,
-    #[serde(default)]
     pub include: Vec<String>,
 }
 
@@ -154,30 +141,4 @@ fn is_visible(
     let target_excluded = is_target_filtered(exclude, target);
 
     target_included || !target_excluded
-}
-
-fn default_user_agent() -> String {
-    "WhatsApp/2".to_string()
-}
-
-fn default_timeout_ms() -> u64 {
-    10 * 1_000
-}
-
-/// 10 mb
-fn default_max_image_size() -> usize {
-    10 * 1024 * 1024
-}
-
-// 500 kb
-fn default_max_scrape_size() -> usize {
-    500 * 1024
-}
-
-fn default_concurrency() -> usize {
-    4
-}
-
-fn default_delay_ms() -> u64 {
-    500
 }

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -7,11 +7,15 @@ use serde::{Deserialize, Deserializer};
 
 use crate::config;
 use crate::serde::{
-    default_bool_true, deserialize_path_buf_with_tilde_expansion,
+    deserialize_path_buf_with_tilde_expansion,
     deserialize_path_buf_with_tilde_expansion_maybe,
 };
 
+const DEFAULT_PORT: u16 = 6667;
+const DEFAULT_TLS_PORT: u16 = 6697;
+
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(default)]
 pub struct Server {
     /// The client's nickname.
     pub nickname: String,
@@ -19,19 +23,16 @@ pub struct Server {
     pub nick_password: Option<String>,
     /// The client's NICKSERV password file.
     #[serde(
-        default,
         deserialize_with = "deserialize_path_buf_with_tilde_expansion_maybe"
     )]
     pub nick_password_file: Option<PathBuf>,
     /// Truncate read from NICKSERV password file to first newline
-    #[serde(default = "default_bool_true")]
     pub nick_password_file_first_line_only: bool,
     /// The client's NICKSERV password command.
     pub nick_password_command: Option<String>,
     /// The server's NICKSERV IDENTIFY syntax.
     pub nick_identify_syntax: Option<IdentifySyntax>,
     /// Alternative nicknames for the client, if the default is taken.
-    #[serde(default)]
     pub alt_nicks: Vec<String>,
     /// The client's username.
     pub username: Option<String>,
@@ -40,79 +41,59 @@ pub struct Server {
     /// The server to connect to.
     pub server: String,
     /// The port to connect on.
-    #[serde(default = "default_tls_port")]
     pub port: u16,
     /// The password to connect to the server.
     pub password: Option<String>,
     /// The file with the password to connect to the server.
     #[serde(
-        default,
         deserialize_with = "deserialize_path_buf_with_tilde_expansion_maybe"
     )]
     pub password_file: Option<PathBuf>,
     /// Truncate read from password file to first newline
-    #[serde(default = "default_bool_true")]
     pub password_file_first_line_only: bool,
     /// The command which outputs a password to connect to the server.
     pub password_command: Option<String>,
     /// A list of channels to join on connection.
-    #[serde(default)]
     pub channels: Vec<String>,
     /// A mapping of channel names to keys for join-on-connect.
-    #[serde(default)]
     pub channel_keys: HashMap<String, String>,
     /// The amount of inactivity in seconds before the client will ping the server.
-    #[serde(default = "default_ping_time")]
     pub ping_time: u64,
     /// The amount of time in seconds for a client to reconnect due to no ping response.
-    #[serde(default = "default_ping_timeout")]
     pub ping_timeout: u64,
     /// The amount of time in seconds before attempting to reconnect to the server when disconnected.
-    #[serde(default = "default_reconnect_delay")]
     pub reconnect_delay: u64,
     /// Whether the client should use NickServ GHOST to reclaim its primary nickname if it is in
     /// use. This has no effect if `nick_password` is not set.
-    #[serde(default)]
     pub should_ghost: bool,
     /// The command(s) that should be sent to NickServ to recover a nickname. The nickname and
     /// password will be appended in that order after the command.
     /// E.g. `["RECOVER", "RELEASE"]` means `RECOVER nick pass` and `RELEASE nick pass` will be sent
     /// in that order.
-    #[serde(default = "default_ghost_sequence")]
     pub ghost_sequence: Vec<String>,
     /// User modestring to set on connect. Example: "+RB-x"
     pub umodes: Option<String>,
     /// Whether or not to use TLS.
     /// Clients will automatically panic if this is enabled without TLS support.
-    #[serde(default = "default_use_tls")]
     pub use_tls: bool,
     /// On `true`, all certificate validations are skipped. Defaults to `false`.
-    #[serde(default)]
     pub dangerously_accept_invalid_certs: bool,
     /// The path to the root TLS certificate for this server in PEM format.
     #[serde(
-        default,
         deserialize_with = "deserialize_path_buf_with_tilde_expansion_maybe"
     )]
     root_cert_path: Option<PathBuf>,
     /// Sasl authentication
     pub sasl: Option<Sasl>,
     /// Commands which are executed once connected.
-    #[serde(default)]
     pub on_connect: Vec<String>,
     /// Enable WHO polling. Defaults to `true`.
-    #[serde(default = "default_who_poll_enabled")]
     pub who_poll_enabled: bool,
     /// WHO poll interval for servers without away-notify.
-    #[serde(
-        default = "default_who_poll_interval",
-        deserialize_with = "deserialize_duration_from_u64"
-    )]
+    #[serde(deserialize_with = "deserialize_duration_from_u64")]
     pub who_poll_interval: Duration,
     /// A list of nicknames to monitor (if MONITOR is supported by the server).
-    #[serde(default)]
     pub monitor: Vec<String>,
-    #[serde(default = "default_chathistory")]
     pub chathistory: bool,
 }
 
@@ -128,9 +109,9 @@ impl Server {
             nickname,
             server,
             port: port.unwrap_or(if use_tls {
-                default_tls_port()
+                DEFAULT_TLS_PORT
             } else {
-                default_port()
+                DEFAULT_PORT
             }),
             channels,
             use_tls,
@@ -175,35 +156,35 @@ impl Default for Server {
             nickname: String::default(),
             nick_password: Option::default(),
             nick_password_file: Option::default(),
-            nick_password_file_first_line_only: default_bool_true(),
+            nick_password_file_first_line_only: true,
             nick_password_command: Option::default(),
             nick_identify_syntax: Option::default(),
             alt_nicks: Vec::default(),
             username: Option::default(),
             realname: Option::default(),
             server: String::default(),
-            port: default_tls_port(),
+            port: DEFAULT_TLS_PORT,
             password: Option::default(),
             password_file: Option::default(),
-            password_file_first_line_only: default_bool_true(),
+            password_file_first_line_only: true,
             password_command: Option::default(),
             channels: Vec::default(),
             channel_keys: HashMap::default(),
-            ping_time: default_ping_time(),
-            ping_timeout: default_ping_timeout(),
-            reconnect_delay: default_reconnect_delay(),
+            ping_time: 180,
+            ping_timeout: 20,
+            reconnect_delay: 10,
             should_ghost: Default::default(),
-            ghost_sequence: default_ghost_sequence(),
+            ghost_sequence: vec!["REGAIN".into()],
             umodes: Option::default(),
-            use_tls: default_use_tls(),
+            use_tls: true,
             dangerously_accept_invalid_certs: Default::default(),
             root_cert_path: Option::default(),
             sasl: Option::default(),
             on_connect: Vec::default(),
-            who_poll_enabled: default_who_poll_enabled(),
-            who_poll_interval: default_who_poll_interval(),
+            who_poll_enabled: true,
+            who_poll_interval: Duration::from_secs(2),
             monitor: Vec::default(),
-            chathistory: default_chathistory(),
+            chathistory: true,
         }
     }
 }
@@ -328,44 +309,4 @@ where
 {
     let seconds: u64 = Deserialize::deserialize(deserializer)?;
     Ok(Duration::from_secs(seconds.clamp(1, 3600)))
-}
-
-fn default_use_tls() -> bool {
-    true
-}
-
-fn default_tls_port() -> u16 {
-    6697
-}
-
-fn default_port() -> u16 {
-    6667
-}
-
-fn default_ping_time() -> u64 {
-    180
-}
-
-fn default_ping_timeout() -> u64 {
-    20
-}
-
-fn default_reconnect_delay() -> u64 {
-    10
-}
-
-fn default_ghost_sequence() -> Vec<String> {
-    vec!["REGAIN".into()]
-}
-
-fn default_who_poll_enabled() -> bool {
-    true
-}
-
-fn default_who_poll_interval() -> Duration {
-    Duration::from_secs(2)
-}
-
-fn default_chathistory() -> bool {
-    true
 }

--- a/data/src/config/sidebar.rs
+++ b/data/src/config/sidebar.rs
@@ -1,22 +1,29 @@
 use serde::Deserialize;
 
 use crate::config::Scrollbar;
-use crate::serde::default_bool_true;
 
 #[derive(Debug, Copy, Clone, Deserialize)]
+#[serde(default)]
 pub struct Sidebar {
-    #[serde(default)]
     pub max_width: Option<u16>,
-    #[serde(default)]
     pub unread_indicator: UnreadIndicator,
-    #[serde(default)]
     pub position: Position,
-    #[serde(default = "default_bool_true")]
     pub show_user_menu: bool,
-    #[serde(default)]
     pub order_by: OrderBy,
-    #[serde(default)]
     pub scrollbar: Scrollbar,
+}
+
+impl Default for Sidebar {
+    fn default() -> Self {
+        Sidebar {
+            max_width: None,
+            unread_indicator: UnreadIndicator::default(),
+            position: Position::default(),
+            show_user_menu: true,
+            order_by: OrderBy::default(),
+            scrollbar: Scrollbar::default(),
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone, Deserialize, Default)]
@@ -53,17 +60,4 @@ pub enum OrderBy {
     #[default]
     Alpha,
     Config,
-}
-
-impl Default for Sidebar {
-    fn default() -> Self {
-        Sidebar {
-            max_width: None,
-            unread_indicator: UnreadIndicator::default(),
-            position: Position::default(),
-            show_user_menu: default_bool_true(),
-            order_by: OrderBy::default(),
-            scrollbar: Scrollbar::default(),
-        }
-    }
 }

--- a/data/src/serde.rs
+++ b/data/src/serde.rs
@@ -63,10 +63,6 @@ where
     Ok(Option::<T>::deserialize(intermediate).unwrap_or_default())
 }
 
-pub fn default_bool_true() -> bool {
-    true
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/data/src/window.rs
+++ b/data/src/window.rs
@@ -1,5 +1,6 @@
+use std::io;
 use std::path::PathBuf;
-use std::{io, sync::Arc};
+use std::sync::Arc;
 
 use iced_core::{Point, Size};
 use serde::{Deserialize, Serialize};
@@ -13,10 +14,11 @@ pub mod position;
 pub mod size;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(default)]
 pub struct Window {
-    #[serde(default, with = "serde_position")]
+    #[serde(with = "serde_position")]
     pub position: Option<Point>,
-    #[serde(default = "default_size", with = "serde_size")]
+    #[serde(with = "serde_size")]
     pub size: Size,
 }
 
@@ -24,15 +26,11 @@ impl Default for Window {
     fn default() -> Self {
         Self {
             position: None,
-            size: default_size(),
+            size: Size {
+                width: 1024.0,
+                height: 768.0,
+            },
         }
-    }
-}
-
-pub fn default_size() -> Size {
-    Size {
-        width: 1024.0,
-        height: 768.0,
     }
 }
 


### PR DESCRIPTION
Utilizes [`#[serde(default)]`](https://serde.rs/container-attrs.html#default) on (de)serialized `structs` to avoid
- Having to use functions to define defaults (often not nearby where the field itself is defined)
- Having to define field defaults in multiple places

In a few cases I moved the `impl Default` for a struct closer to the struct's definition to make it easier to see what a field's serde default value will be.

In a few cases I did not convert field `#[serde(default)]` attributes to a struct attribute where it was either inconvenient to properly implement `Default` or the existing `Default` utilized deserialization.