### PR TITLE
feat(config): allow forcing wgpu backend and power preference via config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Added:
   - `new_horizontal_buffer` (not bound by default)
   - `new_vertical_buffer` (not bound by default)
   - `quit_application` (defaults to `Ctrl+Q` on linux, not bound on Windows/MacOS)
+- Add optional [wgpu] configuration section to allow users to override the graphics backend and GPU power preference.
 
 Fixed:
 

--- a/book/src/configuration/wgpu.md
+++ b/book/src/configuration/wgpu.md
@@ -1,0 +1,56 @@
+# wgpu
+
+Controls the wgpu graphics backend and GPU power preference.
+These settings are applied by exporting the corresponding WGPU_* environment variables before the renderer is initialized. Environment variables always take precedence over the config file, allowing power users and packagers to override behaviour at runtime.
+These settings are only applied during application startup and have no effect when the configuration is reloaded at runtime.
+
+- [wgpu](#wgpu)
+  - [Example](#example)
+  - [backend](#backend)
+  - [power\_pref](#power_pref)
+
+## Example
+
+```toml
+[wgpu]
+backend = "dx12"
+power_pref = "high"
+```
+
+## backend
+
+Forces a specific wgpu graphics backend. The allowed values are platform specific (see <https://github.com/gfx-rs/wgpu?tab=readme-ov-file#supported-platforms>).
+
+```to
+# Type: string
+# Values: "auto", "vulkan", "metal, "dx12", "opengl"
+# Default: "auto"
+
+[wgpu]
+backend = "auto"
+```
+
+Notes
+
+- "auto" leaves backend selection to wgpu.
+- This setting maps to the WGPU_BACKEND environment variable.
+
+## power_pref
+
+Forces a specific GPU power preference.
+
+```to
+# Type: string
+# Values: "low", "high"
+# Default: not set (wgpu default behaviour)
+
+[wgpu]
+power_pref = "low"
+```
+
+Notes
+
+- "low" prefers integrated GPUs (lower power usage).
+- "high" prefers dedicated GPUs (higher performance).
+
+This setting maps to the WGPU_POWER_PREF environment variable.

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -25,6 +25,7 @@ pub use self::preview::Preview;
 pub use self::proxy::Proxy;
 pub use self::server::Server;
 pub use self::sidebar::Sidebar;
+pub use self::wgpu::Wgpu;
 use crate::appearance::theme::Styles;
 use crate::appearance::{self, Appearance};
 use crate::audio::{self};
@@ -50,6 +51,7 @@ pub mod preview;
 pub mod proxy;
 pub mod server;
 pub mod sidebar;
+pub mod wgpu;
 
 const CONFIG_TEMPLATE: &str = include_str!("../../config.toml");
 const DEFAULT_THEME_NAME: &str = "ferra";
@@ -75,6 +77,7 @@ pub struct Config {
     pub ctcp: Ctcp,
     pub logs: Logs,
     pub platform_specific: PlatformSpecific,
+    pub wgpu: Wgpu,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize)]
@@ -330,6 +333,7 @@ impl Config {
             pub ctcp: Ctcp,
             pub logs: Logs,
             pub platform_specific: PlatformSpecific,
+            pub wgpu: Wgpu,
         }
 
         impl Default for Configuration {
@@ -354,6 +358,7 @@ impl Config {
                     ctcp: Ctcp::default(),
                     logs: Logs::default(),
                     platform_specific: PlatformSpecific::default(),
+                    wgpu: Wgpu::default(),
                 }
             }
         }
@@ -388,6 +393,7 @@ impl Config {
             ctcp,
             logs,
             platform_specific,
+            wgpu,
         } = serde_ignored::deserialize(config, |ignored| {
             log::warn!("[config.toml] Ignoring unknown setting: {ignored}");
         })
@@ -419,6 +425,7 @@ impl Config {
             ctcp,
             logs,
             platform_specific,
+            wgpu,
         })
     }
 

--- a/data/src/config/wgpu.rs
+++ b/data/src/config/wgpu.rs
@@ -1,0 +1,119 @@
+use std::fmt;
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(default)]
+pub struct Wgpu {
+    pub backend: WgpuBackend,
+    pub power_pref: WgpuPowerPref,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum WgpuBackend {
+    #[default]
+    Auto,
+    Vulkan,
+    Metal,
+    #[serde(rename = "dx12")]
+    Dx12,
+    OpenGL,
+}
+
+impl fmt::Display for WgpuBackend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            WgpuBackend::Auto => "auto",
+            WgpuBackend::Vulkan => "vulkan",
+            WgpuBackend::Metal => "metal",
+            WgpuBackend::Dx12 => "dx12",
+            WgpuBackend::OpenGL => "gl",
+        };
+
+        write!(f, "{s}")
+    }
+}
+
+impl WgpuBackend {
+    pub fn to_wgpu_backends(self) -> iced::wgpu::Backends {
+        match self {
+            WgpuBackend::Auto => default_wgpu_backend(),
+
+            WgpuBackend::Vulkan => {
+                #[cfg(any(target_os = "linux", target_os = "windows"))]
+                {
+                    iced::wgpu::Backends::VULKAN
+                }
+                #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+                {
+                    default_wgpu_backend()
+                }
+            }
+
+            WgpuBackend::Metal => {
+                #[cfg(target_os = "macos")]
+                {
+                    iced::wgpu::Backends::METAL
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    default_wgpu_backend()
+                }
+            }
+
+            WgpuBackend::Dx12 => {
+                #[cfg(target_os = "windows")]
+                {
+                    iced::wgpu::Backends::DX12
+                }
+                #[cfg(not(target_os = "windows"))]
+                {
+                    default_wgpu_backend()
+                }
+            }
+
+            WgpuBackend::OpenGL => {
+                #[cfg(any(target_os = "linux", target_os = "windows"))]
+                {
+                    iced::wgpu::Backends::GL
+                }
+            }
+        }
+    }
+}
+
+pub fn default_wgpu_backend() -> iced::wgpu::Backends {
+    if cfg!(target_os = "windows") {
+        iced::wgpu::Backends::VULKAN
+    } else if cfg!(target_os = "macos") {
+        iced::wgpu::Backends::METAL
+    } else if cfg!(any(target_os = "linux", target_os = "android")) {
+        iced::wgpu::Backends::VULKAN
+    } else {
+        iced::wgpu::Backends::all()
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum WgpuPowerPref {
+    #[default]
+    NotSet,
+
+    Low,
+    High,
+}
+
+impl fmt::Display for WgpuPowerPref {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            WgpuPowerPref::NotSet => "not set",
+
+            WgpuPowerPref::Low => "low",
+            WgpuPowerPref::High => "high",
+        };
+
+        write!(f, "{s}")
+    }
+}


### PR DESCRIPTION
This adds a small escape hatch for users experiencing wgpu/driver specific issues. (#1449)

Since iced::daemon currently does not expose renderer backend selection, we apply the official wgpu override mechanism via environment variables early during startup.

The change is fully backwards compatible and opt-in.