### PR TITLE
Flickering Preview Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Fixed:
 - Filters are applied only to the server they are specified for
 - Filters are renormalized properly when ISUPPORT is updated
 - Crash when typing `/bouncer` into the message box
+- Scroll state no longer changes rapidly when long previews for URL(s) are present in history
 
 Changed:
 
@@ -25,7 +26,7 @@ Changed:
 Thanks:
 
 - Contributions: @Toby222, @Frikilinux, @4e554c4c
-- Bug reports: @Toby222, @deepspaceaxolotl, @zhelezov, @Erroneuz, @dgz0, @csmith
+- Bug reports: @Toby222, @deepspaceaxolotl, @zhelezov, @Erroneuz, @dgz0, @csmith, @otonoton
 - Feature requests: @j0lol, @xcfrg
 
 # 2025.9 (2025-09-16)

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -263,36 +263,17 @@ pub fn view<'a>(
                             .visible_url_messages
                             .contains_key(&message.hash);
 
-                        let element = if is_message_visible {
-                            notify_visibility(
-                                element,
-                                2000.0,
-                                notify_visibility::When::NotVisible,
-                                Message::ExitingViewport(message.hash),
-                            )
-                        } else {
-                            notify_visibility(
-                                element,
-                                1000.0,
-                                notify_visibility::When::Visible,
-                                Message::EnteringViewport(
-                                    message.hash,
-                                    urls.clone(),
-                                ),
-                            )
-                        };
-
                         let mut column = column![element];
 
-                        for (idx, url) in urls.into_iter().enumerate() {
-                            if message.hidden_urls.contains(&url) {
+                        for (idx, url) in urls.iter().enumerate() {
+                            if message.hidden_urls.contains(url) {
                                 continue;
                             }
 
                             if let (
                                 true,
                                 Some(preview::State::Loaded(preview)),
-                            ) = (is_message_visible, previews.get(&url))
+                            ) = (is_message_visible, previews.get(url))
                             {
                                 let is_hovered =
                                     state.hovered_preview.is_some_and(
@@ -302,7 +283,7 @@ pub fn view<'a>(
                                 column = column.push(preview_row(
                                     message,
                                     preview,
-                                    &url,
+                                    url,
                                     idx,
                                     max_nick_width,
                                     max_prefix_width,
@@ -313,7 +294,21 @@ pub fn view<'a>(
                             }
                         }
 
-                        column.into()
+                        if is_message_visible {
+                            notify_visibility(
+                                column,
+                                2000.0,
+                                notify_visibility::When::NotVisible,
+                                Message::ExitingViewport(message.hash),
+                            )
+                        } else {
+                            notify_visibility(
+                                column,
+                                1000.0,
+                                notify_visibility::When::Visible,
+                                Message::EnteringViewport(message.hash, urls),
+                            )
+                        }
                     } else {
                         element
                     }


### PR DESCRIPTION
Updates logic to notify that a message is exiting the viewport when it *and* its preview rows have exited (by a margin).  Prevents issue where message preview row could cause the message itself to trigger an exiting the viewport notification, causing the preview to unload and the message to re-enter the viewport, which then triggers an entering the viewport notification, etc. (resulting in the message cycling between entering and exiting the viewport causing the view to flicker).