### PR TITLE
deduplicate clippy lints in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,19 +131,6 @@ opt-level = 1
 [profile.dev.package."*"]
 opt-level = 3
 
-[lints.clippy]
-cloned_instead_of_copied = "deny"
-default_trait_access = "deny"
-ignored_unit_patterns = "deny"
-items_after_statements = "deny"
-manual_is_variant_and = "deny"
-manual_string_new = "deny"
-map_unwrap_or = "deny"
-redundant_closure_for_method_calls = "deny"
-semicolon_if_nothing_returned = "deny"
-uninlined_format_args = "deny"
-unnecessary_wraps = "deny"
-
 [workspace.lints.clippy]
 cloned_instead_of_copied = "deny"
 default_trait_access = "deny"
@@ -156,6 +143,9 @@ redundant_closure_for_method_calls = "deny"
 semicolon_if_nothing_returned = "deny"
 uninlined_format_args = "deny"
 unnecessary_wraps = "deny"
+
+[lints]
+workspace = true
 
 [workspace.metadata.typos.default]
 extend-ignore-re = [


### PR DESCRIPTION
Instead of specifying the lints for the workspace and repeating them we can just use the workspace lints with a simple single line in the `Cargo.toml`.