### PR TITLE
Minor Documentation Improvements

### DIFF
--- a/book/src/configuration/sidebar.md
+++ b/book/src/configuration/sidebar.md
@@ -139,7 +139,7 @@ Changes the icon which appears when unread highlight messages are present. To di
 ```toml
 # Type: string
 # Values: "dot", "circle-empty", "dot-circled", "certificate", "asterisk", "speaker", "lightbulb", "star", "none"
-# Default: "dot"
+# Default: "circle-empty"
 
 [sidebar.unread_indicator]
 highlight_icon = "circle-empty"

--- a/book/src/guides/single-pane.md
+++ b/book/src/guides/single-pane.md
@@ -1,6 +1,6 @@
 # Single pane
 
-The settings below will configure Halloy to have a single pane (or fixed number of panes) in regular use.  When needed, new panes can be opened via the context menu on sidebar items (e.g. right-click on a channel in the sidebar and select "Open in new pane").
+The settings below will configure Halloy to have a single pane (or fixed number of panes) in regular use.  After applying these settings, close all but one pane.  Then, when activating another channel or query in the sidebar, that buffer will replace the view in the sole remaining pane (rather than opening a new pane).  When needed, new panes can be opened via the context menu on sidebar items (e.g. right-click on a channel in the sidebar and select "Open in new pane").
 
 ```toml
 [actions.buffer]


### PR DESCRIPTION
A couple minor improvements based on recent support interactions:
- Add more detail to the single pane guide.
- Fix the default reported for `sidebar.unread_indicator.highlight_icon`.