### PR TITLE
Show All Access Levels Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Added:
   - `new_horizontal_buffer` (not bound by default)
   - `new_vertical_buffer` (not bound by default)
   - `quit_application` (defaults to `Ctrl+Q` on linux, not bound on Windows/MacOS)
+- Expand show_access_levels to allow all access levels (in addition to highest or no access levels) in buffer/nicklist/input
 
 Fixed:
 
@@ -29,7 +30,7 @@ Changed:
 Thanks:
 
 - Contributions: @Hummer12007, @chamlis
-- Feature requests: @megumintyan
+- Feature requests: @megumintyan, @4e554c4c
 - Bug reports: @someone2037492034
 
 # 2026.2 (2026-02-01)

--- a/book/src/configuration/buffer/channel/nicklist.md
+++ b/book/src/configuration/buffer/channel/nicklist.md
@@ -89,15 +89,15 @@ position = "right"
 
 ### show_access_levels
 
-Show access levels in front of nicknames (`@`, `+`, `~`, etc.).
+Show access level(s) in front of nicknames (`@`, `+`, `~`, etc.).
 
 ```toml
-# Type: boolean
-# Values: true, false
-# Default: true
+# Type: string
+# Values: "all", "highest", or "none"
+# Default: "highest"
 
 [buffer.channel.nicklist]
-show_access_levels = true
+show_access_levels = "all"
 ```
 
 ### width

--- a/book/src/configuration/buffer/nickname/README.md
+++ b/book/src/configuration/buffer/nickname/README.md
@@ -94,15 +94,15 @@ offline = "none"
 
 ### show_access_levels
 
-Show access levels in front of nicknames (`@`, `+`, `~`, etc.).
+Show access level(s) in front of nicknames (`@`, `+`, `~`, etc.).
 
 ```toml
-# Type: boolean
-# Values: true, false
-# Default: true
+# Type: string
+# Values: "all", "highest", or "none"
+# Default: "highest"
 
 [buffer.nickname]
-show_access_levels = true
+show_access_levels = "none"
 ```
 
 ### shown_status

--- a/book/src/configuration/buffer/text-input/nickname.md
+++ b/book/src/configuration/buffer/text-input/nickname.md
@@ -5,7 +5,7 @@ Customize nickname left of text input
 - [Nickname](#nickname)
   - [Configuration](#configuration)
     - [enabled](#enabled)
-    - [show\_access\_level](#show_access_level)
+    - [show\_access\_levels](#show_access_levels)
 
 ## Configuration
 
@@ -22,16 +22,15 @@ Display own nickname next to text input field
 enabled = true
 ```
 
-### show_access_level
+### show_access_levels
 
-Show access levels in front of nickname (`@`, `+`, `~`, etc.).
+Show access level(s) in front of nickname (`@`, `+`, `~`, etc.).
 
 ```toml
-# Type: boolean
-# Values: true, false
-# Default: true
+# Type: string
+# Values: "all", "highest", or "none"
+# Default: "highest"
 
 [buffer.text_input.nickname]
-show_access_level = true
+show_access_level = "highest"
 ```
-

--- a/data/src/config/buffer/channel.rs
+++ b/data/src/config/buffer/channel.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use super::NicknameClickAction;
 use crate::buffer::Color;
 use crate::channel::Position;
-use crate::config::buffer::Away;
+use crate::config::buffer::{AccessLevelFormat, Away};
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
@@ -29,7 +29,7 @@ pub struct Nicklist {
     pub color: Color,
     pub width: Option<f32>,
     pub alignment: Alignment,
-    pub show_access_levels: bool,
+    pub show_access_levels: AccessLevelFormat,
     pub click: NicknameClickAction,
 }
 
@@ -42,7 +42,7 @@ impl Default for Nicklist {
             color: Color::default(),
             width: None,
             alignment: Alignment::default(),
-            show_access_levels: true,
+            show_access_levels: AccessLevelFormat::default(),
             click: NicknameClickAction::default(),
         }
     }

--- a/data/src/config/buffer/nickname.rs
+++ b/data/src/config/buffer/nickname.rs
@@ -2,9 +2,9 @@ use chrono::TimeDelta;
 use serde::{Deserialize, Deserializer};
 
 use crate::buffer::{Alignment, Brackets, Color};
-use crate::config::buffer::{Away, NicknameClickAction};
+use crate::config::buffer::{AccessLevelFormat, Away, NicknameClickAction};
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
 pub struct Nickname {
     pub away: Away,
@@ -12,28 +12,11 @@ pub struct Nickname {
     pub color: Color,
     pub brackets: Brackets,
     pub alignment: Alignment,
-    pub show_access_levels: bool,
+    pub show_access_levels: AccessLevelFormat,
     pub click: NicknameClickAction,
     pub shown_status: ShownStatus,
     pub truncate: Option<u16>,
     pub hide_consecutive: HideConsecutive,
-}
-
-impl Default for Nickname {
-    fn default() -> Self {
-        Self {
-            away: Away::default(),
-            offline: Offline::default(),
-            color: Color::default(),
-            brackets: Brackets::default(),
-            alignment: Alignment::default(),
-            show_access_levels: true,
-            click: NicknameClickAction::default(),
-            shown_status: ShownStatus::default(),
-            truncate: None,
-            hide_consecutive: HideConsecutive::default(),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, Default, Deserialize)]

--- a/data/src/config/buffer/text_input.rs
+++ b/data/src/config/buffer/text_input.rs
@@ -1,5 +1,7 @@
 use serde::Deserialize;
 
+use crate::config::buffer::AccessLevelFormat;
+
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
 pub struct TextInput {
@@ -39,14 +41,15 @@ pub enum Visibility {
 #[serde(default)]
 pub struct Nickname {
     pub enabled: bool,
-    pub show_access_level: bool,
+    #[serde(alias = "show_access_level")]
+    pub show_access_levels: AccessLevelFormat,
 }
 
 impl Default for Nickname {
     fn default() -> Self {
         Self {
             enabled: true,
-            show_access_level: true,
+            show_access_levels: AccessLevelFormat::default(),
         }
     }
 }

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -496,7 +496,7 @@ pub fn view<'a>(
             our_user.map(|user| {
                 container(
                     text(user.display(
-                        config.buffer.text_input.nickname.show_access_level,
+                        config.buffer.text_input.nickname.show_access_levels,
                         None,
                     ))
                     .style(move |_| our_user_style)


### PR DESCRIPTION
Expand all show_access_levels settings with the option to show all access levels (in addition to the highest access level or no access levels).  Keeps backwards compatibility by mapping `true` to highest access level and `false` to no access levels.