### PR TITLE
Update GH Pages Actions

### DIFF
--- a/.github/workflows/gh-page-unstable.yml
+++ b/.github/workflows/gh-page-unstable.yml
@@ -13,12 +13,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check links
-        id: lychee
+      - name: Check internal links
+        id: lychee-interal
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --config ./.config/lychee.toml './book/**/*.md'
+          args: --config ./.config/lychee-internal.toml './book/**/*.md'
           fail: true
+
+      - name: Check external links
+        id: lychee-external
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --config ./.config/lychee-external.toml './book/**/*.md'
+          fail: true
+        continue-on-error: true
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1

--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -13,12 +13,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check links
-        id: lychee
+      - name: Check internal links
+        id: lychee-interal
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --config ./.config/lychee.toml './book/**/*.md'
+          args: --config ./.config/lychee-internal.toml './book/**/*.md'
           fail: true
+
+      - name: Check external links
+        id: lychee-external
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --config ./.config/lychee-external.toml './book/**/*.md'
+          fail: true
+        continue-on-error: true
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1


### PR DESCRIPTION
Update the GitHub pages actions to use the newly separated internal & external link checks from PR #1244.