### PR TITLE
Delete Logs History Metadata on Launch

### DIFF
--- a/data/src/history/metadata.rs
+++ b/data/src/history/metadata.rs
@@ -160,6 +160,14 @@ pub async fn update(
     Ok(())
 }
 
+pub async fn delete(kind: &Kind) -> Result<(), Error> {
+    let path = path(kind).await?;
+
+    fs::remove_file(path).await?;
+
+    Ok(())
+}
+
 async fn path(kind: &Kind) -> Result<PathBuf, Error> {
     let dir = dir_path().await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,12 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         .enable_all()
         .build()?;
 
-    let _ = rt.block_on(history::delete(&history::Kind::Logs));
+    let _ = rt.block_on(async {
+        tokio::join!(
+            history::delete(&history::Kind::Logs),
+            history::metadata::delete(&history::Kind::Logs)
+        )
+    });
 
     let log_stream =
         logger::setup(is_debug, logs_config).expect("setup logging");


### PR DESCRIPTION
If the there was a warning/error in the logs from a previous launch, then the "has unread log(s)" indicator would persist across launches even if no warning/error occurred since last launch.  This PR deletes the logs history metadata on launch as well, to avoid that issue.