### PR TITLE
show Detach entry for all connected channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Changed:
 
 Thanks:
 
-- Contributions: @KaiKorla, @englut, @mango766
+- Contributions: @KaiKorla, @englut, @mango766, @ncfavier
 - Bug reports: chmod222, @whitequark, @englut, sebbu, @ascarion, @4e554c4c, @BKVad1m, @mango766
 - Feature requests: @gAlleb, @jtbx, @cyrneko, @englut
 

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -1,3 +1,4 @@
+use std::iter;
 use std::time::Duration;
 
 use data::config::{self, Config, sidebar};
@@ -805,13 +806,11 @@ impl Entry {
                     .collect_vec(),
             },
             if connected {
-                vec![Leave]
+                (matches!(buffer, buffer::Upstream::Channel(_, _))
+                    && supports_detach)
+                    .then_some(Detach)
                     .into_iter()
-                    .chain(
-                        (matches!(buffer, buffer::Upstream::Channel(_, _))
-                            && supports_detach)
-                            .then_some(Detach),
-                    )
+                    .chain(iter::once(Leave))
                     .collect_vec()
             } else {
                 vec![]


### PR DESCRIPTION
Currently the "Detach from channel" context menu entry is only shown for channels that aren't opened. I think it makes more sense to show it for all connected channels, like the Leave entry.