### PR TITLE
Move View-Time-Invariant Filtering Out of `history_view`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -426,6 +426,7 @@ impl Halloy {
                                     dashboard.update_filters(
                                         &self.servers,
                                         &self.clients,
+                                        &self.config.buffer,
                                     );
                                 }
                             }
@@ -722,6 +723,7 @@ impl Halloy {
                                                         &server,
                                                         casemapping,
                                                         message,
+                                                        &self.config.buffer,
                                                     )
                                                     .map(Message::Dashboard),
                                             );
@@ -746,12 +748,12 @@ impl Halloy {
                                             if let Some((mut message, channel, user, description)) =
                                                 message.into_highlight(server.clone())
                                             {
-                                                FilterChain::borrow(dashboard.get_filters())
-                                                    .filter_message_of_kind(
-                                                        &mut message,
-                                                        &history::Kind::Channel(server.clone(), channel.clone()),
-                                                        casemapping,
-                                                    );
+                                                dashboard.block_message(
+                                                    &mut message,
+                                                    &history::Kind::Channel(server.clone(), channel.clone()),
+                                                    casemapping,
+                                                    &self.config.buffer,
+                                                );
 
                                                 if !message.blocked && highlight_notification_enabled {
                                                     self.notifications.notify(
@@ -768,7 +770,6 @@ impl Halloy {
 
                                                 let task = dashboard.record_highlight(
                                                     message,
-                                                    casemapping,
                                                 );
                                                 commands.push(task.map(Message::Dashboard));
                                             }
@@ -779,6 +780,7 @@ impl Halloy {
                                                         &server,
                                                         casemapping,
                                                         message,
+                                                        &self.config.buffer,
                                                     )
                                                     .map(Message::Dashboard),
                                             );
@@ -802,6 +804,7 @@ impl Halloy {
                                                         &server,
                                                         casemapping,
                                                         message.with_target(target),
+                                                        &self.config.buffer,
                                                     )
                                                     .map(Message::Dashboard),
                                             );


### PR DESCRIPTION
Since there is now an existing structure for filtering/blocking messages at load/record, we can move server message filtering into the `block_message`/`block_messages` and avoid some repetitious filtering in `history_view`.  Internal messages filtering is left in `history_view` since the filtering may depend on the time of render.  In my rough profiling via comet there was ~10% speed up in view rendering, but view rendering is so dependent on system state that I'm not especially confident in that number.  Here are flamegraphs for `history_view` before
 
<img width="933" height="834" alt="Screenshot 2025-08-02 at 15-13-07 halloy – Pop!_OS 22 04 LTS – 8_2_2025 10 03 27 PM UTC – Firefox Profiler" src="https://github.com/user-attachments/assets/53f43324-fdea-4ef2-894d-626886a51916" />

and after

<img width="933" height="834" alt="Screenshot 2025-08-02 at 15-13-18 halloy – Pop!_OS 22 04 LTS – 8_2_2025 10 02 04 PM UTC – Firefox Profiler" src="https://github.com/user-attachments/assets/71a1ca9d-6958-4b8d-99d5-fca75a00c334" />
