### PR TITLE
Utilize CHANTYPES in `Channel::from_str`

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -319,8 +319,11 @@ impl Client {
                         )
                     })
                 } else {
-                    let target_channel =
-                        target::Channel::from_str(&mask, self.casemapping());
+                    let target_channel = target::Channel::from_str(
+                        &mask,
+                        self.chantypes(),
+                        self.casemapping(),
+                    );
 
                     self.user_who_request(&target_channel)
                 }
@@ -374,7 +377,11 @@ impl Client {
                 ) {
                     Some(channel)
                 } else if mask == "*" {
-                    Some(target::Channel::from_str(mask, self.casemapping()))
+                    Some(target::Channel::from_str(
+                        mask,
+                        self.chantypes(),
+                        self.casemapping(),
+                    ))
                 } else {
                     None
                 };
@@ -1845,8 +1852,11 @@ impl Client {
                 } else if mask == "*" {
                     // Some servers respond with the mask * instead of the requested
                     // channel name when rate-limiting WHO requests
-                    let target_channel =
-                        target::Channel::from_str(mask, self.casemapping());
+                    let target_channel = target::Channel::from_str(
+                        mask,
+                        self.chantypes(),
+                        self.casemapping(),
+                    );
 
                     if let Some(pos) = self
                         .who_polls
@@ -2416,7 +2426,9 @@ impl Client {
                 }
                 self.registration_step = RegistrationStep::Complete;
 
-                if let Some(id) = self.server.bouncer_netid() && self.resolved_netid.is_none() {
+                if let Some(id) = self.server.bouncer_netid()
+                    && self.resolved_netid.is_none()
+                {
                     // we want to be a bouncer network, but we never connected to one.
                     bail!("Requested bouncer id {id}, but was not connected.");
                 }

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -88,7 +88,9 @@ impl FromStr for Operation {
                         "BOT" => Ok(Operation::Add(Parameter::BOT(
                             parse_required_letter(value, None)?,
                         ))),
-                        "BOUNCER_NETID" => Ok(Operation::Add(Parameter::BOUNCER_NETID(value.to_owned()))),
+                        "BOUNCER_NETID" => Ok(Operation::Add(
+                            Parameter::BOUNCER_NETID(value.to_owned()),
+                        )),
                         "CALLERID" => Ok(Operation::Add(Parameter::CALLERID(
                             parse_required_letter(
                                 value,
@@ -980,6 +982,8 @@ pub const DEFAULT_CHANMODES: &[ModeKind] = &[
         modes: Cow::Borrowed("imstn"),
     },
 ];
+
+pub const DEFAULT_CHANTYPES: &[char] = proto::DEFAULT_CHANNEL_PREFIXES;
 
 const DEFAULT_DEAF_LETTER: char = 'D';
 

--- a/data/src/target.rs
+++ b/data/src/target.rs
@@ -160,25 +160,28 @@ impl Channel {
         self.0.raw.as_ref()
     }
 
-    pub fn from_str(target: &str, casemapping: isupport::CaseMap) -> Self {
-        let inner =
-            if let Some(index) = target.find(proto::DEFAULT_CHANNEL_PREFIXES) {
-                // This will not panic, since `find` always returns a valid codepoint index.
-                // We call `find` -> `split_at` because it is an _inclusive_ split, which includes the match.
-                let (prefixes, channel) = target.split_at(index);
+    pub fn from_str(
+        target: &str,
+        chantypes: &[char],
+        casemapping: isupport::CaseMap,
+    ) -> Self {
+        let inner = if let Some(index) = target.find(chantypes) {
+            // This will not panic, since `find` always returns a valid codepoint index.
+            // We call `find` -> `split_at` because it is an _inclusive_ split, which includes the match.
+            let (prefixes, channel) = target.split_at(index);
 
-                ChannelData {
-                    prefixes: prefixes.chars().collect(),
-                    normalized: casemapping.normalize(channel),
-                    raw: target.to_string(),
-                }
-            } else {
-                ChannelData {
-                    prefixes: vec![],
-                    normalized: casemapping.normalize(target),
-                    raw: target.to_string(),
-                }
-            };
+            ChannelData {
+                prefixes: prefixes.chars().collect(),
+                normalized: casemapping.normalize(channel),
+                raw: target.to_string(),
+            }
+        } else {
+            ChannelData {
+                prefixes: vec![],
+                normalized: casemapping.normalize(target),
+                raw: target.to_string(),
+            }
+        };
         Channel::from(inner)
     }
 

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -48,6 +48,7 @@ pub fn view<'a>(
     is_focused: bool,
 ) -> Element<'a, Message> {
     let server = &state.server;
+    let chantypes = clients.get_chantypes(server);
     let casemapping = clients.get_casemapping(server);
     let prefix = clients.get_prefix(server);
     let channel = &state.target;
@@ -75,6 +76,7 @@ pub fn view<'a>(
 
     let message_formatter = ChannelQueryLayout {
         config,
+        chantypes,
         casemapping,
         prefix,
         server,
@@ -323,6 +325,7 @@ fn topic<'a>(
         return None;
     }
 
+    let chantypes = clients.get_chantypes(&state.server);
     let casemapping = clients.get_casemapping(&state.server);
     let prefix = clients.get_prefix(&state.server);
 
@@ -331,6 +334,7 @@ fn topic<'a>(
     Some(
         topic::view(
             &state.server,
+            chantypes,
             casemapping,
             prefix,
             &state.target,

--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -41,6 +41,7 @@ pub fn update(message: Message) -> Option<Event> {
 
 pub fn view<'a>(
     server: &'a Server,
+    chantypes: &'a [char],
     casemapping: isupport::CaseMap,
     prefix: &'a [isupport::PrefixMap],
     channel: &'a target::Channel,
@@ -112,6 +113,7 @@ pub fn view<'a>(
     let content = column![
         message_content(
             content,
+            chantypes,
             casemapping,
             theme,
             Message::Link,

--- a/src/buffer/highlights.rs
+++ b/src/buffer/highlights.rs
@@ -120,6 +120,7 @@ pub fn view<'a>(
                             )
                         });
 
+                    let chantypes = clients.get_chantypes(server);
                     let casemapping = clients.get_casemapping(server);
                     let prefix = clients.get_prefix(server);
 
@@ -146,6 +147,7 @@ pub fn view<'a>(
 
                     let text = message_content::with_context(
                         &message.content,
+                        chantypes,
                         casemapping,
                         theme,
                         scroll_view::Message::Link,
@@ -217,10 +219,12 @@ pub fn view<'a>(
                         ])
                         .on_link(scroll_view::Message::Link);
 
+                    let chantypes = clients.get_chantypes(server);
                     let casemapping = clients.get_casemapping(server);
 
                     let text = message_content(
                         &message.content,
+                        chantypes,
                         casemapping,
                         theme,
                         scroll_view::Message::Link,

--- a/src/buffer/logs.rs
+++ b/src/buffer/logs.rs
@@ -78,6 +78,7 @@ pub fn view<'a>(
 
                     let message = message_content(
                         &message.content,
+                        isupport::DEFAULT_CHANTYPES,
                         isupport::CaseMap::default(),
                         theme,
                         scroll_view::Message::Link,

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -55,6 +55,7 @@ impl<'a> TargetInfo<'a> {
 #[derive(Clone, Copy)]
 pub struct ChannelQueryLayout<'a> {
     pub config: &'a Config,
+    pub chantypes: &'a [char],
     pub casemapping: CaseMap,
     pub prefix: &'a [PrefixMap],
     pub server: &'a Server,
@@ -194,6 +195,7 @@ impl<'a> ChannelQueryLayout<'a> {
 
         let message_content = message_content::with_context(
             &message.content,
+            self.chantypes,
             self.casemapping,
             self.theme,
             Message::Link,
@@ -250,6 +252,7 @@ impl<'a> ChannelQueryLayout<'a> {
         let fm = *self;
         let message_content = message_content::with_context(
             &message.content,
+            fm.chantypes,
             fm.casemapping,
             self.theme,
             Message::Link,
@@ -336,6 +339,7 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
 
                     let message_content = message_content(
                         &message.content,
+                        self.chantypes,
                         self.casemapping,
                         self.theme,
                         Message::Link,
@@ -367,6 +371,7 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
 
                     let message = message_content(
                         &message.content,
+                        self.chantypes,
                         self.casemapping,
                         self.theme,
                         Message::Link,

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -41,6 +41,7 @@ pub fn view<'a>(
     is_focused: bool,
 ) -> Element<'a, Message> {
     let server = &state.server;
+    let chantypes = clients.get_chantypes(server);
     let casemapping = clients.get_casemapping(server);
     let prefix = clients.get_prefix(server);
     let query = &state.target;
@@ -60,6 +61,7 @@ pub fn view<'a>(
 
     let message_formatter = ChannelQueryLayout {
         config,
+        chantypes,
         casemapping,
         prefix,
         server,

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -35,6 +35,7 @@ pub fn view<'a>(
     is_focused: bool,
 ) -> Element<'a, Message> {
     let status = clients.status(&state.server);
+    let chantypes = clients.get_chantypes(&state.server);
     let casemapping = clients.get_casemapping(&state.server);
     let buffer = &state.buffer;
     let input = history.input(buffer);
@@ -65,6 +66,7 @@ pub fn view<'a>(
                     message::Source::Server(server) => {
                         let message = message_content(
                             &message.content,
+                            chantypes,
                             casemapping,
                             theme,
                             scroll_view::Message::Link,
@@ -90,6 +92,7 @@ pub fn view<'a>(
                     ) => {
                         let message = message_content(
                             &message.content,
+                            chantypes,
                             casemapping,
                             theme,
                             scroll_view::Message::Link,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1075,10 +1075,18 @@ impl Halloy {
                                         );
                                     }
                                     data::client::Event::AddedIsupportParam(param) => {
-                                        if let data::isupport::Parameter::CASEMAPPING(casemapping) = param {
+                                        if matches!(
+                                            param,
+                                            data::isupport::Parameter::CASEMAPPING(_)
+                                                | data::isupport::Parameter::CHANTYPES(_)
+                                        ) {
+                                            let chantypes = self.clients.get_chantypes(&server);
+                                            let casemapping = self.clients.get_casemapping(&server);
+
                                             FilterChain::sync_channels(
                                                 dashboard.get_filters(),
                                                 &server,
+                                                chantypes,
                                                 casemapping
                                             );
                                         }

--- a/src/widget/message_content.rs
+++ b/src/widget/message_content.rs
@@ -9,6 +9,7 @@ use crate::{Theme, font};
 
 pub fn message_content<'a, M: 'a>(
     content: &'a message::Content,
+    chantypes: &[char],
     casemapping: isupport::CaseMap,
     theme: &'a Theme,
     on_link: impl Fn(message::Link) -> M + 'a,
@@ -18,6 +19,7 @@ pub fn message_content<'a, M: 'a>(
 ) -> Element<'a, M> {
     message_content_impl::<(), M>(
         content,
+        chantypes,
         casemapping,
         theme,
         on_link,
@@ -30,6 +32,7 @@ pub fn message_content<'a, M: 'a>(
 
 pub fn with_context<'a, T: Copy + 'a, M: 'a>(
     content: &'a message::Content,
+    chantypes: &[char],
     casemapping: isupport::CaseMap,
     theme: &'a Theme,
     on_link: impl Fn(message::Link) -> M + 'a,
@@ -41,6 +44,7 @@ pub fn with_context<'a, T: Copy + 'a, M: 'a>(
 ) -> Element<'a, M> {
     message_content_impl(
         content,
+        chantypes,
         casemapping,
         theme,
         on_link,
@@ -54,6 +58,7 @@ pub fn with_context<'a, T: Copy + 'a, M: 'a>(
 #[allow(clippy::type_complexity)]
 fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
     content: &'a message::Content,
+    chantypes: &[char],
     casemapping: isupport::CaseMap,
     theme: &'a Theme,
     on_link: impl Fn(message::Link) -> M + 'a,
@@ -95,6 +100,7 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
                             .link(message::Link::Channel(
                                 target::Channel::from_str(
                                     s.as_str(),
+                                    chantypes,
                                     casemapping,
                                 ),
                             )),


### PR DESCRIPTION
Since we can provide the server's CHANTYPES to `Channel::from_str`, rather than always using the default set of channel prefixes, I believe we should.  This PR makes that change in `Channel::from_str`, and the rest of the changes are downstream from that.