### PR TITLE
Add clarification for what the server variable in WHOIS does.

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -59,7 +59,7 @@ Aliases are resolved before built-in commands and take precedence when they use 
 | `sysinfo`       |              | Send system information (OS, CPU, memory, GPU, uptime)                                   |
 | `topic`         | `t`          | Retrieve the topic of a channel or set a new topic[^1]                                   |
 | `upload`        |              | Upload a file via `draft/FILEHOST`[^12]                                                  |
-| `whois`         |              | Retrieve information about user(s)                                                       |
+| `whois`         |              | Retrieve information about user(s) from a specific server[^13]                           |
 
 [^1]: The `channel` argument can be skipped when used in a channel buffer to target the channel in the buffer.
 [^2]: The `nick` argument can be skipped when used in a query buffer to target the other user in the buffer.
@@ -73,3 +73,4 @@ Aliases are resolved before built-in commands and take precedence when they use 
 [^10]: If not joined to the channel in the buffer, then the `chanlist` argument can be skipped to target the channel in the buffer.
 [^11]: The command is executed locally with `sh -c` on Unix-like systems and `cmd /C` on Windows. Only the first non-empty line of stdout is used. If that line starts with `/`, it is treated as a command; otherwise it is sent as a normal message. `/exec` is disabled by default and must be explicitly enabled in [`buffer.commands.exec`](configuration/buffer#exec).
 [^12]: Requires the server to advertise `draft/FILEHOST` support, or [`filehost.override`](./configuration/servers#filehost) to be set.
+[^13]: The server variable refers to the server to poll, and can be set to the nickname being queried in order to auto-select the server. Eg. if you are in Libera chat, and you want to run WHOIS on `hunter2`, `/whois hunter2 hunter2` will try `/whois zinc.libera.chat hunter2` 


### PR DESCRIPTION
Adds extra clarification on what the server variable in WHOIS does and how to auto select the server, from this discussion on IRC.
```
17:07 MD87 │ You can specify which server you want to ask for the info. You get slightly more info from the server the user is connected to. If I `/whois zinc.libera.chat WinnerWind` I see your sign on time and idle time, which I don't get if I just use `/whois WinnerWind` (which is answered by the server I'm connected to)
17:08 MD87 │ You can also just use a nickname in place of the server on most networks (so `/whois WinnerWind WinnerWind` is "ask the server WinnerWind is connected to who WinnerWind is")
```