### PR TITLE
Misc. Message Parsing

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1408,11 +1408,11 @@ impl Client {
             Command::QUIT(comment) => {
                 let user = ok!(message.user());
 
+                let channels = self.user_channels(user.nickname());
+
                 self.chanmap.values_mut().for_each(|channel| {
                     channel.users.remove(&user);
                 });
-
-                let channels = self.user_channels(user.nickname());
 
                 return Ok(vec![Event::Broadcast(Broadcast::Quit {
                     user,

--- a/src/main.rs
+++ b/src/main.rs
@@ -663,6 +663,7 @@ impl Halloy {
                                 let chantypes = self.clients.get_chantypes(&server);
                                 let statusmsg = self.clients.get_statusmsg(&server);
                                 let casemapping = self.clients.get_casemapping(&server);
+                                let prefix = self.clients.get_prefix(&server);
 
                                 match event {
                                     data::client::Event::Single(encoded, our_nick) => {
@@ -675,6 +676,7 @@ impl Halloy {
                                             chantypes,
                                             statusmsg,
                                             casemapping,
+                                            prefix,
                                         ) {
                                             commands.push(
                                                 dashboard
@@ -700,6 +702,7 @@ impl Halloy {
                                             chantypes,
                                             statusmsg,
                                             casemapping,
+                                            prefix,
                                         ) {
                                             if let Some((message, channel, user)) =
                                                 message.into_highlight(server.clone())
@@ -748,6 +751,7 @@ impl Halloy {
                                             chantypes,
                                             statusmsg,
                                             casemapping,
+                                            prefix,
                                         ) {
                                             commands.push(
                                                 dashboard
@@ -944,6 +948,7 @@ impl Halloy {
                                             chantypes,
                                             statusmsg,
                                             casemapping,
+                                            prefix,
                                         )
                                             && let Ok(query) = target::Query::parse(
                                                 user.as_str(),


### PR DESCRIPTION
A few minor message-parsing-related improvements/fixes:
- Colorize nickname(s) in a few messages that were not being colorized (`RPL_WHOISCERTFP`, `RPL_WHOISHOST`, `RPL_MONONLINE`, `RPL_MONOFFLINE`, and `RPL_WELCOME`).
- When creating the message text for `RPL_TOPICWHOTIME`, parse the user name given (since it's expected to have the format `nickname!user@host`, not just a bare nickname).
- Fix for a quit message not being broadcast to the channels the user was in.