### PR TITLE
Hide Secondary Unread Indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Added:
 - Setting for split axis chosen as the shorter dimension of the focused pane (new default behavior)
 - Setting for split axis chosen as the shorter dimension of the largest splittable pane
 - `soju.im/bouncer-networks` support
+- Setting to hide the backlog divider when all messages in the buffer have been read
 
 Fixed:
 
@@ -20,10 +21,11 @@ Fixed:
 - Window position is now validated, preventing windows from opening on disconnected monitors
 - When kicked from a channel the kick message will be broadcast in the server buffer (which remains open) as well as in the channel history (which is closed on kick)
 - Preview images with large dimensions will not be displayed if larger than the allowed buffer size
+- Do not activate the mark as read buffer when blocked/hidden messages are unread in the buffer
 
 Thanks:
 
-- Bug reports: @privacyadmin, @rlndd, @wingedonezero, @Seishiin, @Erroneuz, @andar1an, freakyy85, ThinkT510, alexia
+- Bug reports: @privacyadmin, @rlndd, @wingedonezero, @Seishiin, @Erroneuz, @andar1an, freakyy85, ThinkT510, alexia, @darienm
 - Feature requests: @deepspaceaxolotl, @4e554c4c
 
 # 2025.8 (2025-08-31)

--- a/book/src/configuration/buffer.md
+++ b/book/src/configuration/buffer.md
@@ -8,6 +8,7 @@ Buffer settings for Halloy.
    3. [Topic](#bufferchanneltopic) - Topic settings within a channel buffer
 2. [Chathistory](#bufferchathistory) - IRCv3 Chat History extension settings
 3. [Commands](#buffercommands) - Commands settings
+4. [Backlog Separator](#bufferbacklog_separator) - Customize when the backlog separator is displayed within a buffer
 4. [Date Separators](#bufferdate_separators) - Customize how date separators are displayed within a buffer
 5. [Emojis](#bufferemojis) - Emojis settings
 6. [Internal Messages](#bufferinternal_messages) - Internal messages are messages sent from Halloy itself
@@ -225,6 +226,23 @@ Show or hide the description for a command
 
 [buffer.commands]
 show_description = true
+```
+
+## `[buffer.backlog_separator]`
+
+Customize when the backlog separator is displayed within a buffer
+
+### `hide_when_all_read`
+
+Hide backlog divider when all messages in the buffer have been marked as read.
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: false
+
+[buffer.buffer_separator]
+hide_when_all_read = true
 ```
 
 ## `[buffer.date_separators]`

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -222,6 +222,12 @@ impl Default for Timestamp {
     }
 }
 
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct BacklogSeparator {
+    pub hide_when_all_read: bool,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct DateSeparators {

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -8,7 +8,8 @@ pub mod channel;
 pub mod nickname;
 
 use crate::buffer::{
-    DateSeparators, SkinTone, StatusMessagePrefix, TextInput, Timestamp,
+    BacklogSeparator, DateSeparators, SkinTone, StatusMessagePrefix, TextInput,
+    Timestamp,
 };
 use crate::message::source;
 
@@ -23,6 +24,7 @@ pub struct Buffer {
     pub internal_messages: InternalMessages,
     pub status_message_prefix: StatusMessagePrefix,
     pub chathistory: ChatHistory,
+    pub backlog_separator: BacklogSeparator,
     pub date_separators: DateSeparators,
     pub commands: Commands,
     pub emojis: Emojis,

--- a/data/src/history/metadata.rs
+++ b/data/src/history/metadata.rs
@@ -41,13 +41,16 @@ impl ReadMarker {
         messages
             .iter()
             .rev()
-            .find(|message| match message.target.source() {
-                source::Source::Internal(source) => match source {
-                    source::Internal::Status(_) => false,
-                    // Logs are in their own buffer and this gives us backlog support there
-                    source::Internal::Logs(_) => true,
-                },
-                _ => true,
+            .find(|message| {
+                !message.blocked
+                    && match message.target.source() {
+                        source::Source::Internal(source) => match source {
+                            source::Internal::Status(_) => false,
+                            // Logs are in their own buffer and this gives us backlog support there
+                            source::Internal::Logs(_) => true,
+                        },
+                        _ => true,
+                    }
             })
             .map(|message| message.server_time)
             .map(Self)

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -365,7 +365,11 @@ pub fn view<'a>(
         !has_more_older_messages
     } else {
         // Always show backlog divider after any visible older messages
-        true
+        if config.buffer.backlog_separator.hide_when_all_read {
+            !new_messages.is_empty()
+        } else {
+            true
+        }
     };
 
     let divider = if show_backlog_divier {


### PR DESCRIPTION
Adds the fix and feature requested in #979.  Specifically:
- Messages that are hidden/blocked no longer cause the "Mark messages as read" button to activate.  (This utilizes the changes made in #1113, which is why this PR is branching off of that PR.)
- A setting to hide the backlog divider when all messages have been marked as read (similar to how Discord handles its backlog divider).  This has a potential for confusion (i.e. a user familiar with the current behavior could wind up looking for the divider for a while, not realizing it's hidden), so I am leaving the default setting as false.