### PR TITLE
fix(emojipicker): click-through and mouse selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@
 Added:
 
 - Setting to limit reaction display length (`buffer.channel.message.max_reaction_display`) and maximum length (`buffer.channel.message.max_reaction_chars`)
+- Emoji and command picker entries are now clickable and insert the selected completion directly into the input.
 
 Fixed:
 
 - Improved message length calculation (when known the bytes required to relay a message are included in the calculation, when unknown an estimate is used)
 - Prevent interaction leakage behind open modals: clicks, cursor changes, and hover states no longer affect underlying UI while preserving outside-click and `Esc` to close
+- Prevent clicks from passing through completion picker overlays to content behind them (for example nicknames in the buffer).
 
 Thanks:
 

--- a/src/appearance/theme/button.rs
+++ b/src/appearance/theme/button.rs
@@ -125,6 +125,25 @@ pub fn secondary(theme: &Theme, status: Status, selected: bool) -> Style {
     button(foreground, background, background_hover, status)
 }
 
+pub fn picker(theme: &Theme, status: Status, is_selected: bool) -> Style {
+    let foreground = theme.styles().text.primary.color;
+    let button_colors = theme.styles().buttons.primary;
+
+    let background = if is_selected {
+        button_colors.background_hover
+    } else {
+        button_colors.background
+    };
+
+    let background_hover = if is_selected {
+        button_colors.background_selected
+    } else {
+        button_colors.background_hover
+    };
+
+    button(foreground, background, background_hover, status)
+}
+
 pub fn bare(_theme: &Theme, status: Status) -> Style {
     match status {
         Status::Active | Status::Pressed | Status::Hovered => Style {

--- a/src/appearance/theme/container.rs
+++ b/src/appearance/theme/container.rs
@@ -87,19 +87,6 @@ pub fn none(_theme: &Theme) -> Style {
     }
 }
 
-pub fn primary_background_hover(theme: &Theme) -> Style {
-    Style {
-        background: Some(Background::Color(
-            theme.styles().buttons.primary.background_hover,
-        )),
-        border: Border {
-            radius: 4.0.into(),
-            ..Default::default()
-        },
-        ..Default::default()
-    }
-}
-
 pub fn root(theme: &Theme) -> Style {
     Style {
         text_color: Some(theme.styles().text.primary.color),

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -63,6 +63,7 @@ pub enum Message {
     DeleteWordBackward(bool),
     DeleteToEnd(bool),
     DeleteToStart(bool),
+    SelectCompletion(usize),
     Tab(bool),
     Up,
     Down,
@@ -534,7 +535,8 @@ pub fn view<'a>(
             state.input_content.text().as_str(),
             server,
             config,
-            theme
+            theme,
+            Message::SelectCompletion,
         ),
         state
             .error
@@ -1172,6 +1174,25 @@ impl State {
                     self.input_content.cursor().position.column;
 
                 if let Some(entry) = self.completion.tab(reverse) {
+                    let chantypes = clients.get_chantypes(buffer.server());
+                    let actions = entry.complete_input(
+                        input.as_str(),
+                        cursor_position,
+                        chantypes,
+                        config,
+                    );
+
+                    self.on_completion(buffer, history, actions, true)
+                } else {
+                    (Task::none(), None)
+                }
+            }
+            Message::SelectCompletion(index) => {
+                let input = self.input_content.text();
+                let cursor_position =
+                    self.input_content.cursor().position.column;
+
+                if let Some(entry) = self.completion.select_at(index, config) {
                     let chantypes = clients.get_chantypes(buffer.server());
                     let actions = entry.complete_input(
                         input.as_str(),

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -17,7 +17,7 @@ use data::user::{ChannelUsers, Nick, NickRef};
 use data::{Config, mode};
 use iced::Length;
 use iced::widget::text::Shaping;
-use iced::widget::{column, container, row, text_editor, tooltip};
+use iced::widget::{button, column, container, row, text_editor, tooltip};
 use irc::proto;
 use itertools::{Either, Itertools};
 use strsim::jaro_winkler;
@@ -125,6 +125,17 @@ impl Completion {
             .or(self.emojis.select(config).map(Entry::Emoji))
     }
 
+    pub fn select_at(
+        &mut self,
+        index: usize,
+        config: &Config,
+    ) -> Option<Entry> {
+        self.commands
+            .select_at(index)
+            .map(Entry::Command)
+            .or(self.emojis.select_at(index, config).map(Entry::Emoji))
+    }
+
     pub fn complete_emoji(
         &self,
         input: &str,
@@ -183,15 +194,18 @@ impl Completion {
         false
     }
 
-    pub fn view<'a, Message: 'a>(
+    pub fn view<'a, Message: Clone + 'a>(
         &self,
         input: &str,
         server: &Server,
         config: &Config,
         theme: &'a Theme,
+        on_select_command: impl Fn(usize) -> Message + Copy + 'a,
     ) -> Option<Element<'a, Message>> {
-        let command_view = self.commands.view(input, server, config, theme);
-        let emojis_view = self.emojis.view(config);
+        let command_view =
+            self.commands
+                .view(input, server, config, theme, on_select_command);
+        let emojis_view = self.emojis.view(config, on_select_command);
 
         if command_view.is_some() || emojis_view.is_some() {
             Some(column![emojis_view, command_view].spacing(4).into())
@@ -544,12 +558,23 @@ impl Commands {
     }
 
     fn select(&mut self) -> Option<Command> {
-        if let Self::Selecting {
+        let index = if let Self::Selecting {
             highlighted: Some(index),
-            filtered,
+            ..
         } = self
+        {
+            *index
+        } else {
+            return None;
+        };
+
+        self.select_at(index)
+    }
+
+    fn select_at(&mut self, index: usize) -> Option<Command> {
+        if let Self::Selecting { filtered, .. } = self
             && let Some(command) =
-                filtered.get(*index).map(|(_, command)| command.clone())
+                filtered.get(index).map(|(_, command)| command.clone())
         {
             *self = Self::Selected {
                 command: command.clone(),
@@ -576,12 +601,13 @@ impl Commands {
         }
     }
 
-    fn view<'a, Message: 'a>(
+    fn view<'a, Message: Clone + 'a>(
         &self,
         input: &str,
         server: &Server,
         config: &Config,
         theme: &'a Theme,
+        on_select_command: impl Fn(usize) -> Message + Copy + 'a,
     ) -> Option<Element<'a, Message>> {
         match self {
             Self::Idle => None,
@@ -613,15 +639,15 @@ impl Commands {
                         let content = text(format!("/{title}"));
 
                         Element::from(
-                            container(content)
+                            button(content)
                                 .width(width)
-                                .style(if selected {
-                                    theme::container::primary_background_hover
-                                } else {
-                                    theme::container::none
-                                })
                                 .padding(6)
-                                .center_y(Length::Shrink),
+                                .style(move |theme, status| {
+                                    theme::button::picker(
+                                        theme, status, selected,
+                                    )
+                                })
+                                .on_press(on_select_command(*index)),
                         )
                     }))
                 };
@@ -2792,11 +2818,22 @@ impl Emojis {
     }
 
     fn select(&mut self, config: &Config) -> Option<String> {
-        if let Self::Selecting {
+        let index = if let Self::Selecting {
             highlighted: Some(index),
-            filtered,
+            ..
         } = self
-            && let Some(shortcode) = filtered.get(*index).copied()
+        {
+            *index
+        } else {
+            return None;
+        };
+
+        self.select_at(index, config)
+    }
+
+    fn select_at(&mut self, index: usize, config: &Config) -> Option<String> {
+        if let Self::Selecting { filtered, .. } = self
+            && let Some(shortcode) = filtered.get(index).copied()
         {
             *self = Self::Idle;
 
@@ -2821,9 +2858,10 @@ impl Emojis {
         }
     }
 
-    fn view<'a, Message: 'a>(
+    fn view<'a, Message: Clone + 'a>(
         &self,
         config: &Config,
+        on_select_command: impl Fn(usize) -> Message + Copy + 'a,
     ) -> Option<Element<'a, Message>> {
         match self {
             Self::Idle | Self::Selected { .. } => None,
@@ -2864,15 +2902,15 @@ impl Emojis {
                         .shaping(Shaping::Advanced);
 
                         Element::from(
-                            container(content)
+                            button(content)
                                 .width(width)
-                                .style(if selected {
-                                    theme::container::primary_background_hover
-                                } else {
-                                    theme::container::none
-                                })
                                 .padding(6)
-                                .center_y(Length::Shrink),
+                                .style(move |theme, status| {
+                                    theme::button::picker(
+                                        theme, status, selected,
+                                    )
+                                })
+                                .on_press(on_select_command(*index)),
                         )
                     }))
                 };

--- a/src/widget/anchored_overlay.rs
+++ b/src/widget/anchored_overlay.rs
@@ -281,6 +281,9 @@ impl<Message> overlay::Overlay<Message, Theme, Renderer>
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
     ) {
+        let should_capture = matches!(event, Event::Mouse(_) | Event::Touch(_))
+            && cursor.is_over(layout.bounds());
+
         self.content.as_widget_mut().update(
             self.tree,
             event,
@@ -291,6 +294,10 @@ impl<Message> overlay::Overlay<Message, Theme, Renderer>
             shell,
             &layout.bounds(),
         );
+
+        if should_capture {
+            shell.capture_event();
+        }
     }
 
     fn mouse_interaction(


### PR DESCRIPTION
- prevent click-through on completion picker overlays
- allow mouse selection for emoji and command picker entries