### PR TITLE
`file_transfer.enabled` Setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Added:
 - Reload Halloy by sending `SIGUSR1` on Unix system
 - Ability to hide the indicator when a new version of Halloy is available 
 - Fuzzy matching when searching in command bar
+- Setting to disable file transfers (DCC), removing it from the UI
 
 Fixed:
 
@@ -30,7 +31,7 @@ Thanks:
 
 - Contributions: @kasperkronborg, @mistivia
 - Bug reports: @Frikilinux, ThePendulum, @crabbedhaloablution, @findus, @Darksecond
-- Feature requests: @cyrneko, ilya
+- Feature requests: @cyrneko, ilya, abby
 
 # 2025.11 (2025-10-27)
 

--- a/book/src/configuration/file-transfer/README.md
+++ b/book/src/configuration/file-transfer/README.md
@@ -4,6 +4,7 @@ File transfer configuration options.
 
 - [File Transfer](#file-transfer)
   - [Configuration](#configuration)
+    - [enabled](#enabled)
     - [save\_directory](#save_directory)
     - [passive](#passive)
     - [timeout](#timeout)
@@ -11,6 +12,20 @@ File transfer configuration options.
   - [Server](#server)
 
 ## Configuration
+
+### enabled
+
+Control if file transfers are shown in the UI (e.g. file transfer requests are
+shown, file transfer options are presented in menus, etc).
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: true
+
+[file_transfer]
+enabled = true
+```
 
 ### save_directory
 

--- a/data/src/config/file_transfer.rs
+++ b/data/src/config/file_transfer.rs
@@ -10,6 +10,7 @@ use crate::serde::deserialize_path_buf_with_path_transformations_maybe;
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct FileTransfer {
+    pub enabled: bool,
     /// Default directory to save files in. If not set, user will see a file dialog.
     #[serde(
         deserialize_with = "deserialize_path_buf_with_path_transformations_maybe"
@@ -27,6 +28,7 @@ pub struct FileTransfer {
 impl Default for FileTransfer {
     fn default() -> Self {
         Self {
+            enabled: true,
             save_directory: None,
             passive: true,
             timeout: 60 * 5,

--- a/src/buffer/highlights.rs
+++ b/src/buffer/highlights.rs
@@ -162,7 +162,11 @@ pub fn view<'a>(
                         Option::<fn(Color) -> Color>::None,
                         move |link| match link {
                             message::Link::User(_) => {
-                                context_menu::Entry::user_list(true, None)
+                                context_menu::Entry::user_list(
+                                    true,
+                                    None,
+                                    config.file_transfer.enabled,
+                                )
                             }
                             message::Link::Url(_) => {
                                 context_menu::Entry::url_list()

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -290,6 +290,7 @@ impl<'a> ChannelQueryLayout<'a> {
                 message::Link::User(_) => context_menu::Entry::user_list(
                     formatter.target.is_channel(),
                     formatter.target.our_user(),
+                    formatter.config.file_transfer.enabled,
                 ),
                 message::Link::Url(_) => context_menu::Entry::url_list(),
                 _ => vec![],
@@ -397,6 +398,7 @@ impl<'a> ChannelQueryLayout<'a> {
                 message::Link::User(_) => context_menu::Entry::user_list(
                     formatter.target.is_channel(),
                     formatter.target.our_user(),
+                    formatter.config.file_transfer.enabled,
                 ),
                 message::Link::Url(_) => context_menu::Entry::url_list(),
                 _ => vec![],
@@ -456,6 +458,7 @@ impl<'a> ChannelQueryLayout<'a> {
                 message::Link::User(_) => context_menu::Entry::user_list(
                     formatter.target.is_channel(),
                     formatter.target.our_user(),
+                    formatter.config.file_transfer.enabled,
                 ),
                 message::Link::Url(_) => context_menu::Entry::url_list(),
                 _ => vec![],

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -5,7 +5,7 @@ use std::{convert, slice};
 
 use chrono::format::SecondsFormat;
 use chrono::{DateTime, Local, Utc};
-use data::config::buffer::ScrollPosition;
+use data::config::buffer::{ScrollPosition, UsernameFormat};
 use data::dashboard::{self, BufferAction};
 use data::environment::{RELEASE_WEBSITE, WIKI_WEBSITE};
 use data::history::ReadMarker;
@@ -3027,6 +3027,15 @@ impl Dashboard {
         request: file_transfer::ReceiveRequest,
         config: &Config,
     ) -> Option<Task<Message>> {
+        if !config.file_transfer.enabled {
+            log::info!(
+                "file transfer request from {} ignored",
+                request.from.formatted(UsernameFormat::Full)
+            );
+
+            return None;
+        }
+
         let event = self.file_transfers.receive(request.clone(), config)?;
 
         self.notifications.notify(


### PR DESCRIPTION
Adds a setting to disable file transfers (i.e. automatically reject file transfers and show no file transfer UI).  File transfers remain enabled by default.