### PR TITLE
Fix `dimmed = false` for Individual Server Message Kinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Fixed:
 
 - Window state is saved even if altered shortly before quitting
+- Default dimmed value for server messages no longer overrides `dimmed = false` set for individual server message kinds
 
 Thanks:
 


### PR DESCRIPTION
Restructures `Dimmed` so that the default value will not override `dimmed = false` set for individual server message kinds.