### PR TITLE
Add `AWS_LC_SYS_CFLAGS="-O0"` to fix flatpak build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+AWS_LC_SYS_CFLAGS="-O0"


### PR DESCRIPTION
Seeing the following error when building the latest `iced-update` branch for flatpak:

```log
warning: aws-lc-sys@0.38.0:    47 |  #error "The CPU Jitter random number generator must not be compiled with optimizations. See documentation. Use the compiler switch -O0 for compiling jitterentropy.c."
warning: aws-lc-sys@0.38.0:       |   ^~~~~
warning: aws-lc-sys@0.38.0: ToolExecError: command did not execute successfully (status code exit status: 1): LC_ALL="C" "cc" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "-m64" "-I" "/run/build/halloy/cargo/vendor/aws-lc-sys-0.38.0/generated-include" "-I" "/run/build/halloy/cargo/vendor/aws-lc-sys-0.38.0/include" "-I" "/run/build/halloy/cargo/vendor/aws-lc-sys-0.38.0/aws-lc/include" "-I" "/run/build/halloy/cargo/vendor/aws-lc-sys-0.38.0/aws-lc/third_party/s2n-bignum/include" "-I" "/run/build/halloy/cargo/vendor/aws-lc-sys-0.38.0/aws-lc/third_party/s2n-bignum/s2n-bignum-imported/include" "-I" "/run/build/halloy/cargo/vendor/aws-lc-sys-0.38.0/aws-lc/third_party/jitterentropy/jitterentropy-library" "-fwrapv" "--param" "ssp-buffer-size=4" "-fvisibility=hidden" "-Wcast-align" "-Wmissing-field-initializers" "-Wshadow" "-Wswitch-enum" "-Wextra" "-Wall" "-pedantic" "-O0" "-fwrapv" "-Wconversion" "--include=/run/build/halloy/cargo/vendor/aws-lc-sys-0.38.0/generated-include/openssl/boringssl_prefix_symbols.h" "-DBORINGSSL_IMPLEMENTATION=1" "-DBORINGSSL_PREFIX=aws_lc_0_38_0" "-DAWSLC=1" "-O2" "-pipe" "-g" "-Wp,-D_FORTIFY_SOURCE=3" "-Wp,-D_GLIBCXX_ASSERTIONS" "-fexceptions" "-fstack-protector-strong" "-grecord-gcc-switches" "-fasynchronous-unwind-tables" "-fstack-clash-protection" "-fcf-protection" "-fno-omit-frame-pointer" "-mno-omit-leaf-frame-pointer" "-O2" "-pipe" "-g" "-Wp,-D_FORTIFY_SOURCE=3" "-Wp,-D_GLIBCXX_ASSERTIONS" "-fexceptions" "-fstack-protector-strong" "-grecord-gcc-switches" "-fasynchronous-unwind-tables" "-fstack-clash-protection" "-fcf-protection" "-fno-omit-frame-pointer" "-mno-omit-leaf-frame-pointer" "-o" "/run/build/halloy/target/release/build/aws-lc-sys-27884e386f0f02c7/out/2d40dbbd793ef942-jitterentropy-base.o" "-c" "/run/build/halloy/cargo/vendor/aws-lc-sys-0.38.0/aws-lc/third_party/jitterentropy/jitterentropy-library/src/jitterentropy-base.c"cargo:rerun-if-env-changed=CC_x86_64-unknown-linux-gnu
error: failed to run custom build command for `aws-lc-sys v0.38.0`

Caused by:
  process didn't exit successfully: `/run/build/halloy/target/release/build/aws-lc-sys-cea60fe430f0ee23/build-script-main` (exit status: 1)
  --- stdout
```

@andymandias suggested using `AWS_LC_SYS_CFLAGS="-O0"` to build, which indeed fixes the build for flatpak. 

Including the flag in `.cargo/config.toml` to ensure all builds behave similarly.