### PR TITLE
Add `libxcb-devel` to Fedora install docs/script

### DIFF
--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -69,7 +69,7 @@ Requirements:
 * [Rust toolchain](https://www.rust-lang.org/tools/install)
 * [Git version control system](https://git-scm.com/)
 * Packages:
-  - Fedora-based distributions: `alsa-lib-devel openssl-devel`
+  - Fedora-based distributions: `alsa-lib-devel openssl-devel libxcb-devel`
   - Debian-based distributions: `librust-alsa-sys-dev libssl-dev libxcb1-dev`
 
 ```sh

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -20,7 +20,7 @@
   prefix=$(realpath -- "$prefix")
 
 # To build successfully, install packages:
-#   alsa-lib-devel openssl-devel (on Fedora-based distros)
+#   alsa-lib-devel openssl-devel libxcb-devel (on Fedora-based distros)
 #   librust-alsa-sys-dev libssl-dev libxcb1-dev (on Debian-based distros)
 
   cargo install --locked --force --path "$git_root_dir" --root "$prefix"


### PR DESCRIPTION
`libxcb-devel` is needed to build on Fedora now. So, it has been added to the installation documentation and Linux install script.