### PR TITLE
Transparent background support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Added:
 - Setting to adjust inner spacing and outer padding for panes (`pane.gap.inner`, `pane.gap.outer`)
 - Setting to style unread query buffers as highlights in the sidebar (`sidebar.unread_indicator.query_as_highlight`)
 - Settings to configure card and imagge preview dimensions 
+- Support for transparent background.
 
 Fixed:
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -105,6 +105,7 @@ pub fn settings(config: &Config) -> Settings {
             override_redirect: false,
         },
         decorations: config.platform_specific.linux.decorations,
+        transparent: true,
         ..Default::default()
     }
 }
@@ -120,6 +121,7 @@ pub fn settings(config: &Config) -> Settings {
             fullsize_content_view: true,
         },
         decorations: config.platform_specific.macos.decorations,
+        transparent: true,
         ..Default::default()
     }
 }
@@ -143,6 +145,7 @@ pub fn settings(config: &Config) -> Settings {
                 )
                 .ok(),
                 decorations: config.platform_specific.windows.decorations,
+                transparent: true,
                 ..Default::default()
             },
             None => Settings::default(),


### PR DESCRIPTION
⚠️  **DISCLAIMER**: When setting an RGBA background color, beware that iced may (or may not) use premultiplied alpha for RGBA. This means that you should manually multiply the colors by the alpha if they feel odd for correct rendering.

**Example**: To get #181818CC you should use #131313CC in your theme
(CC corresponds to alpha of 0.8, and 0x18 * 0.8 = 0x13)