### PR TITLE
Scroll Performance Fix

### DIFF
--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -911,6 +911,9 @@ fn with_limit<'a>(
             let length = collected.len();
             collected[length.saturating_sub(n)..length].to_vec()
         }
+        Some(Limit::Since(timestamp)) => messages
+            .skip_while(|message| message.server_time < timestamp)
+            .collect(),
         None => messages.collect(),
     }
 }

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -2280,6 +2280,7 @@ fn content<'a>(
 pub enum Limit {
     Top(usize),
     Bottom(usize),
+    Since(DateTime<Utc>),
 }
 
 pub fn is_action(text: &str) -> bool {


### PR DESCRIPTION
Revert changes intended to fix issue when scrolling with multiple messages in history that have the exact same server time due to severe performance regression.  Will attempt another fix of that issue later.

Should address #1275.