### PR TITLE
Allow `insert-nickname` Action in Server Buffers

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -423,10 +423,15 @@ impl Buffer {
     ) -> Task<Message> {
         match self {
             Buffer::Empty
-            | Buffer::Server(_)
             | Buffer::FileTransfers(_)
             | Buffer::Logs(_)
             | Buffer::Highlights(_) => Task::none(),
+            Buffer::Server(state) => state
+                .input_view
+                .insert_user(nick, state.buffer.clone(), history, autocomplete)
+                .map(|message| {
+                    Message::Server(server::Message::InputView(message))
+                }),
             Buffer::Channel(state) => state
                 .input_view
                 .insert_user(nick, state.buffer.clone(), history, autocomplete)


### PR DESCRIPTION
There are a few messages that can contain user fragments now (in particular, monitor related messages).  If `insert-nickname` is set as the click action then nothing happens when clicking on those usernames (`open-query` works fine).  This PR allows that click action to work in the server buffer, even if it is of limited use.