### PR TITLE
Optional TimeDelta Setting for `hide_consecutive`

### DIFF
--- a/book/src/configuration/buffer/nickname/README.md
+++ b/book/src/configuration/buffer/nickname/README.md
@@ -148,15 +148,21 @@ truncate = 10
 
 ### hide_consecutive
 
-Hide nickname if consecutive messages are from the same user.
+Hide nickname if consecutive messages are from the same user.  If specified as
+`{ smart = integer }` then the nickname will be hidden for consecutive messages
+are from the same user and each is within `smart` seconds of each other.
 
 > ⚠️ `hide_consecutive` does not work in conjunction with `alignment = "top"` .
 
 ```toml
 # Type: boolean
-# Values: true, false
+# Values: true, false, or { smart = integer }
 # Default: false
 
 [buffer.nickname]
 hide_consecutive = true
+
+# hide if the previous message was from the same user and sent within 2m of the current message
+[buffer.nickname]
+hide_consecutive = { smart = 120 }
 ```

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -259,19 +259,18 @@ impl<'a> ChannelQueryLayout<'a> {
             self.theme,
         );
 
-        let nick_element: Element<_> =
-            if hide_nickname && self.config.buffer.nickname.hide_consecutive {
-                let width = match self.config.buffer.nickname.alignment {
-                    data::buffer::Alignment::Left
-                    | data::buffer::Alignment::Top => 0.0,
-                    data::buffer::Alignment::Right => {
-                        right_aligned_width.unwrap_or_default()
-                    }
-                };
-                Space::new().width(width).into()
-            } else {
-                nick
+        let nick_element: Element<_> = if hide_nickname {
+            let width = match self.config.buffer.nickname.alignment {
+                data::buffer::Alignment::Left
+                | data::buffer::Alignment::Top => 0.0,
+                data::buffer::Alignment::Right => {
+                    right_aligned_width.unwrap_or_default()
+                }
             };
+            Space::new().width(width).into()
+        } else {
+            nick
+        };
 
         let formatter = *self;
 


### PR DESCRIPTION
Adds a smart option to the `hide_consecutive` setting to only hide the message's nickname for consecutive messages that are sent within a specified time delta (given in seconds) of each other.  E.g. the following configuration

```toml
[buffer.nickname]
hide_consecutive = { smart = 120 }
```

will hide the nickname for messages where the previous message was from the same user and was sent within 2 minutes of the message.  Existing boolean configuration continues to work as it did previously.