### PR TITLE
Filters Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Fixed:
 - Larger fonts (and font sizes) can be used without blanking out the sidebar or pane title bar(s)
 - The primary clipboard (with copy on selection & paste with middle click) is supported on Linux
 - Sound effects are now properly reloaded when config file is refreshed from within the application
+- Filters are applied only to the server they are specified for
+- Filters are renormalized properly when ISUPPORT is updated
 
 Thanks:
 

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -796,26 +796,13 @@ impl Manager {
 
             let chain = FilterChain::borrow(&self.filters);
 
-            match &kind {
-                history::Kind::Highlights => {
-                    messages.iter_mut().for_each(|message| {
-                        if message.blocked {
-                            return;
-                        }
-
-                        chain.filter_message_of_kind(message, &kind);
-                    });
+            messages.iter_mut().for_each(|message| {
+                if message.blocked {
+                    return;
                 }
-                _ => {
-                    messages.iter_mut().for_each(|message| {
-                        if message.blocked {
-                            return;
-                        }
 
-                        chain.filter_message_of_kind(message, &kind);
-                    });
-                }
-            }
+                chain.filter_message_of_kind(message, &kind);
+            });
 
             messages
                 .iter_mut()
@@ -863,6 +850,20 @@ impl Manager {
         }
 
         log::debug!("processed messages in {kind}");
+    }
+
+    pub fn renormalize_messages(
+        &mut self,
+        kind: history::Kind,
+        casemapping: isupport::CaseMap,
+    ) {
+        if let Some(History::Full { messages, .. }) =
+            self.data.map.get_mut(&kind)
+        {
+            messages
+                .iter_mut()
+                .for_each(|message| message.renormalize(casemapping));
+        }
     }
 }
 

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -284,6 +284,10 @@ impl User {
         self.away = away;
     }
 
+    pub fn renormalize(&mut self, casemapping: isupport::CaseMap) {
+        self.nickname.renormalize(casemapping);
+    }
+
     pub fn formatted(&self, user_format: UsernameFormat) -> String {
         let user = self.username();
         let host = self.hostname();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1100,6 +1100,12 @@ impl Halloy {
                                         );
                                     }
                                     data::client::Event::AddedIsupportParam(param) => {
+                                        if matches!(param, data::isupport::Parameter::CASEMAPPING(_)) {
+                                            let casemapping = self.clients.get_casemapping(&server);
+
+                                            dashboard.renormalize_history(&server, casemapping);
+                                        }
+
                                         if matches!(
                                             param,
                                             data::isupport::Parameter::CASEMAPPING(_)
@@ -1108,12 +1114,14 @@ impl Halloy {
                                             let chantypes = self.clients.get_chantypes(&server);
                                             let casemapping = self.clients.get_casemapping(&server);
 
-                                            FilterChain::sync_channels(
+                                            FilterChain::sync_isupport(
                                                 dashboard.get_filters(),
                                                 &server,
                                                 chantypes,
                                                 casemapping
                                             );
+
+                                            dashboard.reprocess_history(&self.clients, &self.config.buffer);
                                         }
                                     }
                                     Event::BouncerNetwork(server, config) => {

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -149,33 +149,63 @@ impl Dashboard {
     ) {
         self.init_filters(servers, clients);
 
-        // get all channels that are open
-        let open_pane_data: Vec<(data::Server, target::Channel)> = self
+        self.reprocess_history(clients, buffer_config);
+    }
+
+    pub fn reprocess_history(
+        &mut self,
+        clients: &client::Map,
+        buffer_config: &config::Buffer,
+    ) {
+        let open_pane_kinds: Vec<history::Kind> = self
             .panes
             .iter()
-            .filter_map(|(_window_id, _grid_pane, pane)| match &pane.buffer {
-                Buffer::Channel(channel) => {
-                    Some((channel.server.clone(), channel.target.clone()))
+            .filter_map(|(_window_id, _grid_pane, pane)| {
+                if matches!(
+                    pane.buffer,
+                    Buffer::Channel(_)
+                        | Buffer::Server(_)
+                        | Buffer::Query(_)
+                        | Buffer::Highlights(_)
+                ) {
+                    pane.buffer.data().and_then(history::Kind::from_buffer)
+                } else {
+                    None
                 }
-                _ => None,
             })
             .collect();
 
-        // rebuild cache for channels with open panes
-        for (server, channel) in open_pane_data {
-            self.history.process_messages(
-                history::Kind::Channel(server, channel),
-                clients,
-                buffer_config,
-            );
-        }
+        open_pane_kinds.into_iter().for_each(|kind| {
+            self.history.process_messages(kind, clients, buffer_config);
+        });
+    }
 
-        // always rebuild for highlights
-        self.history.process_messages(
-            history::Kind::Highlights,
-            clients,
-            buffer_config,
-        );
+    pub fn renormalize_history(
+        &mut self,
+        server: &data::Server,
+        casemapping: isupport::CaseMap,
+    ) {
+        let open_pane_kinds: Vec<history::Kind> = self
+            .panes
+            .iter()
+            .filter_map(|(_window_id, _grid_pane, pane)| {
+                if pane
+                    .buffer
+                    .server()
+                    .is_some_and(|buffer_server| buffer_server == *server)
+                    || matches!(pane.buffer, Buffer::Highlights(_))
+                {
+                    pane.buffer.data().and_then(history::Kind::from_buffer)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        println!("open_pane_kinds {open_pane_kinds:?}");
+
+        open_pane_kinds.into_iter().for_each(|kind| {
+            self.history.renormalize_messages(kind, casemapping);
+        });
     }
 
     pub fn update(


### PR DESCRIPTION
Minor bug fixes for filters:
- Filters are applied only to the servers they are specified for
- Filters are renormalized properly when ISUPPORT is updated (and open histories are renormalized properly when ISUPPORT is updated, so that updated filters can be applied)