### PR TITLE
filehost: use proxy configuration

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -178,7 +178,7 @@ pub struct Client {
     anti_flood: Option<TokenBucket<message::Encoded>>,
     mode_requests: Vec<ModeRequest>,
     channel_discovery_manager: channel_discovery::Manager,
-    http_client: Option<Arc<reqwest::Client>>,
+    http_client: Option<Arc<reqwest::Client>>, // Only Some if config.proxy.is_some()
 }
 
 impl fmt::Debug for Client {
@@ -193,16 +193,18 @@ impl Client {
         config: Arc<config::Server>,
         sender: mpsc::Sender<proto::Message>,
     ) -> Self {
-        let http_client = {
-            match config::proxy::build_client(&config.proxy, None) {
+        // If config.proxy.is_none() then the default HTTP client will be used,
+        // in that case http_client can be None
+        let http_client = config.proxy.as_ref().and_then(|proxy| {
+            match config::proxy::build_client(Some(proxy), None) {
                 Ok(http_client) => Some(http_client),
                 Err(error) => {
-                    log::warn!("[{server}] Preview fetching disabled: {error}");
+                    log::warn!("[{server}] Unable to build HTTP client, preview fetching and file upload disabled: {error}");
 
                     None
                 }
             }
-        };
+        });
 
         Self {
             server,
@@ -4731,6 +4733,15 @@ impl Map {
     ) -> Option<Arc<reqwest::Client>> {
         self.client(server)
             .and_then(|client| client.http_client.clone())
+    }
+
+    pub fn get_server_proxy_config(
+        &self,
+        server: &Server,
+    ) -> Option<&config::Proxy> {
+        self.client(server)
+            .as_ref()
+            .and_then(|client| client.config.proxy.as_ref())
     }
 
     pub fn get_seed(&self, kind: &history::Kind) -> Option<history::Seed> {

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -178,7 +178,7 @@ pub struct Client {
     anti_flood: Option<TokenBucket<message::Encoded>>,
     mode_requests: Vec<ModeRequest>,
     channel_discovery_manager: channel_discovery::Manager,
-    preview_proxy_client: Option<Arc<reqwest::Client>>,
+    http_client: Option<Arc<reqwest::Client>>,
 }
 
 impl fmt::Debug for Client {
@@ -193,17 +193,15 @@ impl Client {
         config: Arc<config::Server>,
         sender: mpsc::Sender<proto::Message>,
     ) -> Self {
-        let preview_proxy_client = if let Some(proxy) = config.proxy.as_ref() {
-            match config::proxy::build_client(proxy) {
-                Ok(preview_proxy_client) => Some(preview_proxy_client),
+        let http_client = {
+            match config::proxy::build_client(&config.proxy, None) {
+                Ok(http_client) => Some(http_client),
                 Err(error) => {
                     log::warn!("[{server}] Preview fetching disabled: {error}");
 
                     None
                 }
             }
-        } else {
-            None
         };
 
         Self {
@@ -244,7 +242,7 @@ impl Client {
             resolved_netid: None,
             anti_flood: Some(TokenBucket::new(config.anti_flood, 10)),
             mode_requests: Vec::new(),
-            preview_proxy_client: preview_proxy_client.map(Arc::new),
+            http_client: http_client.map(Arc::new),
             config,
             channel_discovery_manager: channel_discovery::Manager::new(),
         }
@@ -4727,12 +4725,12 @@ impl Map {
         self.client(server).is_some()
     }
 
-    pub fn get_server_preview_proxy_client(
+    pub fn get_server_http_client(
         &self,
         server: &Server,
     ) -> Option<Arc<reqwest::Client>> {
         self.client(server)
-            .and_then(|client| client.preview_proxy_client.clone())
+            .and_then(|client| client.http_client.clone())
     }
 
     pub fn get_seed(&self, kind: &history::Kind) -> Option<history::Seed> {

--- a/data/src/config/proxy.rs
+++ b/data/src/config/proxy.rs
@@ -67,14 +67,18 @@ impl fmt::Display for Proxy {
     }
 }
 
-pub fn build_client(config: &Proxy) -> Result<reqwest::Client, BuildError> {
-    match config {
-        Proxy::Http {
+pub fn build_client(
+    proxy: &Option<Proxy>,
+    identity: Option<reqwest::Identity>,
+) -> Result<reqwest::Client, BuildError> {
+    let mut builder = match proxy {
+        None => reqwest::Client::builder(),
+        Some(Proxy::Http {
             host,
             port,
             username,
             password,
-        } => {
+        }) => {
             let mut proxy =
                 reqwest::Proxy::all(format!("http://{host}:{port}"))?;
 
@@ -84,14 +88,14 @@ pub fn build_client(config: &Proxy) -> Result<reqwest::Client, BuildError> {
                 proxy = proxy.basic_auth(username, password);
             }
 
-            Ok(reqwest::Client::builder().proxy(proxy).build()?)
+            reqwest::Client::builder().proxy(proxy)
         }
-        Proxy::Socks5 {
+        Some(Proxy::Socks5 {
             host,
             port,
             username,
             password,
-        } => {
+        }) => {
             let mut proxy =
                 reqwest::Proxy::all(format!("socks5://{host}:{port}"))?;
 
@@ -101,11 +105,17 @@ pub fn build_client(config: &Proxy) -> Result<reqwest::Client, BuildError> {
                 proxy = proxy.basic_auth(username, password);
             }
 
-            Ok(reqwest::Client::builder().proxy(proxy).build()?)
+            reqwest::Client::builder().proxy(proxy)
         }
         #[cfg(feature = "tor")]
-        Proxy::Tor => Err(BuildError::Tor),
+        Some(Proxy::Tor) => Err(BuildError::Tor),
+    };
+
+    if let Some(identity) = identity {
+        builder = builder.identity(identity);
     }
+
+    Ok(builder.build()?)
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/data/src/config/proxy.rs
+++ b/data/src/config/proxy.rs
@@ -68,7 +68,7 @@ impl fmt::Display for Proxy {
 }
 
 pub fn build_client(
-    proxy: &Option<Proxy>,
+    proxy: Option<&Proxy>,
     identity: Option<reqwest::Identity>,
 ) -> Result<reqwest::Client, BuildError> {
     let mut builder = match proxy {

--- a/data/src/fileupload.rs
+++ b/data/src/fileupload.rs
@@ -71,7 +71,7 @@ pub async fn upload(
     auth: Option<Auth>,
     irc_uses_tls: bool,
     client: Arc<Client>,
-    proxy_config: &Option<proxy::Proxy>,
+    proxy_config: Option<&proxy::Proxy>,
 ) -> Result<String, Error> {
     let base =
         Url::parse(upload_url).map_err(|e| Error::InvalidUri(e.to_string()))?;
@@ -126,7 +126,7 @@ pub async fn upload(
         }
         None => (None, None),
     };
-    let upload_client = external_client.as_ref().map_or(&*client, |c| c);
+    let upload_client = external_client.as_ref().unwrap_or(&client);
 
     log::debug!("uploading {file_name} to {base}");
 
@@ -174,7 +174,7 @@ pub async fn upload(
 async fn sasl_external_client(
     cert: &Path,
     key: Option<&Path>,
-    proxy_config: &Option<proxy::Proxy>,
+    proxy_config: Option<&proxy::Proxy>,
 ) -> Result<reqwest::Client, Error> {
     let cert_bytes = tokio::fs::read(cert).await?;
     let pem = if let Some(key_path) = key {

--- a/data/src/fileupload.rs
+++ b/data/src/fileupload.rs
@@ -8,6 +8,7 @@ use tokio_util::io::ReaderStream;
 use url::Url;
 
 use crate::config::server::Sasl;
+use crate::config::{self, proxy};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -23,6 +24,8 @@ pub enum Error {
     NoLocation,
     #[error("client certificate error: {0}")]
     ClientCert(String),
+    #[error("client build error: {0}")]
+    ClientBuildError(#[from] proxy::BuildError),
 }
 
 #[derive(Debug)]
@@ -68,6 +71,7 @@ pub async fn upload(
     auth: Option<Auth>,
     irc_uses_tls: bool,
     client: Arc<Client>,
+    proxy_config: &Option<proxy::Proxy>,
 ) -> Result<String, Error> {
     let base =
         Url::parse(upload_url).map_err(|e| Error::InvalidUri(e.to_string()))?;
@@ -111,7 +115,10 @@ pub async fn upload(
 
     let (external_client, auth_header) = match &auth {
         Some(Auth::External { cert, key }) => (
-            Some(sasl_external_client(cert, key.as_deref()).await?),
+            Some(
+                sasl_external_client(cert, key.as_deref(), proxy_config)
+                    .await?,
+            ),
             None,
         ),
         Some(Auth::Basic { username, password }) => {
@@ -167,6 +174,7 @@ pub async fn upload(
 async fn sasl_external_client(
     cert: &Path,
     key: Option<&Path>,
+    proxy_config: &Option<proxy::Proxy>,
 ) -> Result<reqwest::Client, Error> {
     let cert_bytes = tokio::fs::read(cert).await?;
     let pem = if let Some(key_path) = key {
@@ -178,10 +186,9 @@ async fn sasl_external_client(
 
     let identity = reqwest::tls::Identity::from_pem(&pem)
         .map_err(|e: reqwest::Error| Error::ClientCert(e.to_string()))?;
-    reqwest::Client::builder()
-        .identity(identity)
-        .build()
-        .map_err(Error::Http)
+
+    config::proxy::build_client(proxy_config, Some(identity))
+        .map_err(Error::ClientBuildError)
 }
 
 fn basic_auth_header(username: &str, password: &str) -> String {

--- a/data/src/version.rs
+++ b/data/src/version.rs
@@ -42,7 +42,7 @@ pub async fn latest_remote_version(
         tag_name: String,
     }
 
-    let client = config::proxy::build_client(&proxy, None).ok()?;
+    let client = config::proxy::build_client(proxy.as_ref(), None).ok()?;
 
     let response = client
         .get(LATEST_REMOTE_RELEASE_URL)

--- a/data/src/version.rs
+++ b/data/src/version.rs
@@ -42,19 +42,11 @@ pub async fn latest_remote_version(
         tag_name: String,
     }
 
-    let client = if let Some(proxy) = proxy {
-        // If the proxy fails to build it should be logged when the
-        // preview client is created, we can handle it silently here.
-        config::proxy::build_client(&proxy).ok()?
-    } else {
-        reqwest::Client::builder()
-            .user_agent("halloy")
-            .build()
-            .ok()?
-    };
+    let client = config::proxy::build_client(&proxy, None).ok()?;
 
     let response = client
         .get(LATEST_REMOTE_RELEASE_URL)
+        .header(reqwest::header::USER_AGENT, "halloy")
         .header(reqwest::header::ACCEPT, "application/vnd.github.v3+json")
         .send()
         .await

--- a/docs/configuration/sidebar.md
+++ b/docs/configuration/sidebar.md
@@ -225,8 +225,8 @@ Show unread/highlight indicators on buffers that have an open pane.
 # Values: true, false
 # Default: true
 
-[sidebar.show_on_open_buffers]
-show_on_open_buffers = true
+[sidebar.unread_indicator]
+show_on_open_buffers = false
 ```
 
 

--- a/docs/configuration/sidebar.md
+++ b/docs/configuration/sidebar.md
@@ -225,8 +225,8 @@ Show unread/highlight indicators on buffers that have an open pane.
 # Values: true, false
 # Default: true
 
-[sidebar.unread_indicator]
-show_on_open_buffers = false
+[sidebar.show_on_open_buffers]
+show_on_open_buffers = true
 ```
 
 

--- a/src/filehost.rs
+++ b/src/filehost.rs
@@ -68,8 +68,8 @@ impl Manager {
         &mut self,
         pending: PendingUpload,
         clients: &client::Map,
-        http_client: Arc<reqwest::Client>,
-        proxy: &Option<Proxy>,
+        default_http_client: Option<Arc<reqwest::Client>>,
+        default_proxy_config: &Option<Proxy>,
     ) -> (Task<Message>, Option<Event>) {
         let upload_url = pending.upload_url.clone();
         let has_credentials = pending.has_credentials;
@@ -77,8 +77,34 @@ impl Manager {
 
         if self.known.contains(&upload_url) {
             let irc_uses_tls = clients.get_use_tls(&pending.server);
+            let (http_client, proxy_config) = if let Some(proxy_config) =
+                clients.get_server_proxy_config(&pending.server)
+            {
+                (
+                    clients.get_server_http_client(&pending.server),
+                    Some(proxy_config),
+                )
+            } else {
+                (default_http_client, default_proxy_config.as_ref())
+            };
+
+            let Some(http_client) = http_client else {
+                // Detailed HTTP client build error should already be in the logs
+                log::warn!(
+                    "[{}] File upload disabled: Unable to build HTTP client",
+                    pending.server
+                );
+                return (Task::none(), None);
+            };
+
             (
-                start_tasks(pending, clients, irc_uses_tls, http_client, proxy),
+                start_tasks(
+                    pending,
+                    clients,
+                    irc_uses_tls,
+                    http_client,
+                    proxy_config,
+                ),
                 None,
             )
         } else {
@@ -98,8 +124,8 @@ impl Manager {
     pub fn proceed(
         &mut self,
         clients: &client::Map,
-        http_client: Arc<reqwest::Client>,
-        proxy_config: &Option<proxy::Proxy>,
+        default_http_client: Option<Arc<reqwest::Client>>,
+        default_proxy_config: &Option<proxy::Proxy>,
     ) -> Task<Message> {
         let pending = std::mem::take(&mut self.pending);
         if pending.is_empty() {
@@ -110,14 +136,26 @@ impl Manager {
             .into_iter()
             .map(|p| {
                 self.known.insert(p.upload_url.clone());
+
                 let irc_uses_tls = clients.get_use_tls(&p.server);
-                start_tasks(
-                    p,
-                    clients,
-                    irc_uses_tls,
-                    http_client.clone(),
-                    &proxy_config.clone(),
-                )
+                let (http_client, proxy_config) = if let Some(proxy_config) =
+                    clients.get_server_proxy_config(&p.server)
+                {
+                    (
+                        clients.get_server_http_client(&p.server),
+                        Some(proxy_config),
+                    )
+                } else {
+                    (default_http_client.clone(), default_proxy_config.as_ref())
+                };
+
+                let Some(http_client) = http_client else {
+                    // Detailed HTTP client build error should already be in the logs
+                    log::warn!("[{}] File upload disabled: Unable to build HTTP client", p.server);
+                    return Task::none();
+                };
+
+                start_tasks(p, clients, irc_uses_tls, http_client, proxy_config)
             })
             .collect();
 
@@ -160,7 +198,7 @@ fn start_tasks(
     clients: &client::Map,
     irc_uses_tls: bool,
     http_client: Arc<reqwest::Client>,
-    proxy_config: &Option<proxy::Proxy>,
+    proxy_config: Option<&proxy::Proxy>,
 ) -> Task<Message> {
     let PendingUpload {
         window,
@@ -182,7 +220,7 @@ fn start_tasks(
             let http_client = http_client.clone();
             let server = server.clone();
             let target = target.clone();
-            let proxy_config = proxy_config.clone();
+            let proxy_config = proxy_config.cloned();
 
             Task::perform(
                 async move {
@@ -192,7 +230,7 @@ fn start_tasks(
                         auth,
                         irc_uses_tls,
                         http_client,
-                        &proxy_config,
+                        proxy_config.as_ref(),
                     );
                     futures::future::Abortable::new(fut, registration).await
                 },

--- a/src/filehost.rs
+++ b/src/filehost.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use data::config::{Proxy, proxy};
 use data::target::Target;
 use data::{client, fileupload};
 use iced::Task;
@@ -68,6 +69,7 @@ impl Manager {
         pending: PendingUpload,
         clients: &client::Map,
         http_client: Arc<reqwest::Client>,
+        proxy: &Option<Proxy>,
     ) -> (Task<Message>, Option<Event>) {
         let upload_url = pending.upload_url.clone();
         let has_credentials = pending.has_credentials;
@@ -76,7 +78,7 @@ impl Manager {
         if self.known.contains(&upload_url) {
             let irc_uses_tls = clients.get_use_tls(&pending.server);
             (
-                start_tasks(pending, clients, irc_uses_tls, http_client),
+                start_tasks(pending, clients, irc_uses_tls, http_client, proxy),
                 None,
             )
         } else {
@@ -97,6 +99,7 @@ impl Manager {
         &mut self,
         clients: &client::Map,
         http_client: Arc<reqwest::Client>,
+        proxy_config: &Option<proxy::Proxy>,
     ) -> Task<Message> {
         let pending = std::mem::take(&mut self.pending);
         if pending.is_empty() {
@@ -108,7 +111,13 @@ impl Manager {
             .map(|p| {
                 self.known.insert(p.upload_url.clone());
                 let irc_uses_tls = clients.get_use_tls(&p.server);
-                start_tasks(p, clients, irc_uses_tls, http_client.clone())
+                start_tasks(
+                    p,
+                    clients,
+                    irc_uses_tls,
+                    http_client.clone(),
+                    &proxy_config.clone(),
+                )
             })
             .collect();
 
@@ -151,6 +160,7 @@ fn start_tasks(
     clients: &client::Map,
     irc_uses_tls: bool,
     http_client: Arc<reqwest::Client>,
+    proxy_config: &Option<proxy::Proxy>,
 ) -> Task<Message> {
     let PendingUpload {
         window,
@@ -172,6 +182,7 @@ fn start_tasks(
             let http_client = http_client.clone();
             let server = server.clone();
             let target = target.clone();
+            let proxy_config = proxy_config.clone();
 
             Task::perform(
                 async move {
@@ -181,6 +192,7 @@ fn start_tasks(
                         auth,
                         irc_uses_tls,
                         http_client,
+                        &proxy_config,
                     );
                     futures::future::Abortable::new(fut, registration).await
                 },

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -62,7 +62,7 @@ pub struct Dashboard {
     theme_editor: Option<ThemeEditor>,
     notifications: notification::Notifications,
     previews: preview::Collection,
-    preview_client: Option<Arc<reqwest::Client>>,
+    http_client: Option<Arc<reqwest::Client>>,
     buffer_settings: dashboard::BufferSettings,
     pub filehost: filehost::Manager,
 }
@@ -143,7 +143,7 @@ impl Dashboard {
             theme_editor: None,
             notifications: notification::Notifications::new(config),
             previews: preview::Collection::default(),
-            preview_client: preview_client_from_config(config).map(Arc::new),
+            http_client: http_client_from_config(config).map(Arc::new),
             buffer_settings: dashboard::BufferSettings::default(),
             filehost: filehost::Manager::new(),
         };
@@ -219,7 +219,7 @@ impl Dashboard {
         config: &Config,
     ) -> Task<Message> {
         Task::batch(
-            self.visible_urls_with_preview_clients(clients, config)
+            self.visible_urls_with_preview_clients(clients)
                 .into_iter()
                 .map(|(url, client)| {
                     Task::perform(
@@ -1714,13 +1714,9 @@ impl Dashboard {
                 );
             }
             Message::ProceedWithFilehostUpload => {
-                let http_client = self
-                    .preview_client
-                    .clone()
-                    .unwrap_or_else(|| Arc::new(reqwest::Client::new()));
                 let task = self
                     .filehost
-                    .proceed(clients, http_client, &config.proxy)
+                    .proceed(clients, self.http_client.clone(), &config.proxy)
                     .map(Message::Filehost);
                 return (task, None);
             }
@@ -2488,8 +2484,7 @@ impl Dashboard {
                 }
             }
             buffer::Event::PreviewChanged => {
-                let visible =
-                    self.visible_urls_with_preview_clients(clients, config);
+                let visible = self.visible_urls_with_preview_clients(clients);
                 let tracking =
                     self.previews.keys().cloned().collect::<HashSet<_>>();
                 let missing = visible
@@ -2650,11 +2645,6 @@ impl Dashboard {
                     return (task, None);
                 };
 
-                let http_client = self
-                    .preview_client
-                    .clone()
-                    .unwrap_or_else(|| Arc::new(reqwest::Client::new()));
-
                 let pending = filehost::PendingUpload {
                     window,
                     pane_id: id,
@@ -2671,7 +2661,7 @@ impl Dashboard {
                 let (task, event) = self.filehost.upload(
                     pending,
                     clients,
-                    http_client,
+                    self.http_client.clone(),
                     &config.proxy,
                 );
 
@@ -4132,7 +4122,7 @@ impl Dashboard {
             theme_editor: None,
             notifications: notification::Notifications::new(config),
             previews: preview::Collection::default(),
-            preview_client: preview_client_from_config(config).map(Arc::new),
+            http_client: http_client_from_config(config).map(Arc::new),
             buffer_settings: data.buffer_settings.clone(),
             filehost: filehost::Manager::new(),
         };
@@ -4420,28 +4410,25 @@ impl Dashboard {
     fn visible_urls_with_preview_clients(
         &self,
         clients: &client::Map,
-        config: &Config,
     ) -> HashMap<url::Url, Arc<reqwest::Client>> {
-        let pane_map =
-            |pane: &Pane| -> Vec<(url::Url, Arc<reqwest::Client>)> {
-                let preview_client = if let Some(server) = pane.buffer.server()
-                    && config.servers.get(&server).is_some_and(
-                        |server_config| server_config.proxy.is_some(),
-                    ) {
-                    clients.get_server_http_client(&server)
-                } else {
-                    self.preview_client.clone()
-                };
-
-                if let Some(preview_client) = preview_client {
-                    pane.visible_urls()
-                        .into_iter()
-                        .map(move |url| (url.clone(), preview_client.clone()))
-                        .collect()
-                } else {
-                    vec![]
-                }
+        let pane_map = |pane: &Pane| -> Vec<(url::Url, Arc<reqwest::Client>)> {
+            let preview_client = if let Some(server) = pane.buffer.server()
+                && clients.get_server_proxy_config(&server).is_some()
+            {
+                clients.get_server_http_client(&server)
+            } else {
+                self.http_client.clone()
             };
+
+            if let Some(preview_client) = preview_client {
+                pane.visible_urls()
+                    .into_iter()
+                    .map(move |url| (url.clone(), preview_client.clone()))
+                    .collect()
+            } else {
+                vec![]
+            }
+        };
 
         self.panes
             .main
@@ -4817,13 +4804,15 @@ fn cycle_previous_unread_buffer(
         .cloned()
 }
 
-fn preview_client_from_config(config: &Config) -> Option<reqwest::Client> {
-    let preview_client = config::proxy::build_client(&config.proxy, None);
+fn http_client_from_config(config: &Config) -> Option<reqwest::Client> {
+    let http_client = config::proxy::build_client(config.proxy.as_ref(), None);
 
-    match preview_client {
-        Ok(preview_client) => Some(preview_client),
+    match http_client {
+        Ok(http_client) => Some(http_client),
         Err(error) => {
-            log::warn!("Preview fetching disabled by default: {error}");
+            log::warn!(
+                "Unable to build HTTP client, preview fetching and file upload disabled by default: {error}"
+            );
 
             None
         }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1720,7 +1720,7 @@ impl Dashboard {
                     .unwrap_or_else(|| Arc::new(reqwest::Client::new()));
                 let task = self
                     .filehost
-                    .proceed(clients, http_client)
+                    .proceed(clients, http_client, &config.proxy)
                     .map(Message::Filehost);
                 return (task, None);
             }
@@ -2668,8 +2668,12 @@ impl Dashboard {
                     abort_registrations,
                 };
 
-                let (task, event) =
-                    self.filehost.upload(pending, clients, http_client);
+                let (task, event) = self.filehost.upload(
+                    pending,
+                    clients,
+                    http_client,
+                    &config.proxy,
+                );
 
                 let task = task.map(Message::Filehost);
 
@@ -4424,7 +4428,7 @@ impl Dashboard {
                     && config.servers.get(&server).is_some_and(
                         |server_config| server_config.proxy.is_some(),
                     ) {
-                    clients.get_server_preview_proxy_client(&server)
+                    clients.get_server_http_client(&server)
                 } else {
                     self.preview_client.clone()
                 };
@@ -4814,13 +4818,7 @@ fn cycle_previous_unread_buffer(
 }
 
 fn preview_client_from_config(config: &Config) -> Option<reqwest::Client> {
-    let preview_client = if let Some(proxy) = config.proxy.as_ref() {
-        config::proxy::build_client(proxy)
-    } else {
-        reqwest::Client::builder()
-            .build()
-            .map_err(config::proxy::BuildError::Reqwest)
-    };
+    let preview_client = config::proxy::build_client(&config.proxy, None);
 
     match preview_client {
         Ok(preview_client) => Some(preview_client),


### PR DESCRIPTION
filehost did not inherit from the proxy reqwest interface, meaning no filehost uploads were going through any configured proxy

also renames `preview_proxy_client` to the more generic `http_client`: indicating it serves http traffic in general. it was already being used for filehost (oops?) but maybe this is fine? also open to having two http clients for-purpose, though they should be mostly equivalent in their configuration. curious what maintainers think about this.

as a part of this refactor, we also reduced duplicated code paths that created a proxy client or regular client (yay!)

suggested by @andymandias in irc 