### PR TITLE
Mark as Read on Buffer Close Iff Scrolled to Bottom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Added:
 
 - Notification indicator on sidebar menu for warning & error log messages
+- Ability to mark as read on buffer close only if scrolled to the bottom of the buffer (new `default behavior)
 
 # 2025.8 (2025-08-31)
 

--- a/book/src/configuration/buffer.md
+++ b/book/src/configuration/buffer.md
@@ -405,15 +405,15 @@ on_application_exit = false
 
 ### `on_buffer_close`
 
-When closing a buffer (a buffer is considered closed when it is replaced or if it is open when the application exits).
+When closing a buffer (a buffer is considered closed when it is replaced or if it is open when the application exits).  If set to `"if-scrolled-to-bottom"` then a buffer will only be marked as read if it is scrolled to the bottom when closing (i.e. if the most recent messages are visible).
 
 ```toml
 # Type: boolean
-# Values: true, false
-# Default: true
+# Values: true, false, "if-scrolled-to-bottom"
+# Default: "if-scrolled-to-bottom"
 
 [buffer.mark_as_read]
-on_buffer_close = true
+on_buffer_close = "if-scrolled-to-bottom"
 ```
 
 ### `on_scroll_to_bottom`

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -68,7 +68,7 @@ pub struct Url {
 #[serde(default)]
 pub struct MarkAsRead {
     pub on_application_exit: bool,
-    pub on_buffer_close: bool,
+    pub on_buffer_close: OnBufferClose,
     pub on_scroll_to_bottom: bool,
     pub on_message_sent: bool,
 }
@@ -77,11 +77,41 @@ impl Default for MarkAsRead {
     fn default() -> Self {
         Self {
             on_application_exit: false,
-            on_buffer_close: true,
+            on_buffer_close: OnBufferClose::default(),
             on_scroll_to_bottom: true,
             on_message_sent: true,
         }
     }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum OnBufferClose {
+    Bool(bool),
+    Condition(OnBufferCloseCondition),
+}
+
+impl Default for OnBufferClose {
+    fn default() -> Self {
+        Self::Condition(OnBufferCloseCondition::IfScrolledToBottom)
+    }
+}
+
+impl OnBufferClose {
+    pub fn mark_as_read(&self, is_scrolled_to_bottom: Option<bool>) -> bool {
+        match self {
+            OnBufferClose::Bool(mark) => *mark,
+            OnBufferClose::Condition(_) => {
+                is_scrolled_to_bottom.unwrap_or(false)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OnBufferCloseCondition {
+    IfScrolledToBottom,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,7 +180,7 @@ impl Halloy {
             Err(error) => {
                 log::warn!("failed to load dashboard: {error}");
 
-                screen::Dashboard::empty(config, &main_window)
+                screen::Dashboard::empty(&main_window)
             }
         };
 
@@ -371,7 +371,7 @@ impl Halloy {
                 );
 
                 // Retrack after dashboard state changes
-                let track = dashboard.track(&self.config);
+                let track = dashboard.track();
 
                 let event_task = match event {
                     Some(dashboard::Event::ConfigReloaded(config)) => {
@@ -1177,7 +1177,7 @@ impl Halloy {
                                 &mut self.screen
                             {
                                 return dashboard
-                                    .exit(&self.config)
+                                    .exit(&mut self.clients, &self.config)
                                     .map(Message::Dashboard);
                             } else {
                                 return iced::exit();

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -86,10 +86,7 @@ pub enum Event {
 }
 
 impl Dashboard {
-    pub fn empty(
-        config: &Config,
-        main_window: &Window,
-    ) -> (Self, Task<Message>) {
+    pub fn empty(main_window: &Window) -> (Self, Task<Message>) {
         let (main_panes, pane) =
             pane_grid::State::new(Pane::new(Buffer::Empty));
 
@@ -115,7 +112,7 @@ impl Dashboard {
             buffer_settings: dashboard::BufferSettings::default(),
         };
 
-        let command = dashboard.track(config);
+        let command = dashboard.track();
 
         (dashboard, command)
     }
@@ -128,7 +125,7 @@ impl Dashboard {
         let (mut dashboard, task) =
             Dashboard::from_data(dashboard, config, main_window);
 
-        let tasks = Task::batch(vec![task, dashboard.track(config)]);
+        let tasks = Task::batch(vec![task, dashboard.track()]);
 
         (dashboard, tasks)
     }
@@ -166,7 +163,12 @@ impl Dashboard {
                     pane::Message::PaneDragged(_) => {}
                     pane::Message::ClosePane => {
                         return (
-                            self.close_pane(self.focus.window, self.focus.pane),
+                            self.close_pane(
+                                clients,
+                                config,
+                                self.focus.window,
+                                self.focus.pane,
+                            ),
                             None,
                         );
                     }
@@ -301,6 +303,7 @@ impl Dashboard {
                                                     self.open_buffer(
                                                         data::Buffer::Upstream(buffer),
                                                         buffer_action,
+                                                        clients,
                                                         config,
                                                     ),
                                                 ]),
@@ -438,6 +441,7 @@ impl Dashboard {
                                                     .actions
                                                     .buffer
                                                     .click_highlight,
+                                                clients,
                                                 config,
                                             ),
                                         );
@@ -577,10 +581,10 @@ impl Dashboard {
                     }
                     pane::Message::MaximizePane => self.maximize_pane(),
                     pane::Message::Popout => {
-                        return (self.popout_pane(config), None);
+                        return (self.popout_pane(clients, config), None);
                     }
                     pane::Message::Merge => {
-                        return (self.merge_pane(config), None);
+                        return (self.merge_pane(clients, config), None);
                     }
                     pane::Message::ScrollToBottom => {
                         let Focus { window, pane } = self.focus;
@@ -630,6 +634,7 @@ impl Dashboard {
                         self.open_buffer(
                             data::Buffer::Upstream(buffer),
                             BufferAction::NewPane,
+                            clients,
                             config,
                         ),
                         None,
@@ -638,6 +643,7 @@ impl Dashboard {
                         self.open_buffer(
                             data::Buffer::Upstream(buffer),
                             BufferAction::NewWindow,
+                            clients,
                             config,
                         ),
                         None,
@@ -649,24 +655,24 @@ impl Dashboard {
                         self.open_buffer(
                             data::Buffer::Upstream(buffer),
                             BufferAction::ReplacePane,
+                            clients,
                             config,
                         ),
                         None,
                     ),
                     sidebar::Event::Close(window, pane) => {
-                        (self.close_pane(window, pane), None)
+                        (self.close_pane(clients, config, window, pane), None)
                     }
                     sidebar::Event::Swap(window, pane) => {
                         (self.swap_pane_with_focus(window, pane), None)
                     }
-                    sidebar::Event::Leave(buffer) => self.leave_buffer(
-                        clients,
-                        buffer,
-                        config.buffer.mark_as_read.on_buffer_close,
-                    ),
-                    sidebar::Event::ToggleInternalBuffer(buffer) => {
-                        (self.toggle_internal_buffer(config, buffer), None)
+                    sidebar::Event::Leave(buffer) => {
+                        self.leave_buffer(clients, config, buffer)
                     }
+                    sidebar::Event::ToggleInternalBuffer(buffer) => (
+                        self.toggle_internal_buffer(clients, config, buffer),
+                        None,
+                    ),
                     sidebar::Event::ToggleCommandBar => (
                         self.toggle_command_bar(
                             &closed_buffers(self, clients),
@@ -768,37 +774,7 @@ impl Dashboard {
                                 );
                             }
                         }
-                        history::manager::Event::Closed(kind, read_marker) => {
-                            if let (
-                                Some(server),
-                                Some(target),
-                                Some(read_marker),
-                            ) = (kind.server(), kind.target(), read_marker)
-                            {
-                                clients.send_markread(
-                                    server,
-                                    target,
-                                    read_marker,
-                                );
-                            }
-                        }
-                        history::manager::Event::Exited(results) => {
-                            for (kind, read_marker) in results {
-                                if let (
-                                    Some(server),
-                                    Some(target),
-                                    Some(read_marker),
-                                ) =
-                                    (kind.server(), kind.target(), read_marker)
-                                {
-                                    clients.send_markread(
-                                        server,
-                                        target,
-                                        read_marker,
-                                    );
-                                }
-                            }
-
+                        history::manager::Event::Exited => {
                             return (Task::none(), Some(Event::Exit));
                         }
                         history::manager::Event::SentMessageUpdated(
@@ -855,20 +831,21 @@ impl Dashboard {
                                 }
                                 command_bar::Buffer::Close => {
                                     let Focus { window, pane } = self.focus;
-                                    (self.close_pane(window, pane), None)
+                                    (self.close_pane(clients, config, window, pane), None)
                                 }
                                 command_bar::Buffer::Replace(buffer) => (
                                     self.open_buffer(
                                         data::Buffer::Upstream(buffer),
                                         BufferAction::ReplacePane,
+                                        clients,
                                         config,
                                     ),
                                     None,
                                 ),
-                                command_bar::Buffer::Popout => (self.popout_pane(config), None),
-                                command_bar::Buffer::Merge => (self.merge_pane(config), None),
+                                command_bar::Buffer::Popout => (self.popout_pane(clients, config), None),
+                                command_bar::Buffer::Merge => (self.merge_pane(clients, config), None),
                                 command_bar::Buffer::ToggleInternal(buffer) => {
-                                    (self.toggle_internal_buffer(config, buffer), None)
+                                    (self.toggle_internal_buffer(clients, config, buffer), None)
                                 }
                             },
                             command_bar::Command::Configuration(command) => match command {
@@ -929,7 +906,7 @@ impl Dashboard {
                                 }
                             },
                             command_bar::Command::Application(application) => match application {
-                                command_bar::Application::Quit => (self.exit(config), None),
+                                command_bar::Application::Quit => (self.exit(clients, config), None),
                             },
                         };
 
@@ -992,7 +969,10 @@ impl Dashboard {
                     }
                     CloseBuffer => {
                         let Focus { window, pane } = self.focus;
-                        return (self.close_pane(window, pane), None);
+                        return (
+                            self.close_pane(clients, config, window, pane),
+                            None,
+                        );
                     }
                     MaximizeBuffer => {
                         let Focus { window, pane } = self.focus;
@@ -1045,11 +1025,7 @@ impl Dashboard {
                             && let Some(buffer) =
                                 state.buffer.upstream().cloned()
                         {
-                            return self.leave_buffer(
-                                clients,
-                                buffer,
-                                config.buffer.mark_as_read.on_buffer_close,
-                            );
+                            return self.leave_buffer(clients, config, buffer);
                         }
                     }
                     ToggleNicklist => {
@@ -1106,6 +1082,7 @@ impl Dashboard {
                     FileTransfers => {
                         return (
                             self.toggle_internal_buffer(
+                                clients,
                                 config,
                                 buffer::Internal::FileTransfers,
                             ),
@@ -1115,6 +1092,7 @@ impl Dashboard {
                     Logs => {
                         return (
                             self.toggle_internal_buffer(
+                                clients,
                                 config,
                                 buffer::Internal::Logs,
                             ),
@@ -1130,6 +1108,7 @@ impl Dashboard {
                     Highlights => {
                         return (
                             self.toggle_internal_buffer(
+                                clients,
                                 config,
                                 buffer::Internal::Highlights,
                             ),
@@ -1139,7 +1118,9 @@ impl Dashboard {
                     ToggleFullscreen => {
                         return (window::toggle_fullscreen(), None);
                     }
-                    QuitApplication => return (self.exit(config), None),
+                    QuitApplication => {
+                        return (self.exit(clients, config), None);
+                    }
                     ScrollUpPage => {
                         return (
                             self.get_focused_mut().map_or_else(
@@ -1739,6 +1720,7 @@ impl Dashboard {
 
     fn toggle_internal_buffer(
         &mut self,
+        clients: &mut data::client::Map,
         config: &Config,
         buffer: buffer::Internal,
     ) -> Task<Message> {
@@ -1750,11 +1732,12 @@ impl Dashboard {
         });
 
         if let Some((window, pane)) = open {
-            self.close_pane(window, pane)
+            self.close_pane(clients, config, window, pane)
         } else {
             self.open_buffer(
                 data::Buffer::Internal(buffer),
                 config.actions.buffer.local,
+                clients,
                 config,
             )
         }
@@ -1764,6 +1747,7 @@ impl Dashboard {
         &mut self,
         buffer: data::Buffer,
         buffer_action: BufferAction,
+        clients: &mut data::client::Map,
         config: &Config,
     ) -> Task<Message> {
         let panes = self.panes.clone();
@@ -1785,6 +1769,10 @@ impl Dashboard {
                 }
 
                 let Focus { window, pane } = self.focus;
+
+                self.mark_as_read_on_buffer_close(
+                    window, pane, clients, config,
+                );
 
                 if let Some(state) = self.panes.get_mut(window, pane) {
                     state.buffer = Buffer::from(buffer);
@@ -1884,8 +1872,8 @@ impl Dashboard {
     pub fn leave_buffer(
         &mut self,
         clients: &mut data::client::Map,
+        config: &Config,
         buffer: buffer::Upstream,
-        mark_as_read: bool,
     ) -> (Task<Message>, Option<Event>) {
         let open = self.panes.iter().find_map(|(window, pane, state)| {
             (state.buffer.upstream() == Some(&buffer)).then_some((window, pane))
@@ -1895,7 +1883,7 @@ impl Dashboard {
 
         // Close pane
         if let Some((window, pane)) = open {
-            tasks.push(self.close_pane(window, pane));
+            tasks.push(self.close_pane(clients, config, window, pane));
 
             self.last_changed = Some(Instant::now());
         }
@@ -1915,10 +1903,7 @@ impl Dashboard {
 
                 tasks.push(
                     self.history
-                        .close(
-                            history::Kind::Channel(server, channel),
-                            mark_as_read,
-                        )
+                        .close(history::Kind::Channel(server, channel))
                         .map_or_else(Task::none, |task| {
                             Task::perform(task, Message::History)
                         }),
@@ -1929,7 +1914,7 @@ impl Dashboard {
             buffer::Upstream::Query(server, nick) => {
                 tasks.push(
                     self.history
-                        .close(history::Kind::Query(server, nick), mark_as_read)
+                        .close(history::Kind::Query(server, nick))
                         .map_or_else(Task::none, |task| {
                             Task::perform(task, Message::History)
                         }),
@@ -2294,9 +2279,13 @@ impl Dashboard {
 
     fn close_pane(
         &mut self,
+        clients: &mut data::client::Map,
+        config: &Config,
         window: window::Id,
         pane: pane_grid::Pane,
     ) -> Task<Message> {
+        self.mark_as_read_on_buffer_close(window, pane, clients, config);
+
         self.last_changed = Some(Instant::now());
 
         if window == self.main_window() {
@@ -2322,7 +2311,11 @@ impl Dashboard {
         Task::none()
     }
 
-    fn popout_pane(&mut self, config: &Config) -> Task<Message> {
+    fn popout_pane(
+        &mut self,
+        clients: &mut data::client::Map,
+        config: &Config,
+    ) -> Task<Message> {
         let Focus { pane, .. } = self.focus;
 
         self.focus_history = self
@@ -2335,13 +2328,22 @@ impl Dashboard {
         if let Some((pane, _)) = self.panes.main.close(pane)
             && let Some(buffer) = pane.buffer.data()
         {
-            return self.open_buffer(buffer, BufferAction::NewWindow, config);
+            return self.open_buffer(
+                buffer,
+                BufferAction::NewWindow,
+                clients,
+                config,
+            );
         }
 
         Task::none()
     }
 
-    fn merge_pane(&mut self, config: &Config) -> Task<Message> {
+    fn merge_pane(
+        &mut self,
+        clients: &mut data::client::Map,
+        config: &Config,
+    ) -> Task<Message> {
         let Focus { window, pane } = self.focus;
 
         if let Some(pane) = self
@@ -2351,9 +2353,12 @@ impl Dashboard {
             .and_then(|panes| panes.get(pane).cloned())
         {
             let task = match pane.buffer.data() {
-                Some(buffer) => {
-                    self.open_buffer(buffer, BufferAction::NewPane, config)
-                }
+                Some(buffer) => self.open_buffer(
+                    buffer,
+                    BufferAction::NewPane,
+                    clients,
+                    config,
+                ),
                 None => self.new_pane(pane_grid::Axis::Horizontal),
             };
 
@@ -2403,12 +2408,12 @@ impl Dashboard {
         }
     }
 
-    pub fn track(&mut self, config: &Config) -> Task<Message> {
+    pub fn track(&mut self) -> Task<Message> {
         let resources = self.panes.resources().collect();
 
         Task::batch(
             self.history
-                .track(resources, config)
+                .track(resources)
                 .into_iter()
                 .map(|fut| Task::perform(fut, Message::History))
                 .collect::<Vec<_>>(),
@@ -2655,6 +2660,7 @@ impl Dashboard {
                 tasks.push(dashboard.open_buffer(
                     buffer,
                     BufferAction::NewWindow,
+                    &mut data::client::Map::default(),
                     config,
                 ));
             }
@@ -2732,12 +2738,36 @@ impl Dashboard {
         }
     }
 
-    pub fn exit(&mut self, config: &Config) -> Task<Message> {
-        let history = self.history.exit(
-            config.buffer.mark_as_read.on_application_exit,
-            config.buffer.mark_as_read.on_buffer_close
-                || config.buffer.mark_as_read.on_application_exit,
-        );
+    pub fn exit(
+        &mut self,
+        clients: &mut data::client::Map,
+        config: &Config,
+    ) -> Task<Message> {
+        if config.buffer.mark_as_read.on_application_exit {
+            self.history.kinds()
+        } else {
+            self.panes
+                .iter()
+                .filter_map(|(_, _, state)| {
+                    if config
+                        .buffer
+                        .mark_as_read
+                        .on_buffer_close
+                        .mark_as_read(state.buffer.is_scrolled_to_bottom())
+                    {
+                        state.buffer.data().and_then(history::Kind::from_buffer)
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        }
+        .into_iter()
+        .for_each(|kind| {
+            self.mark_as_read(kind, clients);
+        });
+
+        let history = self.history.exit();
         let last_changed = self.last_changed.take();
         let dashboard = data::Dashboard::from(&*self);
 
@@ -2775,7 +2805,12 @@ impl Dashboard {
             clients.join(&server, slice::from_ref(&channel));
         }
 
-        self.open_buffer(data::Buffer::Upstream(buffer), buffer_action, config)
+        self.open_buffer(
+            data::Buffer::Upstream(buffer),
+            buffer_action,
+            clients,
+            config,
+        )
     }
 
     pub fn open_target(
@@ -2799,7 +2834,7 @@ impl Dashboard {
                     server, query,
                 ));
 
-                self.open_buffer(buffer.clone(), buffer_action, config)
+                self.open_buffer(buffer.clone(), buffer_action, clients, config)
             }
         }
     }
@@ -2829,6 +2864,27 @@ impl Dashboard {
             (kind.server(), kind.target(), read_marker)
         {
             clients.send_markread(server, target, read_marker);
+        }
+    }
+
+    fn mark_as_read_on_buffer_close(
+        &mut self,
+        window: window::Id,
+        pane: pane_grid::Pane,
+        clients: &mut data::client::Map,
+        config: &Config,
+    ) {
+        if let Some(state) = self.panes.get(window, pane) {
+            if config
+                .buffer
+                .mark_as_read
+                .on_buffer_close
+                .mark_as_read(state.buffer.is_scrolled_to_bottom())
+                && let Some(kind) =
+                    state.buffer.data().and_then(history::Kind::from_buffer)
+            {
+                self.mark_as_read(kind, clients);
+            }
         }
     }
 }


### PR DESCRIPTION
Adds a setting to mark as read on buffer close only if the buffer is scrolled to the bottom (as requested in #1111).  The new setting is used as the default since I suspect it's the most common expectation these days.

Moves some of the mark as read logic out of history into dashboard, in order to have ready access to the UI state.