### PR TITLE
config.toml: fix broken link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,7 @@
 # Halloy config.
 #
 # For a complete list of available options,
-# please visit https://halloy.chat/configuration/
+# please visit https://halloy.chat/configuration.html
 
 [servers.liberachat]
 nickname = "__NICKNAME__"


### PR DESCRIPTION
The `/configuration/` directory doesn't actually exist on the website.

Though the proposed `/configuration.html` mostly says where to find the config.toml, so I guess linking to it from config.toml is a little redundant – but there doesn't seem to be an "config parameters overview" page, only the sidebar, so at least it'll link to _something_ that's not a 404 Not Found.