### PR TITLE
Prevent Search Query in Channel Discovery Flashing

### DIFF
--- a/src/appearance/theme/text_input.rs
+++ b/src/appearance/theme/text_input.rs
@@ -49,12 +49,6 @@ pub fn primary(theme: &Theme, status: Status) -> Style {
                 a: 0.2,
                 ..theme.styles().text.secondary.color
             },
-            border: Border {
-                radius: 4.0.into(),
-                width: 0.0,
-                color: Color::TRANSPARENT,
-                // XXX Not currently displayed in application.
-            },
             ..active
         },
     }

--- a/src/buffer/channel_discovery.rs
+++ b/src/buffer/channel_discovery.rs
@@ -138,6 +138,19 @@ pub fn view<'a>(
                 .placeholder("Select server"),
                 text_input("Search..", &state.search_query)
                     .id(state.search_query_id.clone())
+                    .style(move |theme, status| {
+                        // Show the disabled text_input as active, since we only
+                        // expect it to be disabled when moving panes (and that
+                        // disabling does not need to be indicated to the user)
+                        if matches!(status, text_input::Status::Disabled) {
+                            theme::text_input::primary(
+                                theme,
+                                text_input::Status::Active,
+                            )
+                        } else {
+                            theme::text_input::primary(theme, status)
+                        }
+                    })
                     .on_input_maybe(
                         selected_server
                             .map(|_| |query| Message::SearchQuery(query))


### PR DESCRIPTION
Prevents the text_input in Channel Discovery from flashing when the pane is grabbed.
Also removes a redundant specification in primary theme for text_input.