### PR TITLE
Complete Registration on `RPL_ENDOFMOTD` or `ERR_NOMOTD`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Fixed:
 
 - Sidebar menu is now drawn with the correct offset
 - Prevent messages with previews from shifting position on hover
+- Recognize registration completion on older servers without capability negotiation (i.e. send `on_connect`, `umodes`, etc.)
 
 Changed:
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -2270,7 +2270,7 @@ impl Client {
                 // sent on successfully completing the registration process (after
                 // RPL_ISUPPORT message(s) are sent).
                 // https://modern.ircdocs.horse/#connection-registration
-                if self.registration_step == RegistrationStep::End {
+                if self.registration_step != RegistrationStep::Complete {
                     self.registration_step = RegistrationStep::Complete;
 
                     // Send nick password & ghost


### PR DESCRIPTION
Previously we would only mark registration as complete if CAP negotiation had completed successfully.  Based on [horsedocs description of connection registration](https://modern.ircdocs.horse/#connection-registration) I believe we can expect that behavior when connecting to a modern server (when nothing goes wrong).  But if something has gone wrong in CAP negotiation (or an older does not support it), then registration never completes.  I believe the appearance of `RPL_ENDOFMOTD` or `ERR_NOTMOTD` (which should only be sent after the rest of the registration process completes) is sufficient indication that something has gone wrong (or CAP negotiation is not supported by the server), so we should mark registration as complete (if it is not already been marked as such).