### PR TITLE
Hide Automated RPL_CREATIONTIME Messages 

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -2273,19 +2273,18 @@ impl Client {
                     self.chantypes(),
                     self.statusmsg(),
                     self.casemapping(),
-                ) {
-                    let mode_request_response = if let Some(position) =
-                        self.mode_requests.iter().position(|mode_request| {
-                            mode_request.channel == target_channel
-                                && matches!(
-                                    mode_request.status,
-                                    ModeStatus::Received(_)
-                                )
-                        }) {
-                        self.mode_requests.swap_remove(position);
+                ) && let Some(position) =
+                    self.mode_requests.iter().position(|mode_request| {
+                        mode_request.channel == target_channel
+                            && matches!(
+                                mode_request.status,
+                                ModeStatus::Received(_)
+                            )
+                    })
+                {
+                    self.mode_requests.swap_remove(position);
 
-                        return Ok(vec![]);
-                    }
+                    return Ok(vec![]);
                 }
             }
             Command::Numeric(ERR_NOCHANMODES, args) => {


### PR DESCRIPTION
The server automatically responds with an RPL_CREATIONTIME message after sending RPL_CHANNELMODEIS (this is specified by [horse docs](https://modern.ircdocs.horse/#mode-message), I just overlooked it).  This PR updates the logic of channel mode requests a bit to automatically hide those messages.