### PR TITLE
Allow cycling unread buffers with no current buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,11 @@ Added:
 Fixed:
 
 - Channel mode in pane headers not updating immediately after mode changes
+- Cycle next/previous (unread) buffer shortcuts work from an empty pane
 
 Thanks:
 
-- Contributions: @Hummer12007
+- Contributions: @Hummer12007, @chamlis
 - Feature requests: @megumintyan
 
 # 2026.2 (2026-02-01)

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -4083,13 +4083,16 @@ fn cycle_next_buffer(
 ) -> Option<buffer::Upstream> {
     all.retain(|buffer| Some(buffer) == current || !opened.contains(buffer));
 
-    let next = || {
-        let buffer = current?;
-        let index = all.iter().position(|b| b == buffer)?;
-        all.get(index + 1)
-    };
+    let index = current
+        .and_then(|buffer| all.iter().position(|b| b == buffer))
+        .unwrap_or(all.len().saturating_sub(1));
 
-    next().or_else(|| all.first()).cloned()
+    if index == all.len().saturating_sub(1) {
+        all.first()
+    } else {
+        all.get(index + 1)
+    }
+    .cloned()
 }
 
 fn cycle_previous_buffer(
@@ -4099,14 +4102,16 @@ fn cycle_previous_buffer(
 ) -> Option<buffer::Upstream> {
     all.retain(|buffer| Some(buffer) == current || !opened.contains(buffer));
 
-    let previous = || {
-        let buffer = current?;
-        let index = all.iter().position(|b| b == buffer).filter(|i| *i > 0)?;
+    let index = current
+        .and_then(|buffer| all.iter().position(|b| b == buffer))
+        .unwrap_or(0);
 
+    if index == 0 {
+        all.last()
+    } else {
         all.get(index - 1)
-    };
-
-    previous().or_else(|| all.last()).cloned()
+    }
+    .cloned()
 }
 
 fn cycle_next_unread_buffer(
@@ -4120,7 +4125,7 @@ fn cycle_next_unread_buffer(
 
     let index = current
         .and_then(|buffer| all.iter().position(|(b, _)| b == buffer))
-        .unwrap_or(all.len());
+        .unwrap_or(all.len().saturating_sub(1));
 
     let next_after = || {
         all.iter()
@@ -4148,7 +4153,7 @@ fn cycle_previous_unread_buffer(
 
     let index = current
         .and_then(|buffer| all.iter().position(|(b, _)| b == buffer))
-        .unwrap_or(all.len());
+        .unwrap_or(0);
 
     let previous_before = || {
         all.iter()


### PR DESCRIPTION
Treat this case as if an invisible 'zeroth' buffer is selected.

Not the prettiest index maths, and I considered using `rotate_{left,right}()` on `all` but decided to favour a less invasive change. I'm open to suggestions about potentially cleaner ways of expressing this.

Thanks!