### PR TITLE
Remove `AWS_LC_SYS_NO_JITTER_ENTROPY=1` in flatpak manifest

### DIFF
--- a/assets/flatpak/org.squidowl.halloy.json
+++ b/assets/flatpak/org.squidowl.halloy.json
@@ -25,8 +25,7 @@
             "buildsystem": "simple",
             "build-options": {
                 "env": {
-                    "CARGO_HOME": "/run/build/halloy/cargo",
-                    "AWS_LC_SYS_NO_JITTER_ENTROPY": "1"
+                    "CARGO_HOME": "/run/build/halloy/cargo"
                 }
             },
             "build-commands": [


### PR DESCRIPTION
With the latest commit to `main`, the `AWS_LC_SYS_NO_JITTER_ENTROPY` env var used to pass flatpak builds is no longer needed.

The updated version of `aws-lc-sys` builds flatpak successfully without the var.