### PR TITLE
Topic Change Server Messages Setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Added:
 - `soju.im/bouncer-networks` support
 - Setting to hide the backlog divider when all messages in the buffer have been read
 - Setting to specify whether nickname highlighting is case sensitive
+- Setting to hide topic changes
 
 Fixed:
 

--- a/book/src/configuration/buffer.md
+++ b/book/src/configuration/buffer.md
@@ -602,6 +602,7 @@ Server messages are messages sent from an IRC server.
 | `change_host`         | Message is sent when a user changes host                                      |
 | `change_mode`         | Message is sent when a mode is set                                            |
 | `change_nick`         | Message is sent when a user changes nick                                      |
+| `change_topic`        | Message is sent when a channel topic is changed                               |
 | `join`                | Message is sent when a user joins a channel                                   |
 | `kick`                | Message is sent when a user is kicked from a channel                          |
 | `monitored_offline`   | Message is sent when a monitored user goes offline                            |

--- a/data/src/appearance/theme.rs
+++ b/data/src/appearance/theme.rs
@@ -216,6 +216,7 @@ pub struct ServerMessages {
     pub change_host: OptionalTextStyle,
     pub change_mode: OptionalTextStyle,
     pub change_nick: OptionalTextStyle,
+    pub change_topic: OptionalTextStyle,
     pub monitored_online: OptionalTextStyle,
     pub monitored_offline: OptionalTextStyle,
     pub standard_reply_fail: OptionalTextStyle,
@@ -707,6 +708,7 @@ mod binary {
         GeneralScrollbar = 48,
         BufferNicknameOffline = 49,
         GeneralHighlightIndicator = 50,
+        BufferServerMessagesChangeTopic = 51,
     }
 
     impl Tag {
@@ -814,6 +816,9 @@ mod binary {
                 Tag::GeneralScrollbar => styles.general.scrollbar?,
                 Tag::GeneralHighlightIndicator => {
                     styles.general.highlight_indicator?
+                }
+                Tag::BufferServerMessagesChangeTopic => {
+                    styles.buffer.server_messages.change_topic.color?
                 }
             };
 
@@ -941,6 +946,10 @@ mod binary {
                 Tag::GeneralScrollbar => styles.general.scrollbar = Some(color),
                 Tag::GeneralHighlightIndicator => {
                     styles.general.highlight_indicator = Some(color);
+                }
+                Tag::BufferServerMessagesChangeTopic => {
+                    styles.buffer.server_messages.change_topic.color =
+                        Some(color);
                 }
             }
         }

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -197,6 +197,7 @@ pub struct ServerMessages {
     pub standard_reply_note: ServerMessage,
     pub wallops: ServerMessage,
     pub kick: ServerMessage,
+    pub change_topic: ServerMessage,
 }
 
 impl ServerMessages {
@@ -226,6 +227,7 @@ impl ServerMessages {
             ) => Some(&self.standard_reply_note),
             source::server::Kind::WAllOps => Some(&self.wallops),
             source::server::Kind::Kick => Some(&self.kick),
+            source::server::Kind::ChangeTopic => Some(&self.change_topic),
         }
     }
 }

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -792,6 +792,7 @@ fn has_matching_content(
                 | message::source::server::Kind::ChangeHost
                 | message::source::server::Kind::ChangeNick
                 | message::source::server::Kind::ChangeMode
+                | message::source::server::Kind::ChangeTopic
                 | message::source::server::Kind::MonitoredOnline
                 | message::source::server::Kind::MonitoredOffline
                 | message::source::server::Kind::StandardReply(_)

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -963,7 +963,10 @@ fn target(
 
             Some(Target::Channel {
                 channel,
-                source: Source::Server(None),
+                source: Source::Server(Some(source::Server::new(
+                    Kind::ChangeTopic,
+                    Some(user?.nickname().to_owned()),
+                ))),
             })
         }
         Command::KICK(channel, _, _) => {

--- a/data/src/message/source.rs
+++ b/data/src/message/source.rs
@@ -74,6 +74,7 @@ pub mod server {
         StandardReply(StandardReply),
         WAllOps,
         Kick,
+        ChangeTopic,
     }
 
     #[derive(

--- a/src/appearance/theme/font_style.rs
+++ b/src/appearance/theme/font_style.rs
@@ -57,6 +57,7 @@ pub fn server(
             }
             Kind::WAllOps => styles.wallops.font_style,
             Kind::Kick => styles.kick.font_style,
+            Kind::ChangeTopic => styles.change_topic.font_style,
         })
         .or(styles.default.font_style)
 }

--- a/src/appearance/theme/selectable_text.rs
+++ b/src/appearance/theme/selectable_text.rs
@@ -82,6 +82,7 @@ pub fn server(
             Kind::ChangeHost => styles.change_host.color,
             Kind::ChangeMode => styles.change_mode.color,
             Kind::ChangeNick => styles.change_nick.color,
+            Kind::ChangeTopic => styles.change_topic.color,
             Kind::MonitoredOnline => styles.monitored_online.color,
             Kind::MonitoredOffline => styles.monitored_offline.color,
             Kind::StandardReply(StandardReply::Fail) => styles

--- a/src/screen/dashboard/theme_editor.rs
+++ b/src/screen/dashboard/theme_editor.rs
@@ -820,6 +820,7 @@ pub enum ServerMessages {
     ChangeHost,
     ChangeMode,
     ChangeNick,
+    ChangeTopic,
     MonitoredOnline,
     MonitoredOffline,
     StandardReplyFail,
@@ -838,6 +839,7 @@ impl ServerMessages {
             ServerMessages::ReplyTopic => styles.reply_topic.color,
             ServerMessages::ChangeHost => styles.change_host.color,
             ServerMessages::ChangeMode => styles.change_mode.color,
+            ServerMessages::ChangeTopic => styles.change_topic.color,
             ServerMessages::ChangeNick => styles.change_nick.color,
             ServerMessages::MonitoredOnline => styles.monitored_online.color,
             ServerMessages::MonitoredOffline => styles.monitored_offline.color,
@@ -865,6 +867,7 @@ impl ServerMessages {
             ServerMessages::ChangeHost => styles.change_host.font_style,
             ServerMessages::ChangeMode => styles.change_mode.font_style,
             ServerMessages::ChangeNick => styles.change_nick.font_style,
+            ServerMessages::ChangeTopic => styles.change_topic.font_style,
             ServerMessages::MonitoredOnline => {
                 styles.monitored_online.font_style
             }
@@ -920,6 +923,10 @@ impl ServerMessages {
             ServerMessages::ChangeNick => {
                 styles.change_nick.color = color;
                 styles.change_nick.font_style = font_style;
+            }
+            ServerMessages::ChangeTopic => {
+                styles.change_topic.color = color;
+                styles.change_topic.font_style = font_style;
             }
             ServerMessages::MonitoredOnline => {
                 styles.monitored_online.color = color;


### PR DESCRIPTION
Adds a setting to control the visibility of topic change messages (and associated optional text style in theme).