### PR TITLE
Scroll-To Consistency Improvement

### DIFF
--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -911,9 +911,6 @@ fn with_limit<'a>(
             let length = collected.len();
             collected[length.saturating_sub(n)..length].to_vec()
         }
-        Some(Limit::Since(timestamp)) => messages
-            .skip_while(|message| message.server_time < timestamp)
-            .collect(),
         None => messages.collect(),
     }
 }

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -2276,11 +2276,10 @@ fn content<'a>(
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Limit {
     Top(usize),
     Bottom(usize),
-    Since(DateTime<Utc>),
 }
 
 pub fn is_action(text: &str) -> bool {


### PR DESCRIPTION
The latest iced update appears to have changed some of the assumptions the old scroll-to logic was based on, at least on Linux.  As a result scroll-to actions were more frequently stopped mid-action (leaving the scroll state only partway to the backlog/message it was scrolling to).  This PR addresses that behavior by waiting for a content resize of the scroll view before scrolling, to ensure that the target message/backlog-divider is loaded into the scroll view before the scroll action takes place.  The scroll action is attempted whether or not content resizes after a short delay. 