### PR TITLE
Seed Colors with Normalized Nickname

### DIFF
--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -173,7 +173,7 @@ impl User {
     }
 
     pub fn seed(&self) -> &str {
-        self.as_str()
+        self.nickname.seed()
     }
 
     pub fn display(
@@ -404,12 +404,6 @@ pub enum ParseUserError {
 }
 
 #[derive(Debug, Clone)]
-pub struct NickColor {
-    pub seed: Option<String>,
-    pub color: iced_core::Color,
-}
-
-#[derive(Debug, Clone)]
 pub struct Nick {
     raw: String,
     normalized: String,
@@ -500,6 +494,10 @@ impl<'a> Nick {
 
     pub fn renormalize(&mut self, casemapping: isupport::CaseMap) {
         self.normalized = casemapping.normalize(self.raw.as_str());
+    }
+
+    pub fn seed(&self) -> &str {
+        self.normalized.as_ref()
     }
 }
 

--- a/src/buffer/context_menu.rs
+++ b/src/buffer/context_menu.rs
@@ -391,15 +391,11 @@ fn user_info<'a>(
         .is_offline(current_user.is_none());
     let seed = match config.buffer.nickname.color {
         data::buffer::Color::Solid => None,
-        data::buffer::Color::Unique => Some(nickname.to_string()),
+        data::buffer::Color::Unique => Some(nickname.seed()),
     };
 
-    let style = theme::text::nickname(
-        theme,
-        seed.clone(),
-        is_user_away,
-        is_user_offline,
-    );
+    let style =
+        theme::text::nickname(theme, seed, is_user_away, is_user_offline);
 
     let nickname = text(nickname.to_string()).style(move |_| style).font_maybe(
         theme::font_style::nickname(theme, is_user_offline).map(font::get),


### PR DESCRIPTION
Changes seed for unique colors to use the normalized nickname to ensure color consistency in cases where a canonical representation is not known/knowable (e.g. when `RPL_MONOFFLINE` is sent it is sent with the nickname with the casing provided in the monitor request, which may or may not be cased the same as the user's nickname).  Unfortunately some nicknames will take on a new color as a result.