### PR TITLE
Minor Scripts Tweaks

### DIFF
--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env -S bash -e
 
 TARGET="halloy"
 ASSETS_DIR="assets"

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -29,5 +29,8 @@
 
   cp -r "$git_root_dir/assets/linux/icons" "$prefix/share/"
 
+  mkdir -p "$prefix/share/metainfo"
+  cp "$git_root_dir/assets/linux/org.squidowl.halloy.appdata.xml" "$prefix/share/metainfo/"
+
   update-desktop-database "$prefix/share/applications"
   gtk-update-icon-cache -t "$prefix/share/icons/hicolor/"


### PR DESCRIPTION
Two unrelated minor tweaks to build/install scripts:
- Add halt-on-error to the macOS build script.
- Copy the upstream metadata to the appropriate directory in the Linux installation script.