### PR TITLE
docs: show example bindings using non-alphabetical keys

### DIFF
--- a/docs/configuration/keyboard.md
+++ b/docs/configuration/keyboard.md
@@ -5,12 +5,12 @@ Customize keyboard shortcuts. Below is a list of all actions which can be mapped
 
 ```toml
 [keyboard]
-move_up = "alt+k"
-move_down = "alt+j"
-move_left = "alt+h"
-move_right = "alt+l"
-quit_application = ["alt+q", "ctrl+q"]
-command_bar = "noop" # <- use noop or none to disable key bind.
+move_up = ["alt+up", "alt+k"]
+move_down = ["alt+down", "alt+j"]
+move_left = ["alt+left", "alt+h"]
+move_right = ["alt+right", "alt+l"]
+quit_application = "alt+q"
+command_bar = "noop"
 ```
 
 Note you can disable a key bind by setting it to `"noop"` or `"none"`.


### PR DESCRIPTION
The example in the configuration section here does not show off how to bind non-alphabetical keybinds. The default keybindings here are described symbolically (i.e. with ↑ ↓ ← →), which is pretty but nondescriptive.

This just turns the Vim-style example bindings into arrays of keybind strings, and turns the `quit_application` example into a single keybind to ensure single keybinds remain shown off. It also removes the comment on the `"noop"` binding, since that information is reproduced directly below.

This page should probably provide a list of all non-alphabetical keybinds, since there is no consistent behaviour across different applications that bind keys. (i.e. how do you bind `Ctrl` `+`? It's probably `"ctrl+plus"`, but I haven't looked into what Halloy does here yet...)