### PR TITLE
perf: reduce allocations for history

### DIFF
--- a/data/src/dashboard.rs
+++ b/data/src/dashboard.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fs::File;
 use std::io;
 use std::path::PathBuf;
 
@@ -65,15 +66,16 @@ impl Dashboard {
     pub fn load() -> Result<Self, Error> {
         let path = path()?;
 
-        let bytes = std::fs::read(path)?;
+        let file = File::open(path)?;
 
-        Ok(compression::decompress(&bytes)?)
+        Ok(compression::decompress(&file)?)
     }
 
     pub async fn save(self) -> Result<(), Error> {
         let path = path()?;
 
-        let bytes = compression::compress(&self)?;
+        let mut bytes = vec![];
+        compression::compress(&mut bytes, &self)?;
 
         tokio::fs::write(path, &bytes).await?;
 


### PR DESCRIPTION
Currently, two large multi-part (many append) allocations are needed for both writing to and reading history files. One allocation happens in `compression.rs` and one happens externally. The `Read` and `Write` traits exist so that this is not necessary. We can `read()` directly from a file and serialize it into the history struct.

Unfortunately not all allocations could be removed. Since it is usually called from an async context, and serde does not support `AsyncWrite`, we need a single allocation for writing to files. This is tricky to fix and I don't want things to get too complicated, so I am leaving this to a future PR.

My profiling has shown that approximately 20% of halloy's allocation time is spent in these two functions. Hopefully this speeds things up.

Test plan:
send and receive a message on a channel, close hallloy and reopen.

Test result:
history still works and is backwards compatable with previous history.