### PR TITLE
Default to Emacs-like Keybindings on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Fixed:
 - `/sysinfo` is cleared from input when sent, and is recorded to the buffer even if the server doesn't support echoes
 - Channel and user links in messages in the highlight buffer
 
+Changed:
+
+- Keybindings for macOS default to Emacs-like by default, to match native text-input behavior
+
 Thanks:
 
 - Contributions: @csmith

--- a/book/src/configuration/buffer/text-input/README.md
+++ b/book/src/configuration/buffer/text-input/README.md
@@ -48,7 +48,7 @@ Different key bindings for the text input
 ```toml
 # Type: string
 # Values: "default", "emacs"
-# Default: "default
+# Default: "emacs" on macOS, "default" for all other OSes
 
 [buffer.text_input]
 key_bindings = "emacs"

--- a/data/src/config/buffer/text_input.rs
+++ b/data/src/config/buffer/text_input.rs
@@ -10,12 +10,21 @@ pub struct TextInput {
     pub key_bindings: KeyBindings,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum KeyBindings {
-    #[default]
     Default,
     Emacs,
+}
+
+impl Default for KeyBindings {
+    fn default() -> Self {
+        if cfg!(target_os = "macos") {
+            KeyBindings::Emacs
+        } else {
+            KeyBindings::Default
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, Deserialize)]


### PR DESCRIPTION
Set default keybindings for macOS to be Emacs-like, to match native text input behavior.