### PR TITLE
prefix relative paths with config dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ Fixed:
 - Nickname changes properly broadcast in all channels user is in
 - Page up/down behavior moves by consistent page length, and will no longer get stuck at the top of a buffer
 
+Changed:
+
+- Relative paths are now prefixed with config dir (except for file_transfer.save_directory).
+
 Thanks:
 
 - Contributions: @Death916, @4e554c4c, @freakyy85, @hashcatHitman

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,17 +30,17 @@ Fixed:
 - Nickname highlighting is case insensitive by default (and uses the server's specified casemapping)
 - Nickname changes properly broadcast in all channels user is in
 - Page up/down behavior moves by consistent page length, and will no longer get stuck at the top of a buffer
-- `file_transfer.save_directory` is now affected by substitutions.
+- `file_transfer.save_directory` is now affected by path substitutions (tilde expansion & relative path prefixing)
 
 Changed:
 
-- Relative paths are now prefixed with config dir.
+- Relative paths in configuration files are now prefixed with config dir
 
 Thanks:
 
 - Contributions: @Death916, @4e554c4c, @freakyy85, @hashcatHitman, @5GameMaker
 - Bug reports: @privacyadmin, @rlndd, @wingedonezero, @Seishiin, @Erroneuz, @andar1an, freakyy85, ThinkT510, alexia, @darienm, quaff, @zhelezov
-- Feature requests: @deepspaceaxolotl, @4e554c4c, @seraxis, RebeLLz, @cvengler, @barretgoat, @remexre
+- Feature requests: @deepspaceaxolotl, @4e554c4c, @seraxis, RebeLLz, @cvengler, @barretgoat, @remexre, @dmd
 
 # 2025.8 (2025-08-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Changed:
 
 Thanks:
 
-- Contributions: @Death916, @4e554c4c, @freakyy85, @hashcatHitman
+- Contributions: @Death916, @4e554c4c, @freakyy85, @hashcatHitman, @5GameMaker
 - Bug reports: @privacyadmin, @rlndd, @wingedonezero, @Seishiin, @Erroneuz, @andar1an, freakyy85, ThinkT510, alexia, @darienm, quaff, @zhelezov
 - Feature requests: @deepspaceaxolotl, @4e554c4c, @seraxis, RebeLLz, @cvengler, @barretgoat, @remexre
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,11 @@ Fixed:
 - Nickname highlighting is case insensitive by default (and uses the server's specified casemapping)
 - Nickname changes properly broadcast in all channels user is in
 - Page up/down behavior moves by consistent page length, and will no longer get stuck at the top of a buffer
+- `file_transfer.save_directory` is now affected by substitutions.
 
 Changed:
 
-- Relative paths are now prefixed with config dir (except for file_transfer.save_directory).
+- Relative paths are now prefixed with config dir.
 
 Thanks:
 

--- a/book/src/configuration/file_transfer.md
+++ b/book/src/configuration/file_transfer.md
@@ -12,7 +12,7 @@ Default directory to save files in. If not set, user will see a file dialog.
 # Default: not set
 
 [file_transfer]
-save_directory = "/Users/halloy/Downloads"
+save_directory = "/Users/halloy/Downloads" [^1]
 ```
 
 ## `passive`
@@ -153,3 +153,5 @@ masks = [
     '''.*@foobar\.com'''
 ]
 ```
+
+[^1]: Relative paths are prefixed with the config directory (i.e. if you have your config.toml in `/home/me/.config/halloy/config.toml`, path `.passwd/libera` will be converted to `/home/me/.config/halloy/.passwd/libera`).

--- a/book/src/configuration/file_transfer.md
+++ b/book/src/configuration/file_transfer.md
@@ -4,7 +4,7 @@ File transfer configuration options.
 
 ## `save_directory`
 
-Default directory to save files in. If not set, user will see a file dialog.
+Default directory to save files in. If not set, user will see a file dialog. [^1]
 
 ```toml
 # Type: string
@@ -12,7 +12,7 @@ Default directory to save files in. If not set, user will see a file dialog.
 # Default: not set
 
 [file_transfer]
-save_directory = "/Users/halloy/Downloads" [^1]
+save_directory = "/Users/halloy/Downloads"
 ```
 
 ## `passive`

--- a/book/src/configuration/servers.md
+++ b/book/src/configuration/servers.md
@@ -39,7 +39,7 @@ nick_password = ""
 
 ## `nick_password_file`
 
-Read `nick_password` from the file at the given path.[^1]
+Read `nick_password` from the file at the given path.[^1] [^2]
 
 ```toml
 # Type: string
@@ -170,7 +170,7 @@ password = ""
 
 ## `password_file`
 
-Read password from the file at the given path.[^1]
+Read password from the file at the given path.[^1] [^2]
 
 ```toml
 # Type: string
@@ -360,7 +360,7 @@ dangerously_accept_invalid_certs = false
 
 ## `root_cert_path`
 
-The path to the root TLS certificate for this server in PEM format.[^1]
+The path to the root TLS certificate for this server in PEM format.[^1] [^2]
 
 ```toml
 # Type: string
@@ -471,7 +471,7 @@ password = "password"
 
 ### `password_file`
 
-Read `password` from the file at the given path.[^1]
+Read `password` from the file at the given path.[^1] [^2]
 
 ```toml
 # Type: string
@@ -514,7 +514,7 @@ External SASL auth uses a PEM encoded X509 certificate. [Reference](https://libe
 
 ### `cert`
 
-The path to PEM encoded X509 user certificate for external auth.[^1]
+The path to PEM encoded X509 user certificate for external auth.[^1] [^2]
 
 ```toml
 # Type: string
@@ -527,7 +527,7 @@ cert = "/path/to/your/certificate.pem"
 
 ### `key`
 
-The path to PEM encoded PKCS#8 private key for external auth (optional).[^1]
+The path to PEM encoded PKCS#8 private key for external auth (optional).[^1] [^2]
 
 ```toml
 # Type: string
@@ -539,3 +539,4 @@ key = "/path/to/your/private_key.pem"
 ```
 
 [^1]: Windows path strings should usually be specified as literal strings (e.g. `'C:\Users\Default\'`), otherwise directory separators will need to be escaped (e.g. `"C:\\Users\\Default\\"`).
+[^2]: Relative paths are prefixed with the config directory (i.e. if you have your config.toml in `/home/me/.config/halloy/config.toml`, path `.passwd/libera` will be converted to `/home/me/.config/halloy/.passwd/libera`).

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -397,14 +397,14 @@ impl Config {
         let config_dir = Self::config_dir();
         let prefix_with_config_dir = |x: &mut PathBuf| {
             if x.is_relative() {
-                *x = config_dir.join(&mut *x)
+                *x = config_dir.join(&mut *x);
             }
         };
         let prefix_with_config_dir_opt = |x: &mut Option<PathBuf>| {
-            if let Some(x) = x.as_mut() {
-                if x.is_relative() {
-                    *x = config_dir.join(&mut *x)
-                }
+            if let Some(x) = x.as_mut()
+                && x.is_relative()
+            {
+                *x = config_dir.join(&mut *x);
             }
         };
 

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -373,7 +373,7 @@ impl Config {
 
         let Configuration {
             theme,
-            mut servers,
+            servers,
             font,
             proxy,
             scale_factor,
@@ -381,7 +381,7 @@ impl Config {
             sidebar,
             keyboard,
             notifications,
-            mut file_transfer,
+            file_transfer,
             tooltips,
             preview,
             pane,
@@ -393,38 +393,6 @@ impl Config {
             log::warn!("[config.toml] Ignoring unknown setting: {ignored}");
         })
         .map_err(|e| Error::Parse(e.to_string()))?;
-
-        let config_dir = Self::config_dir();
-        let prefix_with_config_dir = |x: &mut PathBuf| {
-            if x.is_relative() {
-                *x = config_dir.join(&mut *x);
-            }
-        };
-        let prefix_with_config_dir_opt = |x: &mut Option<PathBuf>| {
-            if let Some(x) = x.as_mut()
-                && x.is_relative()
-            {
-                *x = config_dir.join(&mut *x);
-            }
-        };
-
-        servers.values_mut().for_each(|x| {
-            prefix_with_config_dir_opt(&mut x.nick_password_file);
-            prefix_with_config_dir_opt(&mut x.root_cert_path);
-            if let Some(x) = x.sasl.as_mut() {
-                use self::server::Sasl;
-                match x {
-                    Sasl::Plain { password_file, .. } => {
-                        prefix_with_config_dir_opt(password_file);
-                    }
-                    Sasl::External { key, cert } => {
-                        prefix_with_config_dir_opt(key);
-                        prefix_with_config_dir(cert);
-                    }
-                }
-            }
-        });
-        prefix_with_config_dir_opt(&mut file_transfer.save_directory);
 
         let servers = ServerMap::new(servers).await?;
 

--- a/data/src/config/file_transfer.rs
+++ b/data/src/config/file_transfer.rs
@@ -5,10 +5,15 @@ use std::path::PathBuf;
 
 use serde::Deserialize;
 
+use crate::serde::deserialize_path_buf_with_path_transformations_maybe;
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct FileTransfer {
     /// Default directory to save files in. If not set, user will see a file dialog.
+    #[serde(
+        deserialize_with = "deserialize_path_buf_with_path_transformations_maybe"
+    )]
     pub save_directory: Option<PathBuf>,
     /// If true, act as the "client" for the transfer. Requires the remote user act as the server.
     pub passive: bool,

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Deserializer};
 
 use crate::config;
 use crate::serde::{
-    deserialize_path_buf_with_tilde_expansion,
-    deserialize_path_buf_with_tilde_expansion_maybe,
+    deserialize_path_buf_with_path_transformations,
+    deserialize_path_buf_with_path_transformations_maybe,
 };
 
 const DEFAULT_PORT: u16 = 6667;
@@ -23,7 +23,7 @@ pub struct Server {
     pub nick_password: Option<String>,
     /// The client's NICKSERV password file.
     #[serde(
-        deserialize_with = "deserialize_path_buf_with_tilde_expansion_maybe"
+        deserialize_with = "deserialize_path_buf_with_path_transformations_maybe"
     )]
     pub nick_password_file: Option<PathBuf>,
     /// Truncate read from NICKSERV password file to first newline
@@ -46,7 +46,7 @@ pub struct Server {
     pub password: Option<String>,
     /// The file with the password to connect to the server.
     #[serde(
-        deserialize_with = "deserialize_path_buf_with_tilde_expansion_maybe"
+        deserialize_with = "deserialize_path_buf_with_path_transformations_maybe"
     )]
     pub password_file: Option<PathBuf>,
     /// Truncate read from password file to first newline
@@ -82,9 +82,9 @@ pub struct Server {
     pub dangerously_accept_invalid_certs: bool,
     /// The path to the root TLS certificate for this server in PEM format.
     #[serde(
-        deserialize_with = "deserialize_path_buf_with_tilde_expansion_maybe"
+        deserialize_with = "deserialize_path_buf_with_path_transformations_maybe"
     )]
-    pub(super) root_cert_path: Option<PathBuf>,
+    root_cert_path: Option<PathBuf>,
     /// Sasl authentication
     pub sasl: Option<Sasl>,
     /// Commands which are executed once connected.
@@ -232,7 +232,7 @@ pub enum Sasl {
         /// Account password file
         #[serde(
             default,
-            deserialize_with = "deserialize_path_buf_with_tilde_expansion_maybe"
+            deserialize_with = "deserialize_path_buf_with_path_transformations_maybe"
         )]
         password_file: Option<PathBuf>,
         /// Truncate read from password file to first newline
@@ -243,13 +243,13 @@ pub enum Sasl {
     External {
         /// The path to PEM encoded X509 user certificate for external auth
         #[serde(
-            deserialize_with = "deserialize_path_buf_with_tilde_expansion"
+            deserialize_with = "deserialize_path_buf_with_path_transformations"
         )]
         cert: PathBuf,
         /// The path to PEM encoded PKCS#8 private key corresponding to the user certificate for external auth
         #[serde(
             default,
-            deserialize_with = "deserialize_path_buf_with_tilde_expansion_maybe"
+            deserialize_with = "deserialize_path_buf_with_path_transformations_maybe"
         )]
         key: Option<PathBuf>,
     },

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -84,7 +84,7 @@ pub struct Server {
     #[serde(
         deserialize_with = "deserialize_path_buf_with_tilde_expansion_maybe"
     )]
-    root_cert_path: Option<PathBuf>,
+    pub(super) root_cert_path: Option<PathBuf>,
     /// Sasl authentication
     pub sasl: Option<Sasl>,
     /// Commands which are executed once connected.


### PR DESCRIPTION
Addresses #499.

Allows using relative paths in any of the config parameters that accept a path (at least from the ones I've found).