### PR TITLE
docs: document `auto-format`'s values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Fixed:
 
 Thanks:
 
-- Contributions: @furudean
+- Contributions: @furudean, @omentic
 - Bug reports: sebbu
 
 # 2026.5 (2026-03-21)

--- a/docs/configuration/buffer.md
+++ b/docs/configuration/buffer.md
@@ -1223,6 +1223,7 @@ auto_format = "markdown"
 ```
 
 ::: tip
+Token-based formatting is included in `"all"`, in addition to Markdown formatting, which provides underline and color formatting that `"markdown"` does not.
 Read more about [text formatting](/guides/text-formatting).
 :::
 

--- a/docs/guides/text-formatting.md
+++ b/docs/guides/text-formatting.md
@@ -79,6 +79,6 @@ By default, Halloy will only format text when using the `/format` command. This,
 auto_format = "disabled" | "markdown" | "all"
 ```
 
-Token-based formatting is included in `"all"`, which has colors while `"markdown"` does not.
+Token-based formatting is included in `"all"`, in addition to Markdown formatting, which provides underline and color formatting that `"markdown"` does not.
 
 When `auto_format` is enabled, it can be disabled for an individual message by using the `/plain` command.


### PR DESCRIPTION
Minor docs addition. It's currently not clear what the difference between `auto-format = "markdown"` and `auto-format = "all"` is.