### PR TITLE
Page Up from Bottom Fix

### DIFF
--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -514,7 +514,10 @@ impl State {
                         if matches!(self.limit, Limit::Bottom(_)) {
                             if old_status.is_page_from_top(
                                 absolute_offset,
-                                height,
+                                // Scale up page height to ensure that there
+                                // isn't a simultaneous anchor flip and message
+                                // load when scrolling up from bottom
+                                2.0 * height,
                                 self.content_size.height,
                             ) && has_more_older_messages
                             {


### PR DESCRIPTION
A follow-up to PR #1171.  When un-anchoring from the bottom and loading new messages at the same time the scroll position will move further back into history than intended.  This fix loads more history when anchored to the bottom than when unlocked so that un-anchoring should never trigger loading new messages.