### PR TITLE
Add Flatpak Location for Log File

### DIFF
--- a/book/src/configuration/README.md
+++ b/book/src/configuration/README.md
@@ -4,7 +4,7 @@ To edit configuration parameters, create a `config.toml` file located in your co
 
 * Windows: `%AppData%\halloy`
 * Mac: `~/Library/Application Support/halloy` or `$HOME/.config/halloy`
-* Linux: `$XDG_CONFIG_HOME/halloy`, `$HOME/.config/halloy` or `$HOME/.var/app/org.squidowl.halloy/config` (Flathub)
+* Linux: `$XDG_CONFIG_HOME/halloy`, `$HOME/.config/halloy` or `$HOME/.var/app/org.squidowl.halloy/config` (Flatpak)
 
 > 💡 You can easily open the config file directory from command bar in Halloy
 

--- a/book/src/configuration/logs.md
+++ b/book/src/configuration/logs.md
@@ -10,7 +10,7 @@ The log file is overwritten on each launch (i.e. contains log messages for the l
 
 * Windows: `%AppData%\Roaming\halloy\halloy.log`
 * Mac: `~/Library/Application Support/halloy/halloy.log` or `$HOME/.local/share/halloy/halloy.log`
-* Linux: `$XDG_DATA_HOME/halloy/halloy.log` or `$HOME/.local/share/halloy/halloy.log`
+* Linux: `$XDG_DATA_HOME/halloy/halloy.log`, `$HOME/.local/share/halloy/halloy.log`, or `$HOME/.var/app/org.squidowl.halloy/data/halloy/halloy.log` (Flatpak)
 
 > ⚠️  Changes to file_level require an application restart to take effect.
 


### PR DESCRIPTION
Adds the location of the log file for Flatpak to the documentation.