### PR TITLE
Fix Lychee Workaround

### DIFF
--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -17,14 +17,14 @@ jobs:
         id: lychee-interal
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --config ./.config/lychee-internal.toml './book/**/*.md'
+          args: --index-files README.md --config ./.config/lychee-internal.toml './book/**/*.md'
           fail: true
 
       - name: Check external links
         id: lychee-external
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --index-files README.md --config ./.config/lychee-external.toml './book/**/*.md'
+          args: --config ./.config/lychee-external.toml './book/**/*.md'
           fail: true
         continue-on-error: true
 


### PR DESCRIPTION
Apply Lychee config parse fix to internal links check (not external links check).