### PR TITLE
Parse RPL_MONONLINE Targets in Message Text

### DIFF
--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -1591,7 +1591,10 @@ fn content<'a>(
             let target_users = params
                 .get(1)?
                 .split(',')
-                .map(|target| User::from(Nick::from(target)))
+                .map(|target| {
+                    User::parse(target, Some(prefix))
+                        .unwrap_or(User::from(Nick::from(target)))
+                })
                 .collect::<ChannelUsers>();
 
             let target_usernames = target_users


### PR DESCRIPTION
A minor fix for how RPL_MONONLINE message text is parsed (matches the fix applied in commit c4cd4923dd0b287c71459a981a6e3ed1e8b700fe).  Keeps RPL_MONOFFLINE parsed the same as RPL_MONONLINE, for simplicity's sake (and since there's no significant cost to it).