### PR TITLE
Fix Pane Initialization

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -65,26 +65,32 @@ pub enum Event {
 }
 
 impl Buffer {
-    pub fn from_data(buffer: data::Buffer, pane_size: Size) -> Self {
+    pub fn from_data(
+        buffer: data::Buffer,
+        pane_size: Size,
+        config: &Config,
+    ) -> Self {
         match buffer {
             data::Buffer::Upstream(upstream) => match upstream {
                 buffer::Upstream::Server(server) => {
-                    Self::Server(Server::new(server, pane_size))
+                    Self::Server(Server::new(server, pane_size, config))
                 }
-                buffer::Upstream::Channel(server, channel) => {
-                    Self::Channel(Channel::new(server, channel, pane_size))
-                }
+                buffer::Upstream::Channel(server, channel) => Self::Channel(
+                    Channel::new(server, channel, pane_size, config),
+                ),
                 buffer::Upstream::Query(server, query) => {
-                    Self::Query(Query::new(server, query, pane_size))
+                    Self::Query(Query::new(server, query, pane_size, config))
                 }
             },
             data::Buffer::Internal(internal) => match internal {
                 buffer::Internal::FileTransfers => {
                     Self::FileTransfers(FileTransfers::new())
                 }
-                buffer::Internal::Logs => Self::Logs(Logs::new(pane_size)),
+                buffer::Internal::Logs => {
+                    Self::Logs(Logs::new(pane_size, config))
+                }
                 buffer::Internal::Highlights => {
-                    Self::Highlights(Highlights::new(pane_size))
+                    Self::Highlights(Highlights::new(pane_size, config))
                 }
             },
         }

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -174,12 +174,13 @@ impl Channel {
         server: Server,
         target: target::Channel,
         pane_size: Size,
+        config: &Config,
     ) -> Self {
         Self {
             buffer: buffer::Upstream::Channel(server.clone(), target.clone()),
             server,
             target,
-            scroll_view: scroll_view::State::new(pane_size),
+            scroll_view: scroll_view::State::new(pane_size, config),
             input_view: input_view::State::new(),
         }
     }

--- a/src/buffer/highlights.rs
+++ b/src/buffer/highlights.rs
@@ -253,9 +253,9 @@ pub struct Highlights {
 }
 
 impl Highlights {
-    pub fn new(pane_size: Size) -> Self {
+    pub fn new(pane_size: Size, config: &Config) -> Self {
         Self {
-            scroll_view: scroll_view::State::new(pane_size),
+            scroll_view: scroll_view::State::new(pane_size, config),
         }
     }
 

--- a/src/buffer/logs.rs
+++ b/src/buffer/logs.rs
@@ -117,9 +117,9 @@ pub struct Logs {
 }
 
 impl Logs {
-    pub fn new(pane_size: Size) -> Self {
+    pub fn new(pane_size: Size, config: &Config) -> Self {
         Self {
-            scroll_view: scroll_view::State::new(pane_size),
+            scroll_view: scroll_view::State::new(pane_size, config),
         }
     }
 

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -124,12 +124,17 @@ pub struct Query {
 }
 
 impl Query {
-    pub fn new(server: Server, target: target::Query, pane_size: Size) -> Self {
+    pub fn new(
+        server: Server,
+        target: target::Query,
+        pane_size: Size,
+        config: &Config,
+    ) -> Self {
         Self {
             buffer: buffer::Upstream::Query(server.clone(), target.clone()),
             server,
             target,
-            scroll_view: scroll_view::State::new(pane_size),
+            scroll_view: scroll_view::State::new(pane_size, config),
             input_view: input_view::State::new(),
         }
     }

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -447,9 +447,12 @@ impl Default for State {
 }
 
 impl State {
-    pub fn new(pane_size: Size) -> Self {
+    pub fn new(pane_size: Size, config: &Config) -> Self {
+        let step_messages = step_messages(pane_size.height, config);
+
         Self {
             pane_size,
+            limit: Limit::Bottom(step_messages),
             ..Self::default()
         }
     }

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -154,11 +154,15 @@ pub struct Server {
 }
 
 impl Server {
-    pub fn new(server: data::server::Server, pane_size: Size) -> Self {
+    pub fn new(
+        server: data::server::Server,
+        pane_size: Size,
+        config: &Config,
+    ) -> Self {
         Self {
             buffer: buffer::Upstream::Server(server.clone()),
             server,
-            scroll_view: scroll_view::State::new(pane_size),
+            scroll_view: scroll_view::State::new(pane_size, config),
             input_view: input_view::State::new(),
         }
     }


### PR DESCRIPTION
Properly initialize pane using the provided pane size (i.e. set its `limit` field with a calculated `step_messages`).  Could result in a blank pane until a resize occurs (when replacing a pane). 