### PR TITLE
Load More Messages when Anchored

### DIFF
--- a/src/buffer/highlights.rs
+++ b/src/buffer/highlights.rs
@@ -247,7 +247,7 @@ pub fn view<'a>(
         .into()
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct Highlights {
     pub scroll_view: scroll_view::State,
 }

--- a/src/buffer/logs.rs
+++ b/src/buffer/logs.rs
@@ -111,7 +111,7 @@ pub fn view<'a>(
         .into()
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct Logs {
     pub scroll_view: scroll_view::State,
 }

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -438,29 +438,19 @@ pub struct State {
     hovered_preview: Option<(message::Hash, usize)>,
 }
 
-impl Default for State {
-    fn default() -> Self {
-        Self {
-            scrollable: scrollable::Id::unique(),
-            pane_size: Size::default(), // Will get set initially via `update_size`
-            content_size: Size::default(), // Will get set initially via `on_resize`
-            limit: Limit::Bottom(0),
-            status: Status::default(),
-            pending_scroll_to: None,
-            visible_url_messages: HashMap::new(),
-            hovered_preview: None,
-        }
-    }
-}
-
 impl State {
     pub fn new(pane_size: Size, config: &Config) -> Self {
         let step_messages = step_messages(pane_size.height, config);
 
         Self {
+            scrollable: scrollable::Id::unique(),
             pane_size,
+            content_size: Size::default(), // Will get set initially via `on_resize`
             limit: Limit::Bottom(step_messages),
-            ..Self::default()
+            status: Status::default(),
+            pending_scroll_to: None,
+            visible_url_messages: HashMap::new(),
+            hovered_preview: None,
         }
     }
 
@@ -526,8 +516,10 @@ impl State {
                                 );
                             }
                         } else {
-                            self.limit =
-                                Limit::Bottom(step_messages(height, config));
+                            self.limit = Limit::Bottom(step_messages(
+                                2.0 * height,
+                                config,
+                            ));
                         }
                     }
                     // Scrolling up from bottom & have more to load
@@ -587,8 +579,10 @@ impl State {
                                     );
                                 }
                             } else {
-                                self.limit =
-                                    Limit::Top(step_messages(height, config));
+                                self.limit = Limit::Top(step_messages(
+                                    2.0 * height,
+                                    config,
+                                ));
                             }
                         }
                     }


### PR DESCRIPTION
Since increasing the number of messages loaded to ensure page up/down does not hit the end of loaded messages I find that after transitioning from unlocked to anchored additional messages need to loaded the vast majority of the time.  This is mostly noticeable by the scrollbar size changing multiples times after hitting the bottom/top.  This PR doubles the number of messages loaded when initially entering an anchored state to avoid that behavior.  (I believe the number of messages was previously tuned without the expectation that we would ensure an extra page's worth of messages to facilitate page up/down.)

I also took this opportunity to remove `Default` implementation for `scroll_view::State` as `new` should be used instead for all current applications (we always want `pane_size` to be set on creation) 