### PR TITLE
Expandable Input Box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Unreleased
 
+Fixed:
+
+- Larger fonts (and font sizes) can be used without blanking out the input box
+
+Thanks:
+
+- Bug reports: @Frikilinux
+
 # 2025.11 (2025-10-27)
 
 Fixed:

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -133,7 +133,9 @@ pub fn view<'a>(
         container(
             row![maybe_our_user, maybe_vertical_rule, input]
                 .spacing(4)
-                .height(20.0)
+                .height(
+                    (theme::line_height(&config.font).ceil() + 4.0).max(20.0)
+                )
                 .align_y(Alignment::Center)
         )
         .padding(8)


### PR DESCRIPTION
Expand input box height to include line height (with padding), so that input messages (and nickname, if shown) do not fail to render for large font sizes.  Fixes #1279.