### PR TITLE
Verify Preview Image Dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@ Fixed:
 - Attempting to navigate to the next/previous unread buffer, when there is no such buffer, will no longer clear the buffer
 - Window position is now validated, preventing windows from opening on disconnected monitors
 - When kicked from a channel the kick message will be broadcast in the server buffer (which remains open) as well as in the channel history (which is closed on kick)
+- Preview images with large dimensions will not be displayed if larger than the allowed buffer size
 
 Thanks:
 
-- Bug reports: @privacyadmin, @rlndd, @wingedonezero, @Seishiin, @Erroneuz, @andar1an, freakyy85, ThinkT510
+- Bug reports: @privacyadmin, @rlndd, @wingedonezero, @Seishiin, @Erroneuz, @andar1an, freakyy85, ThinkT510, alexia
 - Feature requests: @deepspaceaxolotl, @4e554c4c
 
 # 2025.8 (2025-08-31)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1447,6 +1447,7 @@ dependencies = [
  "hex",
  "html-escape",
  "iced_core",
+ "iced_wgpu",
  "image 0.25.6",
  "indexmap 2.10.0",
  "irc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ windows_exe_info = "0.4"
 [patch.crates-io]
 iced = { git = "https://github.com/andymandias/iced", rev = "6a215fa027ae7c8f5b2566c3af8d42aa0017971b" }
 iced_core = { git = "https://github.com/andymandias/iced", rev = "6a215fa027ae7c8f5b2566c3af8d42aa0017971b" }
+iced_wgpu = { git = "https://github.com/andymandias/iced", rev = "6a215fa027ae7c8f5b2566c3af8d42aa0017971b" }
 
 [profile.ci]
 inherits = "dev"

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -33,6 +33,7 @@ xdg = "3.0.0"
 flate2 = "1.0"
 hex = "0.4.3"
 iced_core = "0.14.0-dev"
+iced_wgpu = "0.14.0-dev"
 indexmap = { version = "2.9", features = ["std", "serde"] }
 seahash = "4.1.0"
 serde_json = "1.0"


### PR DESCRIPTION
This adds another check on loading previews, to verify that image data size fits within the maximum buffer size.  The image data size calculation is currently copied out of `iced` to be performed in `preview::load`, with dimensions provided via [`image::image_dimensions`](https://docs.rs/image/latest/image/fn.image_dimensions.html), since I wasn't able to find a way to request it from `iced` itself. [`max_buffer_size`](https://docs.rs/wgpu/latest/wgpu/struct.Limits.html#structfield.max_buffer_size) is taken using [`Limits::downlevel_defaults()`](https://docs.rs/wgpu/latest/wgpu/struct.Limits.html#method.downlevel_defaults) since `wgpu` states: 
> This is a set of limits that is guaranteed to work on almost all backends, including “downlevel” backends such as OpenGL and D3D11, other than WebGL.

If the maximum buffer size is exceeded, then that triggers a panic inside `wgpu`.  Some images can have a data size much larger than their file size, which means [`preview.request.max_image_size`](https://halloy.chat/configuration/preview.html#max_image_size) isn't sufficient prevent exceeding the maximum buffer size.  E.g. when searching for this issue I found an image that is ~4 MB on disk and with a data size of ~458MB.