### PR TITLE
Support unicode nicknames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ Fixed:
 Changed:
 
 - By default the backlog separator is hidden when all messages in a pane have been marked as read (`buffer.backlog_separator.hide_when_all_read`)
-- Buffer context menu items in sidebar are sorted alphabetically 
+- Buffer context menu items in sidebar are sorted alphabetically
+- Unicode nicknames are now supported
 
 Thanks:
 

--- a/data/src/ctcp.rs
+++ b/data/src/ctcp.rs
@@ -66,7 +66,7 @@ pub fn parse_query(text: &str) -> Option<Query<'_>> {
         .strip_prefix('\u{1}')?;
 
     let (command, params) = if let Some((command, params)) =
-        query.split_once(char::is_whitespace)
+        query.split_once(|c| char::is_ascii_whitespace(&c))
     {
         (command.to_uppercase(), Some(params))
     } else {

--- a/irc/proto/src/parse.rs
+++ b/irc/proto/src/parse.rs
@@ -149,7 +149,7 @@ fn user(input: &str) -> IResult<&str, User> {
     let special = |input| one_of("-[]\\`_^{|}*/@")(input);
     // *( <letter> | <number> | <special> )
     let strict_nick = recognize(many1_count(alt((
-        satisfy(|c| c.is_ascii_alphanumeric()),
+        satisfy(|c| c.is_ascii_alphanumeric() || !c.is_ascii()),
         special,
     ))));
     // Used by things like matrix bridge
@@ -159,7 +159,7 @@ fn user(input: &str) -> IResult<&str, User> {
     let expanded_nick = verify(
         recognize(terminated(
             many1_count(alt((
-                satisfy(|c| c.is_ascii_alphanumeric()),
+                satisfy(|c| c.is_ascii_alphanumeric() || !c.is_ascii()),
                 special,
                 one_of(":."),
             ))),


### PR DESCRIPTION
While the original IRC specifications (RFC 2812) do not allow non-ASCII nicknames, some IRC servers (i.e. UnrealIRCd, Ergo, etc.) adopted optional unicode nick support for many years, making it a de facto standard in many communities.

Currently, Halloy does not fully support these unicode nicknames, likely due to restrictions in the existing parser that expects only ASCII characters for nicknames. This prevents users from connecting with Unicode nicknames, and also prevent users from receiving messages from other users with unicode nicknames.

Most modern IRC clients already support this feature, including:

- irssi
- WeeChat
- HexChat
- IRCCloud
- The Lounge
- kvIRC
- ...

With this PR, halloy would support unicode nicknames. But this PR is not thoroughly tested, and I'm not familiar with Halloy codebase, so there can be unexpected bugs. This is just a proof of concept. 