### PR TITLE
bind `cmd+,`/`ctrl+,` to open config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Unreleased
 
+Added:
+
+- <kbd>⌘</kbd> + <kbd>,</kbd> now opens the config file on macOs
+
 Fixed:
 
 - `sidebar.order_by` setting works when set to `"config"`
 
 Thanks:
 
+- Contributions: @furudean
 - Bug reports: sebbu
 
 # 2026.5 (2026-03-21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Added:
 
-- <kbd>⌘</kbd> + <kbd>,</kbd> now opens the config file on macOs
+- <kbd>ctrl</kbd> + <kbd>,</kbd> now opens the config file (<kbd>⌘</kbd> + <kbd>,</kbd> on macOs)
 
 Fixed:
 

--- a/data/src/config/keys.rs
+++ b/data/src/config/keys.rs
@@ -37,6 +37,7 @@ pub struct Keyboard {
     pub cycle_previous_unread_buffer: KeyBinds,
     pub mark_as_read: KeyBinds,
     pub quit_application: KeyBinds,
+    pub open_config_file: KeyBinds,
 }
 
 impl Default for Keyboard {
@@ -74,6 +75,7 @@ impl Default for Keyboard {
                 KeyBind::cycle_previous_unread_buffer().into(),
             mark_as_read: KeyBind::mark_as_read().into(),
             quit_application: KeyBind::quit_application().into(),
+            open_config_file: KeyBind::open_config_file().into(),
         }
     }
 }
@@ -126,6 +128,7 @@ impl Keyboard {
         );
         push(&self.mark_as_read, MarkAsRead);
         push(&self.quit_application, QuitApplication);
+        push(&self.open_config_file, OpenConfigFile);
 
         shortcuts
     }

--- a/data/src/shortcut.rs
+++ b/data/src/shortcut.rs
@@ -107,6 +107,7 @@ pub enum Command {
     CycleNextUnreadBuffer,
     CyclePreviousUnreadBuffer,
     MarkAsRead,
+    OpenConfigFile,
 }
 
 macro_rules! default {
@@ -293,6 +294,8 @@ impl KeyBind {
     default!(quit_application, "q", CTRL);
     #[cfg(not(target_os = "linux"))]
     default!(quit_application);
+    #[cfg(target_os = "macos")]
+    default!(open_config_file, ",", COMMAND);
 }
 
 impl From<(keyboard::Key, keyboard::Modifiers)> for KeyBind {

--- a/data/src/shortcut.rs
+++ b/data/src/shortcut.rs
@@ -297,7 +297,7 @@ impl KeyBind {
     #[cfg(target_os = "macos")]
     default!(open_config_file, ",", COMMAND);
     #[cfg(not(target_os = "macos"))]
-    default!(open_config_file);
+    default!(open_config_file, ",", CTRL);
 }
 
 impl From<(keyboard::Key, keyboard::Modifiers)> for KeyBind {

--- a/data/src/shortcut.rs
+++ b/data/src/shortcut.rs
@@ -296,6 +296,8 @@ impl KeyBind {
     default!(quit_application);
     #[cfg(target_os = "macos")]
     default!(open_config_file, ",", COMMAND);
+    #[cfg(not(target_os = "macos"))]
+    default!(open_config_file);
 }
 
 impl From<(keyboard::Key, keyboard::Modifiers)> for KeyBind {

--- a/docs/configuration/keyboard.md
+++ b/docs/configuration/keyboard.md
@@ -51,4 +51,4 @@ Each shortcut accepts either a single keybind string or an array of keybind stri
 | `theme_editor`                 | Toggle Theme Editor Window          | <kbd>⌘</kbd> + <kbd>t</kbd>                         | <kbd>ctrl</kbd> + <kbd>t</kbd>                      |
 | `highlights`                   | Toggle Highlights Window            | <kbd>⌘</kbd> + <kbd>i</kbd>                         | <kbd>ctrl</kbd> + <kbd>i</kbd>                      |
 | `quit_application`             | Quit Halloy                         | None                                                | None                                                |
-| `open_config_file`             | Open settings file in system editor | <kbd>⌘</kbd> + <kbd>,</kbd>                         | None                                                |
+| `open_config_file`             | Open settings file in system editor | <kbd>⌘</kbd> + <kbd>,</kbd>                         | <kbd>ctrl</kbd> + <kbd>,</kbd>None                  |

--- a/docs/configuration/keyboard.md
+++ b/docs/configuration/keyboard.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable MD033 -->
+
 # Keyboard
 
 Customize keyboard shortcuts. Below is a list of all actions which can be mapped.
@@ -18,35 +19,36 @@ Each shortcut accepts either a single keybind string or an array of keybind stri
 
 ## Types
 
-| Key                            | Description                  | Default MacOS                                       | Default Other                                       |
-| ------------------------------ | ---------------------------- | --------------------------------------------------- | --------------------------------------------------- |
-| `move_up`                      | Moves focus up               | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>↑</kbd>          | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>↑</kbd>     |
-| `move_down`                    | Moves focus down             | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>↓</kbd>          | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>↓</kbd>     |
-| `move_left`                    | Moves focus left             | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>←</kbd>          | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>←</kbd>     |
-| `move_right`                   | Moves focus right            | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>→</kbd>          | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>→</kbd>     |
-| `new_horizontal_buffer`        | New horizontal buffer        | None                                                | None                                                |
-| `new_vertical_buffer`          | New vertical buffer          | None                                                | None                                                |
-| `close_buffer`                 | Close focused buffer         | <kbd>⌘</kbd> + <kbd>w</kbd>                         | <kbd>ctrl</kbd> + <kbd>w</kbd>                      |
-| `maximize_buffer`              | Maximize focused buffer      | <kbd>⌘</kbd> + <kbd>shift</kbd> + <kbd>↑</kbd>      | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>↑</kbd>   |
-| `restore_buffer`               | Restore focused buffer       | <kbd>⌘</kbd> + <kbd>shift</kbd> + <kbd>↓</kbd>      | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>↓</kbd>   |
-| `cycle_next_buffer`            | Cycle to next buffer         | <kbd>ctrl</kbd> + <kbd>tab</kbd>                    | <kbd>ctrl</kbd> + <kbd>tab</kbd>                    |
-| `cycle_previous_buffer`        | Cycle to previous buffer     | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>tab</kbd> | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>tab</kbd> |
-| `cycle_next_unread_buffer`     | Cycle to next buffer         | <kbd>ctrl</kbd> + <kbd>`</kbd>                      | <kbd>ctrl</kbd> + <kbd>`</kbd>                      |
-| `cycle_previous_unread_buffer` | Cycle to previous buffer     | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>`</kbd>   | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>`</kbd>   |
-| `scroll_up_page`               | Scroll buffer up a page      | <kbd>Fn</kbd> + <kbd>↑</kbd>                        | <kbd>pageup</kbd>                                   |
-| `scroll_down_page`             | Scroll buffer down a page    | <kbd>Fn</kbd> + <kbd>↓</kbd>                        | <kbd>pagedown</kbd>                                 |
-| `scroll_to_top`                | Scroll to top of buffer      | <kbd>⌘</kbd> + <kbd>↑</kbd>                         | <kbd>ctrl</kbd> + <kbd>↑</kbd>                      |
-| `scroll_to_bottom`             | Scroll to bottom of buffer   | <kbd>⌘</kbd> + <kbd>↓</kbd>                         | <kbd>ctrl</kbd> + <kbd>↓</kbd>                      |
-| `leave_buffer`                 | Leave channel or close query | <kbd>⌘</kbd> + <kbd>shift</kbd> + <kbd>w</kbd>      | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>w</kbd>   |
-| `mark_as_read`                 | Mark focused buffer as read  | <kbd>⌘</kbd> + <kbd>shift</kbd> + <kbd>m</kbd>      | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>m</kbd>   |
-| `toggle_nick_list`             | Toggle nick list             | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>m</kbd>          | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>m</kbd>     |
-| `toggle_topic`                 | Toggle topic                 | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>t</kbd>          | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>t</kbd>     |
-| `toggle_sidebar`               | Toggle sidebar               | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>b</kbd>          | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>b</kbd>     |
-| `toggle_fullscreen`            | Toggle fullscreen            | <kbd>⌘</kbd> + <kbd>ctrl</kbd> + <kbd>f</kbd>       | <kbd>F11</kbd>                                      |
-| `command_bar`                  | Toggle command bar           | <kbd>⌘</kbd> + <kbd>k</kbd>                         | <kbd>ctrl</kbd> + <kbd>k</kbd>                      |
-| `reload_configuration`         | Reload configuration file    | <kbd>⌘</kbd> + <kbd>r</kbd>                         | <kbd>ctrl</kbd> + <kbd>r</kbd>                      |
-| `file_transfers`               | Toggle File Transfers Buffer | <kbd>⌘</kbd> + <kbd>j</kbd>                         | <kbd>ctrl</kbd> + <kbd>j</kbd>                      |
-| `logs`                         | Toggle Logs Buffer           | <kbd>⌘</kbd> + <kbd>l</kbd>                         | <kbd>ctrl</kbd> + <kbd>l</kbd>                      |
-| `theme_editor`                 | Toggle Theme Editor Window   | <kbd>⌘</kbd> + <kbd>t</kbd>                         | <kbd>ctrl</kbd> + <kbd>t</kbd>                      |
-| `highlights`                   | Toggle Highlights Window     | <kbd>⌘</kbd> + <kbd>i</kbd>                         | <kbd>ctrl</kbd> + <kbd>i</kbd>                      |
-| `quit_application`             | Quit Halloy                  | None                                                | None                                                |
+| Key                            | Description                         | Default MacOS                                       | Default Other                                       |
+| ------------------------------ | ----------------------------------- | --------------------------------------------------- | --------------------------------------------------- |
+| `move_up`                      | Moves focus up                      | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>↑</kbd>          | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>↑</kbd>     |
+| `move_down`                    | Moves focus down                    | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>↓</kbd>          | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>↓</kbd>     |
+| `move_left`                    | Moves focus left                    | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>←</kbd>          | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>←</kbd>     |
+| `move_right`                   | Moves focus right                   | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>→</kbd>          | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>→</kbd>     |
+| `new_horizontal_buffer`        | New horizontal buffer               | None                                                | None                                                |
+| `new_vertical_buffer`          | New vertical buffer                 | None                                                | None                                                |
+| `close_buffer`                 | Close focused buffer                | <kbd>⌘</kbd> + <kbd>w</kbd>                         | <kbd>ctrl</kbd> + <kbd>w</kbd>                      |
+| `maximize_buffer`              | Maximize focused buffer             | <kbd>⌘</kbd> + <kbd>shift</kbd> + <kbd>↑</kbd>      | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>↑</kbd>   |
+| `restore_buffer`               | Restore focused buffer              | <kbd>⌘</kbd> + <kbd>shift</kbd> + <kbd>↓</kbd>      | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>↓</kbd>   |
+| `cycle_next_buffer`            | Cycle to next buffer                | <kbd>ctrl</kbd> + <kbd>tab</kbd>                    | <kbd>ctrl</kbd> + <kbd>tab</kbd>                    |
+| `cycle_previous_buffer`        | Cycle to previous buffer            | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>tab</kbd> | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>tab</kbd> |
+| `cycle_next_unread_buffer`     | Cycle to next buffer                | <kbd>ctrl</kbd> + <kbd>`</kbd>                      | <kbd>ctrl</kbd> + <kbd>`</kbd>                      |
+| `cycle_previous_unread_buffer` | Cycle to previous buffer            | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>`</kbd>   | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>`</kbd>   |
+| `scroll_up_page`               | Scroll buffer up a page             | <kbd>Fn</kbd> + <kbd>↑</kbd>                        | <kbd>pageup</kbd>                                   |
+| `scroll_down_page`             | Scroll buffer down a page           | <kbd>Fn</kbd> + <kbd>↓</kbd>                        | <kbd>pagedown</kbd>                                 |
+| `scroll_to_top`                | Scroll to top of buffer             | <kbd>⌘</kbd> + <kbd>↑</kbd>                         | <kbd>ctrl</kbd> + <kbd>↑</kbd>                      |
+| `scroll_to_bottom`             | Scroll to bottom of buffer          | <kbd>⌘</kbd> + <kbd>↓</kbd>                         | <kbd>ctrl</kbd> + <kbd>↓</kbd>                      |
+| `leave_buffer`                 | Leave channel or close query        | <kbd>⌘</kbd> + <kbd>shift</kbd> + <kbd>w</kbd>      | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>w</kbd>   |
+| `mark_as_read`                 | Mark focused buffer as read         | <kbd>⌘</kbd> + <kbd>shift</kbd> + <kbd>m</kbd>      | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>m</kbd>   |
+| `toggle_nick_list`             | Toggle nick list                    | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>m</kbd>          | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>m</kbd>     |
+| `toggle_topic`                 | Toggle topic                        | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>t</kbd>          | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>t</kbd>     |
+| `toggle_sidebar`               | Toggle sidebar                      | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>b</kbd>          | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>b</kbd>     |
+| `toggle_fullscreen`            | Toggle fullscreen                   | <kbd>⌘</kbd> + <kbd>ctrl</kbd> + <kbd>f</kbd>       | <kbd>F11</kbd>                                      |
+| `command_bar`                  | Toggle command bar                  | <kbd>⌘</kbd> + <kbd>k</kbd>                         | <kbd>ctrl</kbd> + <kbd>k</kbd>                      |
+| `reload_configuration`         | Reload configuration file           | <kbd>⌘</kbd> + <kbd>r</kbd>                         | <kbd>ctrl</kbd> + <kbd>r</kbd>                      |
+| `file_transfers`               | Toggle File Transfers Buffer        | <kbd>⌘</kbd> + <kbd>j</kbd>                         | <kbd>ctrl</kbd> + <kbd>j</kbd>                      |
+| `logs`                         | Toggle Logs Buffer                  | <kbd>⌘</kbd> + <kbd>l</kbd>                         | <kbd>ctrl</kbd> + <kbd>l</kbd>                      |
+| `theme_editor`                 | Toggle Theme Editor Window          | <kbd>⌘</kbd> + <kbd>t</kbd>                         | <kbd>ctrl</kbd> + <kbd>t</kbd>                      |
+| `highlights`                   | Toggle Highlights Window            | <kbd>⌘</kbd> + <kbd>i</kbd>                         | <kbd>ctrl</kbd> + <kbd>i</kbd>                      |
+| `quit_application`             | Quit Halloy                         | None                                                | None                                                |
+| `open_config_file`             | Open settings file in system editor | <kbd>⌘</kbd> + <kbd>,</kbd>                         | None                                                |

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1508,7 +1508,7 @@ impl Dashboard {
                                 TokenPriority::User,
                             );
                         }
-                    },
+                    }
                     OpenConfigFile => {
                         let _ = open_url::open(Config::path());
                     }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1508,6 +1508,9 @@ impl Dashboard {
                                 TokenPriority::User,
                             );
                         }
+                    },
+                    OpenConfigFile => {
+                        let _ = open_url::open(Config::path());
                     }
                 }
             }

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -415,7 +415,7 @@ impl Sidebar {
                             ),
                             Menu::OpenConfigFile => context_button(
                                 text("Open config file"),
-                                None,
+                                Some(&keyboard.open_config_file),
                                 icon::config(),
                                 Message::OpenConfigFile,
                             ),


### PR DESCRIPTION
this has been a standard keybind in mac native programs since pretty much forever

~~there is no standard lingo for this on either linux or windows, so i didn't change anything for those platforms. i'm open to suggestions tho~~ ctrl+, on others!