### PR TITLE
Documentation tip for running password commands in flatpak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Changed:
 
 Thanks:
 
-- Contributions: @KaiKorla, @englut, @mango766, @ncfavier
+- Contributions: @KaiKorla, @englut, @mango766, @ncfavier, @classabbyamp
 - Bug reports: chmod222, @whitequark, @englut, sebbu, @ascarion, @4e554c4c, @BKVad1m, @mango766
 - Feature requests: @gAlleb, @jtbx, @cyrneko, @englut
 

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -204,6 +204,18 @@ Executes the command with `sh` (or equivalent) and reads `password` as the outpu
 password_command = ""
 ```
 
+::: tip
+Flatpak users need to grant host command access.
+
+Run the following in terminal:
+
+```sh
+flatpak override org.squidowl.halloy --talk-name=org.freedesktop.Flatpak
+```
+
+Then set `password_command` to `flatpak-spawn --host <password_command>`
+:::
+
 ## `channels`
 
 A list of channels to join on connection.


### PR DESCRIPTION
Added a little info/tip section to help flatpak users with accessing host commands for `password_command`.

<img width="1009" height="811" alt="Screenshot_20260318_201725" src="https://github.com/user-attachments/assets/e51316b6-49de-4707-916e-a11c9a0339db" />

Was surfaced in #1656 by @classabbyamp