### PR TITLE
Fix MonitoredOffline notifications using wrong config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ Fixed:
 
 Thanks:
 
-- Contributions: @KaiKorla, @englut
-- Bug reports: chmod222, @whitequark, @englut, sebbu, @ascarion, @4e554c4c, @BKVad1m
+- Contributions: @KaiKorla, @englut, @mango766
+- Bug reports: chmod222, @whitequark, @englut, sebbu, @ascarion, @4e554c4c, @BKVad1m, @mango766
 - Feature requests: @gAlleb, @jtbx, @cyrneko, @englut
 
 # 2026.4 (2026-03-03)

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -145,7 +145,7 @@ impl Notifications {
             }
             Notification::MonitoredOffline(targets) => {
                 self.execute(
-                    &config.monitored_online,
+                    &config.monitored_offline,
                     notification,
                     if targets.len() == 1 {
                         "Monitored user is offline"
@@ -157,7 +157,7 @@ impl Notifications {
                     None,
                 );
 
-                config.monitored_online.request_attention
+                config.monitored_offline.request_attention
             }
             Notification::FileTransferRequest {
                 nick,


### PR DESCRIPTION
## Summary

Fixes #1659

The `Notification::MonitoredOffline` handler in `src/notification.rs` was using `config.monitored_online` instead of `config.monitored_offline` in two places:

- `self.execute(&config.monitored_online, ...)` — controls toast, sound, delay, and include/exclude behavior
- `config.monitored_online.request_attention` — controls whether the window requests user attention

This is a copy-paste issue from the `MonitoredOnline` arm directly above it. The result is that any user-configured `[notifications.monitored_offline]` settings (different sound, toast preference, etc.) are silently ignored in favor of the online config.

## Changes

- Changed both `config.monitored_online` references in the `MonitoredOffline` match arm to `config.monitored_offline`

## Test plan

- Verified the two-line diff only touches the `MonitoredOffline` arm and does not affect any other notification path
- Confirmed that `config::Notifications` already has a `monitored_offline` field (used nowhere else in the notify function, further confirming it was simply missed)