### PR TITLE
Fix buffer link in pane documentation

### DIFF
--- a/book/src/configuration/pane.md
+++ b/book/src/configuration/pane.md
@@ -1,6 +1,6 @@
 # `[pane]`
 
-Pane settings for Halloy. A pane contains a [buffer](../configuration//buffer.md).
+Pane settings for Halloy. A pane contains a [buffer](../configuration/buffer.md).
 
 ## `restore_on_launch`
 


### PR DESCRIPTION
On https://halloy.chat/configuration/pane.html there is a link to https://halloy.chat/configuration//buffer.html which causes rendering issues. Removing the double slash fixes it.