### PR TITLE
Configuration Reload Regression Fix

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -406,8 +406,7 @@ impl Halloy {
                                     if let Some(server) =
                                         self.servers.get_mut(&server)
                                     {
-                                        Arc::make_mut(server).order =
-                                            config.order;
+                                        *server = config.clone();
                                     } else {
                                         self.servers
                                             .insert(server, config.clone());


### PR DESCRIPTION
Updates an existing server config in its entirety when reloading the configuration file.  The new values for some server settings (e.g. filters, WHO poll interval, etc) should take immediate effect when reloading the configuration file, and this PR is primarily focused on providing that functionality.  This is not an thorough re-evaluation of the update logic for all server settings, but a reversion to prior behavior.