### PR TITLE
Rename Topic Banner Setting

### DIFF
--- a/book/src/configuration/buffer.md
+++ b/book/src/configuration/buffer.md
@@ -5,7 +5,7 @@ Buffer settings for Halloy.
 1. [Channel](#bufferchannel) - Channel specific settings
    1. [Message](#bufferchannelmessage) - Message settings within a channel buffer
    2. [Nicklist](#bufferchannelnicklist) - Nicklist settings within a channel buffer
-   3. [Topic](#bufferchanneltopic) - Topic settings within a channel buffer
+   3. [Topic Banner](#bufferchanneltopic_banner) - Topic banner settings within a channel buffer
 2. [Chathistory](#bufferchathistory) - IRCv3 Chat History extension settings
 3. [Commands](#buffercommands) - Commands settings
 4. [Backlog Separator](#bufferbacklog_separator) - Customize when the backlog separator is displayed within a buffer
@@ -160,20 +160,20 @@ Click action for when interaction with nicknames.
 click = "open-query"
 ```
 
-### `[buffer.channel.topic]`
+### `[buffer.channel.topic_banner]`
 
-Topic settings within a channel buffer.
+Topic banner settings within a channel buffer.
 
 #### `enabled`
 
-Control if topic should be shown or not by default.
+Control if topic banner should be shown or not by default.
 
 ```toml
 # Type: boolean
 # Values: true, false
 # Default: false
 
-[buffer.channel.topic]
+[buffer.channel.topic_banner]
 enabled = true
 ```
 
@@ -186,7 +186,7 @@ Amount of visible lines before you have to scroll in topic banner.
 # Values: any non-negative integer
 # Default: 2
 
-[buffer.channel.topic]
+[buffer.channel.topic_banner]
 max_lines = 2
 ```
 

--- a/data/src/channel.rs
+++ b/data/src/channel.rs
@@ -5,14 +5,14 @@ use crate::config;
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct Settings {
     pub nicklist: Nicklist,
-    pub topic: Topic,
+    pub topic_banner: TopicBanner,
 }
 
 impl From<config::buffer::Channel> for Settings {
     fn from(config: config::buffer::Channel) -> Self {
         Self {
             nicklist: Nicklist::from(config.nicklist),
-            topic: Topic::from(config.topic),
+            topic_banner: TopicBanner::from(config.topic_banner),
         }
     }
 }
@@ -51,19 +51,19 @@ impl Nicklist {
 }
 
 #[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
-pub struct Topic {
+pub struct TopicBanner {
     pub enabled: bool,
 }
 
-impl From<config::buffer::channel::Topic> for Topic {
-    fn from(config: config::buffer::channel::Topic) -> Self {
-        Topic {
+impl From<config::buffer::channel::TopicBanner> for TopicBanner {
+    fn from(config: config::buffer::channel::TopicBanner) -> Self {
+        TopicBanner {
             enabled: config.enabled,
         }
     }
 }
 
-impl Topic {
+impl TopicBanner {
     pub fn toggle_visibility(&mut self) {
         self.enabled = !self.enabled;
     }

--- a/data/src/config/buffer/channel.rs
+++ b/data/src/config/buffer/channel.rs
@@ -9,7 +9,8 @@ use crate::config::buffer::Away;
 #[serde(default)]
 pub struct Channel {
     pub nicklist: Nicklist,
-    pub topic: Topic,
+    #[serde(alias = "topic")] // For backwards compatibility
+    pub topic_banner: TopicBanner,
     pub message: Message,
 }
 
@@ -57,12 +58,12 @@ pub enum Alignment {
 
 #[derive(Debug, Clone, Copy, Deserialize)]
 #[serde(default)]
-pub struct Topic {
+pub struct TopicBanner {
     pub enabled: bool,
     pub max_lines: u16,
 }
 
-impl Default for Topic {
+impl Default for TopicBanner {
     fn default() -> Self {
         Self {
             enabled: false,

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -311,8 +311,8 @@ fn topic<'a>(
     theme: &'a Theme,
 ) -> Option<Element<'a, Message>> {
     let topic_enabled = settings
-        .map_or(config.buffer.channel.topic.enabled, |settings| {
-            settings.channel.topic.enabled
+        .map_or(config.buffer.channel.topic_banner.enabled, |settings| {
+            settings.channel.topic_banner.enabled
         });
 
     if !topic_enabled {
@@ -335,7 +335,7 @@ fn topic<'a>(
             topic.content.as_ref()?,
             topic.who.as_ref().map(Nick::as_nickref),
             topic.time.as_ref(),
-            config.buffer.channel.topic.max_lines,
+            config.buffer.channel.topic_banner.max_lines,
             users,
             our_user,
             config,

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -653,7 +653,10 @@ impl Dashboard {
                                     &buffer,
                                     Some(config.buffer.clone().into()),
                                 );
-                                settings.channel.topic.toggle_visibility();
+                                settings
+                                    .channel
+                                    .topic_banner
+                                    .toggle_visibility();
                             }
 
                             self.last_changed = Some(Instant::now());
@@ -1168,7 +1171,10 @@ impl Dashboard {
                                     &buffer,
                                     Some(config.buffer.clone().into()),
                                 );
-                                settings.channel.topic.toggle_visibility();
+                                settings
+                                    .channel
+                                    .topic_banner
+                                    .toggle_visibility();
                             }
 
                             self.last_changed = Some(Instant::now());

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -254,8 +254,8 @@ impl TitleBar {
                     && topic.content.is_some()
                 {
                     let topic_enabled = settings.map_or(
-                        config.buffer.channel.topic.enabled,
-                        |settings| settings.channel.topic.enabled,
+                        config.buffer.channel.topic_banner.enabled,
+                        |settings| settings.channel.topic_banner.enabled,
                     );
 
                     let topic_button = button(center(icon::topic()))


### PR DESCRIPTION
Renames `buffer.channel.topic` setting to `buffer.channel.topic_banner` to help clarify that it is distinct from `buffer.server_messages.topic`.  The old setting name is aliased for backwards compatibility.