### PR TITLE
fix: stop replacing tags with a single label

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -10,7 +10,7 @@ use chrono::{DateTime, Utc};
 use futures::channel::mpsc;
 use futures::{Future, FutureExt};
 use indexmap::IndexMap;
-use irc::proto::{self, Command, command, tags};
+use irc::proto::{self, Command, command};
 use itertools::{Either, Itertools};
 use tokio::fs;
 
@@ -402,7 +402,7 @@ impl Client {
                 self.labels.insert(label.clone(), context);
 
                 // IRC: Encode tags
-                message.tags = tags!["label" => label];
+                message.tags.insert("label".to_string(), label);
             }
 
             self.reroute_responses_to =


### PR DESCRIPTION
if the server supports `labeled-response`, then all tags are cleared on every message sent. this fixes that bug