### PR TITLE
Update Iced

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,8 +1271,7 @@ dependencies = [
 [[package]]
 name = "cosmic-text"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173852283a9a57a3cbe365d86e74dc428a09c50421477d5ad6fe9d9509e37737"
+source = "git+https://github.com/pop-os/cosmic-text.git?rev=a07a6190548c8e40a55f6b7761387047ff1bf6ff#a07a6190548c8e40a55f6b7761387047ff1bf6ff"
 dependencies = [
  "bitflags 2.9.1",
  "fontdb",
@@ -1422,7 +1421,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "cryoglyph"
 version = "0.1.0"
-source = "git+https://github.com/iced-rs/cryoglyph.git?rev=99b46959369f38a06c11353bf1be81d383b289fc#99b46959369f38a06c11353bf1be81d383b289fc"
+source = "git+https://github.com/iced-rs/cryoglyph.git?rev=89883bcf38b5bed0d7bade788ef738d9facc857c#89883bcf38b5bed0d7bade788ef738d9facc857c"
 dependencies = [
  "cosmic-text",
  "etagere",
@@ -3213,8 +3212,8 @@ dependencies = [
 
 [[package]]
 name = "iced"
-version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=78ed897db06129746b5029c47db586f16d63511b#78ed897db06129746b5029c47db586f16d63511b"
+version = "0.15.0-dev"
+source = "git+https://github.com/squidowl/iced?rev=74a89b5e374dc82ec7aa7ff4134b2996d4c3965c#74a89b5e374dc82ec7aa7ff4134b2996d4c3965c"
 dependencies = [
  "iced_core",
  "iced_debug",
@@ -3230,8 +3229,8 @@ dependencies = [
 
 [[package]]
 name = "iced_beacon"
-version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=78ed897db06129746b5029c47db586f16d63511b#78ed897db06129746b5029c47db586f16d63511b"
+version = "0.15.0-dev"
+source = "git+https://github.com/squidowl/iced?rev=74a89b5e374dc82ec7aa7ff4134b2996d4c3965c#74a89b5e374dc82ec7aa7ff4134b2996d4c3965c"
 dependencies = [
  "bincode 1.3.3",
  "futures",
@@ -3245,8 +3244,8 @@ dependencies = [
 
 [[package]]
 name = "iced_core"
-version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=78ed897db06129746b5029c47db586f16d63511b#78ed897db06129746b5029c47db586f16d63511b"
+version = "0.15.0-dev"
+source = "git+https://github.com/squidowl/iced?rev=74a89b5e374dc82ec7aa7ff4134b2996d4c3965c#74a89b5e374dc82ec7aa7ff4134b2996d4c3965c"
 dependencies = [
  "bitflags 2.9.1",
  "bytes",
@@ -3263,8 +3262,8 @@ dependencies = [
 
 [[package]]
 name = "iced_debug"
-version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=78ed897db06129746b5029c47db586f16d63511b#78ed897db06129746b5029c47db586f16d63511b"
+version = "0.15.0-dev"
+source = "git+https://github.com/squidowl/iced?rev=74a89b5e374dc82ec7aa7ff4134b2996d4c3965c#74a89b5e374dc82ec7aa7ff4134b2996d4c3965c"
 dependencies = [
  "iced_beacon",
  "iced_core",
@@ -3274,8 +3273,8 @@ dependencies = [
 
 [[package]]
 name = "iced_devtools"
-version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=78ed897db06129746b5029c47db586f16d63511b#78ed897db06129746b5029c47db586f16d63511b"
+version = "0.15.0-dev"
+source = "git+https://github.com/squidowl/iced?rev=74a89b5e374dc82ec7aa7ff4134b2996d4c3965c#74a89b5e374dc82ec7aa7ff4134b2996d4c3965c"
 dependencies = [
  "iced_debug",
  "iced_program",
@@ -3285,8 +3284,8 @@ dependencies = [
 
 [[package]]
 name = "iced_futures"
-version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=78ed897db06129746b5029c47db586f16d63511b#78ed897db06129746b5029c47db586f16d63511b"
+version = "0.15.0-dev"
+source = "git+https://github.com/squidowl/iced?rev=74a89b5e374dc82ec7aa7ff4134b2996d4c3965c#74a89b5e374dc82ec7aa7ff4134b2996d4c3965c"
 dependencies = [
  "futures",
  "iced_core",
@@ -3299,8 +3298,8 @@ dependencies = [
 
 [[package]]
 name = "iced_graphics"
-version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=78ed897db06129746b5029c47db586f16d63511b#78ed897db06129746b5029c47db586f16d63511b"
+version = "0.15.0-dev"
+source = "git+https://github.com/squidowl/iced?rev=74a89b5e374dc82ec7aa7ff4134b2996d4c3965c#74a89b5e374dc82ec7aa7ff4134b2996d4c3965c"
 dependencies = [
  "bitflags 2.9.1",
  "bytemuck",
@@ -3319,8 +3318,8 @@ dependencies = [
 
 [[package]]
 name = "iced_program"
-version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=78ed897db06129746b5029c47db586f16d63511b#78ed897db06129746b5029c47db586f16d63511b"
+version = "0.15.0-dev"
+source = "git+https://github.com/squidowl/iced?rev=74a89b5e374dc82ec7aa7ff4134b2996d4c3965c#74a89b5e374dc82ec7aa7ff4134b2996d4c3965c"
 dependencies = [
  "iced_graphics",
  "iced_runtime",
@@ -3328,8 +3327,8 @@ dependencies = [
 
 [[package]]
 name = "iced_renderer"
-version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=78ed897db06129746b5029c47db586f16d63511b#78ed897db06129746b5029c47db586f16d63511b"
+version = "0.15.0-dev"
+source = "git+https://github.com/squidowl/iced?rev=74a89b5e374dc82ec7aa7ff4134b2996d4c3965c#74a89b5e374dc82ec7aa7ff4134b2996d4c3965c"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -3340,8 +3339,8 @@ dependencies = [
 
 [[package]]
 name = "iced_runtime"
-version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=78ed897db06129746b5029c47db586f16d63511b#78ed897db06129746b5029c47db586f16d63511b"
+version = "0.15.0-dev"
+source = "git+https://github.com/squidowl/iced?rev=74a89b5e374dc82ec7aa7ff4134b2996d4c3965c#74a89b5e374dc82ec7aa7ff4134b2996d4c3965c"
 dependencies = [
  "bytes",
  "iced_core",
@@ -3352,8 +3351,8 @@ dependencies = [
 
 [[package]]
 name = "iced_tiny_skia"
-version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=78ed897db06129746b5029c47db586f16d63511b#78ed897db06129746b5029c47db586f16d63511b"
+version = "0.15.0-dev"
+source = "git+https://github.com/squidowl/iced?rev=74a89b5e374dc82ec7aa7ff4134b2996d4c3965c#74a89b5e374dc82ec7aa7ff4134b2996d4c3965c"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -3369,8 +3368,8 @@ dependencies = [
 
 [[package]]
 name = "iced_wgpu"
-version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=78ed897db06129746b5029c47db586f16d63511b#78ed897db06129746b5029c47db586f16d63511b"
+version = "0.15.0-dev"
+source = "git+https://github.com/squidowl/iced?rev=74a89b5e374dc82ec7aa7ff4134b2996d4c3965c#74a89b5e374dc82ec7aa7ff4134b2996d4c3965c"
 dependencies = [
  "bitflags 2.9.1",
  "bytemuck",
@@ -3389,8 +3388,8 @@ dependencies = [
 
 [[package]]
 name = "iced_widget"
-version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=78ed897db06129746b5029c47db586f16d63511b#78ed897db06129746b5029c47db586f16d63511b"
+version = "0.15.0-dev"
+source = "git+https://github.com/squidowl/iced?rev=74a89b5e374dc82ec7aa7ff4134b2996d4c3965c#74a89b5e374dc82ec7aa7ff4134b2996d4c3965c"
 dependencies = [
  "iced_renderer",
  "log",
@@ -3403,8 +3402,8 @@ dependencies = [
 
 [[package]]
 name = "iced_winit"
-version = "0.14.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=78ed897db06129746b5029c47db586f16d63511b#78ed897db06129746b5029c47db586f16d63511b"
+version = "0.15.0-dev"
+source = "git+https://github.com/squidowl/iced?rev=74a89b5e374dc82ec7aa7ff4134b2996d4c3965c#74a89b5e374dc82ec7aa7ff4134b2996d4c3965c"
 dependencies = [
  "iced_debug",
  "iced_program",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ irc = { version = "0.1.0", path = "irc" }
 signal-hook = "0.3.18"
 notify-rust = "4.11"
 fern = "0.7.1"
-iced = { version = "0.14.0-dev", default-features = false, features = [
+iced = { version = "0.15.0-dev", default-features = false, features = [
     "wgpu",
     "tiny-skia",
     "fira-sans",
@@ -102,7 +102,7 @@ mundy = { version = "0.1.9", default-features = false, features = [
 
 [target.'cfg(windows)'.dependencies]
 image = "0.24.6"
-iced = { version = "0.14.0-dev", default-features = false, features = [
+iced = { version = "0.15.0-dev", default-features = false, features = [
     "web-colors",
     "sysinfo",
 ] }
@@ -112,9 +112,9 @@ embed-resource = "3.0.2"
 windows_exe_info = "0.4"
 
 [patch.crates-io]
-iced = { git = "https://github.com/squidowl/iced", rev = "78ed897db06129746b5029c47db586f16d63511b" }
-iced_core = { git = "https://github.com/squidowl/iced", rev = "78ed897db06129746b5029c47db586f16d63511b" }
-iced_wgpu = { git = "https://github.com/squidowl/iced", rev = "78ed897db06129746b5029c47db586f16d63511b" }
+iced = { git = "https://github.com/squidowl/iced", rev = "74a89b5e374dc82ec7aa7ff4134b2996d4c3965c" }
+iced_core = { git = "https://github.com/squidowl/iced", rev = "74a89b5e374dc82ec7aa7ff4134b2996d4c3965c" }
+iced_wgpu = { git = "https://github.com/squidowl/iced", rev = "74a89b5e374dc82ec7aa7ff4134b2996d4c3965c" }
 
 [profile.ci]
 inherits = "dev"

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -43,9 +43,9 @@ dirs-next = "2.0.0"
 xdg = "3.0.0"
 flate2 = "1.0"
 hex = "0.4.3"
-iced_core = "0.14.0-dev"
-iced_wgpu = "0.14.0-dev"
-iced = { version = "0.14.0-dev", default-features = false, features = ["sysinfo"] }
+iced_core = "0.15.0-dev"
+iced_wgpu = "0.15.0-dev"
+iced = { version = "0.15.0-dev", default-features = false, features = ["sysinfo"] }
 indexmap = { version = "2.10", features = ["std", "serde"] }
 seahash = "4.1.0"
 serde_json = "1.0"

--- a/src/appearance/theme/menu.rs
+++ b/src/appearance/theme/menu.rs
@@ -1,6 +1,6 @@
 pub use iced::widget::overlay::menu::Style;
 use iced::widget::overlay::menu::{Catalog, StyleFn};
-use iced::{Background, Border};
+use iced::{Background, Border, Shadow};
 
 use super::Theme;
 
@@ -33,5 +33,6 @@ pub fn primary(theme: &Theme) -> Style {
         selected_background: Background::Color(
             buttons.primary.background_hover,
         ),
+        shadow: Shadow::default(),
     }
 }

--- a/src/appearance/theme/scrollable.rs
+++ b/src/appearance/theme/scrollable.rs
@@ -1,6 +1,6 @@
 use iced::widget::container;
 use iced::widget::scrollable::{
-    Catalog, Rail, Scroller, Status, Style, StyleFn,
+    AutoScroll, Catalog, Rail, Scroller, Status, Style, StyleFn,
 };
 use iced::{Background, Border, Color, Shadow};
 
@@ -29,13 +29,24 @@ pub fn primary(theme: &Theme, status: Status) -> Style {
         background: None,
         border: Border::default(),
         scroller: Scroller {
-            color: scroller_color,
+            background: Background::Color(scroller_color),
             border: Border {
                 radius: 8.0.into(),
                 width: 0.0,
                 color: Color::TRANSPARENT,
             },
         },
+    };
+
+    let auto_scroll = AutoScroll {
+        background: Background::Color(Color::TRANSPARENT),
+        border: Border {
+            radius: 8.0.into(),
+            width: 0.0,
+            color: Color::TRANSPARENT,
+        },
+        shadow: Shadow::default(),
+        icon: scroller_color,
     };
 
     match status {
@@ -56,6 +67,7 @@ pub fn primary(theme: &Theme, status: Status) -> Style {
             vertical_rail: rail,
             horizontal_rail: rail,
             gap: None,
+            auto_scroll,
         },
     }
 }
@@ -65,13 +77,24 @@ pub fn hidden(_theme: &Theme, status: Status) -> Style {
         background: None,
         border: Border::default(),
         scroller: Scroller {
-            color: Color::TRANSPARENT,
+            background: Background::Color(Color::TRANSPARENT),
             border: Border {
                 radius: 0.0.into(),
                 width: 0.0,
                 color: Color::TRANSPARENT,
             },
         },
+    };
+
+    let auto_scroll = AutoScroll {
+        background: Background::Color(Color::TRANSPARENT),
+        border: Border {
+            radius: 8.0.into(),
+            width: 0.0,
+            color: Color::TRANSPARENT,
+        },
+        shadow: Shadow::default(),
+        icon: Color::TRANSPARENT,
     };
 
     match status {
@@ -92,6 +115,7 @@ pub fn hidden(_theme: &Theme, status: Status) -> Style {
             vertical_rail: rail,
             horizontal_rail: rail,
             gap: None,
+            auto_scroll,
         },
     }
 }

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -737,7 +737,8 @@ impl State {
             }
             Message::Send => {
                 let raw_input = self.input_content.text().clone();
-                let cursor_position = self.input_content.cursor_position().1;
+                let cursor_position =
+                    self.input_content.cursor().position.column;
 
                 // Reset error
                 self.error = None;
@@ -1149,7 +1150,8 @@ impl State {
             }
             Message::Tab(reverse) => {
                 let input = self.input_content.text();
-                let cursor_position = self.input_content.cursor_position().1;
+                let cursor_position =
+                    self.input_content.cursor().position.column;
 
                 if let Some(entry) = self.completion.tab(reverse) {
                     let chantypes = clients.get_chantypes(buffer.server());
@@ -1450,7 +1452,7 @@ impl State {
                     text_editor::Action::Edit(_) => {
                         let input = self.input_content.text();
                         let cursor_position =
-                            self.input_content.cursor_position().1;
+                            self.input_content.cursor().position.column;
 
                         // Reset error state
                         self.error = None;
@@ -1554,7 +1556,7 @@ impl State {
                     | text_editor::Action::Click(_) => {
                         let input = self.input_content.text();
                         let cursor_position =
-                            self.input_content.cursor_position().1;
+                            self.input_content.cursor().position.column;
 
                         let users = buffer.channel().and_then(|channel| {
                             clients.get_channel_users(buffer.server(), channel)
@@ -1682,7 +1684,7 @@ impl State {
         autocomplete: &Autocomplete,
     ) {
         let text = self.input_content.text();
-        let cursor_position = self.input_content.cursor_position().1;
+        let cursor_position = self.input_content.cursor().position.column;
 
         let insert_text = if cursor_position == 0 {
             let suffix_range = cursor_position

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -1689,8 +1689,8 @@ mod correct_viewport {
                                 let mut operation = scrollable::scroll_to(
                                     scrollable.clone(),
                                     scrollable::AbsoluteOffset {
-                                        x: 0.0,
-                                        y: new_offset,
+                                        x: None,
+                                        y: Some(new_offset),
                                     },
                                 );
                                 inner
@@ -1854,7 +1854,7 @@ mod correct_viewport {
                 state: &mut dyn Scrollable,
             ) {
                 if id.is_some_and(|id| *id == self.target) {
-                    state.scroll_to(self.offset);
+                    state.scroll_to(self.offset.into());
                 }
             }
 

--- a/src/font.rs
+++ b/src/font.rs
@@ -125,6 +125,7 @@ pub fn width_from_chars(len: usize, config: &config::Font) -> f32 {
         align_y: alignment::Vertical::Top,
         shaping: text::Shaping::Basic,
         wrapping: text::Wrapping::default(),
+        hint_factor: None,
     })
     .min_bounds()
     .expand(Size::new(1.0, 0.0))
@@ -151,6 +152,7 @@ pub fn width_of_message_marker(config: &config::Font) -> f32 {
         align_y: alignment::Vertical::Top,
         shaping: text::Shaping::Basic,
         wrapping: text::Wrapping::default(),
+        hint_factor: None,
     })
     .min_bounds()
     .expand(Size::new(1.0, 0.0))

--- a/src/widget/selectable_rich_text.rs
+++ b/src/widget/selectable_rich_text.rs
@@ -460,6 +460,7 @@ where
                     align_y: self.align_y,
                     shaping: Shaping::Advanced,
                     wrapping: text::Wrapping::WordOrGlyph,
+                    hint_factor: renderer.scale_factor(),
                 };
 
                 // Check spoiler
@@ -869,6 +870,7 @@ where
             align_y,
             shaping: Shaping::Advanced,
             wrapping: text::Wrapping::WordOrGlyph,
+            hint_factor: renderer.scale_factor(),
         };
 
         if state.spans != spans {
@@ -896,6 +898,7 @@ where
                 align_y,
                 shaping: Shaping::Advanced,
                 wrapping: text::Wrapping::WordOrGlyph,
+                hint_factor: renderer.scale_factor(),
             }) {
                 text::Difference::None => {}
                 text::Difference::Bounds => {

--- a/src/widget/selectable_text.rs
+++ b/src/widget/selectable_text.rs
@@ -163,6 +163,7 @@ where
                 align_y: self.format.align_y,
                 shaping: self.format.shaping,
                 wrapping: self.format.wrapping,
+                hint_factor: renderer.scale_factor(),
             });
 
             state.paragraph.min_bounds()


### PR DESCRIPTION
Updates Iced, with two changes (at least) that warrant review:
- Auto-scroll functionality has been added to `scrollable`.  I believe this should operate similar to middle-click on Firefox that places an icon then the page's scroll movement is controlled by the cursor's current position relative to the icon.  I extrapolated styling options from the scroller's styling, but I can't get the auto-scroll functionality to work for more than a split-second to verify that the styling is reasonable.  (The auto-scroll functionality only shows for a split-second for me on the unpatched version of iced as well, so it may just be too early in its development to use.)
- [`hint_factor`](https://docs.iced.rs/iced/advanced/struct.Text.html#structfield.hint_factor) has been added to text.  For displayed text fields I've just taken the renderer's `scale_factor()` to use as the `hint_factor`, but I'm not certain that's right.  (Not-displayed text fields are the procedures in `font.rs` that measure the width of characters.)