### PR TITLE
Unread Indicators on Open Buffers

### DIFF
--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -378,7 +378,20 @@ impl History {
                     max_triggers_unread.is_some()
                 }
             }
-            History::Full { .. } => false,
+            History::Full {
+                messages,
+                read_marker,
+                ..
+            } => {
+                let latest = metadata::latest_triggers_unread(messages);
+
+                if let Some(read_marker) = read_marker {
+                    latest
+                        .is_some_and(|latest| read_marker.date_time() < latest)
+                } else {
+                    latest.is_some()
+                }
+            }
         }
     }
 

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -248,6 +248,11 @@ impl TitleBar {
         } else {
             false
         };
+        let has_unread = if let Some(kind) = &maybe_buffer_kind {
+            history.has_unread(kind)
+        } else {
+            false
+        };
 
         // Pane controls.
         let controls = row![
@@ -260,7 +265,7 @@ impl TitleBar {
                         can_mark_as_read.then_some(Message::MarkAsRead),
                     )
                     .style(move |theme, status| {
-                        theme::button::secondary(theme, status, false)
+                        theme::button::secondary(theme, status, has_unread)
                     });
 
                 let mark_as_read_button_with_tooltip = tooltip(


### PR DESCRIPTION
Indicate when open buffers have unread messages by highlighting the mark as read button and putting the unread indicator in the sidebar, to make it easier to tell at a glance whether a buffer has new messages that are not server messages.