### PR TITLE
add cast_lossless clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ opt-level = 1
 opt-level = 3
 
 [workspace.lints.clippy]
+cast_lossless = "deny"
 cloned_instead_of_copied = "deny"
 default_trait_access = "deny"
 ignored_unit_patterns = "deny"

--- a/data/src/appearance/theme.rs
+++ b/data/src/appearance/theme.rs
@@ -472,16 +472,16 @@ pub fn hex_to_color(hex: &str) -> Option<Color> {
 
         return match (hash, r, g, b, a) {
             ("#", Ok(r), Ok(g), Ok(b), None) => Some(Color {
-                r: r as f32 / 255.0,
-                g: g as f32 / 255.0,
-                b: b as f32 / 255.0,
+                r: f32::from(r) / 255.0,
+                g: f32::from(g) / 255.0,
+                b: f32::from(b) / 255.0,
                 a: 1.0,
             }),
             ("#", Ok(r), Ok(g), Ok(b), Some(a)) => Some(Color {
-                r: r as f32 / 255.0,
-                g: g as f32 / 255.0,
-                b: b as f32 / 255.0,
-                a: a as f32 / 255.0,
+                r: f32::from(r) / 255.0,
+                g: f32::from(g) / 255.0,
+                b: f32::from(b) / 255.0,
+                a: f32::from(a) / 255.0,
             }),
             _ => None,
         };
@@ -678,7 +678,7 @@ mod binary {
                     chunk[1],
                     chunk[2],
                     chunk[3],
-                    chunk[4] as f32 / 255.0,
+                    f32::from(chunk[4]) / 255.0,
                 );
 
                 tag.update_color(&mut styles, color);

--- a/data/src/config/sidebar.rs
+++ b/data/src/config/sidebar.rs
@@ -52,7 +52,7 @@ where
                 Ok(ServerIcon::Size(value))
             } else {
                 Err(serde::de::Error::invalid_value(
-                    serde::de::Unexpected::Unsigned(value as u64),
+                    serde::de::Unexpected::Unsigned(u64::from(value)),
                     &"a positive integer",
                 ))
             }

--- a/data/src/preview.rs
+++ b/data/src/preview.rs
@@ -163,9 +163,9 @@ pub async fn load(
             // multiple of wgpu::COPY_BYTES_PER_ROW_ALIGNMENT.
             let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
             let padding = (align - (4 * image_width) % align) % align;
-            let padded_image_width = (4 * image_width + padding) as u64;
+            let padded_image_width = u64::from(4 * image_width + padding);
             let padded_image_data_size =
-                padded_image_width * image_height as u64;
+                padded_image_width * u64::from(image_height);
 
             let max_buffer_size =
                 wgpu::Limits::downlevel_defaults().max_buffer_size;

--- a/src/buffer/context_menu.rs
+++ b/src/buffer/context_menu.rs
@@ -589,7 +589,7 @@ fn menu_button(
 fn right_justified_padding(config: &Config) -> Padding {
     let padding = config.context_menu.padding.entry;
     Padding::from(padding)
-        .right(padding[1] as f32 + double_pass::horizontal_expansion())
+        .right(f32::from(padding[1]) + double_pass::horizontal_expansion())
 }
 
 fn user_info<'a>(

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -351,10 +351,14 @@ impl Notifications {
         let now = Utc::now();
         let delay_key = notification.into();
 
-        if self.recent_notifications.get(&delay_key).is_some_and(|last_notification| {
-            now - last_notification
-                < TimeDelta::milliseconds(config.delay.unwrap_or(500) as i64)
-        }) {
+        if self.recent_notifications.get(&delay_key).is_some_and(
+            |last_notification| {
+                now - last_notification
+                    < TimeDelta::milliseconds(i64::from(
+                        config.delay.unwrap_or(500),
+                    ))
+            },
+        ) {
             return;
         }
 


### PR DESCRIPTION
This lint makes it clear that a cast cannot fail. It also prevents accidental breakage as the type system will warn you if the type changes when refactoring.