### PR TITLE
Delivery Confirmation Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+Added:
+
+- Settings to disable (selectively, or for the entire server) confirmation of delivery for sent messages
+
 Fixed:
 
 - Buffer not showing history until resize
@@ -12,7 +16,7 @@ Changed:
 
 Thanks:
 
-- Bug reports: @e00E, @oooo-ps, @csmith
+- Bug reports: @e00E, @oooo-ps, @csmith, @bw1
 
 # 2026.1.1 (2026-01-21)
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -92,6 +92,7 @@
   - [Filters](configuration/servers/filters.md)
   - [SASL External](configuration/servers/sasl-external.md)
   - [SASL Plain](configuration/servers/sasl-plain.md)
+  - [Confirm Message Delivery](configuration/servers/confirm-message-delivery.md)
 - [Sidebar](configuration/sidebar/README.md)
   - [Scrollbar](configuration/sidebar/scrollbar.md)
   - [Unread Indicator](configuration/sidebar/unread-indicator.md)

--- a/book/src/configuration/buffer/server-messages/README.md
+++ b/book/src/configuration/buffer/server-messages/README.md
@@ -95,7 +95,7 @@ exclude = "*"
 ### include
 
 [Inclusion conditions](/configuration/conditions.md) in which the server message
-will be shown. Server messages will be shown in all conditions (when enabled)W
+will be shown. Server messages will be shown in all conditions (when enabled)
 unless explicitly excluded, so this setting is only relevant when combined with
 the `exclude` setting.
 

--- a/book/src/configuration/servers/README.md
+++ b/book/src/configuration/servers/README.md
@@ -41,6 +41,7 @@ You can define multiple server sections in the configuration file. Each server s
   - [Filters](#filters)
   - [SASL Plain](#sasl-plain)
   - [SASL External](#sasl-external)
+  - [Confirm Message Delivery](#confirm-message-delivery)
 
 ## Examples
 
@@ -472,7 +473,7 @@ chathistory = true
 
 ### proxy
 
-Custom proxy for specified Server
+Custom proxy for specified server
 
 The logic is as follows:
 
@@ -511,6 +512,10 @@ Plain SASL auth using a username and password
 ## [SASL External](sasl-external.md)
 
 External SASL auth uses a PEM encoded X509 certificate.
+
+## [Confirm Message Delivery](confirm-message-delivery.md)
+
+Whether and where to confirm delivery of sent messages, if the server supports [`echo-message`](https://ircv3.net/specs/extensions/echo-message)
 
 [^1]: Windows path strings should usually be specified as literal strings (e.g. `'C:\Users\Default\'`), otherwise directory separators will need to be escaped (e.g. `"C:\\Users\\Default\\"`).
 [^2]: Relative paths are prefixed with the config directory (i.e. if you have your config.toml in `/home/me/.config/halloy/config.toml`, path `.passwd/libera` will be converted to `/home/me/.config/halloy/.passwd/libera`).

--- a/book/src/configuration/servers/confirm-message-delivery.md
+++ b/book/src/configuration/servers/confirm-message-delivery.md
@@ -1,0 +1,56 @@
+# Confirm Message Delivery
+
+Whether and where to confirm delivery of sent messages, if the server supports [`echo-message`](https://ircv3.net/specs/extensions/echo-message)
+
+- [Confirm Message Delivery](#confirm-message-delivery)
+  - [Configuration](#configuration)
+    - [enabled](#enabled)
+    - [exclude](#exclude)
+    - [include](#include)
+
+## Configuration
+
+### enabled
+
+Control if delivery of sent messages is to be confirmed (if the server supports [`echo-message`](https://ircv3.net/specs/extensions/echo-message)).
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: true
+
+[servers.<name>.confirm_message_delivery]
+enabled = true
+```
+
+### exclude
+
+[Exclusion conditions](/configuration/conditions.md) in which sent message
+delivery confirmation will be skipped. Inclusion conditions will take precedence
+over exclusion conditions. You can also exclude all conditions by setting to
+`"all"` or `"*"`.
+
+```toml
+# Type: inclusion/exclusion conditions
+# Values: user & channel inclusion/exclusion conditions
+# Default: not set
+
+[servers.<name>.confirm_message_delivery]
+exclude = "*"
+```
+
+### include
+
+[Inclusion conditions](/configuration/conditions.md) in which sent message
+delivery will be confirmed . Delivery of sent messages be confirmed in all
+conditions (when enabled) unless explicitly excluded, so this setting is only
+relevant when combined with the `exclude` setting.
+
+```toml
+# Type: inclusion/exclusion conditions
+# Values: user & channel inclusion/exclusion conditions
+# Default: not set
+
+[servers.<name>.confirm_message_delivery]
+include = { channels = ["#halloy"] }
+```

--- a/data/src/config/inclusivities.rs
+++ b/data/src/config/inclusivities.rs
@@ -169,7 +169,7 @@ pub fn is_user_channel_server_included(
     is_included || !is_excluded
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Inclusivities {
     pub users: Option<Inclusivity>,
     pub channels: Option<Inclusivity>,
@@ -362,7 +362,7 @@ impl Inclusivities {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Inclusivity {
     All,
     Any(Vec<String>),
@@ -396,7 +396,7 @@ impl<'de> Deserialize<'de> for Inclusivity {
     }
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(default)]
 pub struct Criterion {
     user: Option<String>,

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -62,8 +62,13 @@ pub fn view<'a>(
     let chantypes = clients.get_chantypes(server);
     let casemapping = clients.get_casemapping(server);
     let prefix = clients.get_prefix(server);
-    let supports_echoes = clients.get_server_supports_echoes(server);
     let channel = &state.target;
+    let confirm_message_delivery = clients.get_server_supports_echoes(server)
+        && config.servers.get(server).is_some_and(|server_config| {
+            server_config
+                .confirm_message_delivery
+                .is_target_channel_included(channel, server, casemapping)
+        });
     let our_nick: Option<data::user::NickRef<'_>> =
         clients.nickname(&state.server);
 
@@ -91,7 +96,7 @@ pub fn view<'a>(
         chantypes,
         casemapping,
         prefix,
-        supports_echoes,
+        confirm_message_delivery,
         connected,
         server,
         theme,

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -60,7 +60,7 @@ pub struct ChannelQueryLayout<'a> {
     pub chantypes: &'a [char],
     pub casemapping: CaseMap,
     pub prefix: &'a [PrefixMap],
-    pub supports_echoes: bool,
+    pub confirm_message_delivery: bool,
     pub connected: bool,
     pub server: &'a Server,
     pub theme: &'a Theme,
@@ -184,7 +184,8 @@ impl<'a> ChannelQueryLayout<'a> {
         user: &'a User,
         hide_nickname: bool,
     ) -> (Element<'a, Message>, Element<'a, Message>) {
-        let not_sent = (self.supports_echoes || message.command.is_some())
+        let not_sent = self.confirm_message_delivery
+            && message.command.is_some()
             && matches!(message.direction, message::Direction::Sent)
             && Utc::now().signed_duration_since(message.server_time)
                 > TimeDelta::seconds(10);

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -56,8 +56,13 @@ pub fn view<'a>(
     let chantypes = clients.get_chantypes(server);
     let casemapping = clients.get_casemapping(server);
     let prefix = clients.get_prefix(server);
-    let supports_echoes = clients.get_server_supports_echoes(server);
     let query = &state.target;
+    let confirm_message_delivery = clients.get_server_supports_echoes(server)
+        && config.servers.get(server).is_some_and(|server_config| {
+            server_config
+                .confirm_message_delivery
+                .is_target_query_included(query, server, casemapping)
+        });
     let status = clients.status(server);
     let our_nick = clients.nickname(server);
     let our_user = our_nick.map(|our_nick| User::from(Nick::from(our_nick)));
@@ -78,7 +83,7 @@ pub fn view<'a>(
         chantypes,
         casemapping,
         prefix,
-        supports_echoes,
+        confirm_message_delivery,
         connected,
         server,
         theme,


### PR DESCRIPTION
Adds settings to control whether and where sent messages are checked for confirmation of delivery.  Allows for the wholesale disabling of delivery confirmation, as well as selective disabling for channels/queries where echoes are not supplied as expected (e.g. #1382).

Branching off of `proxy-preview` since it uses `data::server::ConfigMap::get` which was added in that branch.