### PR TITLE
book: fix pane gap example

### DIFF
--- a/book/src/configuration/pane/gap.md
+++ b/book/src/configuration/pane/gap.md
@@ -11,7 +11,7 @@ Gap configuration for pane spacing and padding.
 ## Example
 
 ```toml
-[pane]
+[pane.gap]
 inner = 4
 outer = 4
 ```


### PR DESCRIPTION
Just a small typo I ran into when I was copy-pasting out of the documentation.