### PR TITLE
FIx CTCP Source hyperlink

### DIFF
--- a/book/src/configuration/cctp/README.md
+++ b/book/src/configuration/cctp/README.md
@@ -39,7 +39,7 @@ ping = true
 
 ### source
 
-Whether Halloy will respond to a [CTCP TIME](https://modern.ircdocs.horse/ctcp#source) message.
+Whether Halloy will respond to a [CTCP SOURCE](https://modern.ircdocs.horse/ctcp#source) message.
 
 ```toml
 # Type: boolean


### PR DESCRIPTION
The CTCP docs has a typo for CTCP Source. While the hyperlink points to https://modern.ircdocs.horse/ctcp#source the text still says `CTCP TIME`. 

This PR fixes the typo.