### PR TITLE
Expandable Title Bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@ Added:
 
 Fixed:
 - Enforce delay between notifications
-- Larger fonts (and font sizes) can be used without blanking out the sidebar
+- Larger fonts (and font sizes) can be used without blanking out the sidebar or pane title bar(s)
 - The primary clipboard (with copy on selection & paste with middle click) is supported on Linux
 
 Thanks:
 - Contributions: @Toby222, @Frikilinux
-- Bug reports: @Toby222, @deepspaceaxolotl, @zhelezov
+- Bug reports: @Toby222, @deepspaceaxolotl, @zhelezov, @dgz0
 
 # 2025.9 (2025-09-16)
 

--- a/src/appearance/theme.rs
+++ b/src/appearance/theme.rs
@@ -2,6 +2,8 @@ pub use data::appearance::theme::{
     Buffer, Button, Buttons, General, ServerMessages, Styles, Text,
     color_to_hex, hex_to_color,
 };
+use data::config;
+use iced::widget::text::LineHeight;
 
 use crate::widget::combo_box;
 
@@ -95,3 +97,16 @@ impl iced::theme::Base for Theme {
 }
 
 impl combo_box::Catalog for Theme {}
+
+pub fn line_height(config: &config::Font) -> f32 {
+    LineHeight::default()
+        .to_absolute(
+            if let Some(size) = config.size {
+                f32::from(size)
+            } else {
+                TEXT_SIZE
+            }
+            .into(),
+        )
+        .0
+}

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -10,7 +10,6 @@ use data::preview::{self, Previews};
 use data::server::Server;
 use data::target::{self, Target};
 use data::{Config, Preview, client, history};
-use iced::widget::text::LineHeight;
 use iced::widget::{
     Scrollable, button, center, column, container, horizontal_rule,
     horizontal_space, image, mouse_area, right, row, scrollable, stack, text,
@@ -21,7 +20,6 @@ use iced::{ContentFit, Length, Padding, Size, Task, alignment, padding};
 use self::correct_viewport::correct_viewport;
 use self::keyed::keyed;
 use super::user_context;
-use crate::appearance::theme::TEXT_SIZE;
 use crate::widget::{
     Element, MESSAGE_MARKER_TEXT, notify_visibility, on_resize,
     selectable_text, tooltip,
@@ -995,16 +993,7 @@ impl Default for Status {
 }
 
 fn step_messages(height: f32, config: &Config) -> usize {
-    let line_height = LineHeight::default()
-        .to_absolute(
-            if let Some(size) = config.font.size {
-                f32::from(size)
-            } else {
-                TEXT_SIZE
-            }
-            .into(),
-        )
-        .0;
+    let line_height = theme::line_height(&config.font);
 
     (height / line_height) as usize
 }

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -409,7 +409,7 @@ impl TitleBar {
                 )
                 .shaping(text::Shaping::Advanced),
         )
-        .height(22)
+        .height(theme::line_height(&config.font).ceil().max(22.0))
         .padding([0, 10])
         .align_y(iced::alignment::Vertical::Center);
 


### PR DESCRIPTION
Expand title bar to line height (if it exceeds 22) so that the title does not fail to render for large font sizes.

Fixes #1201.