### PR TITLE
Split Reaction Length Setting in Two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Added:
 
-- Setting to limit reaction text length (`buffer.channel.message.max_reaction_chars`)
+- Setting to limit reaction display length (`buffer.channel.message.max_reaction_display`) and maximum length (`buffer.channel.message.max_reaction_chars`)
 
 Fixed:
 

--- a/book/src/configuration/buffer/channel/message.md
+++ b/book/src/configuration/buffer/channel/message.md
@@ -6,6 +6,7 @@ Message settings within a channel buffer.
   - [Configuration](#configuration)
     - [nickname\_color](#nickname_color)
     - [show\_emoji\_reacts](#show_emoji_reacts)
+    - [max\_reaction\_display](#max_reaction_display)
     - [max\_reaction\_chars](#max_reaction_chars)
 
 ## Configuration
@@ -36,10 +37,10 @@ Whether to display emoji reactions on messages (if [IRCv3 React](https://ircv3.n
 show_emoji_reacts = true
 ```
 
-### max_reaction_chars
+### max_reaction_display
 
 Maximum number of user-visible characters (Unicode grapheme clusters) in a reaction.
-If a reaction exceeds this value, it is truncated to the first `max_reaction_chars` grapheme clusters.
+If a reaction exceeds this value, then its display is truncated to the first `max_reaction_display` grapheme clusters.
 
 ```toml
 # Type: integer
@@ -47,5 +48,19 @@ If a reaction exceeds this value, it is truncated to the first `max_reaction_cha
 # Default: 5
 
 [buffer.channel.message]
-max_reaction_chars = 5
+max_reaction_display = 5
+```
+
+### max_reaction_chars
+
+Maximum number of user-visible characters (Unicode grapheme clusters) in a reaction.
+If a reaction exceeds this value, then it is not stored.
+
+```toml
+# Type: integer
+# Values: positive integers
+# Default: 64
+
+[buffer.channel.message]
+max_reaction_chars = 64
 ```

--- a/data/src/config/buffer/channel.rs
+++ b/data/src/config/buffer/channel.rs
@@ -20,6 +20,8 @@ pub struct Message {
     pub nickname_color: Color,
     pub show_emoji_reacts: bool,
     #[serde(deserialize_with = "crate::serde::deserialize_positive_integer")]
+    pub max_reaction_display: u32,
+    #[serde(deserialize_with = "crate::serde::deserialize_positive_integer")]
     pub max_reaction_chars: u32,
 }
 
@@ -28,7 +30,8 @@ impl Default for Message {
         Self {
             nickname_color: Color::default(),
             show_emoji_reacts: true,
-            max_reaction_chars: 5,
+            max_reaction_display: 5,
+            max_reaction_chars: 64,
         }
     }
 }

--- a/data/src/reaction.rs
+++ b/data/src/reaction.rs
@@ -40,7 +40,14 @@ impl Reaction {
             (None, Some(s)) => (s.clone(), true),
             _ => return None,
         };
-        let text = truncate_text(&text, max_reaction_chars as usize);
+        // Drop reactions above the maximum rather than truncate, to avoid
+        // potentially creating a new, separate reaction when interacting with
+        // it (from the perspective of other clients)
+        if UnicodeSegmentation::graphemes(text.as_str(), true).count()
+            > max_reaction_chars as usize
+        {
+            return None;
+        }
         let in_reply_to = message.in_reply_to()?;
         let server_time = message.server_time();
 
@@ -63,18 +70,6 @@ impl Reaction {
     }
 }
 
-pub fn truncate_text(text: &str, max_chars: usize) -> String {
-    if UnicodeSegmentation::graphemes(text, true).count() <= max_chars {
-        return text.to_string();
-    }
-
-    let mut truncated = UnicodeSegmentation::graphemes(text, true)
-        .take(max_chars)
-        .collect::<String>();
-    truncated.push_str("...");
-    truncated
-}
-
 #[derive(Debug)]
 pub struct Pending {
     pub reactions: Vec<Reaction>,
@@ -87,40 +82,5 @@ impl Pending {
             reactions: vec![],
             server_time,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::truncate_text;
-
-    #[test]
-    fn keeps_short_reaction_text() {
-        assert_eq!(truncate_text("hello", 5), "hello");
-    }
-
-    #[test]
-    fn truncates_ascii_to_limit() {
-        assert_eq!(truncate_text("hello world", 5), "hello...");
-    }
-
-    #[test]
-    fn truncates_unicode_graphemes() {
-        assert_eq!(truncate_text("cafe\u{301}", 4), "cafe\u{301}");
-    }
-
-    #[test]
-    fn limit_one_keeps_first_grapheme_when_truncated() {
-        assert_eq!(truncate_text("👍🏽👍🏽", 1), "👍🏽...");
-    }
-
-    #[test]
-    fn does_not_split_zwj_emoji_clusters() {
-        assert_eq!(truncate_text("👨‍👩‍👧‍👦x", 1), "👨‍👩‍👧‍👦...");
-    }
-
-    #[test]
-    fn does_not_split_combining_mark_clusters() {
-        assert_eq!(truncate_text("a\u{0301}b", 1), "a\u{0301}...");
     }
 }

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -427,6 +427,7 @@ impl<'a> ChannelQueryLayout<'a> {
                 message,
                 self.target.our_user().map(|user| user.nickname()),
                 self.config.font.size.map_or(theme::TEXT_SIZE, f32::from),
+                self.config.buffer.channel.message.max_reaction_display,
                 on_react,
                 on_unreact,
             );

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -1164,26 +1164,10 @@ impl State {
                 }
             }
             Message::Reacted { msgid, text } => {
-                send_reaction(
-                    clients,
-                    buffer,
-                    history,
-                    msgid,
-                    text,
-                    false,
-                    config.buffer.channel.message.max_reaction_chars,
-                );
+                send_reaction(clients, buffer, history, msgid, text, false);
             }
             Message::Unreacted { msgid, text } => {
-                send_reaction(
-                    clients,
-                    buffer,
-                    history,
-                    msgid,
-                    text,
-                    true,
-                    config.buffer.channel.message.max_reaction_chars,
-                );
+                send_reaction(clients, buffer, history, msgid, text, true);
             }
         }
         (Task::none(), None)
@@ -1410,10 +1394,8 @@ fn send_reaction(
     msgid: message::Id,
     text: String,
     unreact: bool,
-    max_reaction_chars: u32,
 ) -> Option<()> {
     let buffer = buffer?;
-    let text = reaction::truncate_text(&text, max_reaction_chars as usize);
     let server = buffer.server();
     let target = buffer.target()?;
     let command = match unreact {

--- a/src/widget/reaction_row.rs
+++ b/src/widget/reaction_row.rs
@@ -1,9 +1,11 @@
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 
 use data::user::NickRef;
 use iced::alignment;
 pub use iced::widget::tooltip::Position;
 use iced::widget::{Space, button, container, row};
+use unicode_segmentation::UnicodeSegmentation;
 
 use super::{Column, Element, Row};
 use crate::theme;
@@ -15,6 +17,7 @@ pub fn reaction_row<'a, M, F1, F2>(
     message: &'a data::Message,
     our_nick: Option<NickRef<'a>>,
     font_size: f32,
+    max_reaction_display: u32,
     on_react: Option<F1>,
     on_unreact: Option<F2>,
 ) -> Element<'a, M>
@@ -68,10 +71,11 @@ where
             on_react.as_ref().map(|f| f(reaction_text))
         };
         let react_count = nicks.len();
-        let emoji = text(*reaction_text)
-            .shaping(iced::widget::text::Shaping::Advanced)
-            .size(emoji_size)
-            .style(theme::text::primary);
+        let emoji =
+            text(truncate_text(reaction_text, max_reaction_display as usize))
+                .shaping(iced::widget::text::Shaping::Advanced)
+                .size(emoji_size)
+                .style(theme::text::primary);
         let mut button_content = row![emoji];
         if react_count >= 2 {
             button_content = button_content.push(Space::new().width(4)).push(
@@ -122,4 +126,51 @@ where
     .wrap();
 
     container(row).into()
+}
+
+pub fn truncate_text<'a>(text: &'a str, max_chars: usize) -> Cow<'a, str> {
+    if UnicodeSegmentation::graphemes(text, true).count() <= max_chars {
+        return text.into();
+    }
+
+    let mut truncated = UnicodeSegmentation::graphemes(text, true)
+        .take(max_chars)
+        .collect::<String>();
+    truncated.push('…');
+    truncated.into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_text;
+
+    #[test]
+    fn keeps_short_reaction_text() {
+        assert_eq!(truncate_text("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncates_ascii_to_limit() {
+        assert_eq!(truncate_text("hello world", 5), "hello…");
+    }
+
+    #[test]
+    fn truncates_unicode_graphemes() {
+        assert_eq!(truncate_text("cafe\u{301}", 4), "cafe\u{301}");
+    }
+
+    #[test]
+    fn limit_one_keeps_first_grapheme_when_truncated() {
+        assert_eq!(truncate_text("👍🏽👍🏽", 1), "👍🏽…");
+    }
+
+    #[test]
+    fn does_not_split_zwj_emoji_clusters() {
+        assert_eq!(truncate_text("👨‍👩‍👧‍👦x", 1), "👨‍👩‍👧‍👦…");
+    }
+
+    #[test]
+    fn does_not_split_combining_mark_clusters() {
+        assert_eq!(truncate_text("a\u{0301}b", 1), "a\u{0301}…");
+    }
 }


### PR DESCRIPTION
Split reaction length setting in two: maximum display length and maximum storage length.

Reactions longer than the storage length are dropped, rather than truncated, in order to avoid creating a new, distinct reaction when interacting with a reaction from a different client (which may allow longer reactions).