### PR TITLE
Reload Configuration Documentation Hint

### DIFF
--- a/book/src/configuration/README.md
+++ b/book/src/configuration/README.md
@@ -8,6 +8,8 @@ To edit configuration parameters, create a `config.toml` file located in your co
 
 > 💡 You can easily open the config file directory from command bar in Halloy
 
+> 💡 Most configuration changes can be applied by reloading the configuration file from the sidebar menu, [keyboard shortcut](keyboard.md), or command bar
+
 The specification for the configuration file format ([TOML](https://toml.io/)) can be found at [https://toml.io/](https://toml.io/).
 
 Example config for connecting to [Libera](https://libera.chat/):

--- a/book/src/configuration/keyboard.md
+++ b/book/src/configuration/keyboard.md
@@ -36,7 +36,7 @@ move_right = "alt+l"
 | `toggle_sidebar`               | Toggle sidebar               | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>b</kbd>          | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>b</kbd>     |
 | `toggle_fullscreen`            | Toggle fullscreen            | <kbd>⌘</kbd> + <kbd>ctrl</kbd> + <kbd>f</kbd>       | <kbd>F11</kbd>                                      |
 | `command_bar`                  | Toggle command bar           | <kbd>⌘</kbd> + <kbd>k</kbd>                         | <kbd>ctrl</kbd> + <kbd>k</kbd>                      |
-| `reload_configuration`         | Refresh configuration file   | <kbd>⌘</kbd> + <kbd>r</kbd>                         | <kbd>ctrl</kbd> + <kbd>r</kbd>                      |
+| `reload_configuration`         | Reload configuration file    | <kbd>⌘</kbd> + <kbd>r</kbd>                         | <kbd>ctrl</kbd> + <kbd>r</kbd>                      |
 | `file_transfers`               | Toggle File Transfers Buffer | <kbd>⌘</kbd> + <kbd>j</kbd>                         | <kbd>ctrl</kbd> + <kbd>j</kbd>                      |
 | `logs`                         | Toggle Logs Buffer           | <kbd>⌘</kbd> + <kbd>l</kbd>                         | <kbd>ctrl</kbd> + <kbd>l</kbd>                      |
 | `theme_editor`                 | Toggle Theme Editor Window   | <kbd>⌘</kbd> + <kbd>t</kbd>                         | <kbd>ctrl</kbd> + <kbd>t</kbd>                      |


### PR DESCRIPTION
Minor addition to the documentation to add a hint about the ability to reload the configuration while Halloy is running.