### PR TITLE
Condense set by defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,11 @@ Fixed:
 
 - Channel mode in pane headers not updating immediately after mode changes
 - Cycle next/previous (unread) buffer shortcuts work from an empty pane
-
-Fixed
-
 - Virtualize message rendering to improve buffer performance
+
+Changed:
+
+- Condensed server messages are now enabled by default for nick changes, joins, parts, and quits
 
 Thanks:
 

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -375,7 +375,12 @@ pub struct Condensation {
 impl Default for Condensation {
     fn default() -> Self {
         Self {
-            messages: HashSet::new(),
+            messages: HashSet::from([
+                CondensationMessage::ChangeNick,
+                CondensationMessage::Join,
+                CondensationMessage::Part,
+                CondensationMessage::Quit,
+            ]),
             format: CondensationFormat::default(),
             dimmed: Some(Dimmed(None)),
         }


### PR DESCRIPTION
Condensed server messages are now enabled by default for nick changes.