### PR TITLE
create a shared text wrapper to always add line_height from config

### DIFF
--- a/src/buffer/context_menu.rs
+++ b/src/buffer/context_menu.rs
@@ -576,7 +576,7 @@ fn menu_button(
     config: &Config,
 ) -> Element<'static, Message> {
     button(
-        text(content, config)
+        text(content)
             .style(theme::text::primary)
             .font_maybe(theme::font_style::primary(theme).map(font::get)),
     )
@@ -603,7 +603,7 @@ fn user_info<'a>(
         Some(user) => {
             if user.is_away() {
                 Some(
-                    text("(Away)", config)
+                    text("(Away)")
                         .style(theme::text::secondary)
                         .font_maybe(
                             theme::font_style::secondary(theme).map(font::get),
@@ -615,7 +615,7 @@ fn user_info<'a>(
             }
         }
         None => Some(
-            text("(Offline)", config)
+            text("(Offline)")
                 .style(theme::text::secondary)
                 .font_maybe(theme::font_style::secondary(theme).map(font::get))
                 .width(length),
@@ -641,11 +641,9 @@ fn user_info<'a>(
     let style =
         theme::text::nickname(theme, seed, is_user_away, is_user_offline);
 
-    let nickname = text(nickname.to_string(), config)
-        .style(move |_| style)
-        .font_maybe(
-            theme::font_style::nickname(theme, is_user_offline).map(font::get),
-        );
+    let nickname = text(nickname.to_string()).style(move |_| style).font_maybe(
+        theme::font_style::nickname(theme, is_user_offline).map(font::get),
+    );
 
     column![
         container(row![nickname, state].width(length).spacing(4))

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -414,7 +414,7 @@ pub fn view<'a>(
                         row![
                             title.line_height(theme::line_height(&config.font)),
                             keybind.map(|kb| {
-                                text(format!("({kb})"), config)
+                                text(format!("({kb})"))
                                     .shaping(Shaping::Advanced)
                                     .size(theme::TEXT_SIZE - 2.0)
                                     .style(theme::text::secondary)
@@ -435,17 +435,17 @@ pub fn view<'a>(
 
             match menu {
                 Actions::Cut => context_button(
-                    text("Cut", config),
+                    text("Cut"),
                     Some(shortcut::cut()),
                     state.input_content.selection().map(|_| Message::Cut),
                 ),
                 Actions::Copy => context_button(
-                    text("Copy", config),
+                    text("Copy"),
                     Some(shortcut::copy()),
                     state.input_content.selection().map(|_| Message::Copy),
                 ),
                 Actions::CopyAll => context_button(
-                    text("Copy All", config),
+                    text("Copy All"),
                     None,
                     if !state.input_content.text().is_empty() {
                         Some(Message::CopyAll)
@@ -454,7 +454,7 @@ pub fn view<'a>(
                     },
                 ),
                 Actions::SelectAll => context_button(
-                    text("Select All", config),
+                    text("Select All"),
                     Some(shortcut::select_all()),
                     if !state.input_content.text().is_empty() {
                         Some(Message::SelectAll)
@@ -463,7 +463,7 @@ pub fn view<'a>(
                     },
                 ),
                 Actions::Paste => context_button(
-                    text("Paste", config),
+                    text("Paste"),
                     Some(shortcut::paste()),
                     Some(Message::Paste),
                 ),
@@ -495,13 +495,10 @@ pub fn view<'a>(
         config.buffer.text_input.nickname.enabled.then(move || {
             our_user.map(|user| {
                 container(
-                    text(
-                        user.display(
-                            config.buffer.text_input.nickname.show_access_level,
-                            None,
-                        ),
-                        config,
-                    )
+                    text(user.display(
+                        config.buffer.text_input.nickname.show_access_level,
+                        None,
+                    ))
                     .style(move |_| our_user_style)
                     .font_maybe(
                         theme::font_style::nickname(theme, false)
@@ -540,7 +537,7 @@ pub fn view<'a>(
         state
             .error
             .as_deref()
-            .map(|error_str| error(error_str, config, theme)),
+            .map(|error_str| error(error_str, theme)),
     ]
     .padding([0, 8])
     .spacing(4);
@@ -550,11 +547,10 @@ pub fn view<'a>(
 
 fn error<'a, 'b, Message: 'a>(
     error: &'b str,
-    config: &'a Config,
     theme: &'a Theme,
 ) -> Element<'a, Message> {
     container(
-        text(error.to_string(), config)
+        text(error.to_string())
             .style(theme::text::error)
             .font_maybe(theme::font_style::error(theme).map(font::get)),
     )

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -938,10 +938,8 @@ impl Commands {
                 let content = |width| {
                     column(entries.iter().map(|(index, command)| {
                         let selected = Some(*index) == *highlighted;
-                        let content = text(
-                            format!("/{}", command.title.to_lowercase()),
-                            config,
-                        );
+                        let content =
+                            text(format!("/{}", command.title.to_lowercase()));
 
                         Element::from(
                             container(content)
@@ -973,12 +971,7 @@ impl Commands {
                 subcommand,
             } => {
                 if config.buffer.commands.show_description {
-                    Some(command.view(
-                        input,
-                        subcommand.as_ref(),
-                        config,
-                        theme,
-                    ))
+                    Some(command.view(input, subcommand.as_ref(), theme))
                 } else {
                     None
                 }
@@ -1085,7 +1078,6 @@ impl Command {
         &self,
         input: &str,
         subcommand: Option<&Command>,
-        config: &Config,
         theme: &'a Theme,
     ) -> Element<'a, Message> {
         let command_prefix = format!("/{}", self.title.to_lowercase());
@@ -1119,10 +1111,10 @@ impl Command {
             .saturating_sub(1),
         );
 
-        let title = Some(Element::from(text(self.title, config)));
+        let title = Some(Element::from(text(self.title)));
 
         let arg_text = |index: usize, arg: &Argument| {
-            let content = text(format!("{arg}"), config)
+            let content = text(format!("{arg}"))
                 .style(move |theme| {
                     if index == active_arg {
                         theme::text::tertiary(theme)
@@ -1137,7 +1129,7 @@ impl Command {
                 );
 
             if let Some(arg_tooltip) = &arg.tooltip {
-                let tooltip_indicator = text("*", config)
+                let tooltip_indicator = text("*")
                     .style(move |theme| {
                         if index == active_arg {
                             theme::text::tertiary(theme)
@@ -1153,12 +1145,12 @@ impl Command {
                     .size(8);
 
                 Element::from(row![
-                    text(" ", config),
+                    text(" "),
                     tooltip(
                         row![content, tooltip_indicator]
                             .align_y(iced::Alignment::Start),
                         container(
-                            text(arg_tooltip.clone(), config)
+                            text(arg_tooltip.clone())
                                 .style(move |theme| {
                                     if index == active_arg {
                                         theme::text::tertiary(theme)
@@ -1181,7 +1173,7 @@ impl Command {
                     .delay(iced::time::Duration::ZERO)
                 ])
             } else {
-                Element::from(row![text(" ", config), content])
+                Element::from(row![text(" "), content])
             }
         };
 
@@ -1198,7 +1190,6 @@ impl Command {
                                 .title
                                 .strip_prefix(self.title)
                                 .unwrap_or_default(),
-                            config
                         )
                         .style(move |theme| {
                             if 0 == active_arg {
@@ -1221,7 +1212,7 @@ impl Command {
 
             Either::Right(if self.subcommands.is_some() {
                 Either::Left(args.chain(iter::once(Element::from(row![
-                    text(" ...", config).style(theme::text::none)
+                    text(" ...").style(theme::text::none)
                 ]))))
             } else {
                 Either::Right(args)
@@ -1234,11 +1225,9 @@ impl Command {
                     subcommand.description()
                 })
                 .map(|description| {
-                    text(description, config)
-                        .style(theme::text::secondary)
-                        .font_maybe(
-                            theme::font_style::secondary(theme).map(font::get),
-                        )
+                    text(description).style(theme::text::secondary).font_maybe(
+                        theme::font_style::secondary(theme).map(font::get),
+                    )
                 }),
             row(title.into_iter().chain(args)),
         ])
@@ -2670,18 +2659,15 @@ impl Emojis {
                 let content = |width| {
                     column(entries.iter().map(|(index, shortcode)| {
                         let selected = Some(*index) == *highlighted;
-                        let content = text(
-                            format!(
-                                "{} :{}:",
-                                pick_emoji(
-                                    shortcode,
-                                    config.buffer.emojis.skin_tone
-                                )
-                                .unwrap_or(" "),
-                                shortcode
-                            ),
-                            config,
-                        )
+                        let content = text(format!(
+                            "{} :{}:",
+                            pick_emoji(
+                                shortcode,
+                                config.buffer.emojis.skin_tone
+                            )
+                            .unwrap_or(" "),
+                            shortcode
+                        ))
                         .shaping(Shaping::Advanced);
 
                         Element::from(

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -215,7 +215,7 @@ impl Sidebar {
                                     data::shortcut::KeyBind::Bind {
                                         ..
                                     } => Some(
-                                        text(format!("({kb})"), config)
+                                        text(format!("({kb})"))
                                             .shaping(Shaping::Advanced)
                                             .size(theme::TEXT_SIZE - 2.0)
                                             .style(theme::text::secondary)
@@ -246,25 +246,25 @@ impl Sidebar {
 
                         match menu {
                             Menu::QuitApplication => context_button(
-                                text("Quit Halloy", config),
+                                text("Quit Halloy"),
                                 Some(&keyboard.quit_application),
                                 icon::quit(),
                                 Message::QuitApplication,
                             ),
                             Menu::RefreshConfig => context_button(
-                                text("Reload config file", config),
+                                text("Reload config file"),
                                 Some(&keyboard.reload_configuration),
                                 icon::refresh(),
                                 Message::ReloadConfigFile,
                             ),
                             Menu::CommandBar => context_button(
-                                text("Command Bar", config),
+                                text("Command Bar"),
                                 Some(&keyboard.command_bar),
                                 icon::search(),
                                 Message::ToggleCommandBar,
                             ),
                             Menu::FileTransfers => context_button(
-                                text("File Transfers", config)
+                                text("File Transfers")
                                     .style(if file_transfers.is_empty() {
                                         theme::text::primary
                                     } else {
@@ -290,7 +290,7 @@ impl Sidebar {
                                 ),
                             ),
                             Menu::Highlights => context_button(
-                                text("Highlights", config),
+                                text("Highlights"),
                                 Some(&keyboard.highlights),
                                 icon::highlights(),
                                 Message::ToggleInternalBuffer(
@@ -298,7 +298,7 @@ impl Sidebar {
                                 ),
                             ),
                             Menu::ChannelDiscovery => context_button(
-                                text("Channel Discovery", config),
+                                text("Channel Discovery"),
                                 None,
                                 icon::channel_discovery(),
                                 Message::ToggleInternalBuffer(
@@ -306,7 +306,7 @@ impl Sidebar {
                                 ),
                             ),
                             Menu::Logs => context_button(
-                                text("Logs", config)
+                                text("Logs")
                                     .style(if logs_has_unread {
                                         theme::text::tertiary
                                     } else {
@@ -330,7 +330,7 @@ impl Sidebar {
                                 ),
                             ),
                             Menu::ThemeEditor => context_button(
-                                text("Theme Editor", config),
+                                text("Theme Editor"),
                                 Some(&keyboard.theme_editor),
                                 icon::theme_editor(),
                                 Message::ToggleThemeEditor,
@@ -344,7 +344,7 @@ impl Sidebar {
                                 }
                             },
                             Menu::Update => context_button(
-                                text("New version available", config)
+                                text("New version available")
                                     .style(theme::text::tertiary)
                                     .font_maybe(
                                         theme::font_style::tertiary(theme)
@@ -355,26 +355,23 @@ impl Sidebar {
                                 Message::OpenReleaseWebsite,
                             ),
                             Menu::Version => container(
-                                text(
-                                    format!("Halloy ({})", version.current),
-                                    config,
-                                )
-                                .style(theme::text::secondary)
-                                .font_maybe(
-                                    theme::font_style::secondary(theme)
-                                        .map(font::get),
-                                ),
+                                text(format!("Halloy ({})", version.current))
+                                    .style(theme::text::secondary)
+                                    .font_maybe(
+                                        theme::font_style::secondary(theme)
+                                            .map(font::get),
+                                    ),
                             )
                             .padding(5)
                             .into(),
                             Menu::Documentation => context_button(
-                                text("Documentation", config),
+                                text("Documentation"),
                                 None,
                                 icon::documentation(),
                                 Message::OpenDocumentation,
                             ),
                             Menu::OpenConfigFile => context_button(
-                                text("Open config file", config),
+                                text("Open config file"),
                                 None,
                                 icon::config(),
                                 Message::OpenConfigFile,
@@ -931,18 +928,18 @@ fn upstream_buffer_button<'a>(
             buffer::Upstream::Server(server) => {
                 if let Some(network) = &server.network {
                     Element::from(row![
-                        text(network.name.to_string(), config)
+                        text(network.name.to_string())
                             .style(buffer_title_style)
                             .font_maybe(buffer_title_font.clone())
                             .shaping(Shaping::Advanced),
                         Space::new().width(6),
-                        text(server.name.to_string(), config)
+                        text(server.name.to_string())
                             .style(theme::text::secondary)
                             .font_maybe(buffer_title_font)
                             .shaping(Shaping::Advanced),
                     ])
                 } else {
-                    text(server.to_string(), config)
+                    text(server.to_string())
                         .style(buffer_title_style)
                         .font_maybe(buffer_title_font)
                         .shaping(Shaping::Advanced)
@@ -950,14 +947,14 @@ fn upstream_buffer_button<'a>(
                 }
             }
             buffer::Upstream::Channel(_, channel) => {
-                text(channel.to_string(), config)
+                text(channel.to_string())
                     .style(buffer_title_style)
                     .font_maybe(buffer_title_font)
                     .shaping(Shaping::Advanced)
                     .into()
             }
             buffer::Upstream::Query(_, query) => {
-                text(query.to_string(), config)
+                text(query.to_string())
                     .style(buffer_title_style)
                     .font_maybe(buffer_title_font)
                     .shaping(Shaping::Advanced)
@@ -1104,7 +1101,7 @@ fn upstream_buffer_button<'a>(
                     ),
                 };
 
-                button(text(content, config))
+                button(text(content))
                     .width(length)
                     .padding(config.context_menu.padding.entry)
                     .style(|theme, status| {

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -20,7 +20,7 @@ pub use self::selectable_text::selectable_text;
 pub use self::shortcut::shortcut;
 pub use self::tooltip::tooltip;
 use crate::appearance::theme::TEXT_SIZE;
-use crate::{Theme, font, theme};
+use crate::{Theme, font};
 
 pub mod anchored_overlay;
 pub mod color_picker;
@@ -64,9 +64,8 @@ pub enum Marker {
 
 pub fn text<'a>(
     content: impl iced::widget::text::IntoFragment<'a>,
-    config: &Config,
 ) -> Text<'a> {
-    iced::widget::text(content).line_height(theme::line_height(&config.font))
+    iced::widget::text(content).line_height(font::line_height())
 }
 
 pub fn message_marker<'a, M>(


### PR DESCRIPTION
this was planned for #1430 but i forgot it...
idea is just to have a shared `widget::text` now so we don't forget the `line_height` moving forward.