### PR TITLE
AppImage packaging script.

### DIFF
--- a/assets/linux/org.squidowl.halloy.appdata.xml
+++ b/assets/linux/org.squidowl.halloy.appdata.xml
@@ -23,7 +23,9 @@
             <image>https://raw.githubusercontent.com/squidowl/halloy/7aec18d29ffb1d3605131667c6e11d8cef6ada7b/assets/screenshot.png</image>
         </screenshot>
     </screenshots>
-    <developer_name>The Squidowl Development Team</developer_name>
+    <developer id="org.squidowl.halloy">
+        <name>The Squidowl Development Team</name>
+    </developer>
     <releases>
         <release version="2026.1.1"
                  date="2026-01-21" />

--- a/scripts/package-linux-appimage.sh
+++ b/scripts/package-linux-appimage.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+if [ ! -f ./VERSION ]; then
+    echo "VERSION file not found"
+    exit 1
+fi
+VERSION=$(cat ./VERSION)
+
+# First we make sure with have appimagetool-x86_64.AppImage
+echo "Using halloy version: $VERSION for AppImage build"
+if [ ! -f ./assets/linux/appimagetool-x86_64.AppImage ]; then
+  echo "Downloading appimagetool-x86_64.AppImage..."
+  curl -L 'https://github.com/AppImage/appimagetool/releases/download/1.9.1/appimagetool-x86_64.AppImage' -o ./assets/linux/appimagetool-x86_64.AppImage
+  chmod +x ./assets/linux/appimagetool-x86_64.AppImage
+fi
+
+script_dir=$(dirname -- "$(realpath -- "${BASH_SOURCE[0]}")")
+git_root_dir=$(git -C "$script_dir" rev-parse --show-toplevel)
+build_dir="/tmp/halloy.AppDir"
+appimage_output_dir="$git_root_dir/target/release/linux-appimage"
+appimage_name="halloy-${VERSION}-x86_64.AppImage"
+
+# Clean up any previous build
+echo "Cleaning up previous build directory..."
+rm -rf "$build_dir"
+
+# Create necessary directories
+echo "Creating build directories..."
+mkdir -p "$appimage_output_dir"
+mkdir -p "$build_dir/usr/bin"
+mkdir -p "$build_dir/usr/share/applications"
+mkdir -p "$build_dir/usr/share/metainfo/"
+
+# Copy desktop stuff
+echo "Copying desktop files..."
+cp "$git_root_dir/assets/linux/org.squidowl.halloy.desktop" "$build_dir/usr/share/applications/"
+cp "$git_root_dir/assets/linux/org.squidowl.halloy.desktop" "$build_dir/usr/share/metainfo/"
+cp "$git_root_dir/assets/linux/org.squidowl.halloy.appdata.xml" "$build_dir/usr/share/metainfo/"
+
+cp "$git_root_dir/assets/linux/org.squidowl.halloy.desktop" "$build_dir/"
+cp "$git_root_dir/assets/linux/icons/hicolor/256x256/apps/org.squidowl.halloy.png" "$build_dir/"
+
+# Create our AppRun file
+echo "Creating AppRun file..."
+cat << 'EOF' > "$build_dir/AppRun"
+#!/bin/sh
+
+cd "$(dirname "$0")" || exit 1
+
+# Launch the application with specific logging settings
+exec ./usr/bin/halloy
+EOF
+
+chmod +x "$build_dir/AppRun"
+
+# Build the Rust binary
+echo "Building Rust binary..."
+
+# Check cargo is installed
+if ! command -v cargo &> /dev/null; then
+    echo "cargo could not be found, please install Rust and Cargo to proceed."
+    exit 1
+fi
+cargo build --release --target x86_64-unknown-linux-gnu || exit 1
+cp "$git_root_dir/target/x86_64-unknown-linux-gnu/release/halloy" "$build_dir/usr/bin/"
+
+# Now we can build the AppImage
+echo "Creating AppImage..."
+"$(realpath -- "$git_root_dir/assets/linux/appimagetool-x86_64.AppImage")" $build_dir "$appimage_output_dir/$appimage_name"
+
+# Clean up build dir
+echo "Cleaning up build directory..."
+rm -rf "$build_dir"
+
+if [ ! -f "$appimage_output_dir/$appimage_name" ]; then
+    echo "AppImage creation failed!"
+    exit 1
+fi
+echo "AppImage created at: $appimage_output_dir/$appimage_name"
+echo "Making AppImage executable..."
+chmod +x "$appimage_output_dir/$appimage_name"
+
+echo "AppImage build process completed successfully."
+exit 0
+
+
+
+
+


### PR DESCRIPTION
Hi all,

Thought I'd do this for you as a thank you. I did this for [OneTalker](https://codeberg.org/OneTalker/OneTalker/src/branch/main/scripts/package-linux-appimage.sh) too. Your code and packaging scripts helped me out a lot. Feel free not to use it if you're happy with flatpak and your tar though. No worries.

I had to upgrade your appdata xml is tiny bit. You can also get listed at:

```
Please consider submitting your AppImage to AppImageHub, the crowd-sourced
central directory of available AppImages, by opening a pull request
at https://github.com/AppImage/appimage.github.io
```

I need to test more on another OS in case of missing libs, but works on my workstation.

Script output looks like this:

```console
./scripts/package-linux-appimage.sh 
Using halloy version: 2026.1.1 for AppImage build
Downloading appimagetool-x86_64.AppImage...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 14.3M  100 14.3M    0     0  7009k      0  0:00:02  0:00:02 --:--:-- 8883k
Cleaning up previous build directory...
Creating build directories...
Copying desktop files...
Creating AppRun file...
Building Rust binary...
   Compiling halloy v0.1.0 (/home/ghenry/RustroverProjects/halloy-ghenry)
    Finished `release` profile [optimized] target(s) in 1m 16s
Creating AppImage...
appimagetool, continuous build (git version 8c8c91f), build 296 built on 2025-12-04 17:55:56 UTC
Using architecture x86_64
/tmp/halloy.AppDir should be packaged as /home/ghenry/RustroverProjects/halloy-ghenry/target/release/linux-appimage/halloy-2026.1.1-x86_64.AppImage
Deleting pre-existing .DirIcon
Creating .DirIcon symlink based on information from desktop file
AppStream upstream metadata found in usr/share/metainfo/org.squidowl.halloy.appdata.xml
Trying to validate AppStream information with the appstreamcli tool
In case of issues, please refer to https://github.com/ximion/appstream
✔ Validation was successful.
Trying to validate AppStream information with the appstream-util tool
In case of issues, please refer to https://github.com/hughsie/appstream-glib
/tmp/halloy.AppDir/usr/share/metainfo/org.squidowl.halloy.appdata.xml: OK
Generating squashfs...
Downloading runtime file from https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-x86_64
Downloaded runtime binary of size 944632
Parallel mksquashfs: Using 12 processors
Creating 4.0 filesystem on /home/ghenry/RustroverProjects/halloy-ghenry/target/release/linux-appimage/halloy-2026.1.1-x86_64.AppImage, block size 131072.
[==========================================================================================================================================================|] 463/463 100%

Exportable Squashfs 4.0 filesystem, zstd compressed, data block size 131072
	compressed data, compressed metadata, compressed fragments,
	compressed xattrs, compressed ids
	duplicates are removed
Filesystem size 19192.66 Kbytes (18.74 Mbytes)
	32.82% of uncompressed filesystem size (58479.68 Kbytes)
Inode table size 1363 bytes (1.33 Kbytes)
	59.44% of uncompressed inode table size (2293 bytes)
Directory table size 200 bytes (0.20 Kbytes)
	54.95% of uncompressed directory table size (364 bytes)
Number of duplicate files found 2
Number of inodes 14
Number of files 7
Number of fragments 1
Number of symbolic links 1
Number of device nodes 0
Number of fifo nodes 0
Number of socket nodes 0
Number of directories 6
Number of hard-links 0
Number of ids (unique uids + gids) 1
Number of uids 1
	root (0)
Number of gids 1
	root (0)
Embedding ELF...
Marking the AppImage as executable...
Embedding MD5 digest
Success

Please consider submitting your AppImage to AppImageHub, the crowd-sourced
central directory of available AppImages, by opening a pull request
at https://github.com/AppImage/appimage.github.io
Cleaning up build directory...
AppImage created at: /home/ghenry/RustroverProjects/halloy-ghenry/target/release/linux-appimage/halloy-2026.1.1-x86_64.AppImage
Making AppImage executable...
AppImage build process completed successfully.
gavins-desktop ~/RustroverProjects/halloy-ghenry [main*]$ ./target/release/linux-appimage/halloy-2026.1.1-x86_64.AppImage 
```

Cheers.