### PR TITLE
Shorter & Largest-Shorter Split Axis Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Added:
 - `/part`, `/topic`, `/mode`, `/kick`, and `/ctcp` commands can have their target(s) argument skipped when it can be inferred from context (e.g. `/topic` will target the current channel by default when used in a channel buffer)
 - `/cleartopic` command to remove a channel's topic (will target the current channel by default when used in a channel buffer)
 - Ability to hide and theme `kick` server messages
+- Setting for split axis chosen as the shorter dimension of the focused pane (new default behavior)
 
 Fixed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Added:
 - `/cleartopic` command to remove a channel's topic (will target the current channel by default when used in a channel buffer)
 - Ability to hide and theme `kick` server messages
 - Setting for split axis chosen as the shorter dimension of the focused pane (new default behavior)
+- Setting for split axis chosen as the shorter dimension of the largest splittable pane
 
 Fixed:
 

--- a/book/src/configuration/pane.md
+++ b/book/src/configuration/pane.md
@@ -34,11 +34,11 @@ scroller_width = 5
 
 ## `split_axis`
 
-Default axis used when splitting a pane (i.e. default orientation of the divider between panes).  `"shorter"` will compare the width and height of the pane to select the splitting axis;  if the width is shorter then the horizontal axis is selected, and if the height is hosrter then the vertical axis is selected.
+Default axis used when splitting the focused pane to create a new pane (i.e. default orientation of the divider between panes).  `"shorter"` will compare the width and height of the pane to select the splitting axis;  if the width is shorter then the horizontal axis is selected, and if the height is hosrter then the vertical axis is selected.  `"largest-shorter"` will split the largest pane in the main window using the same method as `"shorter"`, rather than splitting the focused pane.
 
 ```toml
 # Type: string
-# Values: "horizontal", "shorter", "vertical"
+# Values: "horizontal", "largest-shorter", "shorter", "vertical"
 # Default: "shorter"
 
 [pane]

--- a/book/src/configuration/pane.md
+++ b/book/src/configuration/pane.md
@@ -34,12 +34,12 @@ scroller_width = 5
 
 ## `split_axis`
 
-Default axis used when splitting a pane (i.e. default orientation of the divider between panes).
+Default axis used when splitting a pane (i.e. default orientation of the divider between panes).  `"shorter"` will compare the width and height of the pane to select the splitting axis;  if the width is shorter then the horizontal axis is selected, and if the height is hosrter then the vertical axis is selected.
 
 ```toml
 # Type: string
-# Values: "horizontal", "vertical"
-# Default: "horizontal"
+# Values: "horizontal", "shorter", "vertical"
+# Default: "shorter"
 
 [pane]
 split_axis = "vertical"

--- a/data/src/config/pane.rs
+++ b/data/src/config/pane.rs
@@ -13,7 +13,8 @@ pub struct Pane {
 #[derive(Debug, Copy, Clone, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum SplitAxis {
-    #[default]
     Horizontal,
     Vertical,
+    #[default]
+    Shorter,
 }

--- a/data/src/config/pane.rs
+++ b/data/src/config/pane.rs
@@ -17,4 +17,5 @@ pub enum SplitAxis {
     Vertical,
     #[default]
     Shorter,
+    LargestShorter,
 }

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -438,8 +438,7 @@ impl Default for State {
     fn default() -> Self {
         Self {
             scrollable: scrollable::Id::unique(),
-            size: Size::default(),
-            // Will get set initially via `Message::Resized`
+            size: Size::default(), // Will get set initially via `Message::Resized`
             limit: Limit::Bottom(0),
             status: Status::default(),
             pending_scroll_to: None,

--- a/src/widget/on_resize.rs
+++ b/src/widget/on_resize.rs
@@ -28,7 +28,7 @@ where
                   clipboard: &mut dyn Clipboard,
                   shell: &mut Shell<'_, Message>,
                   viewport: &iced::Rectangle| {
-                let new_size = viewport.size();
+                let new_size = layout.bounds().size();
 
                 if state.last_size.is_none_or(|size| size != new_size) {
                     state.last_size = Some(new_size);


### PR DESCRIPTION
Adds two new settings for `pane.split_axis`:
- `"shorter"` which takes the shorter dimension of the focused pane as the split axis.  E.g. if the pane is taller than it is wide, then the pane will be split horizontally.
- `"largest-shorter"` which will find the largest splittable pane (i.e. pane in the main window), and take its shorter dimension as the split axis.

I switched the default `split_axis` setting to `"shorter"` as I suspect it will be the most often preferred.

I believe one of these should address #983.