### PR TITLE
Release Profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,10 @@ iced = { git = "https://github.com/squidowl/iced", rev = "af28bbe8de1dfafa2ebe7a
 iced_core = { git = "https://github.com/squidowl/iced", rev = "af28bbe8de1dfafa2ebe7a3ac96ebcc87ae05538" }
 iced_wgpu = { git = "https://github.com/squidowl/iced", rev = "af28bbe8de1dfafa2ebe7a3ac96ebcc87ae05538" }
 
+[profile.release]
+lto = "fat"
+codegen-units = 1
+
 [profile.ci]
 inherits = "dev"
 opt-level = 0

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -10,7 +10,6 @@ use tokio::sync::mpsc as tokio_mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
 pub fn setup(
-    is_debug: bool,
     config: config::Logs,
 ) -> Result<ReceiverStream<Vec<Record>>, Error> {
     let env_rust_log = env::var("RUST_LOG")
@@ -36,13 +35,9 @@ pub fn setup(
         ));
     });
 
-    if is_debug {
-        io_sink = io_sink.chain(std::io::stdout());
-    } else {
-        let log_file = data::log::file()?;
+    let log_file = data::log::file()?;
 
-        io_sink = io_sink.chain(log_file);
-    }
+    io_sink = io_sink.chain(log_file);
 
     io_sink = io_sink
         .level(log::LevelFilter::Off)

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,8 +60,6 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let is_debug = cfg!(debug_assertions);
-
     // Prepare notifications.
     notification::prepare();
 
@@ -81,8 +79,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
     });
 
-    let log_stream =
-        logger::setup(is_debug, logs_config).expect("setup logging");
+    let log_stream = logger::setup(logs_config).expect("setup logging");
     log::info!("halloy {} has started", environment::formatted_version());
     log::info!("config dir: {:?}", environment::config_dir());
     log::info!("data dir: {:?}", environment::data_dir());


### PR DESCRIPTION
Adds a packaging profile using in build/install scripts and GH release action.  Packaging profile adds ["fat" LTO](https://doc.rust-lang.org/cargo/reference/profiles.html#lto) and [codegen-units](https://doc.rust-lang.org/cargo/reference/profiles.html#codegen-units) similar to #367.

Significantly increases compile time, optimization benefits need testing, and may need testing with AUR/Nix (#325).

If accepted, will close #361.