### PR TITLE
Join BufferAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+Added:
+
+- Setting to open a new pane, replace current pane, or open a new window after `/join`
+
 Fixed:
 
 - No longer any delay in showing a tooltip after hovering

--- a/book/src/configuration/actions/buffer.md
+++ b/book/src/configuration/actions/buffer.md
@@ -11,6 +11,7 @@ How buffer actions should be enacted
     - [local](#local)
     - [message\_channel](#message_channel)
     - [message\_user](#message_user)
+    - [join\_channel](#join_channel)
 
 ## Example
 
@@ -101,4 +102,17 @@ Action when sending an empty message to a user (via `Message` in the user contex
 
 [actions.buffer]
 message_user = "replace-pane"
+```
+
+### join_channel
+
+Action when sending joining a channel via `/join` command. `"new-pane"` opens a new pane each time. `"replace-pane"` replaces the focused pane with the channel. `"new-window"` opens a new window each time.
+
+```toml
+# Type: string
+# Values: "new-pane", "replace-pane", "new-window"
+# Default: "new-pane"
+
+[actions.buffer]
+join_channel = "replace-pane"
 ```

--- a/data/src/config/actions.rs
+++ b/data/src/config/actions.rs
@@ -15,6 +15,7 @@ pub struct Buffer {
     pub click_channel_name: BufferAction,
     pub click_highlight: BufferAction,
     pub click_username: BufferAction,
+    pub join_channel: Option<BufferAction>,
     pub local: BufferAction,
     pub message_channel: BufferAction,
     pub message_user: BufferAction,

--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -62,10 +62,20 @@ pub struct Input {
 }
 
 impl Input {
-    pub fn command(buffer: buffer::Upstream, command: command::Irc) -> Self {
+    pub fn from_command(
+        buffer: buffer::Upstream,
+        command: command::Irc,
+    ) -> Self {
         Self {
             buffer,
             content: Content::Command(command),
+        }
+    }
+
+    pub fn command(&self) -> Option<&command::Irc> {
+        match &self.content {
+            Content::Text(_) => None,
+            Content::Command(command) => Some(command),
         }
     }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -67,6 +67,10 @@ pub enum Event {
     ImagePreview(PathBuf, url::Url),
     ExpandCondensedMessage(DateTime<Utc>, message::Hash),
     ContractCondensedMessage(DateTime<Utc>, message::Hash),
+    InputSent {
+        history_task: Task<history::manager::Message>,
+        open_buffers: Vec<(Target, BufferAction)>,
+    },
 }
 
 impl Buffer {
@@ -229,6 +233,13 @@ impl Buffer {
                         server_time,
                         hash,
                     ) => Event::ContractCondensedMessage(server_time, hash),
+                    channel::Event::InputSent {
+                        history_task,
+                        open_buffers,
+                    } => Event::InputSent {
+                        history_task,
+                        open_buffers,
+                    },
                 });
 
                 (command.map(Message::Channel), event)
@@ -266,6 +277,13 @@ impl Buffer {
                         server_time,
                         hash,
                     ) => Event::ContractCondensedMessage(server_time, hash),
+                    server::Event::InputSent {
+                        history_task,
+                        open_buffers,
+                    } => Event::InputSent {
+                        history_task,
+                        open_buffers,
+                    },
                 });
 
                 (command.map(Message::Server), event)
@@ -309,6 +327,13 @@ impl Buffer {
                         server_time,
                         hash,
                     ) => Event::ContractCondensedMessage(server_time, hash),
+                    query::Event::InputSent {
+                        history_task,
+                        open_buffers,
+                    } => Event::InputSent {
+                        history_task,
+                        open_buffers,
+                    },
                 });
 
                 (command.map(Message::Query), event)

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -34,6 +34,10 @@ pub enum Event {
     ImagePreview(PathBuf, url::Url),
     ExpandCondensedMessage(DateTime<Utc>, message::Hash),
     ContractCondensedMessage(DateTime<Utc>, message::Hash),
+    InputSent {
+        history_task: Task<history::manager::Message>,
+        open_buffers: Vec<(Target, BufferAction)>,
+    },
 }
 
 pub fn view<'a>(
@@ -227,7 +231,10 @@ impl Query {
                 let command = command.map(Message::InputView);
 
                 match event {
-                    Some(input_view::Event::InputSent { history_task }) => {
+                    Some(input_view::Event::InputSent {
+                        history_task,
+                        open_buffers,
+                    }) => {
                         let command = Task::batch(vec![
                             command,
                             self.scroll_view
@@ -235,7 +242,13 @@ impl Query {
                                 .map(Message::ScrollView),
                         ]);
 
-                        (command, Some(Event::History(history_task)))
+                        (
+                            command,
+                            Some(Event::InputSent {
+                                history_task,
+                                open_buffers,
+                            }),
+                        )
                     }
                     Some(input_view::Event::OpenBuffers { targets }) => {
                         (command, Some(Event::OpenBuffers(targets)))


### PR DESCRIPTION
Add `actions.buffer.join_channel` setting to open a buffer via specified BufferAction when sending a `/join` command.