### PR TITLE
Show focused buffer in window title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Added:
 - Case insensitive sort of query names in sidebar
 - Copied `order_channels_by` from `sidebar` to `server.<name>`, defaults to `sidebar.order_channels_by` if empty.
 - Alias commands (see `buffer.commands.aliases`)
+- The titlebar now displays the current buffer for each window.
 
 Fixed:
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::fmt;
 use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
@@ -1062,6 +1063,21 @@ impl Buffer {
             Buffer::Highlights(highlights) => {
                 highlights.scroll_view.update_pane_size(pane_size, config);
             }
+        }
+    }
+}
+
+impl fmt::Display for Buffer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Buffer::Empty => write!(f, "Empty"),
+            Buffer::Channel(Channel { target, .. }) => write!(f, "{target}"),
+            Buffer::Server(Server { server, .. }) => write!(f, "{server}"),
+            Buffer::Query(Query { target, .. }) => write!(f, "{target}"),
+            Buffer::FileTransfers(_) => write!(f, "File Transfers"),
+            Buffer::Logs(_) => write!(f, "Logs"),
+            Buffer::Highlights(_) => write!(f, "Highlights"),
+            Buffer::ChannelDiscovery(_) => write!(f, "Channel Discovery"),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -402,8 +402,20 @@ impl Halloy {
         Task::none()
     }
 
-    fn title(&self, _window_id: window::Id) -> String {
-        String::from("Halloy")
+    fn title(&self, window_id: window::Id) -> String {
+        let default = "Halloy".to_owned();
+        let s = match &self.screen {
+            Screen::Dashboard(dashboard) => {
+                match dashboard.focused_buffer_name(window_id) {
+                    Some(s) => s,
+                    None => return default,
+                }
+            }
+            Screen::Help(_) => "Help".to_owned(),
+            Screen::Welcome(_) => "Welcome".to_owned(),
+            Screen::Exit { .. } => return default,
+        };
+        format!("{s} – Halloy")
     }
 
     fn update(&mut self, message: Message) -> Task<Message> {

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -2596,9 +2596,7 @@ impl Dashboard {
         config: &Config,
         buffer: buffer::Internal,
     ) -> Task<Message> {
-        let panes = self.panes.clone();
-
-        let open = panes.iter().find_map(|(window_id, pane, state)| {
+        let open = self.panes.iter().find_map(|(window_id, pane, state)| {
             (state.buffer.internal().as_ref() == Some(&buffer))
                 .then_some((window_id, pane))
         });
@@ -2661,6 +2659,7 @@ impl Dashboard {
         clients: &mut data::client::Map,
         config: &Config,
     ) -> Task<Message> {
+        // TODO(pounce) reduce clones
         let panes = self.panes.clone();
 
         self.last_changed = Some(Instant::now());
@@ -3344,10 +3343,8 @@ impl Dashboard {
     pub fn focus_window_pane(&mut self, window: window::Id) -> Task<Message> {
         if self.focus.window == window {
             Task::none()
-        } else if let Some(pane) = self
-            .focus_history
-            .front()
-            .filter(|_| window == self.main_window())
+        } else if let Some(pane) = self.focus_history.front()
+            && window == self.main_window()
         {
             self.focus_pane(window, *pane)
         } else {
@@ -3449,12 +3446,7 @@ impl Dashboard {
         self.last_changed = Some(Instant::now());
 
         if window == self.main_window() {
-            self.focus_history = self
-                .focus_history
-                .iter()
-                .filter(|p| **p != pane)
-                .copied()
-                .collect();
+            self.focus_history.retain(|p| *p != pane);
 
             if let Some((_, sibling)) = self.panes.main.close(pane) {
                 if (Focus { window, pane } == self.focus) {
@@ -3478,12 +3470,7 @@ impl Dashboard {
     ) -> Task<Message> {
         let Focus { pane, .. } = self.focus;
 
-        self.focus_history = self
-            .focus_history
-            .clone()
-            .into_iter()
-            .filter(|p| *p != pane)
-            .collect();
+        self.focus_history.retain(|p| *p != pane);
 
         if let Some((pane, _)) = self.panes.main.close(pane)
             && let Some(buffer) = pane.buffer.data()
@@ -4111,6 +4098,20 @@ impl Dashboard {
                     .flat_map(|state| state.panes.values().flat_map(pane_map)),
             )
             .collect()
+    }
+
+    pub fn focused_buffer_name(&self, w: window::Id) -> Option<String> {
+        if w == self.main_window() {
+            self.focus_history
+                .front()
+                .and_then(|pane| self.panes.get(w, *pane))
+                .map(|pane| pane.buffer.to_string())
+        } else {
+            self.panes.iter().find_map(|(win, _, pane)| {
+                (win == w && !matches!(pane.buffer, Buffer::Empty))
+                    .then_some(pane.buffer.to_string())
+            })
+        }
     }
 }
 


### PR DESCRIPTION
This commit displays the open buffer in the window title, or "Halloy" if none is selected. I was a little frustrated about the clones in `dashboard.rs` (see the triple clone in `open_buffer`) so i removed one clone and dropped a todo for the rest.

Resolves: #1654