### PR TITLE
Blank Sidebar Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 Fixed:
 - Enforce delay between notifications
+- Larger fonts (and font sizes) can be used without blanking out the sidebar
 
 Thanks:
 - Contributions: @Toby222
-- Bug reports: @Toby222
+- Bug reports: @Toby222, @deepspaceaxolotl
 
 # 2025.9 (2025-09-16)
 

--- a/book/src/configuration/sidebar.md
+++ b/book/src/configuration/sidebar.md
@@ -4,7 +4,9 @@ Sidebar settings for Halloy.
 
 ## `server_icon_size`
 
-Adjust server icon size
+Adjust server icon size.
+
+Note: If set larger than the line height of the specified [font](font.md) then the icon will not render.
 
 ```toml
 # Type: integer
@@ -147,6 +149,8 @@ highlight_icon = "circle-empty"
 
 Changes the unread icon size.
 
+Note: If set larger than the line height of the specified [font](font.md) then the icon will not render.
+
 ```toml
 # Type: integer
 # Values: any positive integer"
@@ -159,6 +163,8 @@ icon_size = 6
 ### `highlight_icon_size`
 
 Changes the highlight unread icon size.
+
+Note: If set larger than the line height of the specified [font](font.md) then the icon will not render.
 
 ```toml
 # Type: integer

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -27,6 +27,7 @@ use crate::appearance::theme::Styles;
 use crate::appearance::{self, Appearance};
 use crate::audio::{self};
 use crate::environment::config_dir;
+use crate::serde::deserialize_positive_integer_maybe;
 use crate::server::{ConfigMap as ServerMap, ServerName};
 use crate::{Theme, environment};
 
@@ -111,7 +112,7 @@ impl Default for Scrollbar {
 #[serde(default)]
 pub struct Font {
     pub family: Option<String>,
-    #[serde(deserialize_with = "deserialize_optional_font_size")]
+    #[serde(deserialize_with = "deserialize_positive_integer_maybe")]
     pub size: Option<u8>,
     #[serde(deserialize_with = "deserialize_font_weight_from_string")]
     pub weight: font::Weight,
@@ -128,26 +129,6 @@ impl Default for Font {
             weight: font::Weight::Normal,
             bold_weight: None,
         }
-    }
-}
-
-pub fn deserialize_optional_font_size<'de, D>(
-    deserializer: D,
-) -> Result<Option<u8>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let integer_maybe: Option<u8> = Deserialize::deserialize(deserializer)?;
-
-    if let Some(integer) = integer_maybe
-        && integer == 0
-    {
-        Err(serde::de::Error::invalid_value(
-            serde::de::Unexpected::Unsigned(integer.into()),
-            &"any positive integer",
-        ))
-    } else {
-        Ok(integer_maybe)
     }
 }
 

--- a/data/src/config/sidebar.rs
+++ b/data/src/config/sidebar.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Deserializer};
 use serde_untagged::UntaggedEnumVisitor;
 
 use crate::config::Scrollbar;
+use crate::serde::deserialize_positive_integer;
 
 #[derive(Debug, Copy, Clone, Deserialize)]
 #[serde(default)]
@@ -13,7 +14,7 @@ pub struct Sidebar {
     pub show_user_menu: bool,
     pub order_by: OrderBy,
     pub scrollbar: Scrollbar,
-    #[serde(deserialize_with = "deserialize_icon_size")]
+    #[serde(deserialize_with = "deserialize_positive_integer")]
     pub server_icon_size: u32,
 }
 
@@ -36,10 +37,10 @@ impl Default for Sidebar {
 pub struct UnreadIndicator {
     pub title: bool,
     pub icon: Icon,
-    #[serde(deserialize_with = "deserialize_icon_size")]
+    #[serde(deserialize_with = "deserialize_positive_integer")]
     pub icon_size: u32,
     pub highlight_icon: Icon,
-    #[serde(deserialize_with = "deserialize_icon_size")]
+    #[serde(deserialize_with = "deserialize_positive_integer")]
     pub highlight_icon_size: u32,
 }
 
@@ -141,20 +142,4 @@ pub enum OrderBy {
     #[default]
     Alpha,
     Config,
-}
-
-pub fn deserialize_icon_size<'de, D>(deserializer: D) -> Result<u32, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let integer: u32 = Deserialize::deserialize(deserializer)?;
-
-    if integer == 0 || integer > 17 {
-        Err(serde::de::Error::invalid_value(
-            serde::de::Unexpected::Unsigned(integer.into()),
-            &"any positive integer less than or equal to 17",
-        ))
-    } else {
-        Ok(integer)
-    }
 }

--- a/data/src/serde.rs
+++ b/data/src/serde.rs
@@ -92,6 +92,44 @@ where
     }
 }
 
+pub fn deserialize_positive_integer_maybe<'de, D>(
+    deserializer: D,
+) -> Result<Option<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let integer_maybe: Option<u8> = Deserialize::deserialize(deserializer)?;
+
+    if let Some(integer) = integer_maybe
+        && integer == 0
+    {
+        Err(serde::de::Error::invalid_value(
+            serde::de::Unexpected::Unsigned(integer.into()),
+            &"any positive integer",
+        ))
+    } else {
+        Ok(integer_maybe)
+    }
+}
+
+pub fn deserialize_positive_integer<'de, D>(
+    deserializer: D,
+) -> Result<u32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let integer: u32 = Deserialize::deserialize(deserializer)?;
+
+    if integer == 0 {
+        Err(serde::de::Error::invalid_value(
+            serde::de::Unexpected::Unsigned(integer.into()),
+            &"any positive integer",
+        ))
+    } else {
+        Ok(integer)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -757,7 +757,7 @@ fn upstream_buffer_button<'a>(
 
     let (left_padding, icon) = if position.is_horizontal() {
         icon_tuple.map_or((0, None), |(icon, icon_size)| {
-            (icon_size + 8, Some(container(icon).center_y(17.0)))
+            (icon_size + 8, Some(container(icon).center_y(Length::Fill)))
         })
     } else {
         let max_icon_size = server_icon_size.max(
@@ -774,7 +774,9 @@ fn upstream_buffer_button<'a>(
         (
             max_icon_size + 8,
             icon_tuple.map(|(icon, _)| {
-                container(icon).center_y(17.0).center_x(max_icon_size)
+                container(icon)
+                    .center_y(Length::Fill)
+                    .center_x(max_icon_size)
             }),
         )
     };
@@ -818,49 +820,50 @@ fn upstream_buffer_button<'a>(
         icon
     ]);
 
-    let base = button(content.height(17.0).width(width))
-        .style(move |theme, status| {
-            theme::button::sidebar_buffer(
-                theme,
-                status,
-                is_focused.is_some(),
-                open.is_some(),
-            )
-        })
-        .on_press({
-            match is_focused {
-                Some((window, pane)) => {
-                    if let Some(focus_action) = focused_buffer_action {
-                        match focus_action {
-                            BufferFocusedAction::ClosePane => {
-                                Message::Close(window, pane)
+    let base =
+        button(content.width(width).padding(Padding::default().bottom(1)))
+            .style(move |theme, status| {
+                theme::button::sidebar_buffer(
+                    theme,
+                    status,
+                    is_focused.is_some(),
+                    open.is_some(),
+                )
+            })
+            .on_press({
+                match is_focused {
+                    Some((window, pane)) => {
+                        if let Some(focus_action) = focused_buffer_action {
+                            match focus_action {
+                                BufferFocusedAction::ClosePane => {
+                                    Message::Close(window, pane)
+                                }
                             }
-                        }
-                    } else {
-                        // Re-focus pane on press instead of disabling the button in order
-                        // to have hover status of the button for styling
-                        Message::Focus(window, pane)
-                    }
-                }
-                None => {
-                    if let Some((window, pane)) = open {
-                        Message::Focus(window, pane)
-                    } else {
-                        match buffer_action {
-                            BufferAction::NewPane => {
-                                Message::New(buffer.clone())
-                            }
-                            BufferAction::ReplacePane => {
-                                Message::Replace(buffer.clone())
-                            }
-                            BufferAction::NewWindow => {
-                                Message::Popout(buffer.clone())
-                            }
+                        } else {
+                            // Re-focus pane on press instead of disabling the button in order
+                            // to have hover status of the button for styling
+                            Message::Focus(window, pane)
                         }
                     }
+                    None => {
+                        if let Some((window, pane)) = open {
+                            Message::Focus(window, pane)
+                        } else {
+                            match buffer_action {
+                                BufferAction::NewPane => {
+                                    Message::New(buffer.clone())
+                                }
+                                BufferAction::ReplacePane => {
+                                    Message::Replace(buffer.clone())
+                                }
+                                BufferAction::NewWindow => {
+                                    Message::Popout(buffer.clone())
+                                }
+                            }
+                        }
+                    }
                 }
-            }
-        });
+            });
 
     let entries = Entry::list(&buffer, panes.len(), open, focus);
 


### PR DESCRIPTION
When the text in the sidebar is bigger than the specified fixed height of the container it is in then it will fail to render (as seen in issue #1193).  This removes the fixed height of sidebar buttons, instead having sidebar buttons' height be determined by the text it contains.  Specifically, the size of the `Stack` that the button contains is determined by its first element (the text), so the icon does not change the button height.

Since the font size can get quite large I removed the cap on the icon size.  It is possible to get the icons to fail to render if the icon size is larger than the line height of the text, but I believe we're stuck with that behavior so long as we're using a `Stack`.

I tried to recreate the look of the existing sidebar as best as I could, but it is not exactly the same as before.