### PR TITLE
Renormalization Fixes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1109,9 +1109,7 @@ impl Halloy {
                                     }
                                     data::client::Event::AddedIsupportParam(param) => {
                                         if matches!(param, data::isupport::Parameter::CASEMAPPING(_)) {
-                                            let casemapping = self.clients.get_casemapping(&server);
-
-                                            dashboard.renormalize_history(&server, casemapping);
+                                            dashboard.renormalize_history(&server, &self.clients);
                                         }
 
                                         if matches!(

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -183,7 +183,7 @@ impl Dashboard {
     pub fn renormalize_history(
         &mut self,
         server: &data::Server,
-        casemapping: isupport::CaseMap,
+        clients: &client::Map,
     ) {
         let open_pane_kinds: Vec<history::Kind> = self
             .panes
@@ -203,7 +203,7 @@ impl Dashboard {
             .collect();
 
         open_pane_kinds.into_iter().for_each(|kind| {
-            self.history.renormalize_messages(kind, casemapping);
+            self.history.renormalize_messages(kind, clients);
         });
     }
 


### PR DESCRIPTION
Two fixes related to message renormalization:
- Ensure messages are renormalized when loaded from disk (was previously not being done).
- Ensure highlights are renormalized/processed with per-message ISUPPORT lookup (since each message may originate from a different server).  Previously processing was done with default casemapping rather than looking up the server's casemapping.