### PR TITLE
Log Level Tweak

### DIFF
--- a/data/src/dashboard.rs
+++ b/data/src/dashboard.rs
@@ -56,6 +56,12 @@ pub enum BufferFocusedAction {
 }
 
 impl Dashboard {
+    pub fn exists() -> Result<bool, Error> {
+        let path = path()?;
+
+        Ok(std::fs::exists(path)?)
+    }
+
     pub fn load() -> Result<Self, Error> {
         let path = path()?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,7 +181,13 @@ impl Halloy {
                 }
             }
             Err(error) => {
-                log::warn!("failed to load dashboard: {error}");
+                if data::Dashboard::exists().is_ok_and(|exists| exists) {
+                    log::warn!("failed to load dashboard: {error}");
+                } else {
+                    // Most likely this means it is the user's first launch,
+                    // downgrade severity to info
+                    log::info!("failed to load dashboard: {error}");
+                }
 
                 screen::Dashboard::empty(&main_window, config)
             }


### PR DESCRIPTION
Downgrade "dashboard file is missing" log message to info level (since it most likely means it's the user's first launch).