### PR TITLE
Case-Sensitive Nickname Highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Added:
 - Setting for split axis chosen as the shorter dimension of the largest splittable pane
 - `soju.im/bouncer-networks` support
 - Setting to hide the backlog divider when all messages in the buffer have been read
+- Setting to specify whether nickname highlighting is case sensitive
 
 Fixed:
 
@@ -22,11 +23,12 @@ Fixed:
 - When kicked from a channel the kick message will be broadcast in the server buffer (which remains open) as well as in the channel history (which is closed on kick)
 - Preview images with large dimensions will not be displayed if larger than the allowed buffer size
 - Do not activate the mark as read buffer when blocked/hidden messages are unread in the buffer
+- Nickname highlighting is case insensitive by default (and uses the server's specified casemapping)
 
 Thanks:
 
 - Bug reports: @privacyadmin, @rlndd, @wingedonezero, @Seishiin, @Erroneuz, @andar1an, freakyy85, ThinkT510, alexia, @darienm
-- Feature requests: @deepspaceaxolotl, @4e554c4c
+- Feature requests: @deepspaceaxolotl, @4e554c4c, @barretgoat
 
 # 2025.8 (2025-08-31)
 

--- a/book/src/configuration/highlights.md
+++ b/book/src/configuration/highlights.md
@@ -54,6 +54,20 @@ exclude = ["*"]
 include = ["#halloy"]
 ```
 
+### `case_insensitive`
+
+Whether or not to trigger regardless nickname highlight regardless of case.
+Uses the casemapping [specified by server](https://modern.ircdocs.horse/#casemapping-parameter).
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: true
+
+[highlights.nickname]
+case_insensitive = false
+```
+
 ## `[[highlights.match]]`
 
 Highlight based on matches.

--- a/data/src/config/highlights.rs
+++ b/data/src/config/highlights.rs
@@ -10,11 +10,22 @@ pub struct Highlights {
     pub matches: Vec<Match>,
 }
 
-#[derive(Debug, Clone, Deserialize, Default)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct Nickname {
     pub exclude: Vec<String>,
     pub include: Vec<String>,
+    pub case_insensitive: bool,
+}
+
+impl Default for Nickname {
+    fn default() -> Self {
+        Self {
+            exclude: Vec::default(),
+            include: Vec::default(),
+            case_insensitive: true,
+        }
+    }
 }
 
 impl Nickname {

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -601,8 +601,12 @@ pub fn parse_fragments_with_highlights(
             .map(|fragment| match fragment {
                 Fragment::User(user, raw)
                     if highlights.nickname.is_target_included(target)
-                        && our_nick
-                            .is_some_and(|nick| user.nickname() == *nick) =>
+                        && ((our_nick
+                            .is_some_and(|nick| user.nickname() == *nick)
+                            && highlights.nickname.case_insensitive)
+                            || (our_nick.is_some_and(|nick| {
+                                raw.as_str() == nick.as_str()
+                            }))) =>
                 {
                     Fragment::HighlightNick(user, raw)
                 }
@@ -2152,7 +2156,7 @@ mod tests {
         let tests = [
             (
                 (
-                    "Bob: I'm in #interesting with Greg, George_, &`Bill`. I hope @Dave doesn't notice.".to_string(),
+                    "Bob: I'm in #interesting with Greg, George_, &`bill`. I hope @Dave doesn't notice.".to_string(),
                     [
                         "Greg",
                         "Dave",
@@ -2163,7 +2167,7 @@ mod tests {
                     "#interesting",
                     Some(Nick::from_str("Bob", casemapping)),
                     &Highlights {
-                        nickname: Nickname {exclude: vec![], include: vec!["#interesting".into()]},
+                        nickname: Nickname {exclude: vec![], include: vec!["#interesting".into()], case_insensitive: true},
                         matches: vec![],
                     },
                 ),
@@ -2176,10 +2180,33 @@ mod tests {
                     Fragment::Text(", ".into()),
                     Fragment::User(User::from(Nick::from_str("George_", casemapping)), "George_".into()),
                     Fragment::Text(", &".into()),
-                    Fragment::User(User::from(Nick::from_str("`Bill`", casemapping)), "`Bill`".into()),
+                    Fragment::User(User::from(Nick::from_str("`Bill`", casemapping)), "`bill`".into()),
                     Fragment::Text(". I hope @".into()),
                     Fragment::User(User::from(Nick::from_str("Dave", casemapping)), "Dave".into()),
                     Fragment::Text(" doesn't notice.".into()),
+                ],
+            ),
+            (
+                (
+                    "the boat would bob up and down!".to_string(),
+                    [
+                        "Greg",
+                        "Dave",
+                        "Bob",
+                        "George_",
+                        "`Bill`",
+                    ].into_iter().map(|nick| User::from(Nick::from_str(nick, casemapping))).collect::<ChannelUsers>(),
+                    "#interesting",
+                    Some(Nick::from_str("Bob", casemapping)),
+                    &Highlights {
+                        nickname: Nickname {exclude: vec![], include: vec![], case_insensitive: false},
+                        matches: vec![],
+                    },
+                ),
+                vec![
+                    Fragment::Text("the boat would ".into()),
+                    Fragment::User(User::from(Nick::from_str("Bob", casemapping)), "bob".into()),
+                    Fragment::Text(" up and down!".into()),
                 ],
             ),
             (
@@ -2192,7 +2219,7 @@ mod tests {
                     "#funderscore-sucks",
                     Some(Nick::from_str("f_", casemapping)),
                     &Highlights {
-                        nickname: Nickname {exclude: vec![], include: vec!["*".into()]},
+                        nickname: Nickname {exclude: vec![], include: vec!["*".into()], case_insensitive: true},
                         matches: vec![],
                     },
                 ),


### PR DESCRIPTION
Adds a setting to control case sensitivity when matching nickname for highlight.  Does not intend to control nickname coloring.  Closes #944.