### PR TITLE
Context-Menus Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Fixed:
 
 - Window state is saved even if altered shortly before quitting
 - Default dimmed value for server messages no longer overrides `dimmed = false` set for individual server message kinds
+- Issue where context menu items would not respond to clicks
 
 Thanks:
 

--- a/src/widget/context_menu.rs
+++ b/src/widget/context_menu.rs
@@ -438,7 +438,7 @@ where
             Some(menu) => state.menu_tree.diff(&*menu),
             None => {
                 let _menu = build_menu(entries, entry);
-                state.menu_tree = widget::Tree::new(&_menu);
+                state.menu_tree.diff(&_menu);
                 *menu = Some(_menu);
             }
         },


### PR DESCRIPTION
Fix for context-menu buttons not registering left-clicks.