### PR TITLE
Fix Flathub links

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Join **#halloy** on libera.chat if you have questions or looking for help.
     <img src="https://repology.org/badge/vertical-allrepos/halloy.svg" alt="Packaging status">
 </a>
 
-Halloy is also available from [Flathub](https://flathub.org/apps/org.squidowl.halloy) and [Snap Store](https://snapcraft.io/halloy).
+Halloy is also available from [Flathub](https://flathub.org/en/apps/org.squidowl.halloy) and [Snap Store](https://snapcraft.io/halloy).
 
 ## Features
 

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -46,7 +46,7 @@ The following third party repositories are available for Linux
 
 #### Flatpak
 
-[https://flathub.org/apps/org.squidowl.halloy](https://flathub.org/apps/org.squidowl.halloy)
+[https://flathub.org/en/apps/org.squidowl.halloy](https://flathub.org/en/apps/org.squidowl.halloy)
 
 #### Snapcraft
 


### PR DESCRIPTION
Looks like Flathub updated something and now Lychee isn't happy.

https://github.com/squidowl/halloy/actions/runs/17593468229/job/49979760622