### PR TITLE
Dimmable Server Messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Added:
 - Support for USERINFO CTCP query
 - Configurable anti-flood protection for servers that do not advertise SAFERATE
 - Channel modes will be retrieved on joining a channel (to be shown in the pane title bar)
-- Display own nickname next to text input field
+- Server messages can be dimmed (enabled by default), to lessen their visual impact relative to user messages
 
 Fixed:
 

--- a/book/src/configuration/buffer.md
+++ b/book/src/configuration/buffer.md
@@ -752,6 +752,19 @@ If you pass `["#halloy"]`, the channel `#halloy` will receive the server message
 include = ["#halloy"]
 ```
 
+### `dimmed`
+
+Dim condensed server message.  Either automatically, based on text/background colors (by setting to `true`), or specify a dimming value in the range `0.0` (transparent) to `1.0` (no dimming).
+
+```toml
+# Type: bool or float
+# Values: true, false, or float
+# Default: true
+
+[buffer.server_messages.<server_message>]
+dimmed = true
+```
+
 ### `username_format`
 
 Adjust the amount of information displayed for a username in server messages. If you choose `"short"`, only the nickname will be shown. If you choose `"full"`, the nickname, username, and hostname (if available) will be displayed.
@@ -800,7 +813,7 @@ Dim condensed messages.  Either automatically, based on text/background colors (
 ```toml
 # Type: bool or float
 # Values: true, false, or float
-# Default: false
+# Default: true
 
 [buffer.server_messages.condense]
 dimmed = true

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -259,15 +259,31 @@ impl ServerMessages {
             source::server::Kind::ChangeTopic => Some(&self.change_topic),
         }
     }
+
+    pub fn dimmed(&self, server: Option<&source::Server>) -> Option<&Dimmed> {
+        server.and_then(|server| {
+            self.get(server).and_then(|kind| kind.dimmed.as_ref())
+        })
+    }
 }
 
-#[derive(Debug, Default, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct Condensation {
     pub messages: HashSet<CondensationMessage>,
     pub format: CondensationFormat,
     #[serde(deserialize_with = "deserialize_dimmed_maybe")]
     pub dimmed: Option<Dimmed>,
+}
+
+impl Default for Condensation {
+    fn default() -> Self {
+        Self {
+            messages: HashSet::new(),
+            format: CondensationFormat::default(),
+            dimmed: Some(Dimmed(None)),
+        }
+    }
 }
 
 impl Condensation {
@@ -328,6 +344,8 @@ pub struct ServerMessage {
     pub username_format: UsernameFormat,
     pub exclude: Vec<String>,
     pub include: Vec<String>,
+    #[serde(deserialize_with = "deserialize_dimmed_maybe")]
+    pub dimmed: Option<Dimmed>,
 }
 
 impl Default for ServerMessage {
@@ -338,6 +356,7 @@ impl Default for ServerMessage {
             username_format: UsernameFormat::default(),
             exclude: Vec::default(),
             include: Vec::default(),
+            dimmed: Some(Dimmed(None)),
         }
     }
 }


### PR DESCRIPTION
Add dimmed setting to server message kinds, to lessen their relative visual impact.  Enabled dimmed server messages by default, since I expect many new users find server messages on high-traffic channels overwhelming.

<img width="720" height="302" alt="image" src="https://github.com/user-attachments/assets/2d83e0e2-3d43-4b3a-b55e-8ecb7e897aa9" />
