### PR TITLE
Allow Scroll-To to Anchor to Bottom

### DIFF
--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -938,9 +938,7 @@ impl State {
                     .max(0.0)
                     .min(max_offset);
 
-                if (offset - max_offset).abs() <= f32::EPSILON
-                    && !matches!(self.limit, Limit::Around(_, _))
-                {
+                if (offset - max_offset).abs() <= f32::EPSILON {
                     self.status = Status::Bottom;
 
                     if !matches!(self.limit, Limit::Bottom(_)) {


### PR DESCRIPTION
Allow scroll-to to anchor to bottom when offset from bottom is ~zero.  Otherwise buffers will not be recognized as scrolled to bottom when history does not fill the pane.