### PR TITLE
Accept superfluous \n from ZNC’s backlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ Fixed:
 - Default dimmed value for server messages no longer overrides `dimmed = false` set for individual server message kinds
 - Issue where context menu items would not respond to clicks
 - Filters are loaded on first connection to server via bouncer-networks and updated on config file reload
+- Compatibility with ZNC's backlog service
 
 Thanks:
 
-- Contributions: @melocene, @4e554c4c
-- Bug reports: @barretgoat
+- Contributions: @melocene, @4e554c4c, @TheOneric
+- Bug reports: @barretgoat, @TheOneric
 
 # 2026.3 (2026-02-24)
 

--- a/irc/proto/src/parse.rs
+++ b/irc/proto/src/parse.rs
@@ -27,7 +27,10 @@ pub fn message(input: &str) -> Result<Message, Error> {
             command,
         )),
         // Discard addtl. \r or \n if it exists, allow whitespace before
-        preceded(many0(char(' ')), alt((preceded(one_of("\r\n"), crlf), crlf))),
+        preceded(
+            many0(char(' ')),
+            alt((preceded(one_of("\r\n"), crlf), crlf)),
+        ),
     ));
 
     message(input)


### PR DESCRIPTION
Analogous to the extra \r from 8b8d7dfba45fc360a4244397efa6b9ce22d11350

Fixes: https://github.com/squidowl/halloy/issues/1550