### PR TITLE
Minor Scroll-To Fix

### DIFF
--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -716,6 +716,10 @@ impl State {
                 status: old_status,
                 viewport,
             } => {
+                if self.pending_scroll_to.is_some() || self.is_scrolling_to {
+                    return (Task::none(), None);
+                }
+
                 self.last_scroll_offset = viewport.absolute_offset().y;
 
                 let relative_offset = viewport.relative_offset().y;


### PR DESCRIPTION
Prevents the limit from being changed while a scroll-to is in progress in order to avoid a scenario where scroll_to_backlog would wind up at the correct offset but for the wrong scrollable contents (manifesting as scrolled before the divider and not all of the messages necessary to scroll to the divider are loaded).