### PR TITLE
Logs Notification Dot

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -2084,13 +2084,24 @@ impl Client {
                             };
                         }
                         Err(error) => {
+                            // Last argument is :are supported by this server
                             if index != args_len - 1 {
-                                log::warn!(
-                                    "[{}] unable to parse ISUPPORT parameter: {} ({})",
-                                    self.server,
-                                    arg,
-                                    error
-                                );
+                                if error == isupport::UNKNOWN_ISUPPORT_PARAMETER
+                                {
+                                    log::info!(
+                                        "[{}] unable to parse ISUPPORT parameter: {} ({})",
+                                        self.server,
+                                        arg,
+                                        error
+                                    );
+                                } else {
+                                    log::warn!(
+                                        "[{}] unable to parse ISUPPORT parameter: {} ({})",
+                                        self.server,
+                                        arg,
+                                        error
+                                    );
+                                }
                             }
                         }
                     }

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -49,6 +49,8 @@ pub enum Operation {
     Remove(String),
 }
 
+pub const UNKNOWN_ISUPPORT_PARAMETER: &str = "unknown ISUPPORT parameter";
+
 impl FromStr for Operation {
     type Err = &'static str;
 
@@ -230,11 +232,11 @@ impl FromStr for Operation {
                             if let Some((major, minor)) = value.split_once('.')
                                 && let (Ok(major), Ok(minor)) =
                                     (major.parse::<u16>(), minor.parse::<u16>())
-                                {
-                                    return Ok(Operation::Add(
-                                        Parameter::CLIENTVER(major, minor),
-                                    ));
-                                }
+                            {
+                                return Ok(Operation::Add(
+                                    Parameter::CLIENTVER(major, minor),
+                                ));
+                            }
 
                             Err(
                                 "value must be a <major>.<minor> version number",
@@ -338,16 +340,16 @@ impl FromStr for Operation {
                                 if let Some((modes, limit)) =
                                     modes_limit.split_once(':')
                                     && !modes.is_empty()
-                                        && modes
-                                            .chars()
-                                            .all(|c| c.is_ascii_alphabetic())
-                                        && let Ok(limit) = limit.parse::<u16>()
-                                        {
-                                            modes_limits.push(ModesLimit {
-                                                modes: modes.to_string(),
-                                                limit,
-                                            });
-                                        }
+                                    && modes
+                                        .chars()
+                                        .all(|c| c.is_ascii_alphabetic())
+                                    && let Ok(limit) = limit.parse::<u16>()
+                                {
+                                    modes_limits.push(ModesLimit {
+                                        modes: modes.to_string(),
+                                        limit,
+                                    });
+                                }
                             });
 
                             if !modes_limits.is_empty() {
@@ -452,32 +454,32 @@ impl FromStr for Operation {
                                 if let Some((command, limit)) =
                                     command_target_limit.split_once(':')
                                     && !command.is_empty()
-                                        && command
-                                            .chars()
-                                            .all(|c| c.is_ascii_alphabetic())
+                                    && command
+                                        .chars()
+                                        .all(|c| c.is_ascii_alphabetic())
+                                {
+                                    if limit.is_empty() {
+                                        command_target_limits.push(
+                                            CommandTargetLimit {
+                                                command: command
+                                                    .to_uppercase()
+                                                    .to_string(),
+                                                limit: None,
+                                            },
+                                        );
+                                    } else if let Ok(limit) =
+                                        limit.parse::<u16>()
                                     {
-                                        if limit.is_empty() {
-                                            command_target_limits.push(
-                                                CommandTargetLimit {
-                                                    command: command
-                                                        .to_uppercase()
-                                                        .to_string(),
-                                                    limit: None,
-                                                },
-                                            );
-                                        } else if let Ok(limit) =
-                                            limit.parse::<u16>()
-                                        {
-                                            command_target_limits.push(
-                                                CommandTargetLimit {
-                                                    command: command
-                                                        .to_uppercase()
-                                                        .to_string(),
-                                                    limit: Some(limit),
-                                                },
-                                            );
-                                        }
+                                        command_target_limits.push(
+                                            CommandTargetLimit {
+                                                command: command
+                                                    .to_uppercase()
+                                                    .to_string(),
+                                                limit: Some(limit),
+                                            },
+                                        );
                                     }
+                                }
                             });
 
                             if !command_target_limits.is_empty() {
@@ -591,7 +593,7 @@ impl FromStr for Operation {
                         "VLIST" => Err("value required"),
                         "WATCH" => Err("value required"),
                         "WHOX" => Ok(Operation::Add(Parameter::WHOX)),
-                        _ => Err("unknown ISUPPORT parameter"),
+                        _ => Err(UNKNOWN_ISUPPORT_PARAMETER),
                     }
                 }
             }

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -18,6 +18,7 @@ pub use self::source::Source;
 pub use self::source::server::{Kind, StandardReply};
 use crate::config::Highlights;
 use crate::config::buffer::UsernameFormat;
+use crate::log::Level;
 use crate::serde::fail_as_none;
 use crate::target::Channel;
 use crate::time::Posix;
@@ -204,7 +205,12 @@ impl Message {
                             | Kind::WAllOps
                     )
                 }
-                Source::Internal(source::Internal::Logs { .. }) => true,
+                Source::Internal(source::Internal::Logs(level)) => {
+                    match level {
+                        Level::Warn | Level::Error => true,
+                        Level::Info | Level::Debug | Level::Trace => false,
+                    }
+                }
                 _ => false,
             }
     }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -19,7 +19,6 @@ use iced::widget::pane_grid::{self, PaneGrid};
 use iced::widget::{Space, column, container, row};
 use iced::window::get_position;
 use iced::{Length, Task, Vector, clipboard};
-use log::{debug, error};
 
 use self::command_bar::CommandBar;
 use self::pane::Pane;
@@ -1478,7 +1477,7 @@ impl Dashboard {
                 }
             },
             Message::LoadPreview((url, Ok(preview))) => {
-                debug!("Preview loaded for {url}");
+                log::debug!("Preview loaded for {url}");
                 if let hash_map::Entry::Occupied(mut entry) =
                     self.previews.entry(url)
                 {
@@ -1486,7 +1485,7 @@ impl Dashboard {
                 }
             }
             Message::LoadPreview((url, Err(error))) => {
-                error!("Failed to load preview for {url}: {error}");
+                log::info!("Failed to load preview for {url}: {error}");
                 if self.previews.contains_key(&url) {
                     self.previews.insert(url, preview::State::Error(error));
                 }


### PR DESCRIPTION
Adds a dot to the sidebar menu when there are unread messages in logs.  Unread is changed to only trigger for logs when the log message's level is warn or error.  This somewhat re-contextualizes log messages with warn/error level, as they are now user-notifying.  Accordingly, a couple log messages have been downgraded in severity.