### PR TITLE
Update GH Pages Workflows

### DIFF
--- a/.github/workflows/gh-page-unstable.yml
+++ b/.github/workflows/gh-page-unstable.yml
@@ -17,14 +17,14 @@ jobs:
         id: lychee-interal
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --config ./.config/lychee-internal.toml './book/**/*.md'
+          args: --config ./.config/lychee-internal.toml --root-dir='./book/src' './book/**/*.md'
           fail: true
 
       - name: Check external links
         id: lychee-external
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --config ./.config/lychee-external.toml './book/**/*.md'
+          args: --config ./.config/lychee-external.toml --root-dir='./book/src' './book/**/*.md'
           fail: true
         continue-on-error: true
 

--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -17,14 +17,14 @@ jobs:
         id: lychee-interal
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --config ./.config/lychee-internal.toml './book/**/*.md'
+          args: --config ./.config/lychee-internal.toml --root-dir='./book/src' './book/**/*.md'
           fail: true
 
       - name: Check external links
         id: lychee-external
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --config ./.config/lychee-external.toml './book/**/*.md'
+          args: --config ./.config/lychee-external.toml --root-dir='./book/src' './book/**/*.md'
           fail: true
         continue-on-error: true
 


### PR DESCRIPTION
Update GH pages workflows to use `--root-dir` (matching changes to book.yml, which is now working as intended again).