### PR TITLE
Add Normalized Representation to Nicknames

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -138,7 +138,8 @@ pub struct Client {
     config: Arc<config::Server>,
     handle: server::Handle,
     alt_nick: Option<usize>,
-    resolved_nick: Option<String>,
+    resolved_nick: Option<Nick>,
+    configured_nick: Nick,
     chanmap: IndexMap<target::Channel, Channel>,
     resolved_queries: HashSet<target::Query>,
     labels: HashMap<String, Context>,
@@ -182,6 +183,10 @@ impl Client {
             server,
             handle: sender,
             resolved_nick: None,
+            configured_nick: Nick::from_str(
+                &config.nickname,
+                isupport::CaseMap::default(),
+            ),
             alt_nick: None,
             chanmap: IndexMap::default(),
             resolved_queries: HashSet::new(),
@@ -735,8 +740,10 @@ impl Client {
                             false => None,
                         }
                     }) {
-                    if Some(User::from(Nick::from("HistServ")))
-                        == message.user()
+                    if Some(User::from(Nick::from_str(
+                        "HistServ",
+                        self.casemapping(),
+                    ))) == message.user(self.casemapping())
                     {
                         // HistServ provides event-playback without event-playback
                         // which would require client-side parsing to map appropriately.
@@ -768,12 +775,13 @@ impl Client {
                                         source: source::Source::Server(Some(
                                             source::Server::new(
                                                 source::server::Kind::Quit,
-                                                message.user().map(|user| {
-                                                    Nick::from(
-                                                        user.nickname()
-                                                            .as_ref(),
-                                                    )
-                                                }),
+                                                message
+                                                    .user(self.casemapping())
+                                                    .map(|user| {
+                                                        Nick::from(
+                                                            user.nickname(),
+                                                        )
+                                                    }),
                                             ),
                                         )),
                                     };
@@ -793,16 +801,15 @@ impl Client {
                                     // Ignore historical CTCP queries/responses except for ACTIONs
                                     vec![]
                                 } else {
-                                    if let Some(user) = message.user() {
+                                    if let Some(user) =
+                                        message.user(self.casemapping())
+                                    {
                                         // If direct message, update resolved queries with user
                                         if target
                                             == &self.nickname().to_string()
                                         {
                                             self.resolved_queries.replace(
-                                                target::Query::from_user(
-                                                    &user,
-                                                    self.casemapping(),
-                                                ),
+                                                target::Query::from(user),
                                             );
                                         }
                                     }
@@ -1257,7 +1264,7 @@ impl Client {
                 }
             }
             Command::PRIVMSG(target, text) | Command::NOTICE(target, text) => {
-                if let Some(user) = message.user() {
+                if let Some(user) = message.user(self.casemapping()) {
                     let is_echo = user.nickname() == self.nickname();
 
                     let dcc_command = dcc::decode(text);
@@ -1393,9 +1400,8 @@ impl Client {
                     let direct_message = target == &self.nickname().to_string();
 
                     if direct_message {
-                        self.resolved_queries.replace(
-                            target::Query::from_user(&user, self.casemapping()),
-                        );
+                        self.resolved_queries
+                            .replace(target::Query::from(&user));
                     }
 
                     let event = Event::PrivOrNotice(
@@ -1419,14 +1425,17 @@ impl Client {
                 }
             }
             Command::INVITE(user, channel) => {
-                let user = User::from(Nick::from(user.as_str()));
+                let user = User::from(Nick::from_str(
+                    user.as_str(),
+                    self.casemapping(),
+                ));
                 let channel = context!(target::Channel::parse(
                     channel,
                     self.chantypes(),
                     self.statusmsg(),
                     self.casemapping(),
                 ));
-                let inviter = ok!(message.user());
+                let inviter = ok!(message.user(self.casemapping()));
                 let user_channels = self.user_channels(user.nickname());
 
                 return Ok(vec![Event::Broadcast(Broadcast::Invite {
@@ -1437,14 +1446,18 @@ impl Client {
                 })]);
             }
             Command::NICK(nick) => {
-                let old_user = ok!(message.user());
+                let old_user = ok!(message.user(self.casemapping()));
                 let ourself = self.nickname() == old_user.nickname();
 
                 if ourself {
-                    self.resolved_nick = Some(nick.to_string());
+                    self.resolved_nick = Some(Nick::from_string(
+                        nick.to_string(),
+                        self.casemapping(),
+                    ));
                 }
 
-                let new_nick = Nick::from(nick.as_str());
+                let new_nick =
+                    Nick::from_str(nick.as_str(), self.casemapping());
 
                 self.chanmap.values_mut().for_each(|channel| {
                     if let Some(user) = channel.users.take(&old_user) {
@@ -1491,11 +1504,14 @@ impl Client {
             Command::Numeric(RPL_WELCOME, args) => {
                 // Updated actual nick
                 let nick = ok!(args.first());
-                self.resolved_nick = Some(nick.to_string());
+                self.resolved_nick = Some(Nick::from_string(
+                    nick.to_string(),
+                    self.casemapping(),
+                ));
             }
             // QUIT
             Command::QUIT(comment) => {
-                let user = ok!(message.user());
+                let user = ok!(message.user(self.casemapping()));
 
                 let channels = self.user_channels(user.nickname());
 
@@ -1511,7 +1527,7 @@ impl Client {
                 })]);
             }
             Command::PART(channel, _) => {
-                let user = ok!(message.user());
+                let user = ok!(message.user(self.casemapping()));
 
                 if user.nickname() == self.nickname() {
                     self.chanmap.shift_remove(&context!(
@@ -1534,13 +1550,15 @@ impl Client {
                 }
             }
             Command::JOIN(channel, accountname) => {
-                let user = ok!(message.user());
+                let casemapping = self.casemapping();
+
+                let user = ok!(message.user(casemapping));
 
                 let target_channel = context!(target::Channel::parse(
                     channel,
                     self.chantypes(),
                     self.statusmsg(),
-                    self.casemapping(),
+                    casemapping,
                 ));
 
                 if user.nickname() == self.nickname() {
@@ -1591,18 +1609,22 @@ impl Client {
                 }
             }
             Command::KICK(channel, victim, reason) => {
+                let casemapping = self.casemapping();
+
                 if let Ok(channel) = target::Channel::parse(
                     channel,
                     self.chantypes(),
                     self.statusmsg(),
-                    self.casemapping(),
+                    casemapping,
                 ) {
-                    if victim == self.nickname().as_ref() {
+                    if casemapping.normalize(victim)
+                        == self.nickname().as_normalized_str()
+                    {
                         self.chanmap.shift_remove(&channel);
 
                         return Ok(vec![
                             Event::Broadcast(Broadcast::Kick {
-                                kicker: ok!(message.user()),
+                                kicker: ok!(message.user(casemapping)),
                                 victim: User::from(self.nickname().to_owned()),
                                 reason: reason.clone(),
                                 channel,
@@ -1612,20 +1634,23 @@ impl Client {
                         ]);
                     } else if let Some(channel) = self.chanmap.get_mut(&channel)
                     {
-                        channel
-                            .users
-                            .remove(&User::from(Nick::from(victim.as_str())));
+                        channel.users.remove(&User::from(Nick::from_str(
+                            victim.as_str(),
+                            casemapping,
+                        )));
                     }
                 }
             }
             Command::Numeric(RPL_WHOREPLY, args) => {
                 let channel = ok!(args.get(1));
 
+                let casemapping = self.casemapping();
+
                 if let Ok(target_channel) = target::Channel::parse(
                     channel,
                     self.chantypes(),
                     self.statusmsg(),
-                    self.casemapping(),
+                    casemapping,
                 ) {
                     let user_request = self.user_who_request(&target_channel);
 
@@ -1635,6 +1660,7 @@ impl Client {
                         client_channel.update_user_away(
                             ok!(args.get(5)),
                             ok!(args.get(6)),
+                            casemapping,
                         );
 
                         if let Some(who_poll) = self
@@ -1673,11 +1699,13 @@ impl Client {
             Command::Numeric(RPL_WHOSPCRPL, args) => {
                 let channel = ok!(args.get(2));
 
+                let casemapping = self.casemapping();
+
                 if let Ok(target_channel) = target::Channel::parse(
                     channel,
                     self.chantypes(),
                     self.statusmsg(),
-                    self.casemapping(),
+                    casemapping,
                 ) {
                     let user_request = self.user_who_request(&target_channel);
 
@@ -1738,6 +1766,7 @@ impl Client {
                                     client_channel.update_user_away(
                                         ok!(args.get(3)),
                                         ok!(args.get(4)),
+                                        casemapping,
                                     );
                                 } else if token
                                     == WhoXPollParameters::WithAccountName
@@ -1748,11 +1777,13 @@ impl Client {
                                     client_channel.update_user_away(
                                         user,
                                         ok!(args.get(4)),
+                                        casemapping,
                                     );
 
                                     client_channel.update_user_accountname(
                                         user,
                                         ok!(args.get(5)),
+                                        casemapping,
                                     );
                                 }
                             }
@@ -1882,7 +1913,7 @@ impl Client {
             }
             Command::AWAY(args) => {
                 let away = args.is_some();
-                let user = ok!(message.user());
+                let user = ok!(message.user(self.casemapping()));
 
                 for channel in self.chanmap.values_mut() {
                     if let Some(mut user) = channel.users.take(&user) {
@@ -1916,11 +1947,13 @@ impl Client {
                 }
             }
             Command::MODE(target, Some(modes), Some(args)) => {
+                let casemapping = self.casemapping();
+
                 if let Ok(channel) = target::Channel::parse(
                     target,
                     self.chantypes(),
                     self.statusmsg(),
-                    self.casemapping(),
+                    casemapping,
                 ) {
                     let modes = mode::parse::<mode::Channel>(
                         modes,
@@ -1931,11 +1964,15 @@ impl Client {
 
                     if let Some(channel) = self.chanmap.get_mut(&channel) {
                         for mode in modes {
-                            if let Some((op, lookup)) = mode.operation().zip(
-                                mode.arg()
-                                    .map(|nick| User::from(Nick::from(nick))),
-                            ) && let Some(mut user) =
-                                channel.users.take(&lookup)
+                            if let Some((op, lookup)) =
+                                mode.operation().zip(mode.arg().map(|nick| {
+                                    User::from(Nick::from_str(
+                                        nick,
+                                        casemapping,
+                                    ))
+                                }))
+                                && let Some(mut user) =
+                                    channel.users.take(&lookup)
                             {
                                 user.update_access_level(op, *mode.value());
                                 channel.users.insert(user);
@@ -1946,7 +1983,8 @@ impl Client {
                     // Only check for being logged in via mode if account-notify is not available,
                     // since it is not standardized across networks.
 
-                    if target == self.nickname().as_ref()
+                    if casemapping.normalize(target)
+                        == self.nickname().as_normalized_str()
                         && !self.supports_account_notify
                         && !self.registration_required_channels.is_empty()
                     {
@@ -1986,9 +2024,11 @@ impl Client {
                         self.casemapping(),
                     )))
                 {
+                    let casemapping = isupport::get_casemapping(&self.isupport);
                     let prefix = isupport::get_prefix(&self.isupport);
                     for user in args[3].split(' ') {
-                        if let Ok(user) = User::parse(user, prefix) {
+                        if let Ok(user) = User::parse(user, casemapping, prefix)
+                        {
                             channel.users.insert(user);
                         }
                     }
@@ -2018,12 +2058,14 @@ impl Client {
                 }
             }
             Command::TOPIC(channel, topic) => {
+                let casemapping = self.casemapping();
+
                 if let Some(channel) =
                     self.chanmap.get_mut(&context!(target::Channel::parse(
                         channel,
                         self.chantypes(),
                         self.statusmsg(),
-                        self.casemapping(),
+                        casemapping,
                     )))
                 {
                     if let Some(text) = topic
@@ -2032,7 +2074,7 @@ impl Client {
                         channel.topic.content =
                             Some(message::parse_fragments(text.clone()));
                         channel.topic.who = message
-                            .user()
+                            .user(casemapping)
                             .map(|user| user.nickname().to_owned());
                         channel.topic.time = Some(server_time(&message));
                     } else {
@@ -2075,6 +2117,7 @@ impl Client {
                     channel.topic.who = Some(
                         context!(User::parse(
                             ok!(args.get(2)),
+                            isupport::get_casemapping(&self.isupport),
                             isupport::get_prefix(&self.isupport),
                         ))
                         .nickname()
@@ -2166,6 +2209,17 @@ impl Client {
                                         );
 
                                         match parameter {
+                                            isupport::Parameter::CASEMAPPING(casemapping) => {
+                                                if let Some(resolved_nick) = self.resolved_nick.as_mut() {
+                                                    resolved_nick.renormalize(casemapping);
+                                                }
+                                                self.configured_nick.renormalize(casemapping);
+
+                                                // TODO: When casemapping
+                                                // changes, ChannelUsers,
+                                                // Targets, etc should be
+                                                // renormalized and resorted
+                                            }
                                             isupport::Parameter::MONITOR(
                                                 target_limit,
                                             ) => {
@@ -2244,7 +2298,7 @@ impl Client {
                 return Ok(vec![]);
             }
             Command::ACCOUNT(accountname) => {
-                let old_user = ok!(message.user());
+                let old_user = ok!(message.user(self.casemapping()));
 
                 self.chanmap.values_mut().for_each(|channel| {
                     if let Some(user) = channel.users.take(&old_user) {
@@ -2269,7 +2323,7 @@ impl Client {
                 }
             }
             Command::CHGHOST(new_username, new_hostname) => {
-                let old_user = ok!(message.user());
+                let old_user = ok!(message.user(self.casemapping()));
 
                 let ourself = old_user.nickname() == self.nickname();
 
@@ -2295,13 +2349,18 @@ impl Client {
                 })]);
             }
             Command::Numeric(RPL_MONONLINE, args) => {
+                let casemapping = isupport::get_casemapping(&self.isupport);
                 let prefix = isupport::get_prefix(&self.isupport);
 
                 let targets = ok!(args.get(1))
                     .split(',')
                     .map(|target| {
-                        User::parse(target, prefix)
-                            .unwrap_or(User::from(Nick::from(target)))
+                        User::parse(target, casemapping, prefix).unwrap_or(
+                            User::from(Nick::from_str(
+                                target,
+                                casemapping.unwrap_or_default(),
+                            )),
+                        )
                     })
                     .collect::<Vec<_>>();
 
@@ -2313,7 +2372,7 @@ impl Client {
             Command::Numeric(RPL_MONOFFLINE, args) => {
                 let targets = ok!(args.get(1))
                     .split(',')
-                    .map(Nick::from)
+                    .map(|target| Nick::from_str(target, self.casemapping()))
                     .collect::<Vec<_>>();
 
                 return Ok(vec![
@@ -2437,8 +2496,11 @@ impl Client {
                 if let Some(nick_pass) = self.config.nick_password.as_ref() {
                     // Try ghost recovery if we couldn't claim our nick
                     if self.config.should_ghost
-                        && self.resolved_nick
-                            == Some(self.config.nickname.clone())
+                        && self.resolved_nick.as_ref().is_some_and(
+                            |resolved_nick| {
+                                *resolved_nick == self.configured_nick
+                            },
+                        )
                     {
                         for sequence in &self.config.ghost_sequence {
                             self.handle.try_send(command!(
@@ -2477,9 +2539,9 @@ impl Client {
                                 ))?;
                             }
                         }
-                    } else if self.resolved_nick
-                        == Some(self.config.nickname.clone())
-                    {
+                    } else if self.resolved_nick.as_ref().is_some_and(
+                        |resolved_nick| *resolved_nick == self.configured_nick,
+                    ) {
                         // Use nickname-less identification if possible, since it has
                         // no possible argument order issues.
                         self.handle.try_send(command!(
@@ -2504,7 +2566,11 @@ impl Client {
                 if let (Some(nick), Some(modestring)) =
                     (self.resolved_nick.clone(), self.config.umodes.as_ref())
                 {
-                    self.handle.try_send(command!("MODE", nick, modestring))?;
+                    self.handle.try_send(command!(
+                        "MODE",
+                        nick.to_string(),
+                        modestring
+                    ))?;
                 }
 
                 // Request bouncer networks
@@ -2914,11 +2980,10 @@ impl Client {
 
     pub fn nickname(&self) -> NickRef<'_> {
         // TODO: Fallback nicks
-        NickRef::from(
-            self.resolved_nick
-                .as_deref()
-                .unwrap_or(&self.config.nickname),
-        )
+        self.resolved_nick
+            .as_ref()
+            .unwrap_or(&self.configured_nick)
+            .as_nickref()
     }
 
     pub fn tick(&mut self, now: Instant) -> Result<()> {
@@ -3596,8 +3661,13 @@ pub struct Channel {
 }
 
 impl Channel {
-    pub fn update_user_away(&mut self, user: &str, flags: &str) {
-        let user = User::from(Nick::from(user));
+    pub fn update_user_away(
+        &mut self,
+        user: &str,
+        flags: &str,
+        casemapping: isupport::CaseMap,
+    ) {
+        let user = User::from(Nick::from_str(user, casemapping));
 
         if let Some(away_flag) = flags.chars().next() {
             // H = Here, G = gone (away)
@@ -3614,8 +3684,13 @@ impl Channel {
         }
     }
 
-    pub fn update_user_accountname(&mut self, user: &str, accountname: &str) {
-        let user = User::from(Nick::from(user));
+    pub fn update_user_accountname(
+        &mut self,
+        user: &str,
+        accountname: &str,
+        casemapping: isupport::CaseMap,
+    ) {
+        let user = User::from(Nick::from_str(user, casemapping));
 
         if let Some(user) = self.users.take(&user) {
             self.users.insert(user.with_accountname(accountname));

--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -112,6 +112,7 @@ impl Input {
                                 target,
                                 None,
                                 &config.highlights,
+                                casemapping,
                             ),
                         )
                     })
@@ -126,6 +127,7 @@ impl Input {
                     &target,
                     None,
                     &config.highlights,
+                    casemapping,
                 ),
             )]),
             _ => None,

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -1199,13 +1199,17 @@ pub fn find_target_limit(
 pub fn get_casemapping_or_default(
     isupport: &HashMap<Kind, Parameter>,
 ) -> CaseMap {
+    get_casemapping(isupport).unwrap_or_default()
+}
+
+pub fn get_casemapping(isupport: &HashMap<Kind, Parameter>) -> Option<CaseMap> {
     if let Some(Parameter::CASEMAPPING(casemapping)) =
         isupport.get(&Kind::CASEMAPPING)
     {
-        return *casemapping;
+        Some(*casemapping)
+    } else {
+        None
     }
-
-    CaseMap::default()
 }
 
 // https://modern.ircdocs.horse/#chanmodes-parameter

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -57,7 +57,7 @@ pub fn view<'a>(
     let our_nick = clients.nickname(&state.server);
 
     let our_user = our_nick
-        .map(|our_nick| User::from(Nick::from(our_nick.as_ref())))
+        .map(|our_nick| User::from(Nick::from(our_nick)))
         .and_then(|user| {
             clients.resolve_user_attributes(&state.server, channel, &user)
         });
@@ -105,14 +105,7 @@ pub fn view<'a>(
     .height(Length::Fill);
 
     let nick_list = nick_list::view(
-        server,
-        casemapping,
-        prefix,
-        channel,
-        users,
-        our_user,
-        config,
-        theme,
+        server, prefix, channel, users, our_user, config, theme,
     )
     .map(Message::UserContext);
 
@@ -365,7 +358,6 @@ mod nick_list {
 
     pub fn view<'a>(
         server: &'a Server,
-        casemapping: isupport::CaseMap,
         prefix: &'a [isupport::PrefixMap],
         channel: &'a target::Channel,
         users: Option<&'a ChannelUsers>,
@@ -416,7 +408,6 @@ mod nick_list {
             user_context::view(
                 content,
                 server,
-                casemapping,
                 prefix,
                 Some(channel),
                 user,

--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -72,7 +72,6 @@ pub fn view<'a>(
                         )
                     }),
                 server,
-                casemapping,
                 prefix,
                 Some(channel),
                 user,

--- a/src/buffer/highlights.rs
+++ b/src/buffer/highlights.rs
@@ -128,7 +128,6 @@ pub fn view<'a>(
                         user_context::view(
                             text,
                             server,
-                            casemapping,
                             prefix,
                             Some(channel),
                             user,
@@ -163,7 +162,6 @@ pub fn view<'a>(
                             message::Link::User(user) => entry
                                 .view(
                                     server,
-                                    casemapping,
                                     prefix,
                                     Some(channel),
                                     user,

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -1305,13 +1305,8 @@ impl Text {
                     }
                 }
             })
-            .filter_map(|user| {
-                let normalized_nick =
-                    casemapping.normalize(user.nickname().as_ref());
-                normalized_nick
-                    .starts_with(&nick)
-                    .then(|| user.nickname().to_string())
-            })
+            .filter(|&user| user.as_normalized_str().starts_with(&nick))
+            .map(|user| user.nickname().to_string())
             .collect();
     }
 

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -174,7 +174,6 @@ impl<'a> ChannelQueryLayout<'a> {
             user_context::view(
                 text,
                 self.server,
-                self.casemapping,
                 self.prefix,
                 self.target.channel(),
                 user,
@@ -212,7 +211,6 @@ impl<'a> ChannelQueryLayout<'a> {
                 message::Link::User(user) => entry
                     .view(
                         fm.server,
-                        fm.casemapping,
                         fm.prefix,
                         fm.target.channel(),
                         user,
@@ -269,7 +267,6 @@ impl<'a> ChannelQueryLayout<'a> {
                 message::Link::User(user) => entry
                     .view(
                         fm.server,
-                        fm.casemapping,
                         fm.prefix,
                         fm.target.channel(),
                         user,

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -600,23 +600,21 @@ impl State {
             Message::Link(message::Link::User(user)) => {
                 let event = match config.buffer.nickname.click {
                     data::config::buffer::NicknameClickAction::OpenQuery => {
-                        kind.server().cloned().map(|server| {
-                            let query =
-                                target::Query::from_user(&user, clients.get_casemapping(&server));
-                            Event::OpenBuffer(
-                                Target::Query(query),
-                                config.actions.buffer.click_username,
-                            )
-                        })
+                        let query = target::Query::from(user);
+
+                        Event::OpenBuffer(
+                            Target::Query(query),
+                            config.actions.buffer.click_username,
+                        )
                     }
                     data::config::buffer::NicknameClickAction::InsertNickname => {
-                        Some(Event::UserContext(user_context::Event::InsertNickname(
+                        Event::UserContext(user_context::Event::InsertNickname(
                             user.nickname().to_owned(),
-                        )))
+                        ))
                     }
                 };
 
-                return (Task::none(), event);
+                return (Task::none(), Some(event));
             }
             Message::Link(message::Link::GoToMessage(
                 server,

--- a/src/buffer/user_context.rs
+++ b/src/buffer/user_context.rs
@@ -61,7 +61,6 @@ impl Entry {
     pub fn view<'a>(
         self,
         server: &Server,
-        casemapping: isupport::CaseMap,
         prefix: &[isupport::PrefixMap],
         channel: Option<&target::Channel>,
         user: &User,
@@ -83,7 +82,7 @@ impl Entry {
                 "Message".to_string(),
                 Message::Query(
                     server.clone(),
-                    target::Query::from_user(user, casemapping),
+                    target::Query::from(user),
                     config.actions.buffer.message_user,
                 ),
                 length,
@@ -242,7 +241,6 @@ pub fn update(message: Message) -> Event {
 pub fn view<'a>(
     content: impl Into<Element<'a, Message>>,
     server: &'a Server,
-    casemapping: isupport::CaseMap,
     prefix: &'a [isupport::PrefixMap],
     channel: Option<&'a target::Channel>,
     user: &'a User,
@@ -257,7 +255,7 @@ pub fn view<'a>(
     let message = match click {
         data::config::buffer::NicknameClickAction::OpenQuery => Message::Query(
             server.clone(),
-            target::Query::from_user(user, casemapping),
+            target::Query::from(user),
             config.actions.buffer.click_username,
         ),
         data::config::buffer::NicknameClickAction::InsertNickname => {
@@ -276,7 +274,6 @@ pub fn view<'a>(
         move |entry, length| {
             entry.view(
                 server,
-                casemapping,
                 prefix,
                 channel,
                 user,

--- a/src/main.rs
+++ b/src/main.rs
@@ -816,21 +816,26 @@ impl Halloy {
                                             comment,
                                             channels,
                                             sent_time,
-                                        } => commands.push(
-                                            dashboard
-                                                .broadcast(
-                                                    &server,
-                                                    self.clients.get_casemapping(&server),
-                                                    &self.config,
-                                                    sent_time,
-                                                    Broadcast::Quit {
-                                                        user,
-                                                        comment,
-                                                        user_channels: channels,
-                                                    },
-                                                )
-                                                .map(Message::Dashboard),
-                                        ),
+                                        } => {
+                                            let casemapping = self.clients.get_casemapping(&server);
+
+                                            commands.push(
+                                                dashboard
+                                                    .broadcast(
+                                                        &server,
+                                                        casemapping,
+                                                        &self.config,
+                                                        sent_time,
+                                                        Broadcast::Quit {
+                                                            user,
+                                                            comment,
+                                                            user_channels: channels,
+                                                            casemapping,
+                                                        },
+                                                    )
+                                                    .map(Message::Dashboard),
+                                            );
+                                        },
                                         data::client::Broadcast::Nickname {
                                             old_user,
                                             new_nick,
@@ -840,11 +845,13 @@ impl Halloy {
                                         } => {
                                             let old_nick = old_user.nickname();
 
+                                            let casemapping = self.clients.get_casemapping(&server);
+
                                             commands.push(
                                                 dashboard
                                                     .broadcast(
                                                         &server,
-                                                        self.clients.get_casemapping(&server),
+                                                        casemapping,
                                                         &self.config,
                                                         sent_time,
                                                         Broadcast::Nickname {
@@ -852,6 +859,7 @@ impl Halloy {
                                                             new_nick,
                                                             ourself,
                                                             user_channels: channels,
+                                                            casemapping,
                                                         },
                                                     )
                                                     .map(Message::Dashboard),
@@ -865,17 +873,20 @@ impl Halloy {
                                         } => {
                                             let inviter = inviter.nickname();
 
+                                            let casemapping = self.clients.get_casemapping(&server);
+
                                             commands.push(
                                                 dashboard
                                                     .broadcast(
                                                         &server,
-                                                        self.clients.get_casemapping(&server),
+                                                        casemapping,
                                                         &self.config,
                                                         sent_time,
                                                         Broadcast::Invite {
                                                             inviter: inviter.to_owned(),
                                                             channel,
                                                             user_channels,
+                                                            casemapping,
                                                         },
                                                     )
                                                     .map(Message::Dashboard),
@@ -890,11 +901,13 @@ impl Halloy {
                                             channels,
                                             sent_time,
                                         } => {
+                                            let casemapping = self.clients.get_casemapping(&server);
+
                                             commands.push(
                                                 dashboard
                                                     .broadcast(
                                                         &server,
-                                                        self.clients.get_casemapping(&server),
+                                                        casemapping,
                                                         &self.config,
                                                         sent_time,
                                                         Broadcast::ChangeHost {
@@ -904,6 +917,7 @@ impl Halloy {
                                                             ourself,
                                                             logged_in,
                                                             user_channels: channels,
+                                                            casemapping,
                                                         },
                                                     )
                                                     .map(Message::Dashboard),
@@ -916,11 +930,13 @@ impl Halloy {
                                             channel,
                                             sent_time,
                                         } => {
+                                            let casemapping = self.clients.get_casemapping(&server);
+
                                             commands.push(
                                                 dashboard
                                                     .broadcast(
                                                         &server,
-                                                        self.clients.get_casemapping(&server),
+                                                        casemapping,
                                                         &self.config,
                                                         sent_time,
                                                         Broadcast::Kick {
@@ -928,6 +944,7 @@ impl Halloy {
                                                             victim,
                                                             reason,
                                                             channel,
+                                                            casemapping,
                                                         },
                                                     )
                                                     .map(Message::Dashboard),
@@ -937,8 +954,6 @@ impl Halloy {
                                     Event::FileTransferRequest(request) => {
                                         if let Some(command) = dashboard.receive_file_transfer(
                                             &server,
-                                            chantypes,
-                                            statusmsg,
                                             casemapping,
                                             request,
                                             &self.config,
@@ -1126,6 +1141,7 @@ impl Halloy {
                                             user,
                                             comment: reason,
                                             user_channels: channels,
+                                            casemapping,
                                         },
                                     )
                                     .map(Message::Dashboard)

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1406,13 +1406,9 @@ impl Dashboard {
                 {
                     let casemapping = clients.get_casemapping(&server);
 
+                    let query = target::Query::from(&to);
+
                     if let Some(path) = path
-                        && let Ok(query) = target::Query::parse(
-                            to.nickname().as_ref(),
-                            clients.get_chantypes(&server),
-                            clients.get_statusmsg(&server),
-                            casemapping,
-                        )
                         && let Some(event) = self.file_transfers.send(
                             file_transfer::SendRequest {
                                 to,
@@ -2742,8 +2738,6 @@ impl Dashboard {
     pub fn receive_file_transfer(
         &mut self,
         server: &Server,
-        chantypes: &[char],
-        statusmsg: &[char],
         casemapping: isupport::CaseMap,
         request: file_transfer::ReceiveRequest,
         config: &Config,
@@ -2764,13 +2758,7 @@ impl Dashboard {
             server,
         );
 
-        let query = target::Query::parse(
-            request.from.nickname().as_ref(),
-            chantypes,
-            statusmsg,
-            casemapping,
-        )
-        .ok()?;
+        let query = target::Query::from(request.from);
 
         Some(self.handle_file_transfer_event(
             server,


### PR DESCRIPTION
This PR has two main purposes:
- To fix a minor regression, where nicknames highlighting/coloring is case sensitive.  I.e. `Andymandias` would not be matched against the user `andymandias`.  The pre-regression (intended) behavior is for nickname matching to be case insensitive.
- A minor improvement to case insensitive matching, to use the server's casemapping (as supplied by ISUPPORT parameter).  The pre-regression behavior was for the casemapping used for case insenstiive matching is [`rfc7613`](https://modern.ircdocs.horse/#casemapping-parameter), regardless of received ISUPPORT casemapping parameter.

To those ends, the main change introduced by this PR is converting
```rust
pub struct Nick(String);
```
to
```rust
pub struct Nick {
    raw: String,
    normalized: String,
}
```
where `normalized` is specified from `raw` using `isupport::CaseMap`.  Accordingly, associated hasing and ordering Traits are modified to use `normalized`.  All other changes are downstream from the changes made to `Nick`.

This PR does not attempt to handle the possibility of a network's casemapping changing while connected, both to keep the scope of changes as small as possible and because it is not really an expected event.