### PR TITLE
Detach Command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Added:
 - `/sysinfo` command to send system information to current buffer
 - Copy URLs from context menu by right-clicking on links
 - Settings to condense multiple consecutive server messages into a single abbreviated message
+- `/detach` command to detach from channels (soju feature)
 
 Fixed:
 
@@ -17,7 +18,7 @@ Thanks:
 
 - Contributions: @Toby222, @Frikilinux
 - Bug reports: @Toby222, @deepspaceaxolotl, @zhelezov, @Erroneuz, @dgz0
-- Feature requests: @j0lol
+- Feature requests: @j0lol, @xcfrg
 
 # 2025.9 (2025-09-16)
 

--- a/book/src/commands.md
+++ b/book/src/commands.md
@@ -11,38 +11,40 @@ Example
 Halloy will first try to run below commands, and lastly send it directly to the server.
 The argument(s) for a command are shown in [tooltips](configuration/tooltips.md), and those marked with a `*` will show an additional tooltip with argument-specific information on mouseover.
 
-| Command       | Alias      | Description                                                       |
-| ------------- | ---------- | ----------------------------------------------------------------- |
-| `away`        |            | Mark yourself as away. If already away, the status is removed     |
-| `chathistory` |            | Retrieve message history[^5]                                      |
-| `clear`       |            | Clear the message history in the current buffer                   |
-| `cleartopic`  | `ct`       | Clear the topic of a channel[^1]                                  |
-| `ctcp`        |            | Client-To-Client requests[^2]                                     |
-| `delay`       |            | Delay the specified number of seconds[^6]                         |
-| `format`      | `f`        | Format text with markdown and colors                              |
-| `hop`         | `rejoin`   | Part the current channel and join a new one                       |
-| `join`        | `j`        | Join channel(s) with optional key(s)                              |
-| `kick`        |            | Kick a user from a channel[^1]                                    |
-| `knock`       |            | Request an invite from an invitation-only channel[^5]             |
-| `list`        |            | List channel(s) on the server[^5]                                 |
-| `me`          | `describe` | Send an action message to the channel                             |
-| `mode`        | `m`        | Set mode(s) on a channel or retrieve the current mode(s) set[^3]  |
-| `monitor`     |            | System to notify when users become online/offline[^5]             |
-| `motd`        |            | Request the message of the day                                    |
-| `msg`         | `query`    | Open a query with a nickname and send an optional message         |
-| `nick`        |            | Change your nickname on the current server                        |
-| `notice`      |            | Send a notice message to a target                                 |
-| `part`        | `leave`    | Leave and close channel(s)/quer(ies) with an optional reason [^4] |
-| `quit`        |            | Disconnect from the server with an optional reason                |
-| `raw`         |            | Send data to the server without modifying it                      |
-| `setname`     |            | Change your realname[^5]                                          |
-| `sysinfo`     |            | Send system information (OS, CPU, memory, GPU, uptime)             |
-| `topic`       | `t`        | Retrieve the topic of a channel or set a new topic[^1]            |
-| `whois`       |            | Retrieve information about user(s)                                |
+| Command       | Alias      | Description                                                                        |
+| ------------- | ---------- | ---------------------------------------------------------------------------------- |
+| `away`        |            | Mark yourself as away. If already away, the status is removed                      |
+| `chathistory` |            | Retrieve message history[^5]                                                       |
+| `clear`       |            | Clear the message history in the current buffer                                    |
+| `cleartopic`  | `ct`       | Clear the topic of a channel[^1]                                                   |
+| `ctcp`        |            | Client-To-Client requests[^2]                                                      |
+| `delay`       |            | Delay the specified number of seconds[^7]                                          |
+| `detach`      |            | Hide the channel, but leave the bouncer's connection to the channel active[^5][^6] |
+| `format`      | `f`        | Format text with markdown and colors                                               |
+| `hop`         | `rejoin`   | Part the current channel and join a new one                                        |
+| `join`        | `j`        | Join channel(s) with optional key(s)                                               |
+| `kick`        |            | Kick a user from a channel[^1]                                                     |
+| `knock`       |            | Request an invite from an invitation-only channel[^5]                              |
+| `list`        |            | List channel(s) on the server[^5]                                                  |
+| `me`          | `describe` | Send an action message to the channel                                              |
+| `mode`        | `m`        | Set mode(s) on a channel or retrieve the current mode(s) set[^3]                   |
+| `monitor`     |            | System to notify when users become online/offline[^5]                              |
+| `motd`        |            | Request the message of the day                                                     |
+| `msg`         | `query`    | Open a query with a nickname and send an optional message                          |
+| `nick`        |            | Change your nickname on the current server                                         |
+| `notice`      |            | Send a notice message to a target                                                  |
+| `part`        | `leave`    | Leave and close channel(s)/quer(ies) with an optional reason [^4]                  |
+| `quit`        |            | Disconnect from the server with an optional reason                                 |
+| `raw`         |            | Send data to the server without modifying it                                       |
+| `setname`     |            | Change your realname[^5]                                                           |
+| `sysinfo`     |            | Send system information (OS, CPU, memory, GPU, uptime)                             |
+| `topic`       | `t`        | Retrieve the topic of a channel or set a new topic[^1]                             |
+| `whois`       |            | Retrieve information about user(s)                                                 |
 
 [^1]: The `channel` argument can be skipped when used in a channel buffer to target the channel in the buffer.
 [^2]: The `nick` argument can be skipped when used in a query buffer to target the other user in the buffer.
 [^3]: The `target` argument can be skipped; in a channel buffer it will target the channel in the buffer, in a query buffer it will target the other user in the buffer, and in a server buffer it will target your user.
 [^4]: The `targets` argument can be skipped; in a channel or query buffer it will target the current buffer.
-[^5]: Command must be supported by the server to be executed successfully; if not supported then the command will not appear in the command picker.
-[^6]: Can only be used in [`on_connect`](configuration/servers.md#on_connect).
+[^5]: Command must be supported by the bouncer/server to be executed successfully; if not supported then the command will not appear in the command picker.
+[^6]: See [soju](https://soju.im/)'s [documentation on detaching from channels](https://man.sr.ht/chat.sr.ht/bouncer-usage.md#detaching-from-channels) for more information.
+[^7]: Can only be used in [`on_connect`](configuration/servers.md#on_connect).

--- a/data/src/client/on_connect.rs
+++ b/data/src/client/on_connect.rs
@@ -74,6 +74,15 @@ pub fn on_connect(
                                 targets,
                                 reason,
                             ) => Some(Event::LeaveBuffers(targets, reason)),
+                            command::Internal::Detach(channels) => {
+                                Some(Event::LeaveBuffers(
+                                    channels
+                                        .into_iter()
+                                        .map(Target::Channel)
+                                        .collect(),
+                                    Some("detach".to_string()),
+                                ))
+                            }
                             command::Internal::Delay(seconds) => {
                                 time::sleep(Duration::from_secs(seconds)).await;
                                 None

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -256,6 +256,8 @@ impl State {
                     .get_channels(buffer.server())
                     .cloned()
                     .collect::<Vec<_>>();
+                let supports_detach =
+                    clients.get_server_supports_detach(buffer.server());
                 let isupport = clients.get_isupport(buffer.server());
 
                 self.completion.process(
@@ -265,6 +267,7 @@ impl State {
                     &history.get_last_seen(buffer),
                     &channels,
                     current_target.as_ref(),
+                    supports_detach,
                     &isupport,
                     config,
                 );
@@ -392,6 +395,18 @@ impl State {
                                         Some(Event::LeaveBuffers {
                                             targets,
                                             reason,
+                                        }),
+                                    );
+                                }
+                                command::Internal::Detach(channels) => {
+                                    return (
+                                        Task::none(),
+                                        Some(Event::LeaveBuffers {
+                                            targets: channels
+                                                .into_iter()
+                                                .map(Target::Channel)
+                                                .collect(),
+                                            reason: Some("detach".to_string()),
                                         }),
                                     );
                                 }
@@ -668,6 +683,8 @@ impl State {
                         .get_channels(buffer.server())
                         .cloned()
                         .collect::<Vec<_>>();
+                    let supports_detach =
+                        clients.get_server_supports_detach(buffer.server());
                     let isupport = clients.get_isupport(buffer.server());
 
                     self.completion.process(
@@ -677,6 +694,7 @@ impl State {
                         &history.get_last_seen(buffer),
                         &channels,
                         current_target.as_ref(),
+                        supports_detach,
                         &isupport,
                         config,
                     );
@@ -712,6 +730,8 @@ impl State {
                             .get_channels(buffer.server())
                             .cloned()
                             .collect::<Vec<_>>();
+                        let supports_detach =
+                            clients.get_server_supports_detach(buffer.server());
                         let isupport = clients.get_isupport(buffer.server());
 
                         self.completion.process(
@@ -721,6 +741,7 @@ impl State {
                             &history.get_last_seen(buffer),
                             &channels,
                             current_target.as_ref(),
+                            supports_detach,
                             &isupport,
                             config,
                         );

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -759,6 +759,24 @@ impl Dashboard {
                     sidebar::Event::Swap(window, pane) => {
                         (self.swap_pane_with_focus(window, pane), None)
                     }
+                    sidebar::Event::Detach(buffer) => {
+                        if let Some(target) = buffer.target() {
+                            let server = buffer.server();
+
+                            (
+                                self.leave_server_target(
+                                    clients,
+                                    config,
+                                    server.clone(),
+                                    target,
+                                    Some("detach".to_string()),
+                                ),
+                                None,
+                            )
+                        } else {
+                            (Task::none(), None)
+                        }
+                    }
                     sidebar::Event::Leave(buffer) => {
                         self.leave_buffer(clients, config, buffer)
                     }


### PR DESCRIPTION
Adds the `/detach` command to the command picker and context menu for channels when connected to a soju instance.  A convenience command for [detaching from channels](https://man.sr.ht/chat.sr.ht/bouncer-usage.md#detaching-from-channels).

Partially addresses issue #1206.