### PR TITLE
Do Not Reference Echoes

### DIFF
--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -217,6 +217,7 @@ impl Message {
 
     pub fn can_reference(&self) -> bool {
         if matches!(self.direction, Direction::Sent)
+            || self.is_echo
             || matches!(self.target.source(), Source::Internal(_))
         {
             return false;


### PR DESCRIPTION
Since we replace sent messages with echoes (in order to update their timestamp to the server's canonical value) we cannot rely on solely on a message's direction to determine that it was sent by Halloy.  Accordingly this disallows messages that are echoes from being used as a chathistory reference.  As a result more messages than strictly necessary may end up requested from the server, but no messages should be missed.