### PR TITLE
Targetless Commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Added:
 
 - Notification indicator on sidebar menu for warning & error log messages
 - Ability to mark as read on buffer close only if scrolled to the bottom of the buffer (new default behavior)
+- `/part`, `/topic`, `/mode`, `/kick`, and `/ctcp` commands can have their target(s) argument skipped when it can be inferred from context (e.g. `/topic` will target the current channel by default when used in a channel buffer)
+- `/cleartopic` command to remove a channel's topic (will target the current channel by default when used in a channel buffer)
 
 # 2025.8 (2025-08-31)
 

--- a/book/src/commands.md
+++ b/book/src/commands.md
@@ -10,24 +10,25 @@ Example
 
 Halloy will first try to run below commands, and lastly send it directly to the server.
 
-| Command   | Alias      | Description                                                   |
-| --------- | ---------- | ------------------------------------------------------------- |
-| `away`    |            | Mark yourself as away. If already away, the status is removed |
-| `clear`   |            | Clear the message history in the current buffer               |
-| `ctcp`    |            | Client-To-Client requests                                     |
-| `format`  | `f`        | Format text with markdown and colors                          |
-| `hop`     | `rejoin`   | Part the current channel and join a new one                   |
-| `join`    | `j`        | Join channel(s) with optional key(s)                          |
-| `kick`    |            | Kick a user from a channel                                    |
-| `me`      | `describe` | Send an action message to the channel                         |
-| `mode`    | `m`        | Set mode(s) on a channel or retrieve the current mode(s) set  |
-| `monitor` |            | System to notify when users become online/offline             |
-| `motd`    |            | Request the message of the day                                |
-| `msg`     | `query`    | Open a query with a nickname and send an optional message     |
-| `nick`    |            | Change your nickname on the current server                    |
-| `notice`  |            | Send a notice message to a target                             |
-| `part`    | `leave`    | Leave channel(s) with an optional reason                      |
-| `quit`    |            | Disconnect from the server with an optional reason            |
-| `raw`     |            | Send data to the server without modifying it                  |
-| `topic`   | `t`        | Retrieve the topic of a channel or set a new topic            |
-| `whois`   |            | Retrieve information about user(s)                            |
+| Command      | Alias      | Description                                                   |
+| ------------ | ---------- | ------------------------------------------------------------- |
+| `away`       |            | Mark yourself as away. If already away, the status is removed |
+| `clear`      |            | Clear the message history in the current buffer               |
+| `ctcp`       |            | Client-To-Client requests                                     |
+| `format`     | `f`        | Format text with markdown and colors                          |
+| `hop`        | `rejoin`   | Part the current channel and join a new one                   |
+| `join`       | `j`        | Join channel(s) with optional key(s)                          |
+| `kick`       |            | Kick a user from a channel                                    |
+| `me`         | `describe` | Send an action message to the channel                         |
+| `mode`       | `m`        | Set mode(s) on a channel or retrieve the current mode(s) set  |
+| `monitor`    |            | System to notify when users become online/offline             |
+| `motd`       |            | Request the message of the day                                |
+| `msg`        | `query`    | Open a query with a nickname and send an optional message     |
+| `nick`       |            | Change your nickname on the current server                    |
+| `notice`     |            | Send a notice message to a target                             |
+| `part`       | `leave`    | Leave channel(s) with an optional reason                      |
+| `quit`       |            | Disconnect from the server with an optional reason            |
+| `raw`        |            | Send data to the server without modifying it                  |
+| `topic`      | `t`        | Retrieve the topic of a channel or set a new topic            |
+| `cleartopic` | `ct`       | Clear the topic of a channel                                  |
+| `whois`      |            | Retrieve information about user(s)                            |

--- a/book/src/commands.md
+++ b/book/src/commands.md
@@ -9,26 +9,32 @@ Example
 ```
 
 Halloy will first try to run below commands, and lastly send it directly to the server.
+The argument(s) for a command are shown in [tooltips](configuration/tooltips.md), and those marked with a `*` will show an additional tooltip with argument-specific information on mouseover.
 
-| Command      | Alias      | Description                                                   |
-| ------------ | ---------- | ------------------------------------------------------------- |
-| `away`       |            | Mark yourself as away. If already away, the status is removed |
-| `clear`      |            | Clear the message history in the current buffer               |
-| `ctcp`       |            | Client-To-Client requests                                     |
-| `format`     | `f`        | Format text with markdown and colors                          |
-| `hop`        | `rejoin`   | Part the current channel and join a new one                   |
-| `join`       | `j`        | Join channel(s) with optional key(s)                          |
-| `kick`       |            | Kick a user from a channel                                    |
-| `me`         | `describe` | Send an action message to the channel                         |
-| `mode`       | `m`        | Set mode(s) on a channel or retrieve the current mode(s) set  |
-| `monitor`    |            | System to notify when users become online/offline             |
-| `motd`       |            | Request the message of the day                                |
-| `msg`        | `query`    | Open a query with a nickname and send an optional message     |
-| `nick`       |            | Change your nickname on the current server                    |
-| `notice`     |            | Send a notice message to a target                             |
-| `part`       | `leave`    | Leave channel(s) with an optional reason                      |
-| `quit`       |            | Disconnect from the server with an optional reason            |
-| `raw`        |            | Send data to the server without modifying it                  |
-| `topic`      | `t`        | Retrieve the topic of a channel or set a new topic            |
-| `cleartopic` | `ct`       | Clear the topic of a channel                                  |
-| `whois`      |            | Retrieve information about user(s)                            |
+| Command      | Alias      | Description                                                       |
+| ------------ | ---------- | ----------------------------------------------------------------- |
+| `away`       |            | Mark yourself as away. If already away, the status is removed     |
+| `clear`      |            | Clear the message history in the current buffer                   |
+| `cleartopic` | `ct`       | Clear the topic of a channel[^1]                                  |
+| `ctcp`       |            | Client-To-Client requests[^2]                                     |
+| `format`     | `f`        | Format text with markdown and colors                              |
+| `hop`        | `rejoin`   | Part the current channel and join a new one                       |
+| `join`       | `j`        | Join channel(s) with optional key(s)                              |
+| `kick`       |            | Kick a user from a channel[^1]                                    |
+| `me`         | `describe` | Send an action message to the channel                             |
+| `mode`       | `m`        | Set mode(s) on a channel or retrieve the current mode(s) set[^3]  |
+| `monitor`    |            | System to notify when users become online/offline                 |
+| `motd`       |            | Request the message of the day                                    |
+| `msg`        | `query`    | Open a query with a nickname and send an optional message         |
+| `nick`       |            | Change your nickname on the current server                        |
+| `notice`     |            | Send a notice message to a target                                 |
+| `part`       | `leave`    | Leave and close channel(s)/quer(ies) with an optional reason [^4] |
+| `quit`       |            | Disconnect from the server with an optional reason                |
+| `raw`        |            | Send data to the server without modifying it                      |
+| `topic`      | `t`        | Retrieve the topic of a channel or set a new topic[^1]            |
+| `whois`      |            | Retrieve information about user(s)                                |
+
+[^1]: The `channel` argument can be skipped when used in a channel buffer to target the channel in the buffer.
+[^2]: The `nick` argument can be skipped when used in a query buffer to target the other user in the buffer.
+[^3]: The `target` argument can be skipped; in a channel buffer it will target the channel in the buffer, in a query buffer it will target the other user in the buffer, and in a server buffer it will target your user.
+[^4]: The `targets` argument can be skipped; in a channel or query buffer it will target the current buffer.

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1929,14 +1929,20 @@ impl Client {
                         self.casemapping(),
                     )))
                 {
-                    if let Some(text) = topic {
+                    if let Some(text) = topic
+                        && !text.is_empty()
+                    {
                         channel.topic.content =
                             Some(message::parse_fragments(text.clone()));
+                        channel.topic.who = message
+                            .user()
+                            .map(|user| user.nickname().to_owned());
+                        channel.topic.time = Some(server_time(&message));
+                    } else {
+                        channel.topic.content = None;
+                        channel.topic.who = None;
+                        channel.topic.time = None;
                     }
-
-                    channel.topic.who =
-                        message.user().map(|user| user.nickname().to_owned());
-                    channel.topic.time = Some(server_time(&message));
                 }
             }
             Command::Numeric(RPL_TOPIC, args) => {
@@ -1990,6 +1996,22 @@ impl Client {
                 // Exclude topic message from history to prevent spam during dev
                 #[cfg(feature = "dev")]
                 return Ok(vec![]);
+            }
+            Command::Numeric(RPL_NOTOPIC, args) => {
+                let channel = ok!(args.get(1));
+
+                if let Some(channel) =
+                    self.chanmap.get_mut(&context!(target::Channel::parse(
+                        channel,
+                        self.chantypes(),
+                        self.statusmsg(),
+                        self.casemapping(),
+                    )))
+                {
+                    channel.topic.content = None;
+                    channel.topic.who = None;
+                    channel.topic.time = None;
+                }
             }
             Command::Numeric(RPL_CHANNELMODEIS, args) => {
                 let channel = ok!(args.get(1));

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -2407,6 +2407,7 @@ impl Client {
                     return Ok(vec![Event::OnConnect(on_connect(
                         self.handle.clone(),
                         self.config.clone(),
+                        self.nickname(),
                         &self.isupport,
                     ))]);
                 }

--- a/data/src/client/on_connect.rs
+++ b/data/src/client/on_connect.rs
@@ -12,6 +12,7 @@ use crate::{Command, Target, command, config, isupport, message, server};
 #[derive(Debug)]
 pub enum Event {
     OpenBuffers(Vec<Target>),
+    LeaveBuffers(Vec<Target>, Option<String>),
 }
 
 pub struct Stream(BoxStream<'static, Event>);
@@ -65,6 +66,10 @@ pub fn on_connect(
                             command::Internal::OpenBuffers(targets) => {
                                 Some(Event::OpenBuffers(targets))
                             }
+                            command::Internal::LeaveBuffers(
+                                targets,
+                                reason,
+                            ) => Some(Event::LeaveBuffers(targets, reason)),
                             command::Internal::Delay(seconds) => {
                                 time::sleep(Duration::from_secs(seconds)).await;
                                 None

--- a/data/src/client/on_connect.rs
+++ b/data/src/client/on_connect.rs
@@ -7,6 +7,7 @@ use futures::stream::{self, BoxStream};
 use futures::{SinkExt, StreamExt};
 use tokio::time;
 
+use crate::user::NickRef;
 use crate::{Command, Target, command, config, isupport, message, server};
 
 #[derive(Debug)]
@@ -37,12 +38,15 @@ impl fmt::Debug for Stream {
 pub fn on_connect(
     handle: server::Handle,
     config: Arc<config::Server>,
+    our_nickname: NickRef,
     isupport: &HashMap<isupport::Kind, isupport::Parameter>,
 ) -> Stream {
     let commands = config
         .on_connect
         .iter()
-        .filter_map(|command| command::parse(command, None, isupport).ok())
+        .filter_map(|command| {
+            command::parse(command, None, Some(our_nickname), isupport).ok()
+        })
         .collect::<Vec<_>>();
 
     Stream(

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -374,24 +374,24 @@ impl History {
                 read_marker,
                 ..
             } => {
-                if let Some(last_received) = *last_updated_at {
-                    if now.is_none_or(|now| {
+                if let Some(last_received) = *last_updated_at
+                    && now.is_none_or(|now| {
                         now.duration_since(last_received)
                             >= FLUSH_AFTER_LAST_RECEIVED
-                    }) {
-                        let kind = kind.clone();
-                        let messages = std::mem::take(messages);
-                        let read_marker = *read_marker;
+                    })
+                {
+                    let kind = kind.clone();
+                    let messages = std::mem::take(messages);
+                    let read_marker = *read_marker;
 
-                        *last_updated_at = None;
+                    *last_updated_at = None;
 
-                        return Some(
+                    return Some(
                             async move {
                                 append(&kind, messages, read_marker).await
                             }
                             .boxed(),
                         );
-                    }
                 }
 
                 None
@@ -403,32 +403,31 @@ impl History {
                 read_marker,
                 ..
             } => {
-                if let Some(last_received) = *last_updated_at {
-                    if now.is_none_or(|now| {
+                if let Some(last_received) = *last_updated_at
+                    && now.is_none_or(|now| {
                         now.duration_since(last_received)
                             >= FLUSH_AFTER_LAST_RECEIVED
-                    }) && !messages.is_empty()
-                    {
-                        let kind = kind.clone();
-                        let read_marker = *read_marker;
-                        *last_updated_at = None;
+                    })
+                    && !messages.is_empty()
+                {
+                    let kind = kind.clone();
+                    let read_marker = *read_marker;
+                    *last_updated_at = None;
 
-                        if messages.len() > MAX_MESSAGES {
-                            messages.drain(
-                                0..messages.len()
-                                    - (MAX_MESSAGES - TRUNC_COUNT),
-                            );
-                        }
-
-                        let messages = messages.clone();
-
-                        return Some(
-                            async move {
-                                overwrite(&kind, &messages, read_marker).await
-                            }
-                            .boxed(),
+                    if messages.len() > MAX_MESSAGES {
+                        messages.drain(
+                            0..messages.len() - (MAX_MESSAGES - TRUNC_COUNT),
                         );
                     }
+
+                    let messages = messages.clone();
+
+                    return Some(
+                        async move {
+                            overwrite(&kind, &messages, read_marker).await
+                        }
+                        .boxed(),
+                    );
                 }
 
                 None

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -1202,10 +1202,17 @@ fn content<'a>(
 
             let topic = topic.as_ref()?;
 
-            Some(parse_fragments_with_user(
-                format!("{} changed topic to {topic}", user.nickname()),
-                &user,
-            ))
+            if topic.is_empty() {
+                Some(parse_fragments_with_user(
+                    format!("{} cleared the topic", user.nickname()),
+                    &user,
+                ))
+            } else {
+                Some(parse_fragments_with_user(
+                    format!("{} changed the topic to {topic}", user.nickname()),
+                    &user,
+                ))
+            }
         }
         Command::PART(target, text) => {
             let raw_user = message.user()?;

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -893,21 +893,24 @@ fn target(
     match message.0.command {
         // Channel
         Command::MODE(target, ..) => {
-            let channel = target::Channel::parse(
+            if let Ok(channel) = target::Channel::parse(
                 &target,
                 chantypes,
                 statusmsg,
                 casemapping,
-            )
-            .ok()?;
-
-            Some(Target::Channel {
-                channel,
-                source: Source::Server(Some(source::Server::new(
-                    Kind::ChangeMode,
-                    Some(user?.nickname().to_owned()),
-                ))),
-            })
+            ) {
+                Some(Target::Channel {
+                    channel,
+                    source: Source::Server(Some(source::Server::new(
+                        Kind::ChangeMode,
+                        Some(user?.nickname().to_owned()),
+                    ))),
+                })
+            } else {
+                Some(Target::Server {
+                    source: Source::Server(None),
+                })
+            }
         }
         Command::TOPIC(channel, _) | Command::KICK(channel, _, _) => {
             let channel = target::Channel::parse(
@@ -1310,39 +1313,69 @@ fn content<'a>(
         Command::MODE(target, modes, args) => {
             let raw_user = message.user()?;
 
-            target::Channel::parse(target, chantypes, statusmsg, casemapping)
+            let modes = modes
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(" ");
+
+            let mut args = args
+                .iter()
+                .flatten()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(" ");
+
+            if !args.is_empty() {
+                args.insert(0, ' ');
+            }
+
+            if let Ok(channel) = target::Channel::parse(
+                target,
+                chantypes,
+                statusmsg,
+                casemapping,
+            ) {
+                let user =
+                    resolve_attributes(&raw_user, &channel).unwrap_or(raw_user);
+
+                let channel_users = target::Channel::parse(
+                    target,
+                    chantypes,
+                    statusmsg,
+                    casemapping,
+                )
                 .ok()
-                .map(|channel| {
-                    let user = resolve_attributes(&raw_user, &channel)
-                        .unwrap_or(raw_user);
+                .and_then(|channel| channel_users(&channel));
 
-                    let modes = modes
-                        .iter()
-                        .map(ToString::to_string)
-                        .collect::<Vec<_>>()
-                        .join(" ");
+                Some(parse_fragments_with_users(
+                    format!("{} sets mode {modes}{args}", user.nickname()),
+                    channel_users,
+                ))
+            } else if raw_user.nickname() == *our_nick {
+                if target == our_nick.as_ref() {
+                    Some(parse_fragments(format!(
+                        "User mode set {modes}{args}"
+                    )))
+                } else {
+                    Some(parse_fragments(format!(
+                        "Set {target} mode {modes}{args}"
+                    )))
+                }
+            } else {
+                let channel_users =
+                    [raw_user.clone(), User::from(our_nick.clone())]
+                        .into_iter()
+                        .collect::<ChannelUsers>();
 
-                    let args = args
-                        .iter()
-                        .flatten()
-                        .map(ToString::to_string)
-                        .collect::<Vec<_>>()
-                        .join(" ");
-
-                    let channel_users = target::Channel::parse(
-                        target,
-                        chantypes,
-                        statusmsg,
-                        casemapping,
-                    )
-                    .ok()
-                    .and_then(|channel| channel_users(&channel));
-
-                    parse_fragments_with_users(
-                        format!("{} sets mode {modes} {args}", user.nickname()),
-                        channel_users,
-                    )
-                })
+                Some(parse_fragments_with_users(
+                    format!(
+                        "{} sets {target} mode {modes}{args}",
+                        raw_user.nickname()
+                    ),
+                    Some(&channel_users),
+                ))
+            }
         }
         Command::PRIVMSG(target, text) | Command::NOTICE(target, text) => {
             let channel_users = target::Channel::parse(

--- a/data/src/target.rs
+++ b/data/src/target.rs
@@ -29,6 +29,20 @@ impl Target {
         }
     }
 
+    pub fn as_query(&self) -> Option<&Query> {
+        match self {
+            Target::Channel(_) => None,
+            Target::Query(query) => Some(query),
+        }
+    }
+
+    pub fn to_query(self) -> Option<Query> {
+        match self {
+            Target::Channel(_) => None,
+            Target::Query(query) => Some(query),
+        }
+    }
+
     pub fn as_normalized_str(&self) -> &str {
         match self {
             Target::Channel(channel) => channel.as_normalized_str(),

--- a/data/src/target.rs
+++ b/data/src/target.rs
@@ -22,6 +22,13 @@ impl Target {
         }
     }
 
+    pub fn to_channel(self) -> Option<Channel> {
+        match self {
+            Target::Channel(channel) => Some(channel),
+            Target::Query(_) => None,
+        }
+    }
+
     pub fn as_normalized_str(&self) -> &str {
         match self {
             Target::Channel(channel) => channel.as_normalized_str(),

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -53,6 +53,7 @@ pub enum Message {
 pub enum Event {
     UserContext(user_context::Event),
     OpenBuffers(Vec<(Target, BufferAction)>),
+    LeaveBuffers(Vec<Target>, Option<String>),
     GoToMessage(data::Server, target::Channel, message::Hash),
     History(Task<history::manager::Message>),
     RequestOlderChatHistory,
@@ -116,6 +117,18 @@ impl Buffer {
         }
     }
 
+    pub fn server(&self) -> Option<data::Server> {
+        match self {
+            Buffer::Channel(state) => Some(state.server.clone()),
+            Buffer::Query(state) => Some(state.server.clone()),
+            Buffer::Server(state) => Some(state.server.clone()),
+            Buffer::Empty
+            | Buffer::FileTransfers(_)
+            | Buffer::Logs(_)
+            | Buffer::Highlights(_) => None,
+        }
+    }
+
     pub fn target(&self) -> Option<Target> {
         match self {
             Buffer::Channel(state) => {
@@ -150,6 +163,9 @@ impl Buffer {
                     channel::Event::OpenBuffers(targets) => {
                         Event::OpenBuffers(targets)
                     }
+                    channel::Event::LeaveBuffers(targets, reason) => {
+                        Event::LeaveBuffers(targets, reason)
+                    }
                     channel::Event::History(task) => Event::History(task),
                     channel::Event::RequestOlderChatHistory => {
                         Event::RequestOlderChatHistory
@@ -178,6 +194,9 @@ impl Buffer {
                     server::Event::OpenBuffers(targets) => {
                         Event::OpenBuffers(targets)
                     }
+                    server::Event::LeaveBuffers(targets, reason) => {
+                        Event::LeaveBuffers(targets, reason)
+                    }
                     server::Event::History(task) => Event::History(task),
                     server::Event::MarkAsRead(kind) => Event::MarkAsRead(kind),
                     server::Event::OpenUrl(url) => Event::OpenUrl(url),
@@ -198,6 +217,9 @@ impl Buffer {
                     }
                     query::Event::OpenBuffers(targets) => {
                         Event::OpenBuffers(targets)
+                    }
+                    query::Event::LeaveBuffers(targets, reason) => {
+                        Event::LeaveBuffers(targets, reason)
                     }
                     query::Event::History(task) => Event::History(task),
                     query::Event::RequestOlderChatHistory => {

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -27,6 +27,7 @@ pub enum Message {
 pub enum Event {
     UserContext(user_context::Event),
     OpenBuffers(Vec<(Target, BufferAction)>),
+    LeaveBuffers(Vec<Target>, Option<String>),
     History(Task<history::manager::Message>),
     RequestOlderChatHistory,
     PreviewChanged,
@@ -259,6 +260,10 @@ impl Channel {
                     Some(input_view::Event::OpenBuffers { targets }) => {
                         (command, Some(Event::OpenBuffers(targets)))
                     }
+                    Some(input_view::Event::LeaveBuffers {
+                        targets,
+                        reason,
+                    }) => (command, Some(Event::LeaveBuffers(targets, reason))),
                     Some(input_view::Event::Cleared { history_task }) => {
                         (command, Some(Event::History(history_task)))
                     }

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -199,6 +199,7 @@ impl State {
                     buffer.clone(),
                     config.buffer.text_input.auto_format,
                     &input,
+                    clients.nickname(buffer.server()),
                     &clients.get_isupport(buffer.server()),
                 ) && match error {
                     input::Error::ExceedsByteLimit { .. } => true,
@@ -269,6 +270,7 @@ impl State {
                         buffer.clone(),
                         config.buffer.text_input.auto_format,
                         raw_input,
+                        clients.nickname(buffer.server()),
                         &clients.get_isupport(buffer.server()),
                     ) {
                         Ok(input::Parsed::Internal(command)) => {

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -25,6 +25,10 @@ pub enum Event {
     OpenBuffers {
         targets: Vec<(Target, BufferAction)>,
     },
+    LeaveBuffers {
+        targets: Vec<Target>,
+        reason: Option<String>,
+    },
     Cleared {
         history_task: Task<history::manager::Message>,
     },
@@ -294,6 +298,18 @@ impl State {
                                                     ),
                                                 })
                                                 .collect(),
+                                        }),
+                                    );
+                                }
+                                command::Internal::LeaveBuffers(
+                                    targets,
+                                    reason,
+                                ) => {
+                                    return (
+                                        Task::none(),
+                                        Some(Event::LeaveBuffers {
+                                            targets,
+                                            reason,
                                         }),
                                     );
                                 }

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -163,7 +163,7 @@ impl State {
         history: &mut history::Manager,
         config: &Config,
     ) -> (Task<Message>, Option<Event>) {
-        let current_channel = buffer.channel();
+        let current_target = buffer.target();
 
         match message {
             Message::Input(input) => {
@@ -184,10 +184,11 @@ impl State {
 
                 self.completion.process(
                     &input,
+                    clients.nickname(buffer.server()),
                     users,
                     &history.get_last_seen(buffer),
                     &channels,
-                    current_channel,
+                    current_target.as_ref(),
                     &isupport,
                     config,
                 );
@@ -588,10 +589,11 @@ impl State {
 
                     self.completion.process(
                         &new_input,
+                        clients.nickname(buffer.server()),
                         users,
                         &history.get_last_seen(buffer),
                         &channels,
-                        current_channel,
+                        current_target.as_ref(),
                         &isupport,
                         config,
                     );
@@ -631,10 +633,11 @@ impl State {
 
                         self.completion.process(
                             &new_input,
+                            clients.nickname(buffer.server()),
                             users,
                             &history.get_last_seen(buffer),
                             &channels,
-                            current_channel,
+                            current_target.as_ref(),
                             &isupport,
                             config,
                         );

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -228,6 +228,9 @@ impl State {
                     input::Error::Command(
                         command::Error::NotPositiveInteger,
                     ) => true,
+                    input::Error::Command(
+                        command::Error::InvalidChannelName { .. },
+                    ) => true,
                 } {
                     self.error = Some(error.to_string());
                 }

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -314,9 +314,9 @@ impl Commands {
             {
                 Command {
                     title: "MOTD",
-                    args: vec![Arg {
+                    args: vec![Argument {
                         text: "server",
-                        kind: ArgKind::Optional { skipped: false },
+                        kind: ArgumentKind::Optional { skipped: false },
                         tooltip: None,
                     }],
                     subcommands: None,
@@ -326,9 +326,9 @@ impl Commands {
             {
                 Command {
                     title: "QUIT",
-                    args: vec![Arg {
+                    args: vec![Argument {
                         text: "reason",
-                        kind: ArgKind::Optional { skipped: false },
+                        kind: ArgumentKind::Optional { skipped: false },
                         tooltip: None,
                     }],
                     subcommands: None,
@@ -466,9 +466,9 @@ impl Commands {
             {
                 Command {
                     title: "ME",
-                    args: vec![Arg {
+                    args: vec![Argument {
                         text: "action",
-                        kind: ArgKind::Required,
+                        kind: ArgumentKind::Required,
                         tooltip: None,
                     }],
                     subcommands: None,
@@ -495,12 +495,12 @@ impl Commands {
 
                 Command {
                     title: "MODE",
-                    args: vec![Arg {
+                    args: vec![Argument {
                         text: "target",
                         kind: if default.is_some() {
-                            ArgKind::Optional { skipped: false }
+                            ArgumentKind::Optional { skipped: false }
                         } else {
-                            ArgKind::Required
+                            ArgumentKind::Required
                         },
                         tooltip: Some(tooltip),
                     }],
@@ -515,14 +515,14 @@ impl Commands {
                 Command {
                     title: "RAW",
                     args: vec![
-                        Arg {
+                        Argument {
                             text: "command",
-                            kind: ArgKind::Required,
+                            kind: ArgumentKind::Required,
                             tooltip: None,
                         },
-                        Arg {
+                        Argument {
                             text: "args",
-                            kind: ArgKind::Optional { skipped: false },
+                            kind: ArgumentKind::Optional { skipped: false },
                             tooltip: None,
                         },
                     ],
@@ -533,9 +533,9 @@ impl Commands {
             {
                 Command {
                     title: "FORMAT",
-                    args: vec![Arg {
+                    args: vec![Argument {
                         text: "text",
-                        kind: ArgKind::Required,
+                        kind: ArgumentKind::Required,
                         tooltip: Some(
                             include_str!("./format_tooltip.txt").to_string(),
                         ),
@@ -548,14 +548,14 @@ impl Commands {
                 Command {
                     title: "HOP",
                     args: vec![
-                        Arg {
+                        Argument {
                             text: "channel",
-                            kind: ArgKind::Optional { skipped: false },
+                            kind: ArgumentKind::Optional { skipped: false },
                             tooltip: Some(String::from("the channel to join")),
                         },
-                        Arg {
+                        Argument {
                             text: "message",
-                            kind: ArgKind::Optional { skipped: false },
+                            kind: ArgumentKind::Optional { skipped: false },
                             tooltip: Some(String::from(
                                 "the part message to be sent",
                             )),
@@ -580,12 +580,12 @@ impl Commands {
 
                 Command {
                     title: "CLEARTOPIC",
-                    args: vec![Arg {
+                    args: vec![Argument {
                         text: "channel",
                         kind: if default.is_some() {
-                            ArgKind::Optional { skipped: false }
+                            ArgumentKind::Optional { skipped: false }
                         } else {
-                            ArgKind::Required
+                            ArgumentKind::Required
                         },
                         tooltip: default.map(|default| {
                             format!("may be omitted (default: {default})")
@@ -603,20 +603,20 @@ impl Commands {
                 Command {
                 title: "CTCP",
                 args: vec![
-                    Arg {
+                    Argument {
                         text: "nick",
                         kind: if default.is_some() {
-                            ArgKind::Optional { skipped: false }
+                            ArgumentKind::Optional { skipped: false }
                         } else {
-                            ArgKind::Required
+                            ArgumentKind::Required
                         },
                         tooltip: default.map(|default| {
                             format!("may be skipped (default: {default})")
                         }),
                     },
-                    Arg {
+                    Argument {
                         text: "command",
-                        kind: ArgKind::Required,
+                        kind: ArgumentKind::Required,
                         tooltip: Some(
                             "    ACTION: Display <text> as a third-person action or emote\
                            \nCLIENTINFO: Request a list of the CTCP messages <nick> supports\
@@ -928,7 +928,7 @@ impl Commands {
 #[derive(Debug, Clone)]
 pub struct Command {
     title: &'static str,
-    args: Vec<Arg>,
+    args: Vec<Argument>,
     subcommands: Option<Vec<Command>>,
 }
 
@@ -1049,7 +1049,7 @@ impl Command {
 
         let title = Some(Element::from(text(self.title)));
 
-        let arg_text = |index: usize, arg: &Arg| {
+        let arg_text = |index: usize, arg: &Argument| {
             let content = text(format!("{arg}"))
                 .style(move |theme| {
                     if index == active_arg {
@@ -1174,30 +1174,32 @@ impl Command {
 }
 
 #[derive(Debug, Clone)]
-struct Arg {
+struct Argument {
     text: &'static str,
-    kind: ArgKind,
+    kind: ArgumentKind,
     tooltip: Option<String>,
 }
 
+// Whether the argument can be skipped or omitted, and if so whether it has been
+// skipped
 #[derive(Debug, Clone)]
-enum ArgKind {
+enum ArgumentKind {
     Required,
     Optional { skipped: bool },
 }
 
-impl ArgKind {
+impl ArgumentKind {
     fn skip(&mut self) {
         match self {
-            ArgKind::Required => (),
-            ArgKind::Optional { skipped } => *skipped = true,
+            ArgumentKind::Required => (),
+            ArgumentKind::Optional { skipped } => *skipped = true,
         }
     }
 
     fn skipped(&self) -> bool {
         match self {
-            ArgKind::Required => false,
-            ArgKind::Optional { skipped } => *skipped,
+            ArgumentKind::Required => false,
+            ArgumentKind::Optional { skipped } => *skipped,
         }
     }
 }
@@ -1205,9 +1207,9 @@ impl ArgKind {
 const REQUIRED_ARG_PREFIX: &str = "<";
 const REQUIRED_ARG_SUFFIX: &str = ">";
 
-impl fmt::Display for Arg {
+impl fmt::Display for Argument {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if matches!(self.kind, ArgKind::Optional { .. }) {
+        if matches!(self.kind, ArgumentKind::Optional { .. }) {
             write!(f, "[<{}>]", self.text)
         } else {
             write!(
@@ -1412,9 +1414,9 @@ fn away_command(max_len: Option<u16>) -> Command {
 
     Command {
         title: "AWAY",
-        args: vec![Arg {
+        args: vec![Argument {
             text: "reason",
-            kind: ArgKind::Optional { skipped: false },
+            kind: ArgumentKind::Optional { skipped: false },
             tooltip,
         }],
         subcommands: None,
@@ -1424,9 +1426,9 @@ fn away_command(max_len: Option<u16>) -> Command {
 fn ctcp_action_command() -> Command {
     Command {
         title: "CTCP ACTION",
-        args: vec![Arg {
+        args: vec![Argument {
             text: "text",
-            kind: ArgKind::Required,
+            kind: ArgumentKind::Required,
             tooltip: Some(String::from(
                 "message to display as a third-person action or emote",
             )),
@@ -1446,9 +1448,9 @@ fn ctcp_clientinfo_command() -> Command {
 fn ctcp_ping_command() -> Command {
     Command {
         title: "CTCP PING",
-        args: vec![Arg {
+        args: vec![Argument {
             text: "info",
-            kind: ArgKind::Required,
+            kind: ArgumentKind::Required,
             tooltip: Some(String::from(
                 "text that should be exactly reproduced in the reply PING",
             )),
@@ -1484,9 +1486,9 @@ fn ctcp_version_command() -> Command {
 fn chathistory_command(maximum_limit: &u16) -> Command {
     Command {
         title: "CHATHISTORY",
-        args: vec![Arg {
+        args: vec![Argument {
             text: "subcommand",
-            kind: ArgKind::Required,
+            kind: ArgumentKind::Required,
             tooltip: Some(String::from(
                 " BEFORE: Request messages before a timestamp or msgid\
                \n  AFTER: Request after before a timestamp or msgid\
@@ -1517,21 +1519,21 @@ fn chathistory_after_command(maximum_limit: &u16) -> Command {
     Command {
         title: "CHATHISTORY AFTER",
         args: vec![
-            Arg {
+            Argument {
                 text: "target",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: None,
             },
-            Arg {
+            Argument {
                 text: "timestamp | msgid",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: Some(String::from(
                     "timestamp format: timestamp=YYYY-MM-DDThh:mm:ss.sssZ",
                 )),
             },
-            Arg {
+            Argument {
                 text: "limit",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: Some(limit_tooltip),
             },
         ],
@@ -1549,21 +1551,21 @@ fn chathistory_around_command(maximum_limit: &u16) -> Command {
     Command {
         title: "CHATHISTORY AROUND",
         args: vec![
-            Arg {
+            Argument {
                 text: "target",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: None,
             },
-            Arg {
+            Argument {
                 text: "timestamp | msgid",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: Some(String::from(
                     "timestamp format: timestamp=YYYY-MM-DDThh:mm:ss.sssZ",
                 )),
             },
-            Arg {
+            Argument {
                 text: "limit",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: Some(limit_tooltip),
             },
         ],
@@ -1581,21 +1583,21 @@ fn chathistory_before_command(maximum_limit: &u16) -> Command {
     Command {
         title: "CHATHISTORY BEFORE",
         args: vec![
-            Arg {
+            Argument {
                 text: "target",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: None,
             },
-            Arg {
+            Argument {
                 text: "timestamp | msgid",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: Some(String::from(
                     "timestamp format: timestamp=YYYY-MM-DDThh:mm:ss.sssZ",
                 )),
             },
-            Arg {
+            Argument {
                 text: "limit",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: Some(limit_tooltip),
             },
         ],
@@ -1613,28 +1615,28 @@ fn chathistory_between_command(maximum_limit: &u16) -> Command {
     Command {
         title: "CHATHISTORY BETWEEN",
         args: vec![
-            Arg {
+            Argument {
                 text: "target",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: None,
             },
-            Arg {
+            Argument {
                 text: "timestamp | msgid",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: Some(String::from(
                     "timestamp format: timestamp=YYYY-MM-DDThh:mm:ss.sssZ",
                 )),
             },
-            Arg {
+            Argument {
                 text: "timestamp | msgid",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: Some(String::from(
                     "timestamp format: timestamp=YYYY-MM-DDThh:mm:ss.sssZ",
                 )),
             },
-            Arg {
+            Argument {
                 text: "limit",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: Some(limit_tooltip),
             },
         ],
@@ -1652,22 +1654,22 @@ fn chathistory_latest_command(maximum_limit: &u16) -> Command {
     Command {
         title: "CHATHISTORY LATEST",
         args: vec![
-            Arg {
+            Argument {
                 text: "target",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: None,
             },
-            Arg {
+            Argument {
                 text: "* | timestamp | msgid",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: Some(String::from(
                     "               *: no restriction on returned messages\
                    \ntimestamp format: timestamp=YYYY-MM-DDThh:mm:ss.sssZ",
                 )),
             },
-            Arg {
+            Argument {
                 text: "limit",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: Some(limit_tooltip),
             },
         ],
@@ -1685,23 +1687,23 @@ fn chathistory_targets_command(maximum_limit: &u16) -> Command {
     Command {
         title: "CHATHISTORY TARGETS",
         args: vec![
-            Arg {
+            Argument {
                 text: "timestamp",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: Some(String::from(
                     "timestamp format: timestamp=YYYY-MM-DDThh:mm:ss.sssZ",
                 )),
             },
-            Arg {
+            Argument {
                 text: "timestamp",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: Some(String::from(
                     "timestamp format: timestamp=YYYY-MM-DDThh:mm:ss.sssZ",
                 )),
             },
-            Arg {
+            Argument {
                 text: "limit",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: Some(limit_tooltip),
             },
         ],
@@ -1712,19 +1714,19 @@ fn chathistory_targets_command(maximum_limit: &u16) -> Command {
 static CNOTICE_COMMAND: LazyLock<Command> = LazyLock::new(|| Command {
     title: "CNOTICE",
     args: vec![
-        Arg {
+        Argument {
             text: "nickname",
-            kind: ArgKind::Required,
+            kind: ArgumentKind::Required,
             tooltip: None,
         },
-        Arg {
+        Argument {
             text: "channel",
-            kind: ArgKind::Required,
+            kind: ArgumentKind::Required,
             tooltip: None,
         },
-        Arg {
+        Argument {
             text: "message",
-            kind: ArgKind::Required,
+            kind: ArgumentKind::Required,
             tooltip: None,
         },
     ],
@@ -1734,19 +1736,19 @@ static CNOTICE_COMMAND: LazyLock<Command> = LazyLock::new(|| Command {
 static CPRIVMSG_COMMAND: LazyLock<Command> = LazyLock::new(|| Command {
     title: "CPRIVMSG",
     args: vec![
-        Arg {
+        Argument {
             text: "nickname",
-            kind: ArgKind::Required,
+            kind: ArgumentKind::Required,
             tooltip: None,
         },
-        Arg {
+        Argument {
             text: "channel",
-            kind: ArgKind::Required,
+            kind: ArgumentKind::Required,
             tooltip: None,
         },
-        Arg {
+        Argument {
             text: "message",
-            kind: ArgKind::Required,
+            kind: ArgumentKind::Required,
             tooltip: None,
         },
     ],
@@ -1798,14 +1800,14 @@ fn join_command(
     Command {
         title: "JOIN",
         args: vec![
-            Arg {
+            Argument {
                 text: "channels",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: Some(channels_tooltip),
             },
-            Arg {
+            Argument {
                 text: "keys",
-                kind: ArgKind::Optional { skipped: false },
+                kind: ArgumentKind::Optional { skipped: false },
                 tooltip: Some(keys_tooltip),
             },
         ],
@@ -1833,25 +1835,25 @@ fn kick_command(
     Command {
         title: "KICK",
         args: vec![
-            Arg {
+            Argument {
                 text: "channel",
                 kind: if default.is_some() {
-                    ArgKind::Optional { skipped: false }
+                    ArgumentKind::Optional { skipped: false }
                 } else {
-                    ArgKind::Required
+                    ArgumentKind::Required
                 },
                 tooltip: default.map(|default| {
                     format!("may be skipped (default: {default})")
                 }),
             },
-            Arg {
+            Argument {
                 text: "users",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: Some(users_tooltip),
             },
-            Arg {
+            Argument {
                 text: "comment",
-                kind: ArgKind::Optional { skipped: false },
+                kind: ArgumentKind::Optional { skipped: false },
                 tooltip: comment_tooltip,
             },
         ],
@@ -1862,14 +1864,14 @@ fn kick_command(
 static KNOCK_COMMAND: LazyLock<Command> = LazyLock::new(|| Command {
     title: "KNOCK",
     args: vec![
-        Arg {
+        Argument {
             text: "channel",
-            kind: ArgKind::Required,
+            kind: ArgumentKind::Required,
             tooltip: None,
         },
-        Arg {
+        Argument {
             text: "message",
-            kind: ArgKind::Optional { skipped: false },
+            kind: ArgumentKind::Optional { skipped: false },
             tooltip: None,
         },
     ],
@@ -1878,9 +1880,9 @@ static KNOCK_COMMAND: LazyLock<Command> = LazyLock::new(|| Command {
 
 static LIST_COMMAND: LazyLock<Command> = LazyLock::new(|| Command {
     title: "LIST",
-    args: vec![Arg {
+    args: vec![Argument {
         text: "channels",
-        kind: ArgKind::Optional { skipped: false },
+        kind: ArgumentKind::Optional { skipped: false },
         tooltip: Some(String::from("comma-separated")),
     }],
     subcommands: None,
@@ -1920,14 +1922,14 @@ fn list_command(
         Command {
             title: "LIST",
             args: vec![
-                Arg {
+                Argument {
                     text: "channels",
-                    kind: ArgKind::Optional { skipped: false },
+                    kind: ArgumentKind::Optional { skipped: false },
                     tooltip: Some(channels_tooltip),
                 },
-                Arg {
+                Argument {
                     text: "elistconds",
-                    kind: ArgKind::Optional { skipped: false },
+                    kind: ArgumentKind::Optional { skipped: false },
                     tooltip: Some(elistconds_tooltip),
                 },
             ],
@@ -1936,9 +1938,9 @@ fn list_command(
     } else {
         Command {
             title: "LIST",
-            args: vec![Arg {
+            args: vec![Argument {
                 text: "channels",
-                kind: ArgKind::Optional { skipped: false },
+                kind: ArgumentKind::Optional { skipped: false },
                 tooltip: Some(channels_tooltip),
             }],
             subcommands: None,
@@ -1949,9 +1951,9 @@ fn list_command(
 fn monitor_command(target_limit: &Option<u16>) -> Command {
     Command {
         title: "MONITOR",
-        args: vec![Arg {
+        args: vec![Argument {
             text: "subcommand",
-            kind: ArgKind::Required,
+            kind: ArgumentKind::Required,
             tooltip: Some(String::from(
                 "+: Add user(s) to list being monitored\n\
                  -: Remove user(s) from list being monitored\n\
@@ -1984,9 +1986,9 @@ fn monitor_add_command(target_limit: &Option<u16>) -> Command {
 
     Command {
         title: "MONITOR +",
-        args: vec![Arg {
+        args: vec![Argument {
             text: "targets",
-            kind: ArgKind::Required,
+            kind: ArgumentKind::Required,
             tooltip: Some(targets_tooltip),
         }],
         subcommands: None,
@@ -1995,9 +1997,9 @@ fn monitor_add_command(target_limit: &Option<u16>) -> Command {
 
 static MONITOR_REMOVE_COMMAND: LazyLock<Command> = LazyLock::new(|| Command {
     title: "MONITOR -",
-    args: vec![Arg {
+    args: vec![Argument {
         text: "targets",
-        kind: ArgKind::Required,
+        kind: ArgumentKind::Required,
         tooltip: Some(String::from("comma-separated")),
     }],
     subcommands: None,
@@ -2105,14 +2107,14 @@ fn mode_channel_command(
             REQUIRED_ARG_SUFFIX
         ),
         args: vec![
-            Arg {
+            Argument {
                 text: "modestring",
-                kind: ArgKind::Optional { skipped: false },
+                kind: ArgumentKind::Optional { skipped: false },
                 tooltip: Some(modestring_tooltip),
             },
-            Arg {
+            Argument {
                 text: "arguments",
-                kind: ArgKind::Optional { skipped: false },
+                kind: ArgumentKind::Optional { skipped: false },
                 tooltip: None,
             },
         ],
@@ -2140,9 +2142,9 @@ fn mode_user_command(mode_limit: Option<u16>) -> Command {
             "user",
             REQUIRED_ARG_SUFFIX
         ),
-        args: vec![Arg {
+        args: vec![Argument {
             text: "modestring",
-            kind: ArgKind::Optional { skipped: false },
+            kind: ArgumentKind::Optional { skipped: false },
             tooltip: Some(modestring_tooltip),
         }],
         subcommands: None,
@@ -2184,14 +2186,14 @@ fn msg_command(
     Command {
         title: "MSG",
         args: vec![
-            Arg {
+            Argument {
                 text: "targets",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: Some(targets_tooltip),
             },
-            Arg {
+            Argument {
                 text: "text",
-                kind: ArgKind::Optional { skipped: false },
+                kind: ArgumentKind::Optional { skipped: false },
                 tooltip: None,
             },
         ],
@@ -2213,9 +2215,9 @@ fn names_command(target_limit: Option<u16>) -> Command {
 
     Command {
         title: "NAMES",
-        args: vec![Arg {
+        args: vec![Argument {
             text: "channels",
-            kind: ArgKind::Required,
+            kind: ArgumentKind::Required,
             tooltip: Some(channels_tooltip),
         }],
         subcommands: None,
@@ -2227,9 +2229,9 @@ fn nick_command(max_len: Option<u16>) -> Command {
 
     Command {
         title: "NICK",
-        args: vec![Arg {
+        args: vec![Argument {
             text: "nickname",
-            kind: ArgKind::Required,
+            kind: ArgumentKind::Required,
             tooltip,
         }],
         subcommands: None,
@@ -2271,14 +2273,14 @@ fn notice_command(
     Command {
         title: "NOTICE",
         args: vec![
-            Arg {
+            Argument {
                 text: "targets",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: Some(targets_tooltip),
             },
-            Arg {
+            Argument {
                 text: "text",
-                kind: ArgKind::Optional { skipped: false },
+                kind: ArgumentKind::Optional { skipped: false },
                 tooltip: None,
             },
         ],
@@ -2305,18 +2307,18 @@ fn part_command(default: Option<String>, max_len: Option<u16>) -> Command {
     Command {
         title: "PART",
         args: vec![
-            Arg {
+            Argument {
                 text: "targets",
                 kind: if default.is_some() {
-                    ArgKind::Optional { skipped: false }
+                    ArgumentKind::Optional { skipped: false }
                 } else {
-                    ArgKind::Required
+                    ArgumentKind::Required
                 },
                 tooltip: Some(targets_tooltip),
             },
-            Arg {
+            Argument {
                 text: "reason",
-                kind: ArgKind::Optional { skipped: false },
+                kind: ArgumentKind::Optional { skipped: false },
                 tooltip: None,
             },
         ],
@@ -2327,9 +2329,9 @@ fn part_command(default: Option<String>, max_len: Option<u16>) -> Command {
 fn setname_command(max_len: &u16) -> Command {
     Command {
         title: "SETNAME",
-        args: vec![Arg {
+        args: vec![Argument {
             text: "realname",
-            kind: ArgKind::Required,
+            kind: ArgumentKind::Required,
             tooltip: Some(format!("maximum length: {max_len}")),
         }],
         subcommands: None,
@@ -2347,20 +2349,20 @@ fn topic_command(default: Option<String>, max_len: Option<u16>) -> Command {
     Command {
         title: "TOPIC",
         args: vec![
-            Arg {
+            Argument {
                 text: "channel",
                 kind: if default.is_some() {
-                    ArgKind::Optional { skipped: false }
+                    ArgumentKind::Optional { skipped: false }
                 } else {
-                    ArgKind::Required
+                    ArgumentKind::Required
                 },
                 tooltip: default.map(|default| {
                     format!("may be skipped (default: {default})")
                 }),
             },
-            Arg {
+            Argument {
                 text: "topic",
-                kind: ArgKind::Optional { skipped: false },
+                kind: ArgumentKind::Optional { skipped: false },
                 tooltip: Some(topic_tooltip),
             },
         ],
@@ -2370,9 +2372,9 @@ fn topic_command(default: Option<String>, max_len: Option<u16>) -> Command {
 
 static USERIP_COMMAND: LazyLock<Command> = LazyLock::new(|| Command {
     title: "USERIP",
-    args: vec![Arg {
+    args: vec![Argument {
         text: "nickname",
-        kind: ArgKind::Required,
+        kind: ArgumentKind::Required,
         tooltip: None,
     }],
     subcommands: None,
@@ -2382,14 +2384,14 @@ fn whox_command() -> Command {
     Command {
         title: "WHO",
         args: vec![
-            Arg {
+            Argument {
                 text: "target",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: None,
             },
-            Arg {
+            Argument {
                 text: "fields",
-                kind: ArgKind::Optional { skipped: false },
+                kind: ArgumentKind::Optional { skipped: false },
                 tooltip: Some(String::from(
                     "t: token\n\
                      c: channel\n\
@@ -2406,9 +2408,9 @@ fn whox_command() -> Command {
                      r: realname",
                 )),
             },
-            Arg {
+            Argument {
                 text: "token",
-                kind: ArgKind::Optional { skipped: false },
+                kind: ArgumentKind::Optional { skipped: false },
                 tooltip: Some(String::from("1-3 digits")),
             },
         ],
@@ -2419,9 +2421,9 @@ fn whox_command() -> Command {
 fn who_command() -> Command {
     Command {
         title: "WHO",
-        args: vec![Arg {
+        args: vec![Argument {
             text: "target",
-            kind: ArgKind::Required,
+            kind: ArgumentKind::Required,
             tooltip: None,
         }],
         subcommands: None,
@@ -2441,16 +2443,16 @@ fn whois_command(target_limit: Option<u16>) -> Command {
     Command {
         title: "WHOIS",
         args: vec![
-            Arg {
+            Argument {
                 text: "server",
-                kind: ArgKind::Optional { skipped: false },
+                kind: ArgumentKind::Optional { skipped: false },
                 tooltip: Some(String::from(
                     "may be skipped (default: the connected server)",
                 )),
             },
-            Arg {
+            Argument {
                 text: "nicks",
-                kind: ArgKind::Required,
+                kind: ArgumentKind::Required,
                 tooltip: Some(nicks_tooltip),
             },
         ],

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -729,16 +729,19 @@ impl Commands {
             // Mark skipped arguments as skipped
             match command.title {
                 "CTCP" => {
-                    if let Some(nick) = rest.split_ascii_whitespace().nth(1) {
-                        match nick.to_uppercase().as_str() {
-                            "ACTION" | "CLIENTINFO" | "PING" | "SOURCE"
-                            | "TIME" | "VERSION" => {
-                                if let Some(nick) = command.args.get_mut(0) {
-                                    nick.kind.skip();
-                                }
-                            }
-                            _ => (),
-                        }
+                    if let Some(nick) = rest.split_ascii_whitespace().nth(1)
+                        && matches!(
+                            nick.to_uppercase().as_str(),
+                            "ACTION"
+                                | "CLIENTINFO"
+                                | "PING"
+                                | "SOURCE"
+                                | "TIME"
+                                | "VERSION"
+                        )
+                        && let Some(nick) = command.args.get_mut(0)
+                    {
+                        nick.kind.skip();
                     }
                 }
                 "KICK" => {
@@ -747,20 +750,19 @@ impl Commands {
                         let chantypes =
                             isupport::get_chantypes_or_default(isupport);
 
-                        if !proto::is_channel(channel, chantypes) {
-                            if let Some(channel) = command.args.get_mut(0) {
-                                channel.kind.skip();
-                            }
+                        if !proto::is_channel(channel, chantypes)
+                            && let Some(channel) = command.args.get_mut(0)
+                        {
+                            channel.kind.skip();
                         }
                     }
                 }
                 "MODE" => {
-                    if let Some(target) = rest.split_ascii_whitespace().nth(1) {
-                        if target.starts_with(['+', '-']) {
-                            if let Some(target) = command.args.get_mut(0) {
-                                target.kind.skip();
-                            }
-                        }
+                    if let Some(target) = rest.split_ascii_whitespace().nth(1)
+                        && target.starts_with(['+', '-'])
+                        && let Some(target) = command.args.get_mut(0)
+                    {
+                        target.kind.skip();
                     }
                 }
                 "TOPIC" => {
@@ -769,10 +771,10 @@ impl Commands {
                         let chantypes =
                             isupport::get_chantypes_or_default(isupport);
 
-                        if !proto::is_channel(channel, chantypes) {
-                            if let Some(channel) = command.args.get_mut(0) {
-                                channel.kind.skip();
-                            }
+                        if !proto::is_channel(channel, chantypes)
+                            && let Some(channel) = command.args.get_mut(0)
+                        {
+                            channel.kind.skip();
                         }
                     }
                 }

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -515,7 +515,7 @@ impl Commands {
                         Arg {
                             text: "channel",
                             optional: true,
-                            tooltip: Some(String::from("the #channel to join")),
+                            tooltip: Some(String::from("the channel to join")),
                         },
                         Arg {
                             text: "message",
@@ -533,6 +533,18 @@ impl Commands {
                 Command {
                     title: "CLEAR",
                     args: vec![],
+                    subcommands: None,
+                }
+            },
+            // CLEARTOPIC
+            {
+                Command {
+                    title: "CLEARTOPIC",
+                    args: vec![Arg {
+                        text: "channel",
+                        optional: true,
+                        tooltip: None,
+                    }],
                     subcommands: None,
                 }
             },
@@ -876,7 +888,7 @@ impl Command {
             }
             "hop" => "Parts the current channel and joins a new one",
             "clear" => "Clears the buffer",
-
+            "cleartopic" => "Clear the topic of a channel",
             _ => return None,
         })
     }

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -21,6 +21,7 @@ pub enum Message {
 pub enum Event {
     UserContext(user_context::Event),
     OpenBuffers(Vec<(Target, BufferAction)>),
+    LeaveBuffers(Vec<Target>, Option<String>),
     History(Task<history::manager::Message>),
     RequestOlderChatHistory,
     PreviewChanged,
@@ -206,6 +207,10 @@ impl Query {
                     Some(input_view::Event::OpenBuffers { targets }) => {
                         (command, Some(Event::OpenBuffers(targets)))
                     }
+                    Some(input_view::Event::LeaveBuffers {
+                        targets,
+                        reason,
+                    }) => (command, Some(Event::LeaveBuffers(targets, reason))),
                     Some(input_view::Event::Cleared { history_task }) => {
                         (command, Some(Event::History(history_task)))
                     }

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -19,6 +19,7 @@ pub enum Message {
 pub enum Event {
     UserContext(user_context::Event),
     OpenBuffers(Vec<(Target, BufferAction)>),
+    LeaveBuffers(Vec<Target>, Option<String>),
     History(Task<history::manager::Message>),
     MarkAsRead(history::Kind),
     OpenUrl(String),
@@ -227,6 +228,10 @@ impl Server {
                     Some(input_view::Event::OpenBuffers { targets }) => {
                         (command, Some(Event::OpenBuffers(targets)))
                     }
+                    Some(input_view::Event::LeaveBuffers {
+                        targets,
+                        reason,
+                    }) => (command, Some(Event::LeaveBuffers(targets, reason))),
                     Some(input_view::Event::Cleared { history_task }) => {
                         (command, Some(Event::History(history_task)))
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -410,8 +410,8 @@ impl Halloy {
                             .and_then(|config| Task::done(config.appearance))
                             .map(Message::AppearanceReloaded)
                     }
-                    Some(dashboard::Event::QuitServer(server)) => {
-                        self.clients.quit(&server, None);
+                    Some(dashboard::Event::QuitServer(server, reason)) => {
+                        self.clients.quit(&server, reason);
                         Task::none()
                     }
                     Some(dashboard::Event::IrcError(e)) => {
@@ -1280,6 +1280,25 @@ impl Halloy {
                             &mut self.clients,
                             buffer_action,
                             &self.config,
+                        ));
+                    }
+
+                    Task::batch(commands).map(Message::Dashboard)
+                }
+                client::on_connect::Event::LeaveBuffers(targets, reason) => {
+                    let Screen::Dashboard(dashboard) = &mut self.screen else {
+                        return Task::none();
+                    };
+
+                    let mut commands = vec![];
+
+                    for target in targets {
+                        commands.push(dashboard.leave_server_target(
+                            &mut self.clients,
+                            &self.config,
+                            server.clone(),
+                            target,
+                            reason.clone(),
                         ));
                     }
 


### PR DESCRIPTION
This PR attempts to partially address issue #1047, with the following changes:

- `/part` (`/leave`) allows omission of its target argument when sent from a channel/query buffer (with the buffer being the target being the buffer it is sent from).  Queries targeted in this way will be closed, while channels will have the appropriate `PART` command sent then closed (previously only the `PART` command was sent).  Because queries are now allowed as targets, a reason argument cannot be provided without providing a target (since the first word of a reason could not be simply distinguished from a query).
- `/topic` allows skipping its target argument, when sent from a channel buffer.
- `/cleartopic` command has been added to allow a channel's topic to be cleared (`/topic` without text will request the topic of the target, not clear it).  Its target argument can be omitted in a channel buffer.
- `/mode` allows its target argument to be skipped.  When skipping the target argument in a channel it targets the channel for a channel buffer, the other user in a query, or Halloy's user in a server buffer.
- `/kick` allows the channel argument to be skipped, when sent from a channel buffer.
- `/ctcp` allows the nick argument to be skipped, when sent from a query buffer.

~~(I think we can make at least `/kick`, `/notice`, and `/ctcp` targetless as well, but figured it would be better to get some of the structures that support targetless commands settled before adding too many more lines.)~~