### PR TITLE
More Multiline Fixes

### DIFF
--- a/data/src/capabilities.rs
+++ b/data/src/capabilities.rs
@@ -4,7 +4,7 @@ use std::string::ToString;
 
 use irc::proto::{self, Tags, command, format};
 
-use crate::message::formatting::{Formatting, Modifier, update_with_modifier};
+use crate::message::formatting::{Modifier, update_formatting_with_modifier};
 use crate::{Target, User, config, message};
 
 // This is not an exhaustive list of IRCv3 capabilities, just the ones that
@@ -90,57 +90,73 @@ impl MultilineLimits {
     }
 }
 
-pub fn multiline_concat_lines(
-    concat_bytes: usize,
-    text: &str,
-) -> Vec<(Formatting, &str)> {
+// Forbid splitting inside formatting sequences and attempt to split at spaces
+// for better compatibility with clients that don't support multiline.
+pub fn multiline_concat_lines(concat_bytes: usize, text: &str) -> Vec<&str> {
     let mut lines = Vec::new();
 
     let mut line_start = 0;
+    let mut last_space = 0;
     let mut line_bytes = 0;
 
     let mut modifiers = HashSet::new();
     let mut fg = None;
     let mut bg = None;
 
-    let mut line_modifiers = modifiers.clone();
-    let mut line_fg = None;
-    let mut line_bg = None;
-
     let mut iter = text.chars().peekable();
 
     while let Some(c) = iter.next() {
-        if (line_bytes + c.len_utf8()) > concat_bytes {
-            lines.push((
-                Formatting::new(&line_modifiers, line_fg, line_bg),
-                &text[line_start..line_start + line_bytes],
-            ));
-
-            line_start += line_bytes;
-            line_bytes = Formatting::new(&modifiers, fg, bg).to_string().len();
-
-            line_modifiers = modifiers.clone();
-            line_fg = fg;
-            line_bg = bg;
-        }
-
-        if let Ok(modifier) = Modifier::try_from(c) {
-            update_with_modifier(
+        let sequence_bytes = if let Ok(modifier) = Modifier::try_from(c) {
+            let (sequence_bytes, comma) = update_formatting_with_modifier(
                 &mut modifiers,
                 &mut fg,
                 &mut bg,
                 modifier,
                 &mut iter,
             );
+
+            // This will prevent breaking a color modifier away from a
+            // non-modifier, trailing comma; behaves that way solely for
+            // simplicity's sake
+            sequence_bytes + comma.map_or(0, char::len_utf8)
+        } else {
+            c.len_utf8()
+        };
+
+        if (line_bytes + sequence_bytes) > concat_bytes {
+            if last_space > line_start {
+                lines.push(&text[line_start..last_space + ' '.len_utf8()]);
+
+                println!(
+                    "line_bytes {line_bytes} last_space {last_space} line_start {line_start} space_len {}",
+                    ' '.len_utf8()
+                );
+                line_bytes -= last_space + ' '.len_utf8() - line_start;
+                line_start = last_space + ' '.len_utf8();
+                println!("line_bytes {line_bytes} line_start {line_start}");
+
+                if line_bytes > concat_bytes {
+                    lines.push(&text[line_start..line_start + line_bytes]);
+
+                    line_start += line_bytes;
+                    line_bytes = 0;
+                }
+            } else {
+                lines.push(&text[line_start..line_start + line_bytes]);
+
+                line_start += line_bytes;
+                line_bytes = 0;
+            }
         }
 
-        line_bytes += c.len_utf8();
+        if c == ' ' {
+            last_space = line_start + line_bytes;
+        }
+
+        line_bytes += sequence_bytes;
     }
 
-    lines.push((
-        Formatting::new(&line_modifiers, line_fg, line_bg),
-        &text[line_start..],
-    ));
+    lines.push(&text[line_start..]);
 
     lines
 }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -27,7 +27,7 @@ use crate::isupport::{
     ChatHistoryState, ChatHistorySubcommand, MessageReference, WhoToken,
     WhoXPollParameters, find_target_limit,
 };
-use crate::message::{formatting, source};
+use crate::message::source;
 use crate::rate_limit::{BackoffInterval, TokenBucket, TokenPriority};
 use crate::target::{self, Target};
 use crate::time::Posix;
@@ -670,15 +670,12 @@ impl Client {
                                     .flat_map(|line| {
                                         let mut concat_lines = line
                                             .into_iter()
-                                            .map(|(formatting, text)| {
+                                            .map(|text| {
                                                 multiline_encoded(
                                                     None,
                                                     batch_kind,
                                                     target,
-                                                    format!(
-                                                        "{formatting}{text}"
-                                                    )
-                                                    .as_str(),
+                                                    text,
                                                     message.tags.clone(),
                                                 )
                                             })
@@ -3055,8 +3052,6 @@ impl Client {
                         {
                             text.push('\n');
                         }
-
-                        text.push(formatting::Modifier::Reset.into());
                     } else {
                         *kind = Some(MultilineBatchKind::PRIVMSG);
                     }
@@ -3078,8 +3073,6 @@ impl Client {
                         {
                             text.push('\n');
                         }
-
-                        text.push(formatting::Modifier::Reset.into());
                     } else {
                         *kind = Some(MultilineBatchKind::NOTICE);
                     }

--- a/data/src/message/formatting.rs
+++ b/data/src/message/formatting.rs
@@ -99,9 +99,9 @@ pub fn parse_fragments(
                 }
             }
 
-            if let Some(c) =
-                update_with_modifier(modifiers, fg, bg, modifier, &mut iter)
-            {
+            if let (_, Some(c)) = update_formatting_with_modifier(
+                modifiers, fg, bg, modifier, &mut iter,
+            ) {
                 current_text.push(c);
             }
         } else {
@@ -127,13 +127,15 @@ pub fn parse_fragments(
     Some(fragments)
 }
 
-pub fn update_with_modifier(
+pub fn update_formatting_with_modifier(
     modifiers: &mut HashSet<Modifier>,
     fg: &mut Option<Color>,
     bg: &mut Option<Color>,
     modifier: Modifier,
     mut iter: impl itertools::PeekingNext<Item = char>,
-) -> Option<char> {
+) -> (usize, Option<char>) {
+    let mut sequence_bytes = modifier.char().len_utf8();
+
     match modifier {
         Modifier::Reset => {
             modifiers.clear();
@@ -143,33 +145,41 @@ pub fn update_with_modifier(
         Modifier::Color => {
             // Trailing digit for new color, otherwise resets
             if let Some(c) = iter.peeking_next(char::is_ascii_digit) {
+                sequence_bytes += c.len_utf8();
                 // 1-2 digiits
                 let mut digits = c.to_string();
                 if let Some(c) = iter.peeking_next(char::is_ascii_digit) {
+                    sequence_bytes += c.len_utf8();
                     digits.push(c);
                 }
 
-                let code = digits.parse().ok()?;
+                let Ok(code) = digits.parse() else {
+                    return (sequence_bytes, None);
+                };
 
                 *fg = Color::code(code);
 
                 if let Some(comma) = iter.peeking_next(|c| *c == ',') {
                     // Has background
                     if let Some(c) = iter.peeking_next(char::is_ascii_digit) {
+                        sequence_bytes += comma.len_utf8() + c.len_utf8();
                         // 1-2 digits
                         let mut digits = c.to_string();
                         if let Some(c) = iter.peeking_next(char::is_ascii_digit)
                         {
+                            sequence_bytes += c.len_utf8();
                             digits.push(c);
                         }
 
-                        let code = digits.parse().ok()?;
+                        let Ok(code) = digits.parse() else {
+                            return (sequence_bytes, None);
+                        };
 
                         *bg = Color::code(code);
                     }
                     // Nope, just a normal char
                     else {
-                        return Some(comma);
+                        return (sequence_bytes, Some(comma));
                     }
                 }
             } else {
@@ -180,27 +190,35 @@ pub fn update_with_modifier(
         Modifier::HexColor => {
             // Trailing digit for new color, otherwise resets
             if let Some(c) = iter.peeking_next(char::is_ascii_hexdigit) {
+                sequence_bytes += c.len_utf8();
                 // 6 digits (hex)
                 let mut hex = Vec::from([c]);
                 for _ in 0..5 {
-                    hex.push(iter.next()?);
+                    let Some(hexdigit) = iter.next() else {
+                        return (sequence_bytes, None);
+                    };
+                    sequence_bytes += hexdigit.len_utf8();
+                    hex.push(hexdigit);
                 }
 
-                let r = u8::from_str_radix(
+                let Ok(r) = u8::from_str_radix(
                     &hex.iter().take(2).collect::<String>(),
                     16,
-                )
-                .ok()?;
-                let g = u8::from_str_radix(
+                ) else {
+                    return (sequence_bytes, None);
+                };
+                let Ok(g) = u8::from_str_radix(
                     &hex.iter().skip(2).take(2).collect::<String>(),
                     16,
-                )
-                .ok()?;
-                let b = u8::from_str_radix(
+                ) else {
+                    return (sequence_bytes, None);
+                };
+                let Ok(b) = u8::from_str_radix(
                     &hex.iter().skip(4).take(2).collect::<String>(),
                     16,
-                )
-                .ok()?;
+                ) else {
+                    return (sequence_bytes, None);
+                };
 
                 *fg = Some(Color::Rgb(r, g, b));
 
@@ -208,33 +226,41 @@ pub fn update_with_modifier(
                     // Has background
                     if let Some(c) = iter.peeking_next(char::is_ascii_hexdigit)
                     {
+                        sequence_bytes += comma.len_utf8() + c.len_utf8();
                         // 6 digits (hex)
                         let mut hex = Vec::from([c]);
                         for _ in 0..5 {
-                            hex.push(iter.next()?);
+                            let Some(hexdigit) = iter.next() else {
+                                return (sequence_bytes, None);
+                            };
+                            sequence_bytes += hexdigit.len_utf8();
+                            hex.push(hexdigit);
                         }
 
-                        let r = u8::from_str_radix(
+                        let Ok(r) = u8::from_str_radix(
                             &hex.iter().take(2).collect::<String>(),
                             16,
-                        )
-                        .ok()?;
-                        let g = u8::from_str_radix(
+                        ) else {
+                            return (sequence_bytes, None);
+                        };
+                        let Ok(g) = u8::from_str_radix(
                             &hex.iter().skip(2).take(2).collect::<String>(),
                             16,
-                        )
-                        .ok()?;
-                        let b = u8::from_str_radix(
+                        ) else {
+                            return (sequence_bytes, None);
+                        };
+                        let Ok(b) = u8::from_str_radix(
                             &hex.iter().skip(4).take(2).collect::<String>(),
                             16,
-                        )
-                        .ok()?;
+                        ) else {
+                            return (sequence_bytes, None);
+                        };
 
                         *bg = Some(Color::Rgb(r, g, b));
                     }
                     // Nope, just a normal char
                     else {
-                        return Some(comma);
+                        return (sequence_bytes, Some(comma));
                     }
                 }
             } else {
@@ -251,7 +277,7 @@ pub fn update_with_modifier(
         }
     }
 
-    None
+    (sequence_bytes, None)
 }
 
 #[derive(


### PR DESCRIPTION
Removes format continuation in multiline, to be restored if/when it is more widely supported (previous behavior would break formatting when interacting with IRCCloud, for example).

Improves concatenation line breaks by attempting to break after a space if possible, and prevent breaking within a formatting sequence (this should produce better fallback behavior for clients that don't support multiline).