### PR TITLE
Add Neglected CHANGELOG Entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Added:
 Fixed:
 
 - Receiving files over DCC will no longer stall when sender stops accepting received receipts
+- Attempting to navigate to the next/previous unread buffer, when there is no such buffer, will no longer clear the buffer
 
 Thanks:
 


### PR DESCRIPTION
There was a bugfix in #1119 that didn't get a changelog entry as I wasn't sure if it was a new or old bug (and forgot to check).  Some folks are running into that bug, so this is adding a CHANGELOG entry for the fix.