### PR TITLE
Iced Update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2613,7 +2613,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 1.0.69",
- "windows 0.54.0",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -8939,7 +8939,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Iced itself hasn't changed, this is just updating `Cargo.lock` via `cargo update iced`.  I'm not sure why these dependencies weren't updated the last time I ran `cargo update iced`, but for whatever reason they were not.  I'm hopeful this update will address the build issue for release 2025.9 since it updates the windows package that is producing the build error, but currently do not have the set up to test myself.