### PR TITLE
Reroute private messages

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1479,19 +1479,6 @@ impl Client {
                             query.as_normalized_str()
                                 == self.nickname().as_normalized_str()
                         });
-                    let server_config = config.servers.get(&self.server);
-                    let rerouted_private = direct_message
-                        && server_config.as_ref().is_some_and(|config| {
-                            config
-                                .reroute
-                                .private_messages
-                                .has_reroute_rule_for_query(
-                                    &user_query,
-                                    self.chantypes(),
-                                    self.statusmsg(),
-                                    self.casemapping(),
-                                )
-                        });
 
                     if let Some(channel) =
                         self.message_channel_target(&message.command)
@@ -1514,10 +1501,7 @@ impl Client {
                     // Event::DirectMessage is currently only used to send a
                     // notification, so only return the event it notifications
                     // are allowed.
-                    if direct_message
-                        && self.notification_blackout.allowed()
-                        && !rerouted_private
-                    {
+                    if direct_message && self.notification_blackout.allowed() {
                         return Ok(vec![
                             event,
                             Event::DirectMessage(

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1471,6 +1471,7 @@ impl Client {
                         }
                     }
 
+                    let user_query = target::Query::from(&user);
                     let direct_message = self
                         .message_query_target(&message.command)
                         .as_ref()
@@ -1478,17 +1479,31 @@ impl Client {
                             query.as_normalized_str()
                                 == self.nickname().as_normalized_str()
                         });
+                    let server_config = config.servers.get(&self.server);
+                    let rerouted_private = direct_message
+                        && server_config.as_ref().is_some_and(|config| {
+                            config
+                                .reroute
+                                .private_messages
+                                .has_reroute_rule_for_query(
+                                    &user_query,
+                                    &self.server,
+                                    self.chantypes(),
+                                    self.statusmsg(),
+                                    self.casemapping(),
+                                )
+                        });
 
                     if let Some(channel) =
                         self.message_channel_target(&message.command)
                     {
                         self.clear_channel_typing(&channel, user.nickname());
                     } else if direct_message {
-                        self.clear_query_typing(&target::Query::from(&user));
+                        self.clear_query_typing(&user_query);
                     }
 
                     if direct_message {
-                        self.record_query(&target::Query::from(&user));
+                        self.record_query(&user_query);
                     }
 
                     let event = Event::PrivOrNotice(
@@ -1500,7 +1515,10 @@ impl Client {
                     // Event::DirectMessage is currently only used to send a
                     // notification, so only return the event it notifications
                     // are allowed.
-                    if direct_message && self.notification_blackout.allowed() {
+                    if direct_message
+                        && self.notification_blackout.allowed()
+                        && !rerouted_private
+                    {
                         return Ok(vec![
                             event,
                             Event::DirectMessage(

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1487,7 +1487,6 @@ impl Client {
                                 .private_messages
                                 .has_reroute_rule_for_query(
                                     &user_query,
-                                    &self.server,
                                     self.chantypes(),
                                     self.statusmsg(),
                                     self.casemapping(),

--- a/data/src/command.rs
+++ b/data/src/command.rs
@@ -12,10 +12,11 @@ use crate::buffer::{self, Upstream};
 use crate::capabilities::{Capabilities, Capability};
 use crate::config::buffer::text_input::AutoFormat;
 use crate::features::Features;
+use crate::history::reroute::RerouteRules;
 use crate::isupport::{self, find_target_limit};
 use crate::message::{self, formatting};
 use crate::user::{ChannelUsers, NickRef};
-use crate::{Config, Message, Target, Url, User, ctcp, target};
+use crate::{Config, Message, Server, Target, Url, User, ctcp, target};
 
 pub mod alias;
 
@@ -107,29 +108,38 @@ impl Irc {
         &self,
         user: User,
         channel_users: Option<&ChannelUsers>,
+        server: &Server,
         chantypes: &[char],
         statusmsg: &[char],
         casemapping: isupport::CaseMap,
         supports_echoes: bool,
+        reroute_rules: &RerouteRules,
     ) -> Option<Vec<Message>> {
         let to_message_target = |target: &str, source| {
-            if target == "*" || target.starts_with('$') {
+            if target == "*" {
                 return message::Target::Server { source };
             }
 
-            let target =
-                Target::parse(target, chantypes, statusmsg, casemapping);
-
-            match &target {
-                Target::Channel(channel) => message::Target::Channel {
-                    channel: channel.clone(),
+            if target.starts_with('$') {
+                message::Target::Query {
+                    query: target::Query::from(user.clone()),
                     source,
-                },
+                }
+            } else {
+                let target =
+                    Target::parse(target, chantypes, statusmsg, casemapping);
 
-                Target::Query(query) => message::Target::Query {
-                    query: query.clone(),
-                    source,
-                },
+                match &target {
+                    Target::Channel(channel) => message::Target::Channel {
+                        channel: channel.clone(),
+                        source,
+                    },
+
+                    Target::Query(query) => message::Target::Query {
+                        query: query.clone(),
+                        source,
+                    },
+                }
             }
         };
 
@@ -142,6 +152,14 @@ impl Irc {
                             target,
                             message::Source::User(user.clone()),
                         );
+
+                        let message_target =
+                            message::reroute_private_message_target(
+                                &message_target,
+                                reroute_rules,
+                                server,
+                            )
+                            .unwrap_or(message_target);
 
                         Message::sent(
                             message_target,
@@ -167,6 +185,14 @@ impl Irc {
                             message::Source::User(user.clone()),
                         );
 
+                        let message_target =
+                            message::reroute_private_notice_target(
+                                &message_target,
+                                reroute_rules,
+                                server,
+                            )
+                            .unwrap_or(message_target);
+
                         Message::sent(
                             message_target,
                             message::parse_fragments_with_users(
@@ -187,6 +213,13 @@ impl Irc {
                     target,
                     message::Source::Action(Some(user.clone())),
                 );
+
+                let message_target = message::reroute_private_message_target(
+                    &message_target,
+                    reroute_rules,
+                    server,
+                )
+                .unwrap_or(message_target);
 
                 Some(vec![Message::sent(
                     message_target,

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use fancy_regex::{Regex, RegexBuilder};
 use irc::connection;
 use serde::{Deserialize, Deserializer};
 use tokio::fs;
@@ -20,6 +19,11 @@ use crate::serde::{
 use crate::{config, isupport, target};
 
 pub mod filehost;
+pub mod filters;
+pub mod reroute;
+
+pub use self::filters::{FancyRegex, Filters, Ignore};
+pub use self::reroute::Reroute;
 
 const DEFAULT_PORT: u16 = 6667;
 const DEFAULT_TLS_PORT: u16 = 6697;
@@ -65,6 +69,8 @@ pub struct Server {
     pub password_command: Option<String>,
     /// Filter settings for the server, e.g. ignored nicks
     pub filters: Option<Filters>,
+    /// Message reroute settings scoped to this server.
+    pub reroute: Reroute,
     /// A list of channels to join on connection.
     pub channels: Vec<String>,
     /// A mapping of channel names to keys for join-on-connect.
@@ -213,6 +219,7 @@ impl Default for Server {
             password_file_first_line_only: true,
             password_command: Option::default(),
             filters: Option::default(),
+            reroute: Reroute::default(),
             channels: Vec::default(),
             channel_keys: HashMap::default(),
             order_channels_by: None,
@@ -447,113 +454,6 @@ impl Sasl {
             None
         }
     }
-}
-
-#[derive(PartialEq, Eq, Debug, Clone, Deserialize, Default)]
-#[serde(default)]
-pub struct Filters {
-    pub ignore: Vec<Ignore>,
-    #[serde(deserialize_with = "deserialize_fancy_regexes")]
-    pub regex: Vec<FancyRegex>,
-}
-
-#[derive(PartialEq, Eq, Debug, Clone)]
-pub enum Ignore {
-    User(String),
-    UserInChannel { user: String, channel: String },
-    Regex { regex: FancyRegex },
-    RegexInChannel { regex: FancyRegex, channel: String },
-}
-
-impl<'de> Deserialize<'de> for Ignore {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        #[derive(Debug, Clone, Deserialize)]
-        #[serde(untagged)]
-        pub enum Inner {
-            User(String),
-            UserInChannel { user: String, channel: String },
-            Regex { regex: String },
-            RegexInChannel { regex: String, channel: String },
-        }
-
-        match Inner::deserialize(deserializer)? {
-            Inner::User(user) => Ok(Ignore::User(user)),
-            Inner::UserInChannel { user, channel } => {
-                Ok(Ignore::UserInChannel { user, channel })
-            }
-            Inner::Regex { regex } => {
-                let regex =
-                    RegexBuilder::new(&regex).build().map_err(|err| {
-                        serde::de::Error::custom(format!(
-                            "invalid regex '{regex}': {err}"
-                        ))
-                    })?;
-
-                Ok(Ignore::Regex {
-                    regex: FancyRegex(regex),
-                })
-            }
-            Inner::RegexInChannel { regex, channel } => {
-                let regex =
-                    RegexBuilder::new(&regex).build().map_err(|err| {
-                        serde::de::Error::custom(format!(
-                            "invalid regex '{regex}': {err}"
-                        ))
-                    })?;
-
-                Ok(Ignore::RegexInChannel {
-                    regex: FancyRegex(regex),
-                    channel,
-                })
-            }
-        }
-    }
-}
-
-// We want to build the regex on deserialization to present any errors to the
-// user then, but we need to be able to define PartialEq and Eq. So, we use this
-// Regex wrapper.
-#[derive(Debug, Clone)]
-pub struct FancyRegex(Regex);
-
-impl PartialEq for FancyRegex {
-    fn eq(&self, other: &FancyRegex) -> bool {
-        self.0.as_str() == other.0.as_str()
-    }
-}
-
-impl Eq for FancyRegex {}
-
-impl From<FancyRegex> for Regex {
-    fn from(fancy_regex: FancyRegex) -> Regex {
-        fancy_regex.0
-    }
-}
-
-pub fn deserialize_fancy_regexes<'de, D>(
-    deserializer: D,
-) -> Result<Vec<FancyRegex>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let regex_strings = Vec::<String>::deserialize(deserializer)?;
-
-    regex_strings
-        .iter()
-        .map(|regex_string| {
-            RegexBuilder::new(regex_string)
-                .build()
-                .map_err(|err| {
-                    serde::de::Error::custom(format!(
-                        "invalid regex '{regex_string}': {err}"
-                    ))
-                })
-                .map(FancyRegex)
-        })
-        .collect::<Result<Vec<FancyRegex>, D::Error>>()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -23,7 +23,7 @@ pub mod filters;
 pub mod reroute;
 
 pub use self::filters::{FancyRegex, Filters, Ignore};
-pub use self::reroute::Reroute;
+pub use self::reroute::{Reroute, RerouteRule, RerouteTarget};
 
 const DEFAULT_PORT: u16 = 6667;
 const DEFAULT_TLS_PORT: u16 = 6697;

--- a/data/src/config/server/filters.rs
+++ b/data/src/config/server/filters.rs
@@ -1,0 +1,109 @@
+use fancy_regex::{Regex, RegexBuilder};
+use serde::{Deserialize, Deserializer};
+
+#[derive(PartialEq, Eq, Debug, Clone, Deserialize, Default)]
+#[serde(default)]
+pub struct Filters {
+    pub ignore: Vec<Ignore>,
+    #[serde(deserialize_with = "deserialize_fancy_regexes")]
+    pub regex: Vec<FancyRegex>,
+}
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum Ignore {
+    User(String),
+    UserInChannel { user: String, channel: String },
+    Regex { regex: FancyRegex },
+    RegexInChannel { regex: FancyRegex, channel: String },
+}
+
+impl<'de> Deserialize<'de> for Ignore {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Debug, Clone, Deserialize)]
+        #[serde(untagged)]
+        pub enum Inner {
+            User(String),
+            UserInChannel { user: String, channel: String },
+            Regex { regex: String },
+            RegexInChannel { regex: String, channel: String },
+        }
+
+        match Inner::deserialize(deserializer)? {
+            Inner::User(user) => Ok(Ignore::User(user)),
+            Inner::UserInChannel { user, channel } => {
+                Ok(Ignore::UserInChannel { user, channel })
+            }
+            Inner::Regex { regex } => {
+                let regex =
+                    RegexBuilder::new(&regex).build().map_err(|err| {
+                        serde::de::Error::custom(format!(
+                            "invalid regex '{regex}': {err}"
+                        ))
+                    })?;
+
+                Ok(Ignore::Regex {
+                    regex: FancyRegex(regex),
+                })
+            }
+            Inner::RegexInChannel { regex, channel } => {
+                let regex =
+                    RegexBuilder::new(&regex).build().map_err(|err| {
+                        serde::de::Error::custom(format!(
+                            "invalid regex '{regex}': {err}"
+                        ))
+                    })?;
+
+                Ok(Ignore::RegexInChannel {
+                    regex: FancyRegex(regex),
+                    channel,
+                })
+            }
+        }
+    }
+}
+
+// We want to build the regex on deserialization to present any errors to the
+// user then, but we need to be able to define PartialEq and Eq. So, we use this
+// Regex wrapper.
+#[derive(Debug, Clone)]
+pub struct FancyRegex(pub(crate) Regex);
+
+impl PartialEq for FancyRegex {
+    fn eq(&self, other: &FancyRegex) -> bool {
+        self.0.as_str() == other.0.as_str()
+    }
+}
+
+impl Eq for FancyRegex {}
+
+impl From<FancyRegex> for Regex {
+    fn from(fancy_regex: FancyRegex) -> Regex {
+        fancy_regex.0
+    }
+}
+
+pub fn deserialize_fancy_regexes<'de, D>(
+    deserializer: D,
+) -> Result<Vec<FancyRegex>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let regex_strings = Vec::<String>::deserialize(deserializer)?;
+
+    regex_strings
+        .iter()
+        .map(|regex_string| {
+            RegexBuilder::new(regex_string)
+                .build()
+                .map_err(|err| {
+                    serde::de::Error::custom(format!(
+                        "invalid regex '{regex_string}': {err}"
+                    ))
+                })
+                .map(FancyRegex)
+        })
+        .collect::<Result<Vec<FancyRegex>, D::Error>>()
+}

--- a/data/src/config/server/reroute.rs
+++ b/data/src/config/server/reroute.rs
@@ -49,30 +49,6 @@ pub enum RerouteTarget {
 }
 
 impl PrivateMessages {
-    pub fn has_reroute_rule_for(&self, user: &str, channel: &str) -> bool {
-        self.targets_for_user(user).any(|target| {
-            matches!(
-                target,
-                RerouteTarget::Channel { channel: rule_channel }
-                    if rule_channel.eq_ignore_ascii_case(channel)
-            )
-        })
-    }
-
-    pub fn has_server_reroute_rule_for(
-        &self,
-        user: &str,
-        server: &Server,
-    ) -> bool {
-        self.targets_for_user(user).any(|target| {
-            matches!(
-                target,
-                RerouteTarget::Server { server: rule_server }
-                    if matches_server_label(rule_server, server)
-            )
-        })
-    }
-
     pub fn has_reroute_rule_for_query(
         &self,
         query: &target::Query,
@@ -118,15 +94,6 @@ impl PrivateMessages {
                 } => matches_server_label(rule_server, server)
                     .then_some(&rule.target),
             }
-        })
-    }
-
-    fn targets_for_user<'a>(
-        &'a self,
-        user: &'a str,
-    ) -> impl Iterator<Item = &'a RerouteTarget> + 'a {
-        self.reroute.iter().filter_map(move |rule| {
-            rule.user.eq_ignore_ascii_case(user).then_some(&rule.target)
         })
     }
 }

--- a/data/src/config/server/reroute.rs
+++ b/data/src/config/server/reroute.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-use crate::{Server, isupport, target};
+use crate::{isupport, target};
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
 #[serde(default)]
@@ -42,29 +42,27 @@ pub struct RerouteRule {
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[serde(untagged)]
+#[serde(rename_all = "kebab-case")]
 pub enum RerouteTarget {
-    Channel { channel: String },
-    Server { server: String },
+    Channel(String),
+    Server,
 }
 
 impl PrivateMessages {
     pub fn has_reroute_rule_for_query(
         &self,
         query: &target::Query,
-        server: &Server,
         chantypes: &[char],
         statusmsg: &[char],
         casemapping: isupport::CaseMap,
     ) -> bool {
-        self.target_for_query(query, server, chantypes, statusmsg, casemapping)
+        self.target_for_query(query, chantypes, statusmsg, casemapping)
             .is_some()
     }
 
     pub fn target_for_query(
         &self,
         query: &target::Query,
-        server: &Server,
         chantypes: &[char],
         statusmsg: &[char],
         casemapping: isupport::CaseMap,
@@ -81,7 +79,7 @@ impl PrivateMessages {
             }
 
             match &rule.target {
-                RerouteTarget::Channel { channel } => target::Channel::parse(
+                RerouteTarget::Channel(channel) => target::Channel::parse(
                     channel,
                     chantypes,
                     statusmsg,
@@ -89,10 +87,7 @@ impl PrivateMessages {
                 )
                 .ok()
                 .map(|_| &rule.target),
-                RerouteTarget::Server {
-                    server: rule_server,
-                } => matches_server_label(rule_server, server)
-                    .then_some(&rule.target),
+                RerouteTarget::Server => Some(&rule.target),
             }
         })
     }
@@ -109,13 +104,5 @@ fn query_matches_user(
         .ok()
         .is_some_and(|user_query| {
             user_query.as_normalized_str() == query.as_normalized_str()
-        })
-}
-
-fn matches_server_label(rule_server: &str, server: &Server) -> bool {
-    rule_server.eq_ignore_ascii_case(&server.name)
-        || server.network.as_ref().is_some_and(|network| {
-            rule_server.eq_ignore_ascii_case(&network.name)
-                || rule_server.eq_ignore_ascii_case(&network.id)
         })
 }

--- a/data/src/config/server/reroute.rs
+++ b/data/src/config/server/reroute.rs
@@ -1,0 +1,154 @@
+use serde::Deserialize;
+
+use crate::{Server, isupport, target};
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
+#[serde(default)]
+pub struct Reroute {
+    pub private_messages: PrivateMessages,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PrivateMessages {
+    pub reroute: Vec<RerouteRule>,
+}
+
+impl<'de> Deserialize<'de> for PrivateMessages {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Data {
+            Rules(Vec<RerouteRule>),
+            Legacy {
+                #[serde(default)]
+                reroute: Vec<RerouteRule>,
+            },
+        }
+
+        Ok(match Data::deserialize(deserializer)? {
+            Data::Rules(reroute) => Self { reroute },
+            Data::Legacy { reroute } => Self { reroute },
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct RerouteRule {
+    pub user: String,
+    pub target: RerouteTarget,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum RerouteTarget {
+    Channel { channel: String },
+    Server { server: String },
+}
+
+impl PrivateMessages {
+    pub fn has_reroute_rule_for(&self, user: &str, channel: &str) -> bool {
+        self.targets_for_user(user).any(|target| {
+            matches!(
+                target,
+                RerouteTarget::Channel { channel: rule_channel }
+                    if rule_channel.eq_ignore_ascii_case(channel)
+            )
+        })
+    }
+
+    pub fn has_server_reroute_rule_for(
+        &self,
+        user: &str,
+        server: &Server,
+    ) -> bool {
+        self.targets_for_user(user).any(|target| {
+            matches!(
+                target,
+                RerouteTarget::Server { server: rule_server }
+                    if matches_server_label(rule_server, server)
+            )
+        })
+    }
+
+    pub fn has_reroute_rule_for_query(
+        &self,
+        query: &target::Query,
+        server: &Server,
+        chantypes: &[char],
+        statusmsg: &[char],
+        casemapping: isupport::CaseMap,
+    ) -> bool {
+        self.target_for_query(query, server, chantypes, statusmsg, casemapping)
+            .is_some()
+    }
+
+    pub fn target_for_query(
+        &self,
+        query: &target::Query,
+        server: &Server,
+        chantypes: &[char],
+        statusmsg: &[char],
+        casemapping: isupport::CaseMap,
+    ) -> Option<&RerouteTarget> {
+        self.reroute.iter().find_map(|rule| {
+            if !query_matches_user(
+                query,
+                &rule.user,
+                chantypes,
+                statusmsg,
+                casemapping,
+            ) {
+                return None;
+            }
+
+            match &rule.target {
+                RerouteTarget::Channel { channel } => target::Channel::parse(
+                    channel,
+                    chantypes,
+                    statusmsg,
+                    casemapping,
+                )
+                .ok()
+                .map(|_| &rule.target),
+                RerouteTarget::Server {
+                    server: rule_server,
+                } => matches_server_label(rule_server, server)
+                    .then_some(&rule.target),
+            }
+        })
+    }
+
+    fn targets_for_user<'a>(
+        &'a self,
+        user: &'a str,
+    ) -> impl Iterator<Item = &'a RerouteTarget> + 'a {
+        self.reroute.iter().filter_map(move |rule| {
+            rule.user.eq_ignore_ascii_case(user).then_some(&rule.target)
+        })
+    }
+}
+
+fn query_matches_user(
+    query: &target::Query,
+    user: &str,
+    chantypes: &[char],
+    statusmsg: &[char],
+    casemapping: isupport::CaseMap,
+) -> bool {
+    target::Query::parse(user, chantypes, statusmsg, casemapping)
+        .ok()
+        .is_some_and(|user_query| {
+            user_query.as_normalized_str() == query.as_normalized_str()
+        })
+}
+
+fn matches_server_label(rule_server: &str, server: &Server) -> bool {
+    rule_server.eq_ignore_ascii_case(&server.name)
+        || server.network.as_ref().is_some_and(|network| {
+            rule_server.eq_ignore_ascii_case(&network.name)
+                || rule_server.eq_ignore_ascii_case(&network.id)
+        })
+}

--- a/data/src/config/server/reroute.rs
+++ b/data/src/config/server/reroute.rs
@@ -3,15 +3,15 @@ use serde::Deserialize;
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(default)]
 pub struct Reroute {
-    pub private_messages: Vec<RerouteRule>,
-    pub private_notices: Vec<RerouteRule>,
+    pub query: Vec<RerouteRule>,
+    pub notice: Vec<RerouteRule>,
 }
 
 impl Default for Reroute {
     fn default() -> Self {
         Self {
-            private_messages: Vec::default(),
-            private_notices: vec![RerouteRule {
+            query: Vec::default(),
+            notice: vec![RerouteRule {
                 user: "*".to_string(),
                 target: RerouteTarget::Server,
             }],

--- a/data/src/config/server/reroute.rs
+++ b/data/src/config/server/reroute.rs
@@ -1,17 +1,22 @@
 use serde::Deserialize;
 
-use crate::{isupport, target};
-
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(default)]
 pub struct Reroute {
-    pub private_messages: PrivateMessages,
+    pub private_messages: Vec<RerouteRule>,
+    pub private_notices: Vec<RerouteRule>,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
-#[serde(transparent)]
-pub struct PrivateMessages {
-    pub reroute: Vec<RerouteRule>,
+impl Default for Reroute {
+    fn default() -> Self {
+        Self {
+            private_messages: Vec::default(),
+            private_notices: vec![RerouteRule {
+                user: "*".to_string(),
+                target: RerouteTarget::Server,
+            }],
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -25,63 +30,4 @@ pub struct RerouteRule {
 pub enum RerouteTarget {
     Channel(String),
     Server,
-}
-
-impl PrivateMessages {
-    pub fn has_reroute_rule_for_query(
-        &self,
-        query: &target::Query,
-        chantypes: &[char],
-        statusmsg: &[char],
-        casemapping: isupport::CaseMap,
-    ) -> bool {
-        self.target_for_query(query, chantypes, statusmsg, casemapping)
-            .is_some()
-    }
-
-    pub fn target_for_query(
-        &self,
-        query: &target::Query,
-        chantypes: &[char],
-        statusmsg: &[char],
-        casemapping: isupport::CaseMap,
-    ) -> Option<&RerouteTarget> {
-        self.reroute.iter().find_map(|rule| {
-            if !query_matches_user(
-                query,
-                &rule.user,
-                chantypes,
-                statusmsg,
-                casemapping,
-            ) {
-                return None;
-            }
-
-            match &rule.target {
-                RerouteTarget::Channel(channel) => target::Channel::parse(
-                    channel,
-                    chantypes,
-                    statusmsg,
-                    casemapping,
-                )
-                .ok()
-                .map(|_| &rule.target),
-                RerouteTarget::Server => Some(&rule.target),
-            }
-        })
-    }
-}
-
-fn query_matches_user(
-    query: &target::Query,
-    user: &str,
-    chantypes: &[char],
-    statusmsg: &[char],
-    casemapping: isupport::CaseMap,
-) -> bool {
-    target::Query::parse(user, chantypes, statusmsg, casemapping)
-        .ok()
-        .is_some_and(|user_query| {
-            user_query.as_normalized_str() == query.as_normalized_str()
-        })
 }

--- a/data/src/config/server/reroute.rs
+++ b/data/src/config/server/reroute.rs
@@ -8,31 +8,10 @@ pub struct Reroute {
     pub private_messages: PrivateMessages,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(transparent)]
 pub struct PrivateMessages {
     pub reroute: Vec<RerouteRule>,
-}
-
-impl<'de> Deserialize<'de> for PrivateMessages {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        #[serde(untagged)]
-        enum Data {
-            Rules(Vec<RerouteRule>),
-            Legacy {
-                #[serde(default)]
-                reroute: Vec<RerouteRule>,
-            },
-        }
-
-        Ok(match Data::deserialize(deserializer)? {
-            Data::Rules(reroute) => Self { reroute },
-            Data::Legacy { reroute } => Self { reroute },
-        })
-    }
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -23,6 +23,7 @@ use crate::{
 pub mod filter;
 pub mod manager;
 pub mod metadata;
+pub mod reroute;
 
 // TODO: Make this configurable?
 /// Max # messages to persist

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -681,26 +681,33 @@ impl History {
                 ..
             } => {
                 let kind = kind.clone();
-                let messages = std::mem::take(messages);
+                let last_seen = last_seen.clone();
                 let read_marker = *read_marker;
                 let max_triggers_unread =
-                    metadata::latest_triggers_unread(&messages);
+                    metadata::latest_triggers_unread(messages);
                 let max_triggers_highlight =
-                    metadata::latest_triggers_highlight(&messages);
-
+                    metadata::latest_triggers_highlight(messages);
                 let chathistory_references =
-                    metadata::latest_can_reference(&messages);
+                    metadata::latest_can_reference(messages);
 
-                *self = Self::Partial {
-                    kind: kind.clone(),
-                    messages: vec![],
-                    last_updated_at: None,
-                    read_marker,
-                    max_triggers_unread,
-                    max_triggers_highlight,
-                    chathistory_references,
-                    last_seen: last_seen.clone(),
-                    pending_reactions: HashMap::new(),
+                let full_history = std::mem::replace(
+                    self,
+                    Self::Partial {
+                        kind,
+                        messages: vec![],
+                        last_updated_at: None,
+                        read_marker,
+                        max_triggers_unread,
+                        max_triggers_highlight,
+                        chathistory_references,
+                        last_seen,
+                        pending_reactions: HashMap::new(),
+                    },
+                );
+
+                let (kind, messages) = match full_history {
+                    History::Partial { kind, messages, .. }
+                    | History::Full { kind, messages, .. } => (kind, messages),
                 };
 
                 Some(

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -74,16 +74,34 @@ impl Kind {
     }
 
     pub fn from_server_message(
-        server: Server,
+        server: &Server,
         message: &Message,
     ) -> Option<Self> {
-        match &message.target {
-            message::Target::Server { .. } => Some(Self::Server(server)),
+        Self::from_server_message_target(server, &message.target)
+    }
+
+    pub fn from_server_message_rerouted_from(
+        server: &Server,
+        message: &Message,
+    ) -> Option<Self> {
+        message.rerouted_from.as_ref().and_then(|rerouted_from| {
+            Self::from_server_message_target(server, rerouted_from)
+        })
+    }
+
+    fn from_server_message_target(
+        server: &Server,
+        target: &message::Target,
+    ) -> Option<Self> {
+        match target {
+            message::Target::Server { .. } => {
+                Some(Self::Server(server.clone()))
+            }
             message::Target::Channel { channel, .. } => {
-                Some(Self::Channel(server, channel.clone()))
+                Some(Self::Channel(server.clone(), channel.clone()))
             }
             message::Target::Query { query, .. } => {
-                Some(Self::Query(server, query.clone()))
+                Some(Self::Query(server.clone(), query.clone()))
             }
             message::Target::Logs { .. } => None,
             message::Target::Highlights { .. } => None,
@@ -216,9 +234,16 @@ pub async fn overwrite(
     kind: &Kind,
     messages: &[Message],
     read_marker: Option<ReadMarker>,
+    chathistory_references: Option<MessageReferences>,
 ) -> Result<(), Error> {
     if messages.is_empty() {
-        return metadata::save(kind, messages, read_marker).await;
+        return metadata::save(
+            kind,
+            messages,
+            read_marker,
+            chathistory_references,
+        )
+        .await;
     }
 
     let latest = &messages[messages.len().saturating_sub(MAX_MESSAGES)..];
@@ -228,7 +253,7 @@ pub async fn overwrite(
 
     fs::write(path, &compressed).await?;
 
-    metadata::save(kind, latest, read_marker).await?;
+    metadata::save(kind, latest, read_marker, chathistory_references).await?;
 
     Ok(())
 }
@@ -238,6 +263,7 @@ pub async fn append(
     seed: Option<Seed>,
     mut messages: Vec<Message>,
     read_marker: Option<ReadMarker>,
+    chathistory_references: Option<MessageReferences>,
     pending_reactions: HashMap<message::Id, reaction::Pending>,
 ) -> Result<(), Error> {
     let loaded = load(kind.clone(), seed).await?;
@@ -255,7 +281,7 @@ pub async fn append(
         insert_message(&mut all_messages, message);
     });
 
-    overwrite(kind, &all_messages, read_marker).await
+    overwrite(kind, &all_messages, read_marker, chathistory_references).await
 }
 
 pub async fn delete(kind: &Kind) -> Result<(), Error> {
@@ -322,6 +348,7 @@ pub enum History {
         last_updated_at: Option<Instant>,
         read_marker: Option<ReadMarker>,
         display_read_marker: Option<ReadMarker>,
+        chathistory_references: Option<MessageReferences>,
         last_seen: HashMap<Nick, DateTime<Utc>>,
         cleared: bool,
     },
@@ -597,6 +624,7 @@ impl History {
                 messages,
                 last_updated_at,
                 read_marker,
+                chathistory_references,
                 pending_reactions,
                 ..
             } => {
@@ -609,6 +637,7 @@ impl History {
                     let kind = kind.clone();
                     let messages = std::mem::take(messages);
                     let read_marker = *read_marker;
+                    let chathistory_references = chathistory_references.clone();
                     let pending_reactions = std::mem::take(pending_reactions);
 
                     *last_updated_at = None;
@@ -620,6 +649,7 @@ impl History {
                                 seed,
                                 messages,
                                 read_marker,
+                                chathistory_references,
                                 pending_reactions,
                             )
                             .await
@@ -635,6 +665,7 @@ impl History {
                 messages,
                 last_updated_at,
                 read_marker,
+                chathistory_references,
                 ..
             } => {
                 if let Some(last_received) = *last_updated_at
@@ -646,6 +677,7 @@ impl History {
                 {
                     let kind = kind.clone();
                     let read_marker = *read_marker;
+                    let chathistory_references = chathistory_references.clone();
                     *last_updated_at = None;
 
                     if messages.len() > MAX_MESSAGES {
@@ -658,7 +690,13 @@ impl History {
 
                     return Some(
                         async move {
-                            overwrite(&kind, &messages, read_marker).await
+                            overwrite(
+                                &kind,
+                                &messages,
+                                read_marker,
+                                chathistory_references,
+                            )
+                            .await
                         }
                         .boxed(),
                     );
@@ -678,6 +716,7 @@ impl History {
                 kind,
                 messages,
                 read_marker,
+                chathistory_references,
                 last_seen,
                 ..
             } => {
@@ -689,7 +728,8 @@ impl History {
                 let max_triggers_highlight =
                     metadata::latest_triggers_highlight(messages);
                 let chathistory_references =
-                    metadata::latest_can_reference(messages);
+                    metadata::latest_can_reference(messages)
+                        .max(chathistory_references.clone());
 
                 let full_history = std::mem::replace(
                     self,
@@ -700,7 +740,7 @@ impl History {
                         read_marker,
                         max_triggers_unread,
                         max_triggers_highlight,
-                        chathistory_references,
+                        chathistory_references: chathistory_references.clone(),
                         last_seen,
                         pending_reactions: HashMap::new(),
                     },
@@ -711,9 +751,15 @@ impl History {
                     | History::Full { kind, messages, .. } => (kind, messages),
                 };
 
-                Some(
-                    async move { overwrite(&kind, &messages, read_marker).await },
-                )
+                Some(async move {
+                    overwrite(
+                        &kind,
+                        &messages,
+                        read_marker,
+                        chathistory_references,
+                    )
+                    .await
+                })
             }
         }
     }
@@ -724,18 +770,30 @@ impl History {
                 kind,
                 messages,
                 read_marker,
+                chathistory_references,
                 pending_reactions,
                 ..
             } => {
-                append(&kind, seed, messages, read_marker, pending_reactions)
-                    .await
+                append(
+                    &kind,
+                    seed,
+                    messages,
+                    read_marker,
+                    chathistory_references,
+                    pending_reactions,
+                )
+                .await
             }
             History::Full {
                 kind,
                 messages,
                 read_marker,
+                chathistory_references,
                 ..
-            } => overwrite(&kind, &messages, read_marker).await,
+            } => {
+                overwrite(&kind, &messages, read_marker, chathistory_references)
+                    .await
+            }
         }
     }
 
@@ -783,7 +841,9 @@ impl History {
         match self {
             History::Partial { messages, .. }
             | History::Full { messages, .. } => {
-                messages.iter().find(|message| message.can_reference())
+                messages.iter().find(|message| {
+                    message.can_reference() && !message.is_rerouted()
+                })
             }
         }
     }
@@ -792,36 +852,64 @@ impl History {
         &self,
         server_time: DateTime<Utc>,
     ) -> Option<MessageReferences> {
-        match self {
+        let (messages, chathistory_references) = match self {
             History::Partial {
                 messages,
                 chathistory_references,
                 ..
-            } => messages
-                .iter()
-                .rev()
-                .find(|message| {
-                    message.can_reference() && message.server_time < server_time
-                })
-                .map_or(
-                    if chathistory_references.as_ref().is_some_and(
-                        |chathistory_references| {
-                            chathistory_references.timestamp < server_time
-                        },
-                    ) {
-                        chathistory_references.clone()
-                    } else {
-                        None
+            } => (messages, chathistory_references),
+            History::Full {
+                messages,
+                chathistory_references,
+                ..
+            } => (messages, chathistory_references),
+        };
+
+        messages
+            .iter()
+            .rev()
+            .find(|message| {
+                message.can_reference()
+                    && !message.is_rerouted()
+                    && message.server_time < server_time
+            })
+            .map(Message::references)
+            .max(
+                if chathistory_references.as_ref().is_some_and(
+                    |chathistory_references| {
+                        chathistory_references.timestamp < server_time
                     },
-                    |message| Some(message.references()),
-                ),
-            History::Full { messages, .. } => messages
-                .iter()
-                .rev()
-                .find(|message| {
-                    message.can_reference() && message.server_time < server_time
-                })
-                .map(Message::references),
+                ) {
+                    chathistory_references.clone()
+                } else {
+                    None
+                },
+            )
+    }
+
+    pub fn update_chathistory_references(
+        &mut self,
+        chathistory_references: MessageReferences,
+    ) {
+        let (stored, last_updated_at) = match self {
+            History::Partial {
+                chathistory_references: stored_chathistory_references,
+                last_updated_at,
+                ..
+            } => (stored_chathistory_references, last_updated_at),
+            History::Full {
+                chathistory_references: stored_chathistory_references,
+                last_updated_at,
+                ..
+            } => (stored_chathistory_references, last_updated_at),
+        };
+
+        if stored
+            .as_ref()
+            .is_none_or(|stored| chathistory_references > *stored)
+        {
+            *stored = Some(chathistory_references);
+            *last_updated_at = Some(Instant::now());
         }
     }
 

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -9,6 +9,7 @@ use itertools::Itertools;
 use tokio::time::Instant;
 
 use super::filter::{Filter, FilterChain};
+use super::reroute::RerouteRules;
 use crate::history::{self, History, MessageReferences, ReadMarker};
 use crate::message::broadcast::{self, Broadcast};
 use crate::message::{self, Limit};
@@ -66,6 +67,7 @@ pub enum Event {
 pub struct Manager {
     resources: HashSet<Resource>,
     filters: Vec<Filter>,
+    reroute_rules: RerouteRules,
     data: Data,
     last_draft_changed: Option<tokio::time::Instant>,
 }
@@ -227,6 +229,14 @@ impl Manager {
 
     pub fn filters(&self) -> &[Filter] {
         &self.filters
+    }
+
+    pub fn get_reroute_rules_mut(&mut self) -> &mut RerouteRules {
+        &mut self.reroute_rules
+    }
+
+    pub fn get_reroute_rules(&self) -> &RerouteRules {
+        &self.reroute_rules
     }
 
     pub fn tick(

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -10,7 +10,7 @@ use tokio::time::Instant;
 
 use super::filter::{Filter, FilterChain};
 use super::reroute::RerouteRules;
-use crate::history::{self, History, MessageReferences, ReadMarker};
+use crate::history::{self, History, MessageReferences, ReadMarker, metadata};
 use crate::message::broadcast::{self, Broadcast};
 use crate::message::{self, Limit};
 use crate::reaction::{self, Reaction};
@@ -43,6 +43,11 @@ impl Resource {
 pub enum Message {
     LoadFull(history::Kind, Result<history::Loaded, history::Error>),
     UpdatePartial(history::Kind, Result<history::Metadata, history::Error>),
+    UpdateChatHistoryReferences(
+        history::Kind,
+        MessageReferences,
+        Result<(), history::Error>,
+    ),
     UpdateReadMarker(
         history::Kind,
         history::ReadMarker,
@@ -178,6 +183,24 @@ impl Manager {
             }
             Message::UpdatePartial(kind, Err(error)) => {
                 log::warn!("failed to load metadata for {kind}: {error}");
+            }
+            Message::UpdateChatHistoryReferences(
+                kind,
+                chathistory_references,
+                Ok(()),
+            ) => {
+                log::debug!(
+                    "updated chathistory references for {kind} to {chathistory_references:?}"
+                );
+            }
+            Message::UpdateChatHistoryReferences(
+                kind,
+                chathistory_references,
+                Err(error),
+            ) => {
+                log::warn!(
+                    "failed to update chathistory references for {kind} to {chathistory_references:?}: {error}"
+                );
             }
             Message::UpdateReadMarker(kind, read_marker, Ok(())) => {
                 log::debug!("updated read marker for {kind} to {read_marker}");
@@ -329,7 +352,7 @@ impl Manager {
 
         if config.buffer.mark_as_read.on_message_sent
             && let Some(kind) =
-                history::Kind::from_server_message(server.clone(), &message)
+                history::Kind::from_server_message(server, &message)
         {
             self.update_display_read_marker(
                 kind,
@@ -337,15 +360,12 @@ impl Manager {
             );
         }
 
-        tasks.extend(
-            self.block_and_record_message(
-                server,
-                casemapping,
-                message,
-                &config.buffer,
-            )
-            .map(futures::FutureExt::boxed),
-        );
+        tasks.extend(self.block_and_record_message(
+            server,
+            casemapping,
+            message,
+            &config.buffer,
+        ));
 
         tasks
     }
@@ -371,27 +391,44 @@ impl Manager {
         server: &Server,
         message: crate::Message,
         buffer_config: &config::Buffer,
-    ) -> Option<impl Future<Output = Message> + use<>> {
-        history::Kind::from_server_message(server.clone(), &message).and_then(
-            |kind| {
-                let condensers = (message
-                    .can_condense(&buffer_config.server_messages.condense)
-                    && !message.blocked)
-                    .then_some((kind.clone(), message.clone()));
-
-                let future = self.data.add_message(kind, message);
-
-                if let Some((kind, message)) = condensers {
-                    self.condense_message(
-                        message,
-                        &kind,
-                        &buffer_config.server_messages.condense,
-                    );
+    ) -> Vec<BoxFuture<'static, Message>> {
+        history::Kind::from_server_message_rerouted_from(server, &message)
+            .and_then(|kind| {
+                if message.can_reference() {
+                    self.data
+                        .update_chathistory_references(
+                            kind,
+                            message.references(),
+                        )
+                        .map(futures::FutureExt::boxed)
+                } else {
+                    None
                 }
+            })
+            .into_iter()
+            .chain(
+                history::Kind::from_server_message(server, &message).and_then(
+                    |kind| {
+                        let condensers = (message.can_condense(
+                            &buffer_config.server_messages.condense,
+                        ) && !message.blocked)
+                            .then_some((kind.clone(), message.clone()));
 
-                future
-            },
-        )
+                        let future = self.data.add_message(kind, message);
+
+                        if let Some((kind, message)) = condensers {
+                            self.condense_message(
+                                message,
+                                &kind,
+                                &buffer_config.server_messages.condense,
+                            );
+                        }
+
+                        future.map(futures::FutureExt::boxed)
+                    },
+                ),
+            )
+            .collect()
     }
 
     pub fn record_reaction(
@@ -415,9 +452,8 @@ impl Manager {
         casemapping: isupport::CaseMap,
         mut message: crate::Message,
         buffer_config: &config::Buffer,
-    ) -> Option<impl Future<Output = Message> + use<>> {
-        if let Some(kind) =
-            history::Kind::from_server_message(server.clone(), &message)
+    ) -> Vec<BoxFuture<'static, Message>> {
+        if let Some(kind) = history::Kind::from_server_message(server, &message)
         {
             self.block_message(
                 &mut message,
@@ -479,6 +515,15 @@ impl Manager {
     ) {
         self.data
             .contract_condensed_message(kind, server_time, hash, config);
+    }
+
+    pub fn update_chathistory_references<T: Into<history::Kind>>(
+        &mut self,
+        kind: T,
+        chathistory_references: MessageReferences,
+    ) -> Option<impl Future<Output = Message> + use<T>> {
+        self.data
+            .update_chathistory_references(kind, chathistory_references)
     }
 
     pub fn update_read_marker<T: Into<history::Kind>>(
@@ -663,7 +708,7 @@ impl Manager {
 
         messages
             .into_iter()
-            .filter_map(|message| {
+            .flat_map(|message| {
                 self.block_and_record_message(
                     server,
                     casemapping,
@@ -1193,12 +1238,18 @@ impl Data {
                     messages: new_messages,
                     last_updated_at,
                     read_marker: partial_read_marker,
+                    chathistory_references: partial_chathistory_references,
                     last_seen,
                     pending_reactions,
                     ..
                 } => {
                     let read_marker =
                         (*partial_read_marker).max(metadata.read_marker);
+
+                    let chathistory_references = partial_chathistory_references
+                        .clone()
+                        .max(metadata.chathistory_references)
+                        .max(metadata::latest_can_reference(&messages));
 
                     let last_updated_at = *last_updated_at;
 
@@ -1226,11 +1277,16 @@ impl Data {
                         last_updated_at,
                         read_marker,
                         display_read_marker: read_marker,
+                        chathistory_references,
                         last_seen,
                         cleared: false,
                     });
                 }
                 _ => {
+                    let chathistory_references = metadata
+                        .chathistory_references
+                        .max(metadata::latest_can_reference(&messages));
+
                     let last_seen = history::get_last_seen(&messages);
 
                     entry.insert(History::Full {
@@ -1239,12 +1295,17 @@ impl Data {
                         last_updated_at: None,
                         read_marker: metadata.read_marker,
                         display_read_marker: metadata.read_marker,
+                        chathistory_references,
                         last_seen,
                         cleared: false,
                     });
                 }
             },
             hash_map::Entry::Vacant(entry) => {
+                let chathistory_references = metadata
+                    .chathistory_references
+                    .max(metadata::latest_can_reference(&messages));
+
                 let last_seen = history::get_last_seen(&messages);
 
                 entry.insert(History::Full {
@@ -1253,6 +1314,7 @@ impl Data {
                     last_updated_at: None,
                     read_marker: metadata.read_marker,
                     display_read_marker: metadata.read_marker,
+                    chathistory_references,
                     last_seen,
                     cleared: false,
                 });
@@ -1551,6 +1613,43 @@ impl Data {
         }
     }
 
+    fn update_chathistory_references<T: Into<history::Kind>>(
+        &mut self,
+        kind: T,
+        chathistory_references: MessageReferences,
+    ) -> Option<impl Future<Output = Message> + use<T>> {
+        use std::collections::hash_map;
+
+        let kind = kind.into();
+
+        match self.map.entry(kind.clone()) {
+            hash_map::Entry::Occupied(mut entry) => {
+                entry
+                    .get_mut()
+                    .update_chathistory_references(chathistory_references);
+
+                None
+            }
+            hash_map::Entry::Vacant(_) => Some(
+                async move {
+                    let updated =
+                        history::metadata::update_chathistory_references(
+                            &kind,
+                            &chathistory_references,
+                        )
+                        .await;
+
+                    Message::UpdateChatHistoryReferences(
+                        kind,
+                        chathistory_references,
+                        updated,
+                    )
+                }
+                .boxed(),
+            ),
+        }
+    }
+
     fn update_read_marker<T: Into<history::Kind>>(
         &mut self,
         kind: T,
@@ -1568,8 +1667,11 @@ impl Data {
             }
             hash_map::Entry::Vacant(_) => Some(
                 async move {
-                    let updated =
-                        history::metadata::update(&kind, &read_marker).await;
+                    let updated = history::metadata::update_read_marker(
+                        &kind,
+                        &read_marker,
+                    )
+                    .await;
 
                     Message::UpdateReadMarker(kind, read_marker, updated)
                 }

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -607,10 +607,7 @@ impl Manager {
                 history::Kind::Query(s, query) => (s == server
                     && self.filters.iter().all(|filter| {
                         filter.match_query(query, server) == false
-                    })
-                    && !self
-                        .reroute_rules
-                        .has_reroute_rule_for_query(query, server))
+                    }))
                 .then_some(query),
                 _ => None,
             })

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -562,7 +562,10 @@ impl Manager {
                 history::Kind::Query(s, query) => (s == server
                     && self.filters.iter().all(|filter| {
                         filter.match_query(query, server) == false
-                    }))
+                    })
+                    && !self
+                        .reroute_rules
+                        .has_reroute_rule_for_query(query, server))
                 .then_some(query),
                 _ => None,
             })

--- a/data/src/history/metadata.rs
+++ b/data/src/history/metadata.rs
@@ -109,7 +109,7 @@ pub fn latest_can_reference(messages: &[Message]) -> Option<MessageReferences> {
     messages
         .iter()
         .rev()
-        .find(|message| message.can_reference())
+        .find(|message| message.can_reference() && !message.is_rerouted())
         .map(Message::references)
 }
 
@@ -127,12 +127,14 @@ pub async fn save(
     kind: &Kind,
     messages: &[Message],
     read_marker: Option<ReadMarker>,
+    chathistory_references: Option<MessageReferences>,
 ) -> Result<(), Error> {
     let bytes = serde_json::to_vec(&Metadata {
         read_marker,
         last_triggers_unread: latest_triggers_unread(messages),
         last_triggers_highlight: latest_triggers_highlight(messages),
-        chathistory_references: latest_can_reference(messages),
+        chathistory_references: latest_can_reference(messages)
+            .max(chathistory_references),
     })?;
 
     let path = path(kind).await?;
@@ -142,7 +144,35 @@ pub async fn save(
     Ok(())
 }
 
-pub async fn update(
+pub async fn update_chathistory_references(
+    kind: &Kind,
+    chathistory_references: &MessageReferences,
+) -> Result<(), Error> {
+    let metadata = load(kind.clone()).await?;
+
+    if metadata.chathistory_references.is_some_and(
+        |metadata_chathistory_references| {
+            metadata_chathistory_references >= *chathistory_references
+        },
+    ) {
+        return Ok(());
+    }
+
+    let bytes = serde_json::to_vec(&Metadata {
+        read_marker: metadata.read_marker,
+        last_triggers_unread: metadata.last_triggers_unread,
+        last_triggers_highlight: metadata.last_triggers_highlight,
+        chathistory_references: Some(chathistory_references.clone()),
+    })?;
+
+    let path = path(kind).await?;
+
+    fs::write(path, &bytes).await?;
+
+    Ok(())
+}
+
+pub async fn update_read_marker(
     kind: &Kind,
     read_marker: &ReadMarker,
 ) -> Result<(), Error> {

--- a/data/src/history/reroute.rs
+++ b/data/src/history/reroute.rs
@@ -1,0 +1,165 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::user::Nick;
+use crate::{Server, client, config, isupport, message, server, target};
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RerouteRules {
+    pub direct_messages: HashMap<Server, Vec<DirectMessageRerouteRule>>,
+}
+
+impl RerouteRules {
+    pub fn from_server_map(
+        servers: &server::Map,
+        clients: &client::Map,
+    ) -> Self {
+        Self {
+            direct_messages: servers
+                .entries()
+                .filter_map(|entry| {
+                    let chantypes = clients.get_chantypes(&entry.server);
+                    let statusmsg = clients.get_statusmsg(&entry.server);
+                    let casemapping = clients.get_casemapping(&entry.server);
+
+                    let reroute_rules = parse_reroute_rules(
+                        &entry.server,
+                        entry.config,
+                        chantypes,
+                        statusmsg,
+                        casemapping,
+                    );
+
+                    (!reroute_rules.is_empty())
+                        .then_some((entry.server.clone(), reroute_rules))
+                })
+                .collect(),
+        }
+    }
+
+    pub fn sync_isupport(
+        &mut self,
+        server: &Server,
+        config: Arc<config::Server>,
+        chantypes: &[char],
+        statusmsg: &[char],
+        casemapping: isupport::CaseMap,
+    ) {
+        let reroute_rules = parse_reroute_rules(
+            server,
+            config,
+            statusmsg,
+            chantypes,
+            casemapping,
+        );
+
+        if reroute_rules.is_empty() {
+            self.direct_messages.remove(server);
+        } else {
+            self.direct_messages.insert(server.clone(), reroute_rules);
+        }
+    }
+}
+
+fn parse_reroute_rules(
+    server: &Server,
+    config: Arc<config::Server>,
+    statusmsg: &[char],
+    chantypes: &[char],
+    casemapping: isupport::CaseMap,
+) -> Vec<DirectMessageRerouteRule> {
+    config
+        .reroute
+        .private_messages
+        .reroute
+        .iter()
+        .filter_map(|reroute_rule| {
+            let nick = Nick::from_str(&reroute_rule.user, casemapping);
+
+            match &reroute_rule.target {
+                config::server::RerouteTarget::Channel {
+                    channel: config_channel,
+                } => target::Channel::parse(
+                    config_channel,
+                    chantypes,
+                    statusmsg,
+                    casemapping,
+                )
+                .ok()
+                .map(DirectMessageRerouteTarget::Channel),
+                config::server::RerouteTarget::Server {
+                    server: config_server,
+                } => matches_server_label(config_server, server)
+                    .then_some(DirectMessageRerouteTarget::Server),
+            }
+            .map(|target| DirectMessageRerouteRule {
+                from: nick,
+                to: target,
+            })
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirectMessageRerouteRule {
+    pub from: Nick,
+    pub to: DirectMessageRerouteTarget,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DirectMessageRerouteTarget {
+    Server,
+    Channel(target::Channel),
+}
+
+impl RerouteRules {
+    pub fn has_reroute_rule_for_query(
+        &self,
+        query: &target::Query,
+        server: &Server,
+    ) -> bool {
+        self.direct_messages
+            .get(server)
+            .is_some_and(|reroute_rules| {
+                reroute_rules.iter().any(|reroute_rule| {
+                    query.as_normalized_str()
+                        == reroute_rule.from.as_normalized_str()
+                })
+            })
+    }
+
+    pub fn target_for_query(
+        &self,
+        query: &target::Query,
+        server: &Server,
+        source: &message::Source,
+    ) -> Option<message::Target> {
+        self.direct_messages.get(server).and_then(|reroute_rules| {
+            reroute_rules.iter().find_map(|reroute_rule| {
+                (query.as_normalized_str()
+                    == reroute_rule.from.as_normalized_str())
+                .then_some(match &reroute_rule.to {
+                    DirectMessageRerouteTarget::Channel(channel) => {
+                        message::Target::Channel {
+                            channel: channel.clone(),
+                            source: source.clone(),
+                        }
+                    }
+                    DirectMessageRerouteTarget::Server => {
+                        message::Target::Server {
+                            source: source.clone(),
+                        }
+                    }
+                })
+            })
+        })
+    }
+}
+
+fn matches_server_label(rule_server: &str, server: &Server) -> bool {
+    rule_server.eq_ignore_ascii_case(&server.name)
+        || server.network.as_ref().is_some_and(|network| {
+            rule_server.eq_ignore_ascii_case(&network.name)
+                || rule_server.eq_ignore_ascii_case(&network.id)
+        })
+}

--- a/data/src/history/reroute.rs
+++ b/data/src/history/reroute.rs
@@ -26,7 +26,6 @@ impl RerouteRules {
                         .get_server_casemapping_or_default(&entry.server);
 
                     let reroute_rules = parse_reroute_rules(
-                        &entry.server,
                         entry.config,
                         chantypes,
                         statusmsg,
@@ -48,13 +47,8 @@ impl RerouteRules {
         statusmsg: &[char],
         casemapping: isupport::CaseMap,
     ) {
-        let reroute_rules = parse_reroute_rules(
-            server,
-            config,
-            statusmsg,
-            chantypes,
-            casemapping,
-        );
+        let reroute_rules =
+            parse_reroute_rules(config, chantypes, statusmsg, casemapping);
 
         if reroute_rules.is_empty() {
             self.direct_messages.remove(server);
@@ -65,7 +59,6 @@ impl RerouteRules {
 }
 
 fn parse_reroute_rules(
-    server: &Server,
     config: Arc<config::Server>,
     chantypes: &[char],
     statusmsg: &[char],
@@ -80,20 +73,19 @@ fn parse_reroute_rules(
             let nick = Nick::from_str(&reroute_rule.user, casemapping);
 
             match &reroute_rule.target {
-                config::server::RerouteTarget::Channel {
-                    channel: config_channel,
-                } => target::Channel::parse(
-                    config_channel,
-                    chantypes,
-                    statusmsg,
-                    casemapping,
-                )
-                .ok()
-                .map(DirectMessageRerouteTarget::Channel),
-                config::server::RerouteTarget::Server {
-                    server: config_server,
-                } => matches_server_label(config_server, server)
-                    .then_some(DirectMessageRerouteTarget::Server),
+                config::server::RerouteTarget::Channel(config_channel) => {
+                    target::Channel::parse(
+                        config_channel,
+                        chantypes,
+                        statusmsg,
+                        casemapping,
+                    )
+                    .ok()
+                    .map(DirectMessageRerouteTarget::Channel)
+                }
+                config::server::RerouteTarget::Server => {
+                    Some(DirectMessageRerouteTarget::Server)
+                }
             }
             .map(|target| DirectMessageRerouteRule {
                 from: nick,
@@ -157,12 +149,4 @@ impl RerouteRules {
             })
         })
     }
-}
-
-fn matches_server_label(rule_server: &str, server: &Server) -> bool {
-    rule_server.eq_ignore_ascii_case(&server.name)
-        || server.network.as_ref().is_some_and(|network| {
-            rule_server.eq_ignore_ascii_case(&network.name)
-                || rule_server.eq_ignore_ascii_case(&network.id)
-        })
 }

--- a/data/src/history/reroute.rs
+++ b/data/src/history/reroute.rs
@@ -6,7 +6,8 @@ use crate::{Server, client, config, isupport, message, server, target};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct RerouteRules {
-    pub direct_messages: HashMap<Server, Vec<DirectMessageRerouteRule>>,
+    pub direct_messages: HashMap<Server, Vec<RerouteRule>>,
+    pub direct_notices: HashMap<Server, Vec<RerouteRule>>,
 }
 
 impl RerouteRules {
@@ -14,28 +15,53 @@ impl RerouteRules {
         servers: &server::Map,
         clients: &client::Map,
     ) -> Self {
+        let direct_messages = servers
+            .entries()
+            .filter_map(|entry| {
+                let chantypes =
+                    clients.get_server_chantypes_or_default(&entry.server);
+                let statusmsg =
+                    clients.get_server_statusmsg_or_default(&entry.server);
+                let casemapping =
+                    clients.get_server_casemapping_or_default(&entry.server);
+
+                let reroute_rules = parse_reroute_rules(
+                    &entry.config.reroute.private_messages,
+                    chantypes,
+                    statusmsg,
+                    casemapping,
+                );
+
+                (!reroute_rules.is_empty())
+                    .then_some((entry.server.clone(), reroute_rules))
+            })
+            .collect();
+
+        let direct_notices = servers
+            .entries()
+            .filter_map(|entry| {
+                let chantypes =
+                    clients.get_server_chantypes_or_default(&entry.server);
+                let statusmsg =
+                    clients.get_server_statusmsg_or_default(&entry.server);
+                let casemapping =
+                    clients.get_server_casemapping_or_default(&entry.server);
+
+                let reroute_rules = parse_reroute_rules(
+                    &entry.config.reroute.private_notices,
+                    chantypes,
+                    statusmsg,
+                    casemapping,
+                );
+
+                (!reroute_rules.is_empty())
+                    .then_some((entry.server.clone(), reroute_rules))
+            })
+            .collect();
+
         Self {
-            direct_messages: servers
-                .entries()
-                .filter_map(|entry| {
-                    let chantypes =
-                        clients.get_server_chantypes_or_default(&entry.server);
-                    let statusmsg =
-                        clients.get_server_statusmsg_or_default(&entry.server);
-                    let casemapping = clients
-                        .get_server_casemapping_or_default(&entry.server);
-
-                    let reroute_rules = parse_reroute_rules(
-                        entry.config,
-                        chantypes,
-                        statusmsg,
-                        casemapping,
-                    );
-
-                    (!reroute_rules.is_empty())
-                        .then_some((entry.server.clone(), reroute_rules))
-                })
-                .collect(),
+            direct_messages,
+            direct_notices,
         }
     }
 
@@ -47,106 +73,184 @@ impl RerouteRules {
         statusmsg: &[char],
         casemapping: isupport::CaseMap,
     ) {
-        let reroute_rules =
-            parse_reroute_rules(config, chantypes, statusmsg, casemapping);
+        let reroute_rules = parse_reroute_rules(
+            &config.reroute.private_messages,
+            chantypes,
+            statusmsg,
+            casemapping,
+        );
 
         if reroute_rules.is_empty() {
             self.direct_messages.remove(server);
         } else {
             self.direct_messages.insert(server.clone(), reroute_rules);
         }
+
+        let reroute_rules = parse_reroute_rules(
+            &config.reroute.private_notices,
+            chantypes,
+            statusmsg,
+            casemapping,
+        );
+
+        if reroute_rules.is_empty() {
+            self.direct_notices.remove(server);
+        } else {
+            self.direct_notices.insert(server.clone(), reroute_rules);
+        }
     }
 }
 
 fn parse_reroute_rules(
-    config: Arc<config::Server>,
+    config: &[config::server::RerouteRule],
     chantypes: &[char],
     statusmsg: &[char],
     casemapping: isupport::CaseMap,
-) -> Vec<DirectMessageRerouteRule> {
+) -> Vec<RerouteRule> {
     config
-        .reroute
-        .private_messages
-        .reroute
         .iter()
         .filter_map(|reroute_rule| {
-            let nick = Nick::from_str(&reroute_rule.user, casemapping);
-
-            match &reroute_rule.target {
-                config::server::RerouteTarget::Channel(config_channel) => {
-                    target::Channel::parse(
-                        config_channel,
-                        chantypes,
-                        statusmsg,
-                        casemapping,
-                    )
-                    .ok()
-                    .map(DirectMessageRerouteTarget::Channel)
-                }
-                config::server::RerouteTarget::Server => {
-                    Some(DirectMessageRerouteTarget::Server)
-                }
+            if reroute_rule.user == "*" {
+                // Ignore catch-all "*" user until second pass, to
+                // ensure it is found after any direct match.
+                return None;
             }
-            .map(|target| DirectMessageRerouteRule {
-                from: nick,
-                to: target,
-            })
+
+            RerouteRule::try_from_config(
+                reroute_rule,
+                chantypes,
+                statusmsg,
+                casemapping,
+            )
         })
+        .chain(config.iter().filter_map(|reroute_rule| {
+            if reroute_rule.user != "*" {
+                return None;
+            }
+
+            RerouteRule::try_from_config(
+                reroute_rule,
+                chantypes,
+                statusmsg,
+                casemapping,
+            )
+        }))
         .collect()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DirectMessageRerouteRule {
+pub struct RerouteRule {
     pub from: Nick,
-    pub to: DirectMessageRerouteTarget,
+    pub to: RerouteTarget,
+}
+
+impl RerouteRule {
+    fn try_from_config(
+        reroute_rule: &config::server::RerouteRule,
+        chantypes: &[char],
+        statusmsg: &[char],
+        casemapping: isupport::CaseMap,
+    ) -> Option<Self> {
+        let nick = Nick::from_str(&reroute_rule.user, casemapping);
+
+        match &reroute_rule.target {
+            config::server::RerouteTarget::Channel(config_channel) => {
+                target::Channel::parse(
+                    config_channel,
+                    chantypes,
+                    statusmsg,
+                    casemapping,
+                )
+                .ok()
+                .map(RerouteTarget::Channel)
+            }
+            config::server::RerouteTarget::Server => {
+                Some(RerouteTarget::Server)
+            }
+        }
+        .map(|target| RerouteRule {
+            from: nick,
+            to: target,
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DirectMessageRerouteTarget {
+pub enum RerouteTarget {
     Server,
     Channel(target::Channel),
 }
 
 impl RerouteRules {
-    pub fn has_reroute_rule_for_query(
+    pub fn has_reroute_rule_for_direct_message(
         &self,
         query: &target::Query,
         server: &Server,
     ) -> bool {
-        self.direct_messages
-            .get(server)
-            .is_some_and(|reroute_rules| {
-                reroute_rules.iter().any(|reroute_rule| {
-                    query.as_normalized_str()
-                        == reroute_rule.from.as_normalized_str()
-                })
-            })
+        has_reroute_rule_for_query(&self.direct_messages, query, server)
     }
 
-    pub fn target_for_query(
+    pub fn target_for_direct_message(
         &self,
         query: &target::Query,
         server: &Server,
         source: &message::Source,
     ) -> Option<message::Target> {
-        self.direct_messages.get(server).and_then(|reroute_rules| {
-            reroute_rules.iter().find_map(|reroute_rule| {
-                (query.as_normalized_str()
-                    == reroute_rule.from.as_normalized_str())
+        target_for_query(&self.direct_messages, query, server, source)
+    }
+
+    pub fn has_reroute_rule_for_direct_notice(
+        &self,
+        query: &target::Query,
+        server: &Server,
+    ) -> bool {
+        has_reroute_rule_for_query(&self.direct_notices, query, server)
+    }
+
+    pub fn target_for_direct_notice(
+        &self,
+        query: &target::Query,
+        server: &Server,
+        source: &message::Source,
+    ) -> Option<message::Target> {
+        target_for_query(&self.direct_notices, query, server, source)
+    }
+}
+
+fn has_reroute_rule_for_query(
+    reroute_rules: &HashMap<Server, Vec<RerouteRule>>,
+    query: &target::Query,
+    server: &Server,
+) -> bool {
+    reroute_rules.get(server).is_some_and(|reroute_rules| {
+        reroute_rules.iter().any(|reroute_rule| {
+            query.as_normalized_str() == reroute_rule.from.as_normalized_str()
+        })
+    })
+}
+
+fn target_for_query(
+    reroute_rules: &HashMap<Server, Vec<RerouteRule>>,
+    query: &target::Query,
+    server: &Server,
+    source: &message::Source,
+) -> Option<message::Target> {
+    reroute_rules.get(server).and_then(|reroute_rules| {
+        reroute_rules.iter().find_map(|reroute_rule| {
+            ((query.as_normalized_str()
+                == reroute_rule.from.as_normalized_str())
+                || reroute_rule.from.as_str() == "*")
                 .then_some(match &reroute_rule.to {
-                    DirectMessageRerouteTarget::Channel(channel) => {
+                    RerouteTarget::Channel(channel) => {
                         message::Target::Channel {
                             channel: channel.clone(),
                             source: source.clone(),
                         }
                     }
-                    DirectMessageRerouteTarget::Server => {
-                        message::Target::Server {
-                            source: source.clone(),
-                        }
-                    }
+                    RerouteTarget::Server => message::Target::Server {
+                        source: source.clone(),
+                    },
                 })
-            })
         })
-    }
+    })
 }

--- a/data/src/history/reroute.rs
+++ b/data/src/history/reroute.rs
@@ -26,7 +26,7 @@ impl RerouteRules {
                     clients.get_server_casemapping_or_default(&entry.server);
 
                 let reroute_rules = parse_reroute_rules(
-                    &entry.config.reroute.private_messages,
+                    &entry.config.reroute.query,
                     chantypes,
                     statusmsg,
                     casemapping,
@@ -48,7 +48,7 @@ impl RerouteRules {
                     clients.get_server_casemapping_or_default(&entry.server);
 
                 let reroute_rules = parse_reroute_rules(
-                    &entry.config.reroute.private_notices,
+                    &entry.config.reroute.notice,
                     chantypes,
                     statusmsg,
                     casemapping,
@@ -74,7 +74,7 @@ impl RerouteRules {
         casemapping: isupport::CaseMap,
     ) {
         let reroute_rules = parse_reroute_rules(
-            &config.reroute.private_messages,
+            &config.reroute.query,
             chantypes,
             statusmsg,
             casemapping,
@@ -87,7 +87,7 @@ impl RerouteRules {
         }
 
         let reroute_rules = parse_reroute_rules(
-            &config.reroute.private_notices,
+            &config.reroute.notice,
             chantypes,
             statusmsg,
             casemapping,

--- a/data/src/history/reroute.rs
+++ b/data/src/history/reroute.rs
@@ -18,9 +18,12 @@ impl RerouteRules {
             direct_messages: servers
                 .entries()
                 .filter_map(|entry| {
-                    let chantypes = clients.get_chantypes(&entry.server);
-                    let statusmsg = clients.get_statusmsg(&entry.server);
-                    let casemapping = clients.get_casemapping(&entry.server);
+                    let chantypes =
+                        clients.get_server_chantypes_or_default(&entry.server);
+                    let statusmsg =
+                        clients.get_server_statusmsg_or_default(&entry.server);
+                    let casemapping = clients
+                        .get_server_casemapping_or_default(&entry.server);
 
                     let reroute_rules = parse_reroute_rules(
                         &entry.server,
@@ -64,8 +67,8 @@ impl RerouteRules {
 fn parse_reroute_rules(
     server: &Server,
     config: Arc<config::Server>,
-    statusmsg: &[char],
     chantypes: &[char],
+    statusmsg: &[char],
     casemapping: isupport::CaseMap,
 ) -> Vec<DirectMessageRerouteRule> {
     config

--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -11,6 +11,7 @@ use nom::{Finish, IResult, Parser};
 use crate::capabilities::{Capabilities, MultilineBatchKind};
 use crate::config::buffer::text_input::AutoFormat;
 use crate::features::Features;
+use crate::history::reroute::RerouteRules;
 use crate::message::formatting;
 use crate::target::Target;
 use crate::user::{ChannelUsers, NickRef};
@@ -282,19 +283,23 @@ impl Input {
         &self,
         user: User,
         channel_users: Option<&ChannelUsers>,
+        server: &Server,
         chantypes: &[char],
         statusmsg: &[char],
         casemapping: isupport::CaseMap,
         supports_echoes: bool,
+        reroute_rules: &RerouteRules,
     ) -> Option<Vec<Message>> {
         self.content.command(&self.buffer).and_then(|command| {
             command.messages(
                 user,
                 channel_users,
+                server,
                 chantypes,
                 statusmsg,
                 casemapping,
                 supports_echoes,
+                reroute_rules,
             )
         })
     }

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -115,10 +115,6 @@ pub fn reroute_private_target(
     }
 }
 
-pub fn is_rerouted_private_message(message: &Message) -> bool {
-    message.rerouted_from.is_some()
-}
-
 #[derive(Debug, Clone)]
 pub struct Encoded(pub(crate) proto::Message);
 
@@ -330,7 +326,6 @@ impl Message {
         if matches!(self.direction, Direction::Sent)
             || self.is_echo
             || matches!(self.target.source(), Source::Internal(_))
-            || is_rerouted_private_message(self)
         {
             return false;
         } else if let Source::Server(Some(source)) = self.target.source()
@@ -346,6 +341,10 @@ impl Message {
         }
 
         true
+    }
+
+    pub fn is_rerouted(&self) -> bool {
+        self.rerouted_from.is_some()
     }
 
     pub fn can_condense(

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -102,21 +102,17 @@ pub mod highlight;
 pub mod source;
 
 pub fn reroute_private_target(
-    target: Target,
+    target: &Target,
     reroute_private: Option<&config::server::reroute::PrivateMessages>,
     server: &Server,
     chantypes: &[char],
     statusmsg: &[char],
     casemapping: isupport::CaseMap,
-) -> Target {
-    let Some(reroute_private) = reroute_private else {
-        return target;
-    };
-
+) -> Option<Target> {
     match target {
         Target::Query { query, source } => {
-            if let Some(target) = reroute_private.target_for_query(
-                &query,
+            if let Some(target) = reroute_private?.target_for_query(
+                query,
                 server,
                 chantypes,
                 statusmsg,
@@ -132,63 +128,33 @@ pub fn reroute_private_target(
                             statusmsg,
                             casemapping,
                         ) {
-                            Target::Channel { channel, source }
+                            Some(Target::Channel {
+                                channel,
+                                source: source.clone(),
+                            })
                         } else {
-                            Target::Query { query, source }
+                            Some(Target::Query {
+                                query: query.clone(),
+                                source: source.clone(),
+                            })
                         }
                     }
                     config::server::reroute::RerouteTarget::Server {
                         ..
-                    } => Target::Server { source },
+                    } => Some(Target::Server {
+                        source: source.clone(),
+                    }),
                 }
             } else {
-                Target::Query { query, source }
+                None
             }
         }
-        target => target,
+        _ => None,
     }
 }
 
-pub fn is_rerouted_private_message(
-    message: &Message,
-    reroute_private: Option<&config::server::reroute::PrivateMessages>,
-    server: &Server,
-) -> bool {
-    let Some(reroute_private) = reroute_private else {
-        return false;
-    };
-
-    let Some(
-        command::Irc::Msg(raw_target, _) | command::Irc::Notice(raw_target, _),
-    ) = &message.command
-    else {
-        return false;
-    };
-
-    match &message.target {
-        Target::Channel { channel, source } => {
-            if matches!(message.direction, Direction::Sent) || message.is_echo {
-                reroute_private
-                    .has_reroute_rule_for(raw_target, channel.as_str())
-            } else if let Source::User(user) = source {
-                reroute_private
-                    .has_reroute_rule_for(user.as_str(), channel.as_str())
-            } else {
-                false
-            }
-        }
-        Target::Server { source } => {
-            if matches!(message.direction, Direction::Sent) || message.is_echo {
-                reroute_private.has_server_reroute_rule_for(raw_target, server)
-            } else if let Source::User(user) = source {
-                reroute_private
-                    .has_server_reroute_rule_for(user.as_str(), server)
-            } else {
-                false
-            }
-        }
-        _ => false,
-    }
+pub fn is_rerouted_private_message(message: &Message) -> bool {
+    message.rerouted_from.is_some()
 }
 
 #[derive(Debug, Clone)]
@@ -360,6 +326,7 @@ pub struct Message {
     pub expanded: bool, // Only relevant if can_condense
     pub command: Option<command::Irc>, // Only relevant if direction == Direction::Sent
     pub reactions: Vec<Reaction>,
+    pub rerouted_from: Option<Target>,
 }
 
 impl Message {
@@ -401,6 +368,7 @@ impl Message {
         if matches!(self.direction, Direction::Sent)
             || self.is_echo
             || matches!(self.target.source(), Source::Internal(_))
+            || is_rerouted_private_message(self)
         {
             return false;
         } else if let Source::Server(Some(source)) = self.target.source()
@@ -466,7 +434,7 @@ impl Message {
             casemapping,
             prefix,
         )?;
-        let target = target(
+        let (target, rerouted_from) = target(
             encoded,
             &our_nick,
             config,
@@ -494,6 +462,7 @@ impl Message {
             expanded: false,
             command,
             reactions: vec![],
+            rerouted_from,
         })
     }
 
@@ -527,7 +496,7 @@ impl Message {
             casemapping,
             prefix,
         )?;
-        let target = target(
+        let (target, rerouted_from) = target(
             encoded,
             &our_nick,
             config,
@@ -555,6 +524,7 @@ impl Message {
             expanded: false,
             command,
             reactions: vec![],
+            rerouted_from,
         };
 
         let highlight = highlight.and_then(|kind| {
@@ -622,6 +592,7 @@ impl Message {
             expanded: false,
             command,
             reactions: vec![],
+            rerouted_from: None,
         }
     }
 
@@ -656,6 +627,7 @@ impl Message {
             expanded: false,
             command: None,
             reactions: vec![],
+            rerouted_from: None,
         }
     }
 
@@ -688,11 +660,20 @@ impl Message {
             expanded: false,
             command: None,
             reactions: vec![],
+            rerouted_from: None,
         }
     }
 
     pub fn with_target(self, target: Target) -> Self {
         Self { target, ..self }
+    }
+
+    pub fn reroute_with_target(self, target: Target) -> Self {
+        Self {
+            rerouted_from: Some(self.target),
+            target,
+            ..self
+        }
     }
 
     pub fn plain(&self) -> Option<&str> {
@@ -731,6 +712,7 @@ impl Message {
             expanded: false,
             command: None,
             reactions: vec![],
+            rerouted_from: None,
         }
     }
 
@@ -778,6 +760,7 @@ impl Serialize for Message {
             command: &'a Option<command::Irc>,
             #[serde(skip_serializing_if = "<[_]>::is_empty")]
             reactions: &'a [Reaction],
+            rerouted_from: &'a Option<Target>,
         }
 
         Data {
@@ -792,6 +775,7 @@ impl Serialize for Message {
             is_echo: &self.is_echo,
             command: &self.command,
             reactions: &self.reactions,
+            rerouted_from: &self.rerouted_from,
         }
         .serialize(serializer)
     }
@@ -823,6 +807,8 @@ impl<'de> Deserialize<'de> for Message {
             command: Option<command::Irc>,
             #[serde(default)]
             reactions: Vec<Reaction>,
+            #[serde(default, deserialize_with = "fail_as_none")]
+            rerouted_from: Option<Target>,
         }
 
         let Data {
@@ -837,6 +823,7 @@ impl<'de> Deserialize<'de> for Message {
             is_echo,
             command,
             reactions,
+            rerouted_from,
         } = Data::deserialize(deserializer)?;
 
         let content = if let Some(content) = content {
@@ -868,6 +855,7 @@ impl<'de> Deserialize<'de> for Message {
             expanded: false,
             command,
             reactions,
+            rerouted_from,
         })
     }
 }
@@ -1059,6 +1047,7 @@ pub fn condense(
             expanded: false,
             command: None,
             reactions: vec![],
+            rerouted_from: None,
         }))
     } else {
         None
@@ -2058,7 +2047,7 @@ fn target(
     chantypes: &[char],
     statusmsg: &[char],
     casemapping: isupport::CaseMap,
-) -> Option<Target> {
+) -> Option<(Target, Option<Target>)> {
     use proto::command::Numeric::*;
 
     let user = message.user(casemapping);
@@ -2072,18 +2061,24 @@ fn target(
                 statusmsg,
                 casemapping,
             ) {
-                Some(Target::Channel {
-                    channel,
-                    source: Source::Server(Some(source::Server::new(
-                        Kind::ChangeMode,
-                        Some(user?.nickname().to_owned()),
-                        None,
-                    ))),
-                })
+                Some((
+                    Target::Channel {
+                        channel,
+                        source: Source::Server(Some(source::Server::new(
+                            Kind::ChangeMode,
+                            Some(user?.nickname().to_owned()),
+                            None,
+                        ))),
+                    },
+                    None,
+                ))
             } else {
-                Some(Target::Server {
-                    source: Source::Server(None),
-                })
+                Some((
+                    Target::Server {
+                        source: Source::Server(None),
+                    },
+                    None,
+                ))
             }
         }
         Command::TOPIC(channel, _) => {
@@ -2095,14 +2090,17 @@ fn target(
             )
             .ok()?;
 
-            Some(Target::Channel {
-                channel,
-                source: Source::Server(Some(source::Server::new(
-                    Kind::ChangeTopic,
-                    Some(user?.nickname().to_owned()),
-                    None,
-                ))),
-            })
+            Some((
+                Target::Channel {
+                    channel,
+                    source: Source::Server(Some(source::Server::new(
+                        Kind::ChangeTopic,
+                        Some(user?.nickname().to_owned()),
+                        None,
+                    ))),
+                },
+                None,
+            ))
         }
         Command::KICK(channel, victim, _) => {
             let channel = target::Channel::parse(
@@ -2113,17 +2111,20 @@ fn target(
             )
             .ok()?;
 
-            Some(Target::Channel {
-                channel,
-                source: Source::Server(Some(source::Server::new(
-                    Kind::Kick,
-                    Some(user?.nickname().to_owned()),
-                    Some(Change::Nick(Nick::from_str(
-                        victim.as_str(),
-                        casemapping,
+            Some((
+                Target::Channel {
+                    channel,
+                    source: Source::Server(Some(source::Server::new(
+                        Kind::Kick,
+                        Some(user?.nickname().to_owned()),
+                        Some(Change::Nick(Nick::from_str(
+                            victim.as_str(),
+                            casemapping,
+                        ))),
                     ))),
-                ))),
-            })
+                },
+                None,
+            ))
         }
         Command::PART(channel, _) => {
             let channel = target::Channel::parse(
@@ -2134,14 +2135,17 @@ fn target(
             )
             .ok()?;
 
-            Some(Target::Channel {
-                channel,
-                source: Source::Server(Some(source::Server::new(
-                    Kind::Part,
-                    Some(user?.nickname().to_owned()),
-                    None,
-                ))),
-            })
+            Some((
+                Target::Channel {
+                    channel,
+                    source: Source::Server(Some(source::Server::new(
+                        Kind::Part,
+                        Some(user?.nickname().to_owned()),
+                        None,
+                    ))),
+                },
+                None,
+            ))
         }
         Command::JOIN(channel, _) => {
             let channel = target::Channel::parse(
@@ -2152,14 +2156,17 @@ fn target(
             )
             .ok()?;
 
-            Some(Target::Channel {
-                channel,
-                source: Source::Server(Some(source::Server::new(
-                    Kind::Join,
-                    Some(user?.nickname().to_owned()),
-                    None,
-                ))),
-            })
+            Some((
+                Target::Channel {
+                    channel,
+                    source: Source::Server(Some(source::Server::new(
+                        Kind::Join,
+                        Some(user?.nickname().to_owned()),
+                        None,
+                    ))),
+                },
+                None,
+            ))
         }
         Command::Numeric(RPL_TOPIC | RPL_TOPICWHOTIME, params) => {
             let channel = target::Channel::parse(
@@ -2169,14 +2176,17 @@ fn target(
                 casemapping,
             )
             .ok()?;
-            Some(Target::Channel {
-                channel,
-                source: Source::Server(Some(source::Server::new(
-                    Kind::ReplyTopic,
-                    None,
-                    None,
-                ))),
-            })
+            Some((
+                Target::Channel {
+                    channel,
+                    source: Source::Server(Some(source::Server::new(
+                        Kind::ReplyTopic,
+                        None,
+                        None,
+                    ))),
+                },
+                None,
+            ))
         }
         Command::Numeric(RPL_CHANNELMODEIS, params) => {
             let channel = target::Channel::parse(
@@ -2186,10 +2196,13 @@ fn target(
                 casemapping,
             )
             .ok()?;
-            Some(Target::Channel {
-                channel,
-                source: Source::Server(None),
-            })
+            Some((
+                Target::Channel {
+                    channel,
+                    source: Source::Server(None),
+                },
+                None,
+            ))
         }
         Command::Numeric(RPL_AWAY, params) => {
             let user = params.get(1)?;
@@ -2198,14 +2211,17 @@ fn target(
                 target::Query::parse(user, chantypes, statusmsg, casemapping)
                     .ok()?;
 
-            Some(Target::Query {
-                query,
-                source: Source::Server(Some(source::Server::new(
-                    Kind::Away,
-                    Some(Nick::from_string(user.clone(), casemapping)),
-                    None,
-                ))),
-            })
+            Some((
+                Target::Query {
+                    query,
+                    source: Source::Server(Some(source::Server::new(
+                        Kind::Away,
+                        Some(Nick::from_string(user.clone(), casemapping)),
+                        None,
+                    ))),
+                },
+                None,
+            ))
         }
         Command::Numeric(
             ERR_NOSUCHCHANNEL | ERR_TOOMANYCHANNELS | ERR_CHANNELISFULL
@@ -2221,14 +2237,17 @@ fn target(
             )
             .ok()?;
 
-            Some(Target::Channel {
-                channel,
-                source: Source::Server(Some(source::Server::new(
-                    Kind::StandardReply(StandardReply::Fail),
-                    None,
-                    None,
-                ))),
-            })
+            Some((
+                Target::Channel {
+                    channel,
+                    source: Source::Server(Some(source::Server::new(
+                        Kind::StandardReply(StandardReply::Fail),
+                        None,
+                        None,
+                    ))),
+                },
+                None,
+            ))
         }
         Command::PRIVMSG(target, text) | Command::NOTICE(target, text) => {
             let is_action = is_action(&text);
@@ -2243,7 +2262,7 @@ fn target(
             if target == "*" || target.starts_with('$') {
                 let source = user.map_or(Source::Server(None), source);
 
-                return Some(Target::Server { source });
+                return Some((Target::Server { source }, None));
             }
 
             // CTCP Handling.
@@ -2258,10 +2277,13 @@ fn target(
                     user
                 };
 
-                Some(Target::Query {
-                    query: target::Query::from(user),
-                    source: Source::Server(None),
-                })
+                Some((
+                    Target::Query {
+                        query: target::Query::from(user),
+                        source: Source::Server(None),
+                    },
+                    None,
+                ))
             } else {
                 match (
                     target::Target::parse(
@@ -2276,14 +2298,15 @@ fn target(
                         let source = source(
                             resolve_attributes(&user, &channel).unwrap_or(user),
                         );
-                        Some(Target::Channel { channel, source })
+                        Some((Target::Channel { channel, source }, None))
                     }
-                    (target::Target::Channel(channel), None) => {
-                        Some(Target::Channel {
+                    (target::Target::Channel(channel), None) => Some((
+                        Target::Channel {
                             channel,
                             source: Source::Server(None),
-                        })
-                    }
+                        },
+                        None,
+                    )),
                     (target::Target::Query(query), Some(user)) => {
                         let query = if user.nickname() == *our_nick {
                             if query.as_normalized_str()
@@ -2308,70 +2331,97 @@ fn target(
                             .ok()?
                         };
 
-                        Some(reroute_private_target(
-                            Target::Query {
-                                query,
-                                source: source(user),
-                            },
-                            config
-                                .servers
-                                .get(server)
-                                .as_ref()
-                                .map(|config| &config.reroute.private_messages),
-                            server,
-                            chantypes,
-                            statusmsg,
-                            casemapping,
-                        ))
+                        let target = Target::Query {
+                            query,
+                            source: source(user),
+                        };
+
+                        if let Some(rerouted_target) =
+                            reroute_private_target(
+                                &target,
+                                config.servers.get(server).as_ref().map(
+                                    |config| &config.reroute.private_messages,
+                                ),
+                                server,
+                                chantypes,
+                                statusmsg,
+                                casemapping,
+                            )
+                        {
+                            Some((rerouted_target, Some(target)))
+                        } else {
+                            Some((target, None))
+                        }
                     }
-                    (target::Target::Query(_), None) => Some(Target::Server {
-                        source: Source::Server(None),
-                    }),
+                    (target::Target::Query(_), None) => Some((
+                        Target::Server {
+                            source: Source::Server(None),
+                        },
+                        None,
+                    )),
                 }
             }
         }
-        Command::Numeric(RPL_MONONLINE, _) => Some(Target::Server {
-            source: Source::Server(Some(source::Server::new(
-                Kind::MonitoredOnline,
-                None,
-                None,
-            ))),
-        }),
-        Command::Numeric(RPL_MONOFFLINE, _) => Some(Target::Server {
-            source: Source::Server(Some(source::Server::new(
-                Kind::MonitoredOffline,
-                None,
-                None,
-            ))),
-        }),
-        Command::FAIL(_, _, _, _) => Some(Target::Server {
-            source: Source::Server(Some(source::Server::new(
-                Kind::StandardReply(StandardReply::Fail),
-                None,
-                None,
-            ))),
-        }),
-        Command::WARN(_, _, _, _) => Some(Target::Server {
-            source: Source::Server(Some(source::Server::new(
-                Kind::StandardReply(StandardReply::Warn),
-                None,
-                None,
-            ))),
-        }),
-        Command::NOTE(_, _, _, _) => Some(Target::Server {
-            source: Source::Server(Some(source::Server::new(
-                Kind::StandardReply(StandardReply::Note),
-                None,
-                None,
-            ))),
-        }),
-        Command::WALLOPS(_) => Some(Target::Server {
-            source: Source::Server(Some(source::Server::new(
-                Kind::WAllOps,
-                None,
-                None,
-            ))),
-        }),
+        Command::Numeric(RPL_MONONLINE, _) => Some((
+            Target::Server {
+                source: Source::Server(Some(source::Server::new(
+                    Kind::MonitoredOnline,
+                    None,
+                    None,
+                ))),
+            },
+            None,
+        )),
+        Command::Numeric(RPL_MONOFFLINE, _) => Some((
+            Target::Server {
+                source: Source::Server(Some(source::Server::new(
+                    Kind::MonitoredOffline,
+                    None,
+                    None,
+                ))),
+            },
+            None,
+        )),
+        Command::FAIL(_, _, _, _) => Some((
+            Target::Server {
+                source: Source::Server(Some(source::Server::new(
+                    Kind::StandardReply(StandardReply::Fail),
+                    None,
+                    None,
+                ))),
+            },
+            None,
+        )),
+        Command::WARN(_, _, _, _) => Some((
+            Target::Server {
+                source: Source::Server(Some(source::Server::new(
+                    Kind::StandardReply(StandardReply::Warn),
+                    None,
+                    None,
+                ))),
+            },
+            None,
+        )),
+        Command::NOTE(_, _, _, _) => Some((
+            Target::Server {
+                source: Source::Server(Some(source::Server::new(
+                    Kind::StandardReply(StandardReply::Note),
+                    None,
+                    None,
+                ))),
+            },
+            None,
+        )),
+        Command::WALLOPS(_) => Some((
+            Target::Server {
+                source: Source::Server(Some(source::Server::new(
+                    Kind::WAllOps,
+                    None,
+                    None,
+                ))),
+            },
+            None,
+        )),
         Command::Numeric(ERR_CANNOTSENDTOCHAN, params) => {
             match target::Target::parse(
                 params.get(1)?,
@@ -2379,14 +2429,20 @@ fn target(
                 statusmsg,
                 casemapping,
             ) {
-                target::Target::Channel(channel) => Some(Target::Channel {
-                    channel,
-                    source: Source::Server(None),
-                }),
-                target::Target::Query(query) => Some(Target::Query {
-                    query,
-                    source: Source::Server(None),
-                }),
+                target::Target::Channel(channel) => Some((
+                    Target::Channel {
+                        channel,
+                        source: Source::Server(None),
+                    },
+                    None,
+                )),
+                target::Target::Query(query) => Some((
+                    Target::Query {
+                        query,
+                        source: Source::Server(None),
+                    },
+                    None,
+                )),
             }
         }
         Command::INVITE(invitee, channel) => {
@@ -2465,9 +2521,12 @@ fn target(
         | Command::Numeric(_, _)
         | Command::Unknown(_, _)
         | Command::BOUNCER(_, _)
-        | Command::Raw(_) => Some(Target::Server {
-            source: Source::Server(None),
-        }),
+        | Command::Raw(_) => Some((
+            Target::Server {
+                source: Source::Server(None),
+            },
+            None,
+        )),
     }
 }
 

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -102,14 +102,27 @@ pub mod formatting;
 pub mod highlight;
 pub mod source;
 
-pub fn reroute_private_target(
+pub fn reroute_private_message_target(
     target: &Target,
     reroute_rules: &RerouteRules,
     server: &Server,
 ) -> Option<Target> {
     match target {
         Target::Query { query, source } => {
-            reroute_rules.target_for_query(query, server, source)
+            reroute_rules.target_for_direct_message(query, server, source)
+        }
+        _ => None,
+    }
+}
+
+pub fn reroute_private_notice_target(
+    target: &Target,
+    reroute_rules: &RerouteRules,
+    server: &Server,
+) -> Option<Target> {
+    match target {
+        Target::Query { query, source } => {
+            reroute_rules.target_for_direct_notice(query, server, source)
         }
         _ => None,
     }
@@ -2234,6 +2247,10 @@ fn target(
         }
         Command::PRIVMSG(ref target, ref text)
         | Command::NOTICE(ref target, ref text) => {
+            let is_notice = matches!(message.0.command, Command::NOTICE(_, _));
+            let is_privmsg =
+                matches!(message.0.command, Command::PRIVMSG(_, _));
+
             let is_action = is_action(text);
 
             let source = |user| {
@@ -2244,10 +2261,30 @@ fn target(
                 }
             };
 
-            if target == "*" || target.starts_with('$') {
+            if target == "*" {
                 let source = user.map_or(Source::Server(None), source);
 
                 return Some((Target::Server { source }, None));
+            }
+
+            // Mass message
+            if target.starts_with('$') {
+                if let Some(user) = user {
+                    return Some((
+                        Target::Query {
+                            query: target::Query::from(user.clone()),
+                            source: source(user),
+                        },
+                        None,
+                    ));
+                } else {
+                    return Some((
+                        Target::Server {
+                            source: Source::Server(None),
+                        },
+                        None,
+                    ));
+                }
             }
 
             // CTCP Handling.
@@ -2295,29 +2332,11 @@ fn target(
                     ),
                     (target::Target::Query(query), Some(user)) => {
                         let query = if user.nickname() == *our_nick {
-                            if query.as_normalized_str()
-                                == our_nick.as_normalized_str()
-                            {
-                                // Mass-message echo
-                                return Some((
-                                    Target::Server {
-                                        source: source(user),
-                                    },
-                                    None,
-                                ));
-                            }
-
                             // Message from ourself, from another client.
                             query
                         } else {
                             // Message from conversation partner.
-                            target::Query::parse(
-                                user.as_str(),
-                                chantypes,
-                                statusmsg,
-                                casemapping,
-                            )
-                            .ok()?
+                            target::Query::from(user.clone())
                         };
 
                         let target = Target::Query {
@@ -2325,11 +2344,23 @@ fn target(
                             source: source(user),
                         };
 
-                        if let Some(rerouted_target) = reroute_private_target(
-                            &target,
-                            reroute_rules,
-                            server,
-                        ) {
+                        if is_privmsg
+                            && let Some(rerouted_target) =
+                                reroute_private_message_target(
+                                    &target,
+                                    reroute_rules,
+                                    server,
+                                )
+                        {
+                            (rerouted_target, Some(target))
+                        } else if is_notice
+                            && let Some(rerouted_target) =
+                                reroute_private_notice_target(
+                                    &target,
+                                    reroute_rules,
+                                    server,
+                                )
+                        {
                             (rerouted_target, Some(target))
                         } else {
                             (target, None)

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -21,6 +21,7 @@ pub use self::source::Source;
 pub use self::source::server::{Change, Kind, StandardReply};
 use crate::config::buffer::{CondensationFormat, UsernameFormat};
 use crate::config::{self, Highlights};
+use crate::history::reroute::RerouteRules;
 use crate::log::Level;
 use crate::reaction::Reaction;
 use crate::serde::fail_as_none;
@@ -103,51 +104,12 @@ pub mod source;
 
 pub fn reroute_private_target(
     target: &Target,
-    reroute_private: Option<&config::server::reroute::PrivateMessages>,
+    reroute_rules: &RerouteRules,
     server: &Server,
-    chantypes: &[char],
-    statusmsg: &[char],
-    casemapping: isupport::CaseMap,
 ) -> Option<Target> {
     match target {
         Target::Query { query, source } => {
-            if let Some(target) = reroute_private?.target_for_query(
-                query,
-                server,
-                chantypes,
-                statusmsg,
-                casemapping,
-            ) {
-                match target {
-                    config::server::reroute::RerouteTarget::Channel {
-                        channel,
-                    } => {
-                        if let Ok(channel) = target::Channel::parse(
-                            channel,
-                            chantypes,
-                            statusmsg,
-                            casemapping,
-                        ) {
-                            Some(Target::Channel {
-                                channel,
-                                source: source.clone(),
-                            })
-                        } else {
-                            Some(Target::Query {
-                                query: query.clone(),
-                                source: source.clone(),
-                            })
-                        }
-                    }
-                    config::server::reroute::RerouteTarget::Server {
-                        ..
-                    } => Some(Target::Server {
-                        source: source.clone(),
-                    }),
-                }
-            } else {
-                None
-            }
+            reroute_rules.target_for_query(query, server, source)
         }
         _ => None,
     }
@@ -408,6 +370,7 @@ impl Message {
         encoded: Encoded,
         our_nick: Nick,
         config: &'a Config,
+        reroute_rules: &RerouteRules,
         resolve_attributes: impl Fn(&User, &target::Channel) -> Option<User>,
         channel_users: impl Fn(&target::Channel) -> Option<&'a ChannelUsers>,
         server: &Server,
@@ -437,7 +400,7 @@ impl Message {
         let (target, rerouted_from) = target(
             encoded,
             &our_nick,
-            config,
+            reroute_rules,
             &resolve_attributes,
             server,
             chantypes,
@@ -470,6 +433,7 @@ impl Message {
         encoded: Encoded,
         our_nick: Nick,
         config: &'a Config,
+        reroute_rules: &RerouteRules,
         resolve_attributes: impl Fn(&User, &target::Channel) -> Option<User>,
         channel_users: impl Fn(&target::Channel) -> Option<&'a ChannelUsers>,
         server: &Server,
@@ -499,7 +463,7 @@ impl Message {
         let (target, rerouted_from) = target(
             encoded,
             &our_nick,
-            config,
+            reroute_rules,
             &resolve_attributes,
             server,
             chantypes,
@@ -2041,7 +2005,7 @@ impl From<formatting::Fragment> for Fragment {
 fn target(
     message: Encoded,
     our_nick: &Nick,
-    config: &Config,
+    reroute_rules: &RerouteRules,
     resolve_attributes: &dyn Fn(&User, &target::Channel) -> Option<User>,
     server: &Server,
     chantypes: &[char],
@@ -2336,18 +2300,11 @@ fn target(
                             source: source(user),
                         };
 
-                        if let Some(rerouted_target) =
-                            reroute_private_target(
-                                &target,
-                                config.servers.get(server).as_ref().map(
-                                    |config| &config.reroute.private_messages,
-                                ),
-                                server,
-                                chantypes,
-                                statusmsg,
-                                casemapping,
-                            )
-                        {
+                        if let Some(rerouted_target) = reroute_private_target(
+                            &target,
+                            reroute_rules,
+                            server,
+                        ) {
                             Some((rerouted_target, Some(target)))
                         } else {
                             Some((target, None))
@@ -3970,6 +3927,7 @@ pub mod tests {
         use irc::proto;
 
         use crate::config::Config;
+        use crate::history::reroute::RerouteRules;
         use crate::message::Encoded;
 
         let isupport = HashMap::<isupport::Kind, isupport::Parameter>::new();
@@ -3999,6 +3957,7 @@ pub mod tests {
             Encoded::from(encoded.clone()),
             our_nick.clone(),
             &Config::default(),
+            &RerouteRules::default(),
             |user: &User, _channel: &target::Channel| {
                 channel_users
                     .iter()

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -151,6 +151,26 @@ impl Encoded {
     pub fn server_time_or_now(&self) -> DateTime<Utc> {
         self.server_time().unwrap_or_else(Utc::now)
     }
+
+    pub fn channel_context(
+        &self,
+        chantypes: &[char],
+        statusmsg: &[char],
+        casemapping: isupport::CaseMap,
+    ) -> Option<target::Channel> {
+        self.tags
+            .get("channel-context")
+            .or(self.tags.get("draft/channel-context"))
+            .and_then(|channel| {
+                target::Channel::parse(
+                    channel,
+                    chantypes,
+                    statusmsg,
+                    casemapping,
+                )
+                .ok()
+            })
+    }
 }
 
 fn received_command(encoded: &Encoded) -> Option<command::Irc> {
@@ -2212,8 +2232,10 @@ fn target(
                 None,
             ))
         }
-        Command::PRIVMSG(target, text) | Command::NOTICE(target, text) => {
-            let is_action = is_action(&text);
+        Command::PRIVMSG(ref target, ref text)
+        | Command::NOTICE(ref target, ref text) => {
+            let is_action = is_action(text);
+
             let source = |user| {
                 if is_action {
                     Source::Action(Some(user))
@@ -2229,9 +2251,10 @@ fn target(
             }
 
             // CTCP Handling.
-            if ctcp::is_query(&text) && !is_action {
+            let (target, rerouted_from) = if ctcp::is_query(text) && !is_action
+            {
                 let user = user?;
-                let target = User::from(Nick::from_string(target, casemapping));
+                let target = User::from(Nick::from_str(target, casemapping));
 
                 // We want to show both requests, and responses in query with the client.
                 let user = if user.nickname() == *our_nick {
@@ -2240,17 +2263,17 @@ fn target(
                     user
                 };
 
-                Some((
+                (
                     Target::Query {
                         query: target::Query::from(user),
                         source: Source::Server(None),
                     },
                     None,
-                ))
+                )
             } else {
                 match (
                     target::Target::parse(
-                        &target,
+                        target,
                         chantypes,
                         statusmsg,
                         casemapping,
@@ -2261,15 +2284,15 @@ fn target(
                         let source = source(
                             resolve_attributes(&user, &channel).unwrap_or(user),
                         );
-                        Some((Target::Channel { channel, source }, None))
+                        (Target::Channel { channel, source }, None)
                     }
-                    (target::Target::Channel(channel), None) => Some((
+                    (target::Target::Channel(channel), None) => (
                         Target::Channel {
                             channel,
                             source: Source::Server(None),
                         },
                         None,
-                    )),
+                    ),
                     (target::Target::Query(query), Some(user)) => {
                         let query = if user.nickname() == *our_nick {
                             if query.as_normalized_str()
@@ -2307,19 +2330,37 @@ fn target(
                             reroute_rules,
                             server,
                         ) {
-                            Some((rerouted_target, Some(target)))
+                            (rerouted_target, Some(target))
                         } else {
-                            Some((target, None))
+                            (target, None)
                         }
                     }
-                    (target::Target::Query(_), None) => Some((
+                    (target::Target::Query(_), None) => (
                         Target::Server {
                             source: Source::Server(None),
                         },
                         None,
-                    )),
+                    ),
                 }
-            }
+            };
+
+            let channel_context =
+                message.channel_context(chantypes, statusmsg, casemapping);
+
+            Some(if let Some(channel_context) = channel_context {
+                let channel_context = Target::Channel {
+                    channel: channel_context,
+                    source: target.source().clone(),
+                };
+
+                if rerouted_from.is_some() {
+                    (channel_context, rerouted_from)
+                } else {
+                    (channel_context, Some(target))
+                }
+            } else {
+                (target, rerouted_from)
+            })
         }
         Command::Numeric(RPL_MONONLINE, _) => Some((
             Target::Server {

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -101,6 +101,96 @@ pub mod formatting;
 pub mod highlight;
 pub mod source;
 
+pub fn reroute_private_target(
+    target: Target,
+    reroute_private: Option<&config::server::reroute::PrivateMessages>,
+    server: &Server,
+    chantypes: &[char],
+    statusmsg: &[char],
+    casemapping: isupport::CaseMap,
+) -> Target {
+    let Some(reroute_private) = reroute_private else {
+        return target;
+    };
+
+    match target {
+        Target::Query { query, source } => {
+            if let Some(target) = reroute_private.target_for_query(
+                &query,
+                server,
+                chantypes,
+                statusmsg,
+                casemapping,
+            ) {
+                match target {
+                    config::server::reroute::RerouteTarget::Channel {
+                        channel,
+                    } => {
+                        if let Ok(channel) = target::Channel::parse(
+                            channel,
+                            chantypes,
+                            statusmsg,
+                            casemapping,
+                        ) {
+                            Target::Channel { channel, source }
+                        } else {
+                            Target::Query { query, source }
+                        }
+                    }
+                    config::server::reroute::RerouteTarget::Server {
+                        ..
+                    } => Target::Server { source },
+                }
+            } else {
+                Target::Query { query, source }
+            }
+        }
+        target => target,
+    }
+}
+
+pub fn is_rerouted_private_message(
+    message: &Message,
+    reroute_private: Option<&config::server::reroute::PrivateMessages>,
+    server: &Server,
+) -> bool {
+    let Some(reroute_private) = reroute_private else {
+        return false;
+    };
+
+    let Some(
+        command::Irc::Msg(raw_target, _) | command::Irc::Notice(raw_target, _),
+    ) = &message.command
+    else {
+        return false;
+    };
+
+    match &message.target {
+        Target::Channel { channel, source } => {
+            if matches!(message.direction, Direction::Sent) || message.is_echo {
+                reroute_private
+                    .has_reroute_rule_for(raw_target, channel.as_str())
+            } else if let Source::User(user) = source {
+                reroute_private
+                    .has_reroute_rule_for(user.as_str(), channel.as_str())
+            } else {
+                false
+            }
+        }
+        Target::Server { source } => {
+            if matches!(message.direction, Direction::Sent) || message.is_echo {
+                reroute_private.has_server_reroute_rule_for(raw_target, server)
+            } else if let Source::User(user) = source {
+                reroute_private
+                    .has_server_reroute_rule_for(user.as_str(), server)
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Encoded(pub(crate) proto::Message);
 
@@ -136,6 +226,18 @@ impl Encoded {
 
     pub fn server_time_or_now(&self) -> DateTime<Utc> {
         self.server_time().unwrap_or_else(Utc::now)
+    }
+}
+
+fn received_command(encoded: &Encoded) -> Option<command::Irc> {
+    match &encoded.command {
+        Command::PRIVMSG(target, text) => {
+            Some(command::Irc::Msg(target.clone(), text.clone()))
+        }
+        Command::NOTICE(target, text) => {
+            Some(command::Irc::Notice(target.clone(), text.clone()))
+        }
+        _ => None,
     }
 }
 
@@ -222,6 +324,16 @@ impl Target {
             Target::Query { source, .. } => source,
             Target::Logs { source } => source,
             Target::Highlights { source, .. } => source,
+        }
+    }
+
+    pub fn raw(&self) -> Option<&str> {
+        match self {
+            Target::Channel { channel, .. } => Some(channel.as_str()),
+            Target::Query { query, .. } => Some(query.as_str()),
+            Target::Server { .. }
+            | Target::Logs { .. }
+            | Target::Highlights { .. } => None,
         }
     }
 }
@@ -338,6 +450,7 @@ impl Message {
     ) -> Option<Message> {
         let server_time = encoded.server_time_or_now();
         let id = encoded.message_id();
+        let command = received_command(&encoded);
         let is_echo = encoded
             .user(casemapping)
             .is_some_and(|user| user.nickname() == our_nick);
@@ -356,7 +469,9 @@ impl Message {
         let target = target(
             encoded,
             &our_nick,
+            config,
             &resolve_attributes,
+            server,
             chantypes,
             statusmsg,
             casemapping,
@@ -377,7 +492,7 @@ impl Message {
             blocked: false,
             condensed: None,
             expanded: false,
-            command: None,
+            command,
             reactions: vec![],
         })
     }
@@ -396,6 +511,7 @@ impl Message {
     ) -> Option<(Message, Option<Highlight>)> {
         let server_time = encoded.server_time_or_now();
         let id = encoded.message_id();
+        let command = received_command(&encoded);
         let is_echo = encoded
             .user(casemapping)
             .is_some_and(|user| user.nickname() == our_nick);
@@ -414,7 +530,9 @@ impl Message {
         let target = target(
             encoded,
             &our_nick,
+            config,
             &resolve_attributes,
+            server,
             chantypes,
             statusmsg,
             casemapping,
@@ -435,7 +553,7 @@ impl Message {
             blocked: false,
             condensed: None,
             expanded: false,
-            command: None,
+            command,
             reactions: vec![],
         };
 
@@ -1934,7 +2052,9 @@ impl From<formatting::Fragment> for Fragment {
 fn target(
     message: Encoded,
     our_nick: &Nick,
+    config: &Config,
     resolve_attributes: &dyn Fn(&User, &target::Channel) -> Option<User>,
+    server: &Server,
     chantypes: &[char],
     statusmsg: &[char],
     casemapping: isupport::CaseMap,
@@ -2188,10 +2308,21 @@ fn target(
                             .ok()?
                         };
 
-                        Some(Target::Query {
-                            query,
-                            source: source(user),
-                        })
+                        Some(reroute_private_target(
+                            Target::Query {
+                                query,
+                                source: source(user),
+                            },
+                            config
+                                .servers
+                                .get(server)
+                                .as_ref()
+                                .map(|config| &config.reroute.private_messages),
+                            server,
+                            chantypes,
+                            statusmsg,
+                            casemapping,
+                        ))
                     }
                     (target::Target::Query(_), None) => Some(Target::Server {
                         source: Source::Server(None),
@@ -3322,11 +3453,11 @@ pub mod tests {
     #[allow(unused_imports)]
     use crate::bouncer::BouncerNetwork;
     #[allow(unused_imports)]
-    use crate::config::Highlights;
-    #[allow(unused_imports)]
     use crate::config::highlights::Nickname;
     #[allow(unused_imports)]
     use crate::config::inclusivities::Inclusivities;
+    #[allow(unused_imports)]
+    use crate::config::{Config, Highlights};
     #[allow(unused_imports)]
     use crate::message::formatting::Color;
     #[allow(unused_imports)]
@@ -3335,7 +3466,7 @@ pub mod tests {
         Source, Target, broadcast,
     };
     #[allow(unused_imports)]
-    use crate::server::Server;
+    use crate::server::{Server, ServerName};
     #[allow(unused_imports)]
     use crate::user::{ChannelUsers, Nick, User};
     #[allow(unused_imports)]
@@ -3346,6 +3477,10 @@ pub mod tests {
         use std::collections::HashMap;
 
         use irc::proto;
+
+        let config = Config::default();
+
+        let server = Server::from(ServerName::from("test-server"));
 
         let isupport = HashMap::<isupport::Kind, isupport::Parameter>::new();
 
@@ -3374,7 +3509,9 @@ pub mod tests {
             let actual = message::target(
                 message::Encoded(encoded),
                 &our_nick,
+                &config,
                 &|_: &User, _: &target::Channel| None,
+                &server,
                 chantypes,
                 statusmsg,
                 casemapping,

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -2277,9 +2277,12 @@ fn target(
                                 == our_nick.as_normalized_str()
                             {
                                 // Mass-message echo
-                                return Some(Target::Server {
-                                    source: source(user),
-                                });
+                                return Some((
+                                    Target::Server {
+                                        source: source(user),
+                                    },
+                                    None,
+                                ));
                             }
 
                             // Message from ourself, from another client.
@@ -2407,14 +2410,20 @@ fn target(
 
             if invitee.nickname() == *our_nick {
                 if let Some(user) = user {
-                    return Some(Target::Query {
-                        query: target::Query::from(user),
-                        source: Source::Server(None),
-                    });
+                    return Some((
+                        Target::Query {
+                            query: target::Query::from(user),
+                            source: Source::Server(None),
+                        },
+                        None,
+                    ));
                 } else {
-                    return Some(Target::Server {
-                        source: Source::Server(None),
-                    });
+                    return Some((
+                        Target::Server {
+                            source: Source::Server(None),
+                        },
+                        None,
+                    ));
                 }
             }
 
@@ -2426,10 +2435,13 @@ fn target(
             )
             .ok()?;
 
-            Some(Target::Channel {
-                channel,
-                source: Source::Server(None),
-            })
+            Some((
+                Target::Channel {
+                    channel,
+                    source: Source::Server(None),
+                },
+                None,
+            ))
         }
         // Server
         Command::PASS(_)
@@ -3469,11 +3481,13 @@ pub mod tests {
     #[allow(unused_imports)]
     use crate::bouncer::BouncerNetwork;
     #[allow(unused_imports)]
+    use crate::config::Highlights;
+    #[allow(unused_imports)]
     use crate::config::highlights::Nickname;
     #[allow(unused_imports)]
     use crate::config::inclusivities::Inclusivities;
     #[allow(unused_imports)]
-    use crate::config::{Config, Highlights};
+    use crate::history::reroute::RerouteRules;
     #[allow(unused_imports)]
     use crate::message::formatting::Color;
     #[allow(unused_imports)]
@@ -3494,7 +3508,7 @@ pub mod tests {
 
         use irc::proto;
 
-        let config = Config::default();
+        let reroute_rules = RerouteRules::default();
 
         let server = Server::from(ServerName::from("test-server"));
 
@@ -3511,12 +3525,15 @@ pub mod tests {
 
         let tests = [(
             ":dan!d@localhost PRIVMSG $$* :Mass message! \r\n",
-            Some(Target::Server {
-                source: Source::User(User::from(Nick::from_str(
-                    "dan",
-                    casemapping,
-                ))),
-            }),
+            Some((
+                Target::Server {
+                    source: Source::User(User::from(Nick::from_str(
+                        "dan",
+                        casemapping,
+                    ))),
+                },
+                None,
+            )),
         )];
 
         for (irc_message, expected) in tests {
@@ -3525,7 +3542,7 @@ pub mod tests {
             let actual = message::target(
                 message::Encoded(encoded),
                 &our_nick,
-                &config,
+                &reroute_rules,
                 &|_: &User, _: &target::Channel| None,
                 &server,
                 chantypes,

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -3589,23 +3589,37 @@ pub mod tests {
         let statusmsg = isupport::get_statusmsg_or_default(&isupport);
         let casemapping = isupport::get_casemapping_or_default(&isupport);
 
-        let our_nick = Nick::from_str(
-            "our_nick",
-            isupport::get_casemapping_or_default(&isupport),
-        );
+        let our_nick = Nick::from_str("dan", casemapping);
 
-        let tests = [(
-            ":dan!d@localhost PRIVMSG $$* :Mass message! \r\n",
-            Some((
-                Target::Server {
-                    source: Source::User(User::from(Nick::from_str(
-                        "dan",
-                        casemapping,
-                    ))),
-                },
-                None,
-            )),
-        )];
+        let our_user = User::from(our_nick.clone());
+
+        let tests = [
+            (
+                ":dan!d@localhost NOTICE * :Server notice! \r\n",
+                Some((
+                    Target::Server {
+                        source: Source::User(User::from(Nick::from_str(
+                            "dan",
+                            casemapping,
+                        ))),
+                    },
+                    None,
+                )),
+            ),
+            (
+                ":dan!d@localhost PRIVMSG $$* :Mass message! \r\n",
+                Some((
+                    Target::Query {
+                        query: target::Query::from(our_user),
+                        source: Source::User(User::from(Nick::from_str(
+                            "dan",
+                            casemapping,
+                        ))),
+                    },
+                    None,
+                )),
+            ),
+        ];
 
         for (irc_message, expected) in tests {
             let encoded = proto::parse::message(irc_message).unwrap();

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -43,6 +43,7 @@ fn expand(
             expanded: false,
             command: None,
             reactions: vec![],
+            rerouted_from: None,
         }
     };
 

--- a/docs/configuration/reroute.md
+++ b/docs/configuration/reroute.md
@@ -20,7 +20,7 @@ private and are not visible to other users in the channel.
 [servers.<name>.reroute]
 private_messages = [
   { user = "Q", target = { channel = "#foo" } },
-  { user = "ChanServ", target = { server = "libera" } },
+  { user = "ChanServ", target = "server" },
 ]
 ```
 
@@ -31,4 +31,4 @@ Each entry supports:
 - `user` - the private-message sender/target to match
 - `target` - destination buffer for matching private messages:
   - `{ channel = "#name" }` routes to a channel buffer
-  - `{ server = "name" }` routes to the server buffer for the named server
+  - `"server"` routes to the server buffer

--- a/docs/configuration/reroute.md
+++ b/docs/configuration/reroute.md
@@ -1,0 +1,34 @@
+# Reroute
+
+Configure message rerouting for a specific server.
+
+- [Reroute](#reroute)
+  - [private_messages](#private_messages)
+
+## private_messages
+
+Reroute private `PRIVMSG` / `NOTICE` traffic from specific users into another
+buffer instead of a query buffer.
+
+This only changes where Halloy displays the messages. The messages are still
+private and are not visible to other users in the channel.
+
+```toml
+# Type: array
+# Default: []
+
+[servers.<name>.reroute]
+private_messages = [
+  { user = "Q", target = { channel = "#foo" } },
+  { user = "ChanServ", target = { server = "libera" } },
+]
+```
+
+Reroutes are scoped to the server section they are configured in.
+
+Each entry supports:
+
+- `user` - the private-message sender/target to match
+- `target` - destination buffer for matching private messages:
+  - `{ channel = "#name" }` routes to a channel buffer
+  - `{ server = "name" }` routes to the server buffer for the named server

--- a/docs/configuration/reroute.md
+++ b/docs/configuration/reroute.md
@@ -4,10 +4,22 @@ Configure message rerouting for a specific server.
 
 - [Reroute](#reroute)
   - [private_messages](#private_messages)
+  - [private_notices](#private_notices)
+
+
+Reroutes private `PRIVMSG` / `NOTICE` traffic from users into another
+buffer instead of a query buffer.
+
+Each entry supports:
+
+- `user` - the private-message sender/target to match, "\*" will specify all users
+- `target` - destination buffer for matching private messages:
+  - `{ channel = "#name" }` routes to a channel buffer
+  - `"server"` routes to the server buffer
 
 ## private_messages
 
-Reroute private `PRIVMSG` / `NOTICE` traffic from specific users into another
+Reroute private `PRIVMSG` traffic from specific users into another
 buffer instead of a query buffer.
 
 This only changes where Halloy displays the messages. The messages are still
@@ -24,11 +36,21 @@ private_messages = [
 ]
 ```
 
-Reroutes are scoped to the server section they are configured in.
+## private_notices
 
-Each entry supports:
+Reroute private `NOTICE` traffic from specific users into another
+buffer instead of a query buffer.
 
-- `user` - the private-message sender/target to match
-- `target` - destination buffer for matching private messages:
-  - `{ channel = "#name" }` routes to a channel buffer
-  - `"server"` routes to the server buffer
+This only changes where Halloy displays the notices. The notices are still
+private and are not visible to other users in the channel.
+
+```toml
+# Type: array
+# Default: [{ user = "*", target = "server" }]
+
+[servers.<name>.reroute]
+private_notices = [
+  { user = "MyBot", target = { channel = "#my-channel" } },
+  { user = "*", target = "server" },
+]
+```

--- a/docs/configuration/reroute.md
+++ b/docs/configuration/reroute.md
@@ -3,8 +3,8 @@
 Configure message rerouting for a specific server.
 
 - [Reroute](#reroute)
-  - [private_messages](#private_messages)
-  - [private_notices](#private_notices)
+  - [query](#query)
+  - [notice](#notice)
 
 
 Reroutes private `PRIVMSG` / `NOTICE` traffic from users into another
@@ -17,7 +17,7 @@ Each entry supports:
   - `{ channel = "#name" }` routes to a channel buffer
   - `"server"` routes to the server buffer
 
-## private_messages
+## query
 
 Reroute private `PRIVMSG` traffic from specific users into another
 buffer instead of a query buffer.
@@ -30,13 +30,13 @@ private and are not visible to other users in the channel.
 # Default: []
 
 [servers.<name>.reroute]
-private_messages = [
+query = [
   { user = "Q", target = { channel = "#foo" } },
   { user = "ChanServ", target = "server" },
 ]
 ```
 
-## private_notices
+## notice
 
 Reroute private `NOTICE` traffic from specific users into another
 buffer instead of a query buffer.
@@ -49,7 +49,7 @@ private and are not visible to other users in the channel.
 # Default: [{ user = "*", target = "server" }]
 
 [servers.<name>.reroute]
-private_notices = [
+notice = [
   { user = "MyBot", target = { channel = "#my-channel" } },
   { user = "*", target = "server" },
 ]

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -564,6 +564,10 @@ regex = [
 ]
 ```
 
+## `reroute`
+
+Reroute selected message types within this server. See [Reroute](reroute.md) for details.
+
 ## `sasl.external`
 
 External SASL auth uses a PEM encoded X509 certificate. [Reference](https://libera.chat/guides/certfp).

--- a/src/buffer/context_menu.rs
+++ b/src/buffer/context_menu.rs
@@ -642,6 +642,55 @@ pub fn user<'a>(
         config.file_transfer.enabled,
     );
 
+    user_with_entries(
+        content,
+        server,
+        prefix,
+        channel,
+        user,
+        current_user,
+        config,
+        theme,
+        click,
+        entries,
+    )
+}
+
+pub fn rerouted_private_user<'a>(
+    content: impl Into<Element<'a, Message>>,
+    server: &'a Server,
+    prefix: &'a [isupport::PrefixMap],
+    user: &'a User,
+    config: &'a Config,
+    theme: &'a Theme,
+    click: &'a config::buffer::NicknameClickAction,
+) -> Element<'a, Message> {
+    user_with_entries(
+        content,
+        server,
+        prefix,
+        None,
+        user,
+        None,
+        config,
+        theme,
+        click,
+        vec![Entry::Whois],
+    )
+}
+
+fn user_with_entries<'a>(
+    content: impl Into<Element<'a, Message>>,
+    server: &'a Server,
+    prefix: &'a [isupport::PrefixMap],
+    channel: Option<&'a target::Channel>,
+    user: &'a User,
+    current_user: Option<&'a User>,
+    config: &'a Config,
+    theme: &'a Theme,
+    click: &'a config::buffer::NicknameClickAction,
+    entries: Vec<Entry>,
+) -> Element<'a, Message> {
     let message = match click {
         data::config::buffer::NicknameClickAction::OpenQuery => Message::Query(
             server.clone(),

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -8,7 +8,6 @@ use data::capabilities::{MultilineBatchKind, multiline_concat_lines};
 use data::config::buffer::text_input::{AutoFormat, Autocomplete, KeyBindings};
 use data::dashboard::BufferAction;
 use data::history::filter::FilterChain;
-use data::history::reroute::RerouteRules;
 use data::history::{self, ReadMarker};
 use data::input::{self, CodeFence, RawInput};
 use data::rate_limit::TokenPriority;
@@ -703,22 +702,6 @@ fn notice_view<'a, 'b, Message: 'a>(
     .padding(8)
     .style(theme::container::tooltip)
     .into()
-}
-
-fn reroute_input_message(
-    message: data::Message,
-    reroute_rules: &RerouteRules,
-    server: &Server,
-) -> data::Message {
-    if let Some(rerouted_target) = data::message::reroute_private_target(
-        &message.target,
-        reroute_rules,
-        server,
-    ) {
-        message.reroute_with_target(rerouted_target)
-    } else {
-        message
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -1800,27 +1783,16 @@ impl State {
             let messages = inputs
                 .into_iter()
                 .filter_map(|input| {
-                    input
-                        .messages(
-                            user.clone(),
-                            channel_users,
-                            chantypes,
-                            statusmsg,
-                            casemapping,
-                            supports_echoes,
-                        )
-                        .map(|messages| {
-                            messages
-                                .into_iter()
-                                .map(|message| {
-                                    reroute_input_message(
-                                        message,
-                                        history.get_reroute_rules(),
-                                        buffer.server(),
-                                    )
-                                })
-                                .collect::<Vec<_>>()
-                        })
+                    input.messages(
+                        user.clone(),
+                        channel_users,
+                        buffer.server(),
+                        chantypes,
+                        statusmsg,
+                        casemapping,
+                        supports_echoes,
+                        history.get_reroute_rules(),
+                    )
                 })
                 .flatten()
                 .collect::<Vec<_>>();
@@ -2239,18 +2211,14 @@ impl State {
             if let Some(messages) = input.messages(
                 user,
                 channel_users,
+                buffer.server(),
                 chantypes,
                 statusmsg,
                 casemapping,
                 supports_echoes,
+                history.get_reroute_rules(),
             ) {
                 for message in messages {
-                    let message = reroute_input_message(
-                        message,
-                        history.get_reroute_rules(),
-                        buffer.server(),
-                    );
-
                     history_tasks.extend(
                         history
                             .record_input_message(

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -704,6 +704,56 @@ fn notice_view<'a, 'b, Message: 'a>(
     .into()
 }
 
+fn reroute_input_message(
+    message: data::Message,
+    input: &input::Input,
+    private_messages: Option<&data::config::server::reroute::PrivateMessages>,
+    server: &Server,
+    chantypes: &[char],
+    statusmsg: &[char],
+    casemapping: data::isupport::CaseMap,
+) -> data::Message {
+    let original_target = message.target.clone();
+    let rerouted_target = data::message::reroute_private_target(
+        original_target.clone(),
+        private_messages,
+        server,
+        chantypes,
+        statusmsg,
+        casemapping,
+    );
+    let rerouted = rerouted_target != original_target;
+
+    let mut message = message.with_target(rerouted_target);
+
+    if rerouted
+        && message.command.is_none()
+        && let Some(original_target_raw) = original_target.raw()
+        && let Some(command) = input.command()
+    {
+        message.command = rerouted_command(command, original_target_raw);
+    }
+
+    message
+}
+
+fn rerouted_command(
+    command: &command::Irc,
+    original_target_raw: &str,
+) -> Option<command::Irc> {
+    match command {
+        command::Irc::Msg(_, text) => Some(command::Irc::Msg(
+            original_target_raw.to_string(),
+            text.clone(),
+        )),
+        command::Irc::Notice(_, text) => Some(command::Irc::Notice(
+            original_target_raw.to_string(),
+            text.clone(),
+        )),
+        _ => None,
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct State {
     input_id: widget::Id,
@@ -1779,21 +1829,44 @@ impl State {
             }
 
             let mut history_tasks = vec![];
+            let server_config = config.servers.get(buffer.server());
 
-            if let Some(message) = inputs
+            let messages = inputs
                 .into_iter()
                 .filter_map(|input| {
-                    input.messages(
-                        user.clone(),
-                        channel_users,
-                        chantypes,
-                        statusmsg,
-                        casemapping,
-                        supports_echoes,
-                    )
+                    input
+                        .messages(
+                            user.clone(),
+                            channel_users,
+                            chantypes,
+                            statusmsg,
+                            casemapping,
+                            supports_echoes,
+                        )
+                        .map(|messages| {
+                            messages
+                                .into_iter()
+                                .map(|message| {
+                                    reroute_input_message(
+                                        message,
+                                        &input,
+                                        server_config.as_ref().map(|config| {
+                                            &config.reroute.private_messages
+                                        }),
+                                        buffer.server(),
+                                        chantypes,
+                                        statusmsg,
+                                        casemapping,
+                                    )
+                                })
+                                .collect::<Vec<_>>()
+                        })
                 })
                 .flatten()
-                .reduce(|mut batch_message, message| {
+                .collect::<Vec<_>>();
+
+            if let Some(message) =
+                messages.into_iter().reduce(|mut batch_message, message| {
                     match (&mut batch_message.content, message.content) {
                         (
                             message::Content::Plain(batch_text),
@@ -2202,6 +2275,7 @@ impl State {
             }
 
             let mut history_tasks = vec![];
+            let server_config = config.servers.get(buffer.server());
 
             if let Some(messages) = input.messages(
                 user,
@@ -2212,6 +2286,18 @@ impl State {
                 supports_echoes,
             ) {
                 for message in messages {
+                    let message = reroute_input_message(
+                        message,
+                        &input,
+                        server_config
+                            .as_ref()
+                            .map(|config| &config.reroute.private_messages),
+                        buffer.server(),
+                        chantypes,
+                        statusmsg,
+                        casemapping,
+                    );
+
                     history_tasks.extend(
                         history
                             .record_input_message(

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -8,6 +8,7 @@ use data::capabilities::{MultilineBatchKind, multiline_concat_lines};
 use data::config::buffer::text_input::{AutoFormat, Autocomplete, KeyBindings};
 use data::dashboard::BufferAction;
 use data::history::filter::FilterChain;
+use data::history::reroute::RerouteRules;
 use data::history::{self, ReadMarker};
 use data::input::{self, CodeFence, RawInput};
 use data::rate_limit::TokenPriority;
@@ -706,19 +707,13 @@ fn notice_view<'a, 'b, Message: 'a>(
 
 fn reroute_input_message(
     message: data::Message,
-    private_messages: Option<&data::config::server::reroute::PrivateMessages>,
+    reroute_rules: &RerouteRules,
     server: &Server,
-    chantypes: &[char],
-    statusmsg: &[char],
-    casemapping: data::isupport::CaseMap,
 ) -> data::Message {
     if let Some(rerouted_target) = data::message::reroute_private_target(
         &message.target,
-        private_messages,
+        reroute_rules,
         server,
-        chantypes,
-        statusmsg,
-        casemapping,
     ) {
         message.reroute_with_target(rerouted_target)
     } else {
@@ -1801,7 +1796,6 @@ impl State {
             }
 
             let mut history_tasks = vec![];
-            let server_config = config.servers.get(buffer.server());
 
             let messages = inputs
                 .into_iter()
@@ -1821,13 +1815,8 @@ impl State {
                                 .map(|message| {
                                     reroute_input_message(
                                         message,
-                                        server_config.as_ref().map(|config| {
-                                            &config.reroute.private_messages
-                                        }),
+                                        history.get_reroute_rules(),
                                         buffer.server(),
-                                        chantypes,
-                                        statusmsg,
-                                        casemapping,
                                     )
                                 })
                                 .collect::<Vec<_>>()
@@ -2246,7 +2235,6 @@ impl State {
             }
 
             let mut history_tasks = vec![];
-            let server_config = config.servers.get(buffer.server());
 
             if let Some(messages) = input.messages(
                 user,
@@ -2259,13 +2247,8 @@ impl State {
                 for message in messages {
                     let message = reroute_input_message(
                         message,
-                        server_config
-                            .as_ref()
-                            .map(|config| &config.reroute.private_messages),
+                        history.get_reroute_rules(),
                         buffer.server(),
-                        chantypes,
-                        statusmsg,
-                        casemapping,
                     );
 
                     history_tasks.extend(

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -706,51 +706,23 @@ fn notice_view<'a, 'b, Message: 'a>(
 
 fn reroute_input_message(
     message: data::Message,
-    input: &input::Input,
     private_messages: Option<&data::config::server::reroute::PrivateMessages>,
     server: &Server,
     chantypes: &[char],
     statusmsg: &[char],
     casemapping: data::isupport::CaseMap,
 ) -> data::Message {
-    let original_target = message.target.clone();
-    let rerouted_target = data::message::reroute_private_target(
-        original_target.clone(),
+    if let Some(rerouted_target) = data::message::reroute_private_target(
+        &message.target,
         private_messages,
         server,
         chantypes,
         statusmsg,
         casemapping,
-    );
-    let rerouted = rerouted_target != original_target;
-
-    let mut message = message.with_target(rerouted_target);
-
-    if rerouted
-        && message.command.is_none()
-        && let Some(original_target_raw) = original_target.raw()
-        && let Some(command) = input.command()
-    {
-        message.command = rerouted_command(command, original_target_raw);
-    }
-
-    message
-}
-
-fn rerouted_command(
-    command: &command::Irc,
-    original_target_raw: &str,
-) -> Option<command::Irc> {
-    match command {
-        command::Irc::Msg(_, text) => Some(command::Irc::Msg(
-            original_target_raw.to_string(),
-            text.clone(),
-        )),
-        command::Irc::Notice(_, text) => Some(command::Irc::Notice(
-            original_target_raw.to_string(),
-            text.clone(),
-        )),
-        _ => None,
+    ) {
+        message.reroute_with_target(rerouted_target)
+    } else {
+        message
     }
 }
 
@@ -1849,7 +1821,6 @@ impl State {
                                 .map(|message| {
                                     reroute_input_message(
                                         message,
-                                        &input,
                                         server_config.as_ref().map(|config| {
                                             &config.reroute.private_messages
                                         }),
@@ -2288,7 +2259,6 @@ impl State {
                 for message in messages {
                     let message = reroute_input_message(
                         message,
-                        &input,
                         server_config
                             .as_ref()
                             .map(|config| &config.reroute.private_messages),

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -375,15 +375,8 @@ impl<'a> ChannelQueryLayout<'a> {
             .into_iter()
             .flatten()
             .find(|current_user| *current_user == user);
-        let rerouted_private = data::message::is_rerouted_private_message(
-            message,
-            self.config
-                .servers
-                .get(self.server)
-                .as_ref()
-                .map(|config| &config.reroute.private_messages),
-            self.server,
-        );
+        let rerouted_private =
+            data::message::is_rerouted_private_message(message);
         let is_user_offline = if rerouted_private {
             false
         } else {

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -375,12 +375,29 @@ impl<'a> ChannelQueryLayout<'a> {
             .into_iter()
             .flatten()
             .find(|current_user| *current_user == user);
-        let is_user_offline = match self.config.buffer.nickname.shown_status {
-            ShownStatus::Current => {
-                self.target.is_channel() && user_in_channel.is_none()
+        let rerouted_private = data::message::is_rerouted_private_message(
+            message,
+            self.config
+                .servers
+                .get(self.server)
+                .as_ref()
+                .map(|config| &config.reroute.private_messages),
+            self.server,
+        );
+        let is_user_offline = if rerouted_private {
+            false
+        } else {
+            match self.config.buffer.nickname.shown_status {
+                ShownStatus::Current => {
+                    self.target.is_channel() && user_in_channel.is_none()
+                }
+                ShownStatus::Historical => false,
             }
-            ShownStatus::Historical => false,
         };
+        let is_ourself = self
+            .target
+            .our_user()
+            .is_some_and(|our_user| our_user.nickname() == user.nickname());
 
         let nickname_style = theme::selectable_text::dimmed(
             theme::selectable_text::nickname(
@@ -398,7 +415,6 @@ impl<'a> ChannelQueryLayout<'a> {
 
         let (user_display, show_nickname_tooltip) =
             user.display_with_truncated(with_access_levels, truncate);
-
         let nick_text =
             self.config.buffer.nickname.brackets.format(user_display);
 
@@ -428,19 +444,32 @@ impl<'a> ChannelQueryLayout<'a> {
             }
 
             tooltip(
-                context_menu::user(
-                    nick_text,
-                    self.server,
-                    self.prefix,
-                    self.target.channel(),
-                    user,
-                    user_in_channel,
-                    self.target.our_user(),
-                    self.config,
-                    self.theme,
-                    &self.config.buffer.nickname.click,
-                )
-                .map(Message::ContextMenu),
+                if rerouted_private && !is_ourself {
+                    context_menu::rerouted_private_user(
+                        nick_text,
+                        self.server,
+                        self.prefix,
+                        user,
+                        self.config,
+                        self.theme,
+                        &self.config.buffer.nickname.click,
+                    )
+                    .map(Message::ContextMenu)
+                } else {
+                    context_menu::user(
+                        nick_text,
+                        self.server,
+                        self.prefix,
+                        self.target.channel(),
+                        user,
+                        user_in_channel,
+                        self.target.our_user(),
+                        self.config,
+                        self.theme,
+                        &self.config.buffer.nickname.click,
+                    )
+                    .map(Message::ContextMenu)
+                },
                 show_nickname_tooltip.then_some(user.as_str()),
                 tooltip::Position::Bottom,
                 self.theme,
@@ -451,7 +480,11 @@ impl<'a> ChannelQueryLayout<'a> {
 
         let message_style = move |message_theme: &Theme| {
             theme::selectable_text::dimmed(
-                theme::selectable_text::default(message_theme),
+                if rerouted_private {
+                    theme::selectable_text::tertiary(message_theme)
+                } else {
+                    theme::selectable_text::default(message_theme)
+                },
                 message_theme,
                 dimmed_background_tuple,
             )
@@ -478,12 +511,18 @@ impl<'a> ChannelQueryLayout<'a> {
             theme::font_style::primary,
             color_transformation,
             move |link| match link {
-                message::Link::User(_, _) => context_menu::Entry::user_list(
-                    formatter.target.is_channel(),
-                    user_in_channel,
-                    formatter.target.our_user(),
-                    formatter.config.file_transfer.enabled,
-                ),
+                message::Link::User(_, _) => {
+                    if rerouted_private && !is_ourself {
+                        vec![context_menu::Entry::Whois]
+                    } else {
+                        context_menu::Entry::user_list(
+                            formatter.target.is_channel(),
+                            user_in_channel,
+                            formatter.target.our_user(),
+                            formatter.config.file_transfer.enabled,
+                        )
+                    }
+                }
                 message::Link::Url(_) => formatter.url_entries(message, link),
                 _ => vec![],
             },

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -375,8 +375,7 @@ impl<'a> ChannelQueryLayout<'a> {
             .into_iter()
             .flatten()
             .find(|current_user| *current_user == user);
-        let rerouted_private =
-            data::message::is_rerouted_private_message(message);
+        let rerouted_private = message.is_rerouted();
         let is_user_offline = if rerouted_private {
             false
         } else {

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -243,13 +243,7 @@ pub fn view<'a>(
                         };
 
                         let rerouted_private =
-                            data::message::is_rerouted_private_message(
-                                message,
-                                config.servers.get(&state.server).as_ref().map(
-                                    |config| &config.reroute.private_messages,
-                                ),
-                                &state.server,
-                            );
+                            data::message::is_rerouted_private_message(message);
 
                         let content = message_content(
                             &message.content,

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -242,6 +242,15 @@ pub fn view<'a>(
                             )
                         };
 
+                        let rerouted_private =
+                            data::message::is_rerouted_private_message(
+                                message,
+                                config.servers.get(&state.server).as_ref().map(
+                                    |config| &config.reroute.private_messages,
+                                ),
+                                &state.server,
+                            );
+
                         let content = message_content(
                             &message.content,
                             &state.server,
@@ -250,7 +259,13 @@ pub fn view<'a>(
                             theme,
                             scroll_view::Message::Link,
                             None,
-                            theme::selectable_text::default,
+                            move |theme| {
+                                if rerouted_private {
+                                    theme::selectable_text::tertiary(theme)
+                                } else {
+                                    theme::selectable_text::default(theme)
+                                }
+                            },
                             theme::font_style::primary,
                             Option::<fn(Color) -> Color>::None,
                             config,

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -242,8 +242,7 @@ pub fn view<'a>(
                             )
                         };
 
-                        let rerouted_private =
-                            data::message::is_rerouted_private_message(message);
+                        let rerouted_private = message.is_rerouted();
 
                         let content = message_content(
                             &message.content,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2141,6 +2141,10 @@ fn handle_direct_message(
     notifications: &mut Notifications,
     main_window: &Window,
 ) {
+    if user.nickname() == our_nick.as_nickref() {
+        return;
+    }
+
     let Some(msg) = create_message(
         server,
         encoded,
@@ -2151,6 +2155,10 @@ fn handle_direct_message(
     ) else {
         return;
     };
+
+    if msg.is_rerouted() {
+        return;
+    }
 
     let casemapping = clients.get_server_casemapping_or_default(server);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ use std::{env, mem};
 use appearance::{Theme, theme};
 use data::config::{self, Config};
 use data::history::filter::FilterChain;
+use data::history::reroute::RerouteRules;
 use data::message::{self, Broadcast};
 use data::reaction::Reaction;
 use data::target::{self, Target};
@@ -220,6 +221,8 @@ impl Halloy {
                 servers.set_order(config.sidebar.order_by);
                 let (mut screen, command) = load_dashboard(&config);
                 screen.init_filters(&servers, &data::client::Map::default());
+                screen
+                    .set_reroute_rules(&servers, &data::client::Map::default());
                 (
                     Screen::Dashboard(screen),
                     servers,
@@ -1394,6 +1397,8 @@ impl Halloy {
                 }
 
                 if let Screen::Dashboard(dashboard) = &mut self.screen {
+                    dashboard.set_reroute_rules(&self.servers, &self.clients);
+
                     dashboard.update_filters(
                         &self.servers,
                         &self.clients,
@@ -1709,11 +1714,13 @@ fn create_message(
     our_nick: data::user::Nick,
     config: &Config,
     clients: &data::client::Map,
+    reroute_rules: &RerouteRules,
 ) -> Option<data::Message> {
     data::Message::received(
         encoded,
         our_nick,
         config,
+        reroute_rules,
         |user, channel| {
             clients
                 .resolve_user_attributes(server, channel, user)
@@ -1734,11 +1741,13 @@ fn create_message_with_highlight(
     our_nick: data::user::Nick,
     config: &Config,
     clients: &data::client::Map,
+    reroute_rules: &RerouteRules,
 ) -> Option<(data::Message, Option<message::Highlight>)> {
     data::Message::received_with_highlight(
         encoded,
         our_nick,
         config,
+        reroute_rules,
         |user, channel| {
             clients
                 .resolve_user_attributes(server, channel, user)
@@ -1762,9 +1771,14 @@ fn handle_single_event(
     clients: &data::client::Map,
     config: &Config,
 ) {
-    let Some(message) =
-        create_message(server, encoded, our_nick, config, clients)
-    else {
+    let Some(message) = create_message(
+        server,
+        encoded,
+        our_nick,
+        config,
+        clients,
+        dashboard.get_reroute_rules(),
+    ) else {
         return;
     };
 
@@ -1790,9 +1804,14 @@ fn handle_with_target_event(
     clients: &data::client::Map,
     config: &Config,
 ) {
-    let Some(message) =
-        create_message(server, encoded, our_nick, config, clients)
-    else {
+    let Some(message) = create_message(
+        server,
+        encoded,
+        our_nick,
+        config,
+        clients,
+        dashboard.get_reroute_rules(),
+    ) else {
         return;
     };
 
@@ -1821,7 +1840,12 @@ fn handle_priv_or_notice(
     main_window: &Window,
 ) {
     let Some((mut msg, highlight)) = create_message_with_highlight(
-        server, encoded, our_nick, config, clients,
+        server,
+        encoded,
+        our_nick,
+        config,
+        clients,
+        dashboard.get_reroute_rules(),
     ) else {
         return;
     };
@@ -2115,8 +2139,14 @@ fn handle_direct_message(
     notifications: &mut Notifications,
     main_window: &Window,
 ) {
-    let Some(msg) = create_message(server, encoded, our_nick, config, clients)
-    else {
+    let Some(msg) = create_message(
+        server,
+        encoded,
+        our_nick,
+        config,
+        clients,
+        dashboard.get_reroute_rules(),
+    ) else {
         return;
     };
 
@@ -2160,18 +2190,39 @@ fn handle_isupport_param(
     }
 
     match param {
-        data::isupport::Parameter::CASEMAPPING(_)
+        data::isupport::Parameter::STATUSMSG(_)
+        | data::isupport::Parameter::CASEMAPPING(_)
         | data::isupport::Parameter::CHANTYPES(_) => {
+            let statusmsg = clients.get_server_statusmsg_or_default(server);
             let chantypes = clients.get_server_chantypes_or_default(server);
             let casemapping = clients.get_server_casemapping_or_default(server);
 
-            FilterChain::sync_isupport(
-                dashboard.get_filters(),
-                server,
-                chantypes,
-                casemapping,
-            );
-            dashboard.reprocess_history(clients, &config.buffer);
+            if let Some(server_config) = config.servers.get(server) {
+                let reroute_rules = dashboard.get_reroute_rules_mut();
+
+                reroute_rules.sync_isupport(
+                    server,
+                    server_config,
+                    statusmsg,
+                    chantypes,
+                    casemapping,
+                );
+            }
+
+            if matches!(
+                param,
+                data::isupport::Parameter::CASEMAPPING(_)
+                    | data::isupport::Parameter::CHANTYPES(_)
+            ) {
+                FilterChain::sync_isupport(
+                    dashboard.get_filters(),
+                    server,
+                    chantypes,
+                    casemapping,
+                );
+
+                dashboard.reprocess_history(clients, &config.buffer);
+            }
         }
         data::isupport::Parameter::SAFELIST => {
             dashboard.update_channel_discoveries(clients, server);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1674,6 +1674,8 @@ fn handle_client_events(
             Event::BouncerNetwork(server, server_config) => {
                 servers.insert(server, server_config.into());
 
+                dashboard.set_reroute_rules(servers, clients);
+
                 dashboard.update_filters(servers, clients, &config.buffer);
             }
             Event::AddToSidebar(query) => {
@@ -2203,8 +2205,8 @@ fn handle_isupport_param(
                 reroute_rules.sync_isupport(
                     server,
                     server_config,
-                    statusmsg,
                     chantypes,
+                    statusmsg,
                     casemapping,
                 );
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1853,7 +1853,7 @@ fn handle_priv_or_notice(
     };
 
     let casemapping = clients.get_server_casemapping_or_default(server);
-    let kind = history::Kind::from_server_message(server.clone(), &msg);
+    let kind = history::Kind::from_server_message(server, &msg);
 
     if let Some(kind) = &kind {
         dashboard.block_message(

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -932,10 +932,12 @@ impl Dashboard {
                                 if let Some(messages) = command.messages(
                                     user,
                                     channel_users,
+                                    buffer.server(),
                                     chantypes,
                                     statusmsg,
                                     casemapping,
                                     supports_echoes,
+                                    self.history.get_reroute_rules(),
                                 ) && let Some(encoded) =
                                     proto::Command::try_from(command)
                                         .ok()
@@ -2145,68 +2147,6 @@ impl Dashboard {
                             );
                         }
 
-                        if let Some(nick) = clients.nickname(buffer.server()) {
-                            let mut user = nick.to_owned().into();
-                            let mut channel_users = None;
-                            let chantypes = clients
-                                .get_server_chantypes_or_default(
-                                    buffer.server(),
-                                );
-                            let statusmsg = clients
-                                .get_server_statusmsg_or_default(
-                                    buffer.server(),
-                                );
-                            let casemapping = clients
-                                .get_server_casemapping_or_default(
-                                    buffer.server(),
-                                );
-                            let supports_echoes = clients
-                                .get_server_supports_echoes(buffer.server());
-
-                            // Resolve our attributes if sending this message in a channel
-                            if let buffer::Upstream::Channel(server, channel) =
-                                &buffer
-                            {
-                                channel_users =
-                                    clients.get_channel_users(server, channel);
-
-                                if let Some(user_with_attributes) = clients
-                                    .resolve_user_attributes(
-                                        server, channel, &user,
-                                    )
-                                {
-                                    user = user_with_attributes.clone();
-                                }
-                            }
-
-                            if let Some(messages) = input.messages(
-                                user,
-                                channel_users,
-                                chantypes,
-                                statusmsg,
-                                casemapping,
-                                supports_echoes,
-                            ) {
-                                for message in messages {
-                                    let history_tasks =
-                                        self.history.record_message(
-                                            input.server(),
-                                            message,
-                                            &config.buffer,
-                                        );
-
-                                    tasks.extend(
-                                        history_tasks.into_iter().map(|task| {
-                                            Task::perform(
-                                                task,
-                                                Message::History,
-                                            )
-                                        }),
-                                    );
-                                }
-                            }
-                        }
-
                         None
                     }
                     buffer::context_menu::Event::SendWhowas(server, nick) => {
@@ -2227,68 +2167,6 @@ impl Dashboard {
                                 encoded,
                                 TokenPriority::User,
                             );
-                        }
-
-                        if let Some(nick) = clients.nickname(buffer.server()) {
-                            let mut user = nick.to_owned().into();
-                            let mut channel_users = None;
-                            let chantypes = clients
-                                .get_server_chantypes_or_default(
-                                    buffer.server(),
-                                );
-                            let statusmsg = clients
-                                .get_server_statusmsg_or_default(
-                                    buffer.server(),
-                                );
-                            let casemapping = clients
-                                .get_server_casemapping_or_default(
-                                    buffer.server(),
-                                );
-                            let supports_echoes = clients
-                                .get_server_supports_echoes(buffer.server());
-
-                            // Resolve our attributes if sending this message in a channel
-                            if let buffer::Upstream::Channel(server, channel) =
-                                &buffer
-                            {
-                                channel_users =
-                                    clients.get_channel_users(server, channel);
-
-                                if let Some(user_with_attributes) = clients
-                                    .resolve_user_attributes(
-                                        server, channel, &user,
-                                    )
-                                {
-                                    user = user_with_attributes.clone();
-                                }
-                            }
-
-                            if let Some(messages) = input.messages(
-                                user,
-                                channel_users,
-                                chantypes,
-                                statusmsg,
-                                casemapping,
-                                supports_echoes,
-                            ) {
-                                for message in messages {
-                                    let history_tasks =
-                                        self.history.record_message(
-                                            input.server(),
-                                            message,
-                                            &config.buffer,
-                                        );
-
-                                    tasks.extend(
-                                        history_tasks.into_iter().map(|task| {
-                                            Task::perform(
-                                                task,
-                                                Message::History,
-                                            )
-                                        }),
-                                    );
-                                }
-                            }
                         }
 
                         None

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -2188,18 +2188,21 @@ impl Dashboard {
                                 supports_echoes,
                             ) {
                                 for message in messages {
-                                    if let Some(task) =
+                                    let history_tasks =
                                         self.history.record_message(
                                             input.server(),
                                             message,
                                             &config.buffer,
-                                        )
-                                    {
-                                        tasks.push(Task::perform(
-                                            task,
-                                            Message::History,
-                                        ));
-                                    }
+                                        );
+
+                                    tasks.extend(
+                                        history_tasks.into_iter().map(|task| {
+                                            Task::perform(
+                                                task,
+                                                Message::History,
+                                            )
+                                        }),
+                                    );
                                 }
                             }
                         }
@@ -2269,18 +2272,21 @@ impl Dashboard {
                                 supports_echoes,
                             ) {
                                 for message in messages {
-                                    if let Some(task) =
+                                    let history_tasks =
                                         self.history.record_message(
                                             input.server(),
                                             message,
                                             &config.buffer,
-                                        )
-                                    {
-                                        tasks.push(Task::perform(
-                                            task,
-                                            Message::History,
-                                        ));
-                                    }
+                                        );
+
+                                    tasks.extend(
+                                        history_tasks.into_iter().map(|task| {
+                                            Task::perform(
+                                                task,
+                                                Message::History,
+                                            )
+                                        }),
+                                    );
                                 }
                             }
                         }
@@ -3264,13 +3270,13 @@ impl Dashboard {
         message: data::Message,
         buffer_config: &config::Buffer,
     ) -> Task<Message> {
-        if let Some(task) =
-            self.history.record_message(server, message, buffer_config)
-        {
-            Task::perform(task, Message::History)
-        } else {
-            Task::none()
-        }
+        let tasks = self.history.record_message(server, message, buffer_config);
+
+        Task::batch(
+            tasks
+                .into_iter()
+                .map(|task| Task::perform(task, Message::History)),
+        )
     }
 
     pub fn record_reaction(
@@ -3314,16 +3320,18 @@ impl Dashboard {
         message: data::Message,
         buffer_config: &config::Buffer,
     ) -> Task<Message> {
-        if let Some(task) = self.history.block_and_record_message(
+        let tasks = self.history.block_and_record_message(
             server,
             casemapping,
             message,
             buffer_config,
-        ) {
-            Task::perform(task, Message::History)
-        } else {
-            Task::none()
-        }
+        );
+
+        Task::batch(
+            tasks
+                .into_iter()
+                .map(|task| Task::perform(task, Message::History)),
+        )
     }
 
     pub fn record_log(&mut self, record: data::log::Record) -> Task<Message> {

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -11,6 +11,7 @@ use data::dashboard::{self, BufferAction};
 use data::environment::{RELEASE_WEBSITE, WIKI_WEBSITE};
 use data::history::ReadMarker;
 use data::history::filter::Filter;
+use data::history::reroute::RerouteRules;
 use data::isupport::{self, ChatHistorySubcommand, MessageReference};
 use data::message::{self, Broadcast};
 use data::rate_limit::TokenPriority;
@@ -211,6 +212,16 @@ impl Dashboard {
         self.init_filters(servers, clients);
 
         self.reprocess_history(clients, buffer_config);
+    }
+
+    pub fn set_reroute_rules(
+        &mut self,
+        servers: &server::Map,
+        clients: &client::Map,
+    ) {
+        let reroute_rules = self.get_reroute_rules_mut();
+
+        *reroute_rules = RerouteRules::from_server_map(servers, clients);
     }
 
     pub fn reload_visible_previews(
@@ -4222,6 +4233,14 @@ impl Dashboard {
         } else {
             Task::none()
         }
+    }
+
+    pub fn get_reroute_rules(&self) -> &RerouteRules {
+        self.history.get_reroute_rules()
+    }
+
+    pub fn get_reroute_rules_mut(&mut self) -> &mut RerouteRules {
+        self.history.get_reroute_rules_mut()
     }
 
     pub fn handle_window_event(


### PR DESCRIPTION
Fixes #142, #1492.

Ability to reroute private messages. Good for when talking with bots.
Below is an example where all messages from BotTheo will be rerouted to `#foobar`, including your own messages to him.

```toml
[servers.quakenet.reroute]
private_messages = [
  { user = "BotTheo", target = { channel = "#foobar" }}
]
```