### PR TITLE
Fixes the version detection for the Windows build scripts

### DIFF
--- a/scripts/build-windows-installer.sh
+++ b/scripts/build-windows-installer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 WXS_FILE="wix/main.wxs"
-HALLOY_VERSION=$(cat VERSION).0
+HALLOY_VERSION=$(grep -q '\..*\.' VERSION && cat VERSION || echo "$(cat VERSION).0")
 
 # build the binary
 scripts/build-windows.sh

--- a/scripts/build-windows.sh
+++ b/scripts/build-windows.sh
@@ -4,7 +4,7 @@
 #!/bin/bash
 EXE_NAME="halloy.exe"
 TARGET="x86_64-pc-windows-msvc"
-HALLOY_VERSION=$(cat VERSION).0
+HALLOY_VERSION=$(grep -q '\..*\.' VERSION && cat VERSION || echo "$(cat VERSION).0")
 
 # update package version on Cargo.toml
 cargo install cargo-edit


### PR DESCRIPTION
Fix #1436

cargo-edit in the Windows build scripts only supports Major.Minor.Patch versions. This PR fixes if VERSION file contains Major.Minor.Patch versions. Should now support Major.Minor and Major.Minor.Patch version numbers from the VERSION file.