### PR TITLE
Enable Primary Clipboard on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ Added:
 Fixed:
 - Enforce delay between notifications
 - Larger fonts (and font sizes) can be used without blanking out the sidebar
+- The primary clipboard (with copy on selection & paste with middle click) is supported on Linux
 
 Thanks:
 - Contributions: @Toby222
-- Bug reports: @Toby222, @deepspaceaxolotl
+- Bug reports: @Toby222, @deepspaceaxolotl, @zhelezov
 
 # 2025.9 (2025-09-16)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2992,7 +2992,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?branch=patch#0cf89fb0299755a8e97fe4b9d2ac6a7948a6fb18"
+source = "git+https://github.com/squidowl/iced?rev=489f3aeac407c1a69a67274a9b8daae6e5fb4a13#489f3aeac407c1a69a67274a9b8daae6e5fb4a13"
 dependencies = [
  "iced_core",
  "iced_debug",
@@ -3009,7 +3009,7 @@ dependencies = [
 [[package]]
 name = "iced_beacon"
 version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?branch=patch#0cf89fb0299755a8e97fe4b9d2ac6a7948a6fb18"
+source = "git+https://github.com/squidowl/iced?rev=489f3aeac407c1a69a67274a9b8daae6e5fb4a13#489f3aeac407c1a69a67274a9b8daae6e5fb4a13"
 dependencies = [
  "bincode",
  "futures",
@@ -3024,7 +3024,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?branch=patch#0cf89fb0299755a8e97fe4b9d2ac6a7948a6fb18"
+source = "git+https://github.com/squidowl/iced?rev=489f3aeac407c1a69a67274a9b8daae6e5fb4a13#489f3aeac407c1a69a67274a9b8daae6e5fb4a13"
 dependencies = [
  "bitflags 2.9.1",
  "bytes",
@@ -3042,7 +3042,7 @@ dependencies = [
 [[package]]
 name = "iced_debug"
 version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?branch=patch#0cf89fb0299755a8e97fe4b9d2ac6a7948a6fb18"
+source = "git+https://github.com/squidowl/iced?rev=489f3aeac407c1a69a67274a9b8daae6e5fb4a13#489f3aeac407c1a69a67274a9b8daae6e5fb4a13"
 dependencies = [
  "iced_beacon",
  "iced_core",
@@ -3053,7 +3053,7 @@ dependencies = [
 [[package]]
 name = "iced_devtools"
 version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?branch=patch#0cf89fb0299755a8e97fe4b9d2ac6a7948a6fb18"
+source = "git+https://github.com/squidowl/iced?rev=489f3aeac407c1a69a67274a9b8daae6e5fb4a13#489f3aeac407c1a69a67274a9b8daae6e5fb4a13"
 dependencies = [
  "iced_debug",
  "iced_program",
@@ -3064,7 +3064,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?branch=patch#0cf89fb0299755a8e97fe4b9d2ac6a7948a6fb18"
+source = "git+https://github.com/squidowl/iced?rev=489f3aeac407c1a69a67274a9b8daae6e5fb4a13#489f3aeac407c1a69a67274a9b8daae6e5fb4a13"
 dependencies = [
  "futures",
  "iced_core",
@@ -3078,7 +3078,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?branch=patch#0cf89fb0299755a8e97fe4b9d2ac6a7948a6fb18"
+source = "git+https://github.com/squidowl/iced?rev=489f3aeac407c1a69a67274a9b8daae6e5fb4a13#489f3aeac407c1a69a67274a9b8daae6e5fb4a13"
 dependencies = [
  "bitflags 2.9.1",
  "bytemuck",
@@ -3098,7 +3098,7 @@ dependencies = [
 [[package]]
 name = "iced_program"
 version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?branch=patch#0cf89fb0299755a8e97fe4b9d2ac6a7948a6fb18"
+source = "git+https://github.com/squidowl/iced?rev=489f3aeac407c1a69a67274a9b8daae6e5fb4a13#489f3aeac407c1a69a67274a9b8daae6e5fb4a13"
 dependencies = [
  "iced_graphics",
  "iced_runtime",
@@ -3107,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?branch=patch#0cf89fb0299755a8e97fe4b9d2ac6a7948a6fb18"
+source = "git+https://github.com/squidowl/iced?rev=489f3aeac407c1a69a67274a9b8daae6e5fb4a13#489f3aeac407c1a69a67274a9b8daae6e5fb4a13"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -3119,7 +3119,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?branch=patch#0cf89fb0299755a8e97fe4b9d2ac6a7948a6fb18"
+source = "git+https://github.com/squidowl/iced?rev=489f3aeac407c1a69a67274a9b8daae6e5fb4a13#489f3aeac407c1a69a67274a9b8daae6e5fb4a13"
 dependencies = [
  "bytes",
  "iced_core",
@@ -3132,7 +3132,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?branch=patch#0cf89fb0299755a8e97fe4b9d2ac6a7948a6fb18"
+source = "git+https://github.com/squidowl/iced?rev=489f3aeac407c1a69a67274a9b8daae6e5fb4a13#489f3aeac407c1a69a67274a9b8daae6e5fb4a13"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -3148,7 +3148,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?branch=patch#0cf89fb0299755a8e97fe4b9d2ac6a7948a6fb18"
+source = "git+https://github.com/squidowl/iced?rev=489f3aeac407c1a69a67274a9b8daae6e5fb4a13#489f3aeac407c1a69a67274a9b8daae6e5fb4a13"
 dependencies = [
  "bitflags 2.9.1",
  "bytemuck",
@@ -3167,7 +3167,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?branch=patch#0cf89fb0299755a8e97fe4b9d2ac6a7948a6fb18"
+source = "git+https://github.com/squidowl/iced?rev=489f3aeac407c1a69a67274a9b8daae6e5fb4a13#489f3aeac407c1a69a67274a9b8daae6e5fb4a13"
 dependencies = [
  "iced_renderer",
  "iced_runtime",
@@ -3182,7 +3182,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?branch=patch#0cf89fb0299755a8e97fe4b9d2ac6a7948a6fb18"
+source = "git+https://github.com/squidowl/iced?rev=489f3aeac407c1a69a67274a9b8daae6e5fb4a13#489f3aeac407c1a69a67274a9b8daae6e5fb4a13"
 dependencies = [
  "iced_debug",
  "iced_program",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,9 +104,9 @@ embed-resource = "3.0.2"
 windows_exe_info = "0.4"
 
 [patch.crates-io]
-iced = { git = "https://github.com/squidowl/iced", branch = "patch" }
-iced_core = { git = "https://github.com/squidowl/iced", branch = "patch" }
-iced_wgpu = { git = "https://github.com/squidowl/iced", branch = "patch" }
+iced = { git = "https://github.com/squidowl/iced", rev = "489f3aeac407c1a69a67274a9b8daae6e5fb4a13" }
+iced_core = { git = "https://github.com/squidowl/iced", rev = "489f3aeac407c1a69a67274a9b8daae6e5fb4a13" }
+iced_wgpu = { git = "https://github.com/squidowl/iced", rev = "489f3aeac407c1a69a67274a9b8daae6e5fb4a13" }
 
 [profile.ci]
 inherits = "dev"

--- a/src/event.rs
+++ b/src/event.rs
@@ -5,6 +5,7 @@ pub enum Event {
     Copy,
     Escape,
     LeftClick,
+    UpdatePrimaryClipboard,
 }
 
 pub fn events() -> Subscription<(window::Id, Event)> {
@@ -31,6 +32,11 @@ fn filtered_events(
         iced::Event::Mouse(mouse::Event::ButtonPressed(
             mouse::Button::Left,
         )) if ignored(status) => Some(Event::LeftClick),
+        iced::Event::Mouse(mouse::Event::ButtonReleased(
+            mouse::Button::Left,
+        )) if cfg!(target_os = "linux") && ignored(status) => {
+            Some(Event::UpdatePrimaryClipboard)
+        }
         _ => None,
     };
 


### PR DESCRIPTION
Enables primary clipboard on Linux.  Support in `TextInput` widgets is better done in iced itself, in my opinion, so I added a couple commits to our iced patch to do so.  Those patches allow pasting from the primary clipboard with the middle mouse button (with the paste inserted at the mouse position) and automatically write selections to the primary clipboard.  The changes in Halloy itself are to enable selections in `selectable_text` to be copied into the primary clipboard.

I believe this will fix #1189.