### PR TITLE
filehost: upload progress in input

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -2819,217 +2819,211 @@ impl Client {
                     }
                 }
             }
-            Command::Numeric(RPL_ENDOFMOTD | ERR_NOMOTD, _) => {
+            Command::Numeric(RPL_ENDOFMOTD | ERR_NOMOTD, _)
+                if self.registration_step != RegistrationStep::Complete =>
+            {
                 // MOTD (or ERR_NOMOTD) is the last required message in the numerics
                 // sent on successfully completing the registration process (after
                 // RPL_ISUPPORT message(s) are sent).
                 // https://modern.ircdocs.horse/#connection-registration
-                if self.registration_step != RegistrationStep::Complete {
-                    if self.registration_step != RegistrationStep::End {
-                        log::warn!(
-                            "[{}] Registration completed while in mode: {:?}",
-                            self.server,
-                            self.registration_step
-                        );
-                    }
 
-                    self.registration_step = RegistrationStep::Complete;
+                if self.registration_step != RegistrationStep::End {
+                    log::warn!(
+                        "[{}] Registration completed while in mode: {:?}",
+                        self.server,
+                        self.registration_step
+                    );
+                }
 
-                    if let Some(id) = self.server.bouncer_netid()
-                        && self.resolved_netid.is_none()
-                    {
-                        // we want to be a bouncer network, but we never connected to one.
-                        bail!(
-                            "Requested bouncer id {id}, but was not connected."
-                        );
-                    }
+                self.registration_step = RegistrationStep::Complete;
 
-                    // Send nick password & ghost
-                    if let Some(nick_pass) = self.config.nick_password.as_ref()
-                    {
-                        // Try ghost recovery if we couldn't claim our nick
-                        if self.config.should_ghost
-                            && self.resolved_nick.as_ref().is_some_and(
-                                |resolved_nick| {
-                                    *resolved_nick == self.configured_nick
-                                },
-                            )
-                        {
-                            for sequence in &self.config.ghost_sequence {
-                                self.handle.try_send(command!(
-                                    "PRIVMSG",
-                                    "NickServ",
-                                    format!(
-                                        "{sequence} {} {nick_pass}",
-                                        &self.config.nickname
-                                    )
-                                ))?;
-                            }
-                        }
+                if let Some(id) = self.server.bouncer_netid()
+                    && self.resolved_netid.is_none()
+                {
+                    // we want to be a bouncer network, but we never connected to one.
+                    bail!("Requested bouncer id {id}, but was not connected.");
+                }
 
-                        if let Some(identify_syntax) =
-                            &self.config.nick_identify_syntax
-                        {
-                            match identify_syntax {
-                                config::server::IdentifySyntax::PasswordNick => {
-                                    self.handle.try_send(command!(
-                                        "PRIVMSG",
-                                        "NickServ",
-                                        format!(
-                                            "IDENTIFY {nick_pass} {}",
-                                            &self.config.nickname
-                                        )
-                                    ))?;
-                                }
-                                config::server::IdentifySyntax::NickPassword => {
-                                    self.handle.try_send(command!(
-                                        "PRIVMSG",
-                                        "NickServ",
-                                        format!(
-                                            "IDENTIFY {} {nick_pass}",
-                                            &self.config.nickname
-                                        )
-                                    ))?;
-                                }
-                            }
-                        } else if self.resolved_nick.as_ref().is_some_and(
+                // Send nick password & ghost
+                if let Some(nick_pass) = self.config.nick_password.as_ref() {
+                    // Try ghost recovery if we couldn't claim our nick
+                    if self.config.should_ghost
+                        && self.resolved_nick.as_ref().is_some_and(
                             |resolved_nick| {
                                 *resolved_nick == self.configured_nick
                             },
-                        ) {
-                            // Use nickname-less identification if possible, since it has
-                            // no possible argument order issues.
-                            self.handle.try_send(command!(
-                                "PRIVMSG",
-                                "NickServ",
-                                format!("IDENTIFY {nick_pass}")
-                            ))?;
-                        } else {
-                            // Default to most common syntax if unknown
+                        )
+                    {
+                        for sequence in &self.config.ghost_sequence {
                             self.handle.try_send(command!(
                                 "PRIVMSG",
                                 "NickServ",
                                 format!(
-                                    "IDENTIFY {} {nick_pass}",
+                                    "{sequence} {} {nick_pass}",
                                     &self.config.nickname
                                 )
                             ))?;
                         }
                     }
 
-                    // Send user modestring
-                    if let (Some(nick), Some(modestring)) = (
-                        self.resolved_nick.clone(),
-                        self.config.umodes.as_ref(),
+                    if let Some(identify_syntax) =
+                        &self.config.nick_identify_syntax
+                    {
+                        match identify_syntax {
+                            config::server::IdentifySyntax::PasswordNick => {
+                                self.handle.try_send(command!(
+                                    "PRIVMSG",
+                                    "NickServ",
+                                    format!(
+                                        "IDENTIFY {nick_pass} {}",
+                                        &self.config.nickname
+                                    )
+                                ))?;
+                            }
+                            config::server::IdentifySyntax::NickPassword => {
+                                self.handle.try_send(command!(
+                                    "PRIVMSG",
+                                    "NickServ",
+                                    format!(
+                                        "IDENTIFY {} {nick_pass}",
+                                        &self.config.nickname
+                                    )
+                                ))?;
+                            }
+                        }
+                    } else if self.resolved_nick.as_ref().is_some_and(
+                        |resolved_nick| *resolved_nick == self.configured_nick,
                     ) {
+                        // Use nickname-less identification if possible, since it has
+                        // no possible argument order issues.
                         self.handle.try_send(command!(
-                            "MODE",
-                            nick.to_string(),
-                            modestring
+                            "PRIVMSG",
+                            "NickServ",
+                            format!("IDENTIFY {nick_pass}")
+                        ))?;
+                    } else {
+                        // Default to most common syntax if unknown
+                        self.handle.try_send(command!(
+                            "PRIVMSG",
+                            "NickServ",
+                            format!(
+                                "IDENTIFY {} {nick_pass}",
+                                &self.config.nickname
+                            )
                         ))?;
                     }
+                }
 
-                    // Request bouncer networks
-                    // TODO(pounce) replace this with "bouncer-networks-notify" after the cap handling
-                    // is cleaned up.
-                    if self.is_primary()
-                        && self
-                            .capabilities
-                            .acknowledged(Capability::BouncerNetworks)
-                    {
-                        self.handle
-                            .try_send(command!("BOUNCER", "LISTNETWORKS"))?;
+                // Send user modestring
+                if let (Some(nick), Some(modestring)) =
+                    (self.resolved_nick.clone(), self.config.umodes.as_ref())
+                {
+                    self.handle.try_send(command!(
+                        "MODE",
+                        nick.to_string(),
+                        modestring
+                    ))?;
+                }
+
+                // Request bouncer networks
+                // TODO(pounce) replace this with "bouncer-networks-notify" after the cap handling
+                // is cleaned up.
+                if self.is_primary()
+                    && self
+                        .capabilities
+                        .acknowledged(Capability::BouncerNetworks)
+                {
+                    self.handle
+                        .try_send(command!("BOUNCER", "LISTNETWORKS"))?;
+                }
+
+                let channels = self
+                    .config
+                    .channels
+                    .iter()
+                    .filter_map(|channel| {
+                        target::Channel::parse(
+                            channel,
+                            self.chantypes(),
+                            self.statusmsg(),
+                            self.casemapping(),
+                        )
+                        .ok()
+                    })
+                    .collect::<Vec<_>>();
+
+                // Send JOIN on non bouncer networks
+                if !self.server.is_bouncer_network() {
+                    for message in group_joins(
+                        &channels,
+                        &self.config.channel_keys,
+                        find_target_limit(&self.isupport, "JOIN"),
+                    ) {
+                        self.handle.try_send(message)?;
                     }
+                }
 
-                    let channels = self
-                        .config
-                        .channels
-                        .iter()
-                        .filter_map(|channel| {
-                            target::Channel::parse(
-                                channel,
-                                self.chantypes(),
-                                self.statusmsg(),
-                                self.casemapping(),
-                            )
-                            .ok()
-                        })
-                        .collect::<Vec<_>>();
-
-                    // Send JOIN on non bouncer networks
-                    if !self.server.is_bouncer_network() {
-                        for message in group_joins(
-                            &channels,
-                            &self.config.channel_keys,
-                            find_target_limit(&self.isupport, "JOIN"),
-                        ) {
+                if !self.config.monitor.is_empty() {
+                    if let Some(isupport::Parameter::MONITOR(monitor_limit)) =
+                        self.isupport.get(&isupport::Kind::MONITOR)
+                    {
+                        let messages = group_monitors(
+                            &self.config.monitor,
+                            *monitor_limit,
+                            find_target_limit(&self.isupport, "MONITOR"),
+                            &self.server,
+                        );
+                        for message in messages {
                             self.handle.try_send(message)?;
                         }
-                    }
-
-                    if !self.config.monitor.is_empty() {
-                        if let Some(isupport::Parameter::MONITOR(
-                            monitor_limit,
-                        )) = self.isupport.get(&isupport::Kind::MONITOR)
-                        {
-                            let messages = group_monitors(
-                                &self.config.monitor,
-                                *monitor_limit,
-                                find_target_limit(&self.isupport, "MONITOR"),
-                                &self.server,
-                            );
-                            for message in messages {
-                                self.handle.try_send(message)?;
-                            }
-                        } else {
-                            log::warn!(
-                                "[{}] Monitor list configured for, but is not supported by the server",
-                                self.server,
-                            );
-                        }
-                    }
-
-                    let events = self
-                        .config
-                        .queries
-                        .iter()
-                        .filter_map(|query| {
-                            target::Query::parse(
-                                query,
-                                self.chantypes(),
-                                self.statusmsg(),
-                                self.casemapping(),
-                            )
-                            .ok()
-                            .map(Event::AddToSidebar)
-                        })
-                        .chain(iter::once(Event::OnConnect(on_connect(
-                            self.handle.clone(),
-                            self.config.clone(),
-                            self.nickname(),
-                            &self.isupport,
-                            &self.capabilities,
-                            &self.features,
-                            self.filehost(),
-                            config,
-                        ))))
-                        .collect::<Vec<_>>();
-
-                    if matches!(
-                        self.features.version_request,
-                        VersionRequest::Need(true)
-                    ) {
-                        self.features.version_request = VersionRequest::Sent;
-
-                        self.send(
-                            None,
-                            command!("VERSION").into(),
-                            TokenPriority::Low,
+                    } else {
+                        log::warn!(
+                            "[{}] Monitor list configured for, but is not supported by the server",
+                            self.server,
                         );
                     }
-
-                    return Ok(events);
                 }
+
+                let events = self
+                    .config
+                    .queries
+                    .iter()
+                    .filter_map(|query| {
+                        target::Query::parse(
+                            query,
+                            self.chantypes(),
+                            self.statusmsg(),
+                            self.casemapping(),
+                        )
+                        .ok()
+                        .map(Event::AddToSidebar)
+                    })
+                    .chain(iter::once(Event::OnConnect(on_connect(
+                        self.handle.clone(),
+                        self.config.clone(),
+                        self.nickname(),
+                        &self.isupport,
+                        &self.capabilities,
+                        &self.features,
+                        self.filehost(),
+                        config,
+                    ))))
+                    .collect::<Vec<_>>();
+
+                if matches!(
+                    self.features.version_request,
+                    VersionRequest::Need(true)
+                ) {
+                    self.features.version_request = VersionRequest::Sent;
+
+                    self.send(
+                        None,
+                        command!("VERSION").into(),
+                        TokenPriority::Low,
+                    );
+                }
+
+                return Ok(events);
             }
             Command::Numeric(RPL_VERSION, args) => {
                 if matches!(self.features.version_request, VersionRequest::Sent)

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -1204,11 +1204,12 @@ pub fn insert_message(
         Err(sorted_insert_index) => sorted_insert_index,
     };
 
-    let mut current_index = start_index;
     let mut insert_at = start_index;
     let mut replace_at = None;
 
-    for stored in &messages[start_index..end_index] {
+    for (current_index, stored) in
+        (start_index..).zip(messages[start_index..end_index].iter())
+    {
         if replace_at.is_none() && labeled_response_context.is_none() {
             let use_echo_cmp =
                 matches!(stored.direction, message::Direction::Sent)
@@ -1231,8 +1232,6 @@ pub fn insert_message(
         if message.server_time >= stored.server_time {
             insert_at = current_index + 1;
         }
-
-        current_index += 1;
     }
 
     if let Some(index) = replace_at {

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -644,14 +644,9 @@ impl Manager {
     pub fn server_kinds(&self, server: Server) -> Vec<history::Kind> {
         self.data
             .map
-            .iter()
-            .filter_map(|(kind, _)| {
-                if kind.server().is_some_and(|s| *s == server) {
-                    Some(kind.clone())
-                } else {
-                    None
-                }
-            })
+            .keys()
+            .filter(|kind| kind.server().is_some_and(|s| *s == server))
+            .cloned()
             .collect()
     }
 

--- a/data/src/preview.rs
+++ b/data/src/preview.rs
@@ -422,10 +422,8 @@ fn parse_meta_tag_properties(
 
             match key.as_str() {
                 "property" => property = Some(value),
-                "name" => {
-                    if property.is_none() {
-                        property = Some(value);
-                    }
+                "name" if property.is_none() => {
+                    property = Some(value);
                 }
                 "content" => content = Some(value),
                 _ => {}
@@ -437,25 +435,19 @@ fn parse_meta_tag_properties(
         };
 
         match property.trim().to_ascii_lowercase().as_str() {
-            "og:url" => {
-                if meta.canonical_url.is_none() {
-                    meta.canonical_url = Some(content.parse()?);
-                }
+            "og:url" if meta.canonical_url.is_none() => {
+                meta.canonical_url = Some(content.parse()?);
             }
-            "og:image" | "og:image:url" | "og:image:secure_url" => {
-                if meta.image_url.is_none() {
-                    meta.image_url = Some(content.parse()?);
-                }
+            "og:image" | "og:image:url" | "og:image:secure_url"
+                if meta.image_url.is_none() =>
+            {
+                meta.image_url = Some(content.parse()?);
             }
-            "og:title" => {
-                if meta.title.is_none() {
-                    meta.title = Some(content);
-                }
+            "og:title" if meta.title.is_none() => {
+                meta.title = Some(content);
             }
-            "og:description" => {
-                if meta.description.is_none() {
-                    meta.description = Some(content);
-                }
+            "og:description" if meta.description.is_none() => {
+                meta.description = Some(content);
             }
             _ => {}
         }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -88,6 +88,7 @@ pub enum Event {
         server: data::Server,
         target: Option<Target>,
         file_paths: Vec<std::path::PathBuf>,
+        upload_ids: Vec<u32>,
         abort_registrations: Vec<futures::future::AbortRegistration>,
     },
 }
@@ -314,11 +315,13 @@ impl Buffer {
                         server,
                         target,
                         file_paths,
+                        upload_ids,
                         abort_registrations,
                     } => Event::FilehostUpload {
                         server,
                         target,
                         file_paths,
+                        upload_ids,
                         abort_registrations,
                     },
                 });
@@ -378,11 +381,13 @@ impl Buffer {
                         server,
                         target,
                         file_paths,
+                        upload_ids,
                         abort_registrations,
                     } => Event::FilehostUpload {
                         server,
                         target,
                         file_paths,
+                        upload_ids,
                         abort_registrations,
                     },
                 });
@@ -446,11 +451,13 @@ impl Buffer {
                         server,
                         target,
                         file_paths,
+                        upload_ids,
                         abort_registrations,
                     } => Event::FilehostUpload {
                         server,
                         target,
                         file_paths,
+                        upload_ids,
                         abort_registrations,
                     },
                 });

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -26,7 +26,7 @@ pub enum Message {
     InputView(input_view::Message),
     ContextMenu(context_menu::Message),
     Topic(topic::Message),
-    FilehostUrlReady(String),
+    FilehostUploadDone { id: u32, url: Option<String> },
     FilesDropped(Vec<std::path::PathBuf>),
 }
 
@@ -54,6 +54,7 @@ pub enum Event {
         server: Server,
         target: Option<Target>,
         file_paths: Vec<std::path::PathBuf>,
+        upload_ids: Vec<u32>,
         abort_registrations: Vec<futures::future::AbortRegistration>,
     },
 }
@@ -390,6 +391,7 @@ impl Channel {
                         server,
                         target,
                         file_paths,
+                        upload_ids,
                         abort_registrations,
                     }) => (
                         command,
@@ -397,6 +399,7 @@ impl Channel {
                             server,
                             target,
                             file_paths,
+                            upload_ids,
                             abort_registrations,
                         }),
                     ),
@@ -407,9 +410,9 @@ impl Channel {
                 Task::none(),
                 Some(Event::ContextMenu(context_menu::update(message))),
             ),
-            Message::FilehostUrlReady(url) => {
+            Message::FilehostUploadDone { id, url } => {
                 let (task, _) = self.input_view.update(
-                    input_view::Message::FilehostUrlReady(url),
+                    input_view::Message::FilehostUploadDone { id, url },
                     &self.buffer,
                     clients,
                     history,
@@ -434,11 +437,13 @@ impl Channel {
                             server,
                             target,
                             file_paths,
+                            upload_ids,
                             abort_registrations,
                         } => Some(Event::FilehostUpload {
                             server,
                             target,
                             file_paths,
+                            upload_ids,
                             abort_registrations,
                         }),
                         _ => None,

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -1329,6 +1329,7 @@ impl State {
                                     text_editor::Motion::DocumentEnd,
                                 ),
                             );
+                            // insert a space if there is none immediately before the URL
                             if !self.input_content.text().trim_end().is_empty()
                             {
                                 self.input_content.perform(

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -1309,11 +1309,12 @@ impl State {
                 match url {
                     Some(url) => {
                         if let Some(ghost_byte_pos) = content.find(&ghost) {
-                            let ghost_char_pos = UnicodeSegmentation::graphemes(
-                                &content[..ghost_byte_pos],
-                                true,
-                            )
-                            .count();
+                            let ghost_char_pos =
+                                UnicodeSegmentation::graphemes(
+                                    &content[..ghost_byte_pos],
+                                    true,
+                                )
+                                .count();
                             let replaced = content.replacen(&ghost, &url, 1);
                             let delta = url.chars().count() as i64
                                 - ghost.chars().count() as i64;
@@ -1367,11 +1368,12 @@ impl State {
                         .find_map(|s| content.find(&s).map(|pos| (s, pos)));
 
                         if let Some((search, ghost_byte_pos)) = found {
-                            let ghost_char_pos = UnicodeSegmentation::graphemes(
-                                &content[..ghost_byte_pos],
-                                true,
-                            )
-                            .count();
+                            let ghost_char_pos =
+                                UnicodeSegmentation::graphemes(
+                                    &content[..ghost_byte_pos],
+                                    true,
+                                )
+                                .count();
                             let replaced = content.replacen(&search, "", 1);
                             let delta = -(search.chars().count() as i64);
                             let cursor = adjust_cursor(
@@ -2928,12 +2930,18 @@ fn char_to_line_col(text: &str, start_pos: usize) -> text_editor::Position {
             count += 1;
         }
         if count == remaining {
-            return text_editor::Position { line: i, column: byte_col };
+            return text_editor::Position {
+                line: i,
+                column: byte_col,
+            };
         }
         remaining -= count + 1;
         // track the end of the last seen line so that an out-of-bounds
         // start_pos clamps to the end of the text
-        fallback = text_editor::Position { line: i, column: line.len() };
+        fallback = text_editor::Position {
+            line: i,
+            column: line.len(),
+        };
     }
     fallback
 }

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -1304,91 +1304,8 @@ impl State {
                 }
 
                 let ghost = upload_ghost(id);
-                let content = self.input_content.text();
 
-                match url {
-                    Some(url) => {
-                        if let Some(ghost_byte_pos) = content.find(&ghost) {
-                            let ghost_char_pos =
-                                UnicodeSegmentation::graphemes(
-                                    &content[..ghost_byte_pos],
-                                    true,
-                                )
-                                .count();
-                            let replaced = content.replacen(&ghost, &url, 1);
-                            let delta = url.chars().count() as i64
-                                - ghost.chars().count() as i64;
-                            let cursor = adjust_cursor(
-                                &self.input_content,
-                                &replaced,
-                                ghost_char_pos,
-                                ghost.chars().count(),
-                                delta,
-                            );
-                            self.input_content =
-                                text_editor::Content::with_text(&replaced);
-                            self.input_content.move_to(cursor);
-                        } else {
-                            // the user edited the ghost away while uploading — append it rather than losing it
-                            self.input_content.perform(
-                                text_editor::Action::Move(
-                                    text_editor::Motion::DocumentEnd,
-                                ),
-                            );
-                            // insert a space if there is none immediately before the URL
-                            if !self.input_content.text().trim_end().is_empty()
-                            {
-                                self.input_content.perform(
-                                    text_editor::Action::Edit(
-                                        text_editor::Edit::Insert(' '),
-                                    ),
-                                );
-                            }
-                            self.input_content.perform(
-                                text_editor::Action::Edit(
-                                    text_editor::Edit::Paste(
-                                        std::sync::Arc::new(url),
-                                    ),
-                                ),
-                            );
-                        }
-                    }
-                    None => {
-                        // upload failed or cancelled
-
-                        // the ghost may have inserted surrounding spaces; try widest match
-                        // first so we don't leave a stray space behind.
-                        let found = [
-                            format!(" {ghost} "),
-                            format!(" {ghost}"),
-                            format!("{ghost} "),
-                            ghost.clone(),
-                        ]
-                        .into_iter()
-                        .find_map(|s| content.find(&s).map(|pos| (s, pos)));
-
-                        if let Some((search, ghost_byte_pos)) = found {
-                            let ghost_char_pos =
-                                UnicodeSegmentation::graphemes(
-                                    &content[..ghost_byte_pos],
-                                    true,
-                                )
-                                .count();
-                            let replaced = content.replacen(&search, "", 1);
-                            let delta = -(search.chars().count() as i64);
-                            let cursor = adjust_cursor(
-                                &self.input_content,
-                                &replaced,
-                                ghost_char_pos,
-                                search.chars().count(),
-                                delta,
-                            );
-                            self.input_content =
-                                text_editor::Content::with_text(&replaced);
-                            self.input_content.move_to(cursor);
-                        }
-                    }
-                }
+                replace_ghost_with_url(&mut self.input_content, ghost, url);
 
                 history.record_draft(RawInput {
                     buffer: buffer.clone(),
@@ -3007,6 +2924,85 @@ fn adjust_cursor(
     }
 }
 
+fn replace_ghost_with_url(
+    input_content: &mut text_editor::Content,
+    ghost: String,
+    url: Option<String>,
+) {
+    let content = input_content.text();
+
+    match url {
+        Some(url) => {
+            if let Some(ghost_byte_pos) = content.find(&ghost) {
+                let ghost_char_pos = UnicodeSegmentation::graphemes(
+                    &content[..ghost_byte_pos],
+                    true,
+                )
+                .count();
+                let replaced = content.replacen(&ghost, &url, 1);
+                let delta =
+                    url.chars().count() as i64 - ghost.chars().count() as i64;
+                let cursor = adjust_cursor(
+                    input_content,
+                    &replaced,
+                    ghost_char_pos,
+                    ghost.chars().count(),
+                    delta,
+                );
+                *input_content = text_editor::Content::with_text(&replaced);
+                input_content.move_to(cursor);
+            } else {
+                // the user edited the ghost away while uploading — append it rather than losing it
+                input_content.perform(text_editor::Action::Move(
+                    text_editor::Motion::DocumentEnd,
+                ));
+                // insert a space if there is none immediately before the URL
+                if !input_content.text().trim_end().is_empty() {
+                    input_content.perform(text_editor::Action::Edit(
+                        text_editor::Edit::Insert(' '),
+                    ));
+                }
+                input_content.perform(text_editor::Action::Edit(
+                    text_editor::Edit::Paste(std::sync::Arc::new(url)),
+                ));
+            }
+        }
+        None => {
+            // upload failed or cancelled
+
+            // the ghost may have inserted surrounding spaces; try widest match
+            // first so we don't leave a stray space behind.
+            let found = [
+                format!(" {ghost} "),
+                format!(" {ghost}"),
+                format!("{ghost} "),
+                ghost.clone(),
+            ]
+            .into_iter()
+            .find_map(|s| content.find(&s).map(|pos| (s, pos)));
+
+            if let Some((search, ghost_byte_pos)) = found {
+                let ghost_char_pos = UnicodeSegmentation::graphemes(
+                    &content[..ghost_byte_pos],
+                    true,
+                )
+                .count();
+                let replaced = content.replacen(&search, "", 1);
+                let delta = -(search.chars().count() as i64);
+                let cursor = adjust_cursor(
+                    input_content,
+                    &replaced,
+                    ghost_char_pos,
+                    search.chars().count(),
+                    delta,
+                );
+                *input_content = text_editor::Content::with_text(&replaced);
+                input_content.move_to(cursor);
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3115,5 +3111,123 @@ mod tests {
     fn adjust_char_pos_positive_delta() {
         // region at 5..8 replaced with 6 chars (delta +3), cursor at 10
         assert_eq!(adjust_char_pos(10, 5, 3, 3), 13);
+    }
+
+    fn set_cursor(
+        content: &mut text_editor::Content,
+        motion: i64,
+        select: i64,
+    ) {
+        if motion > 0 {
+            content.perform(text_editor::Action::Move(
+                text_editor::Motion::DocumentStart,
+            ));
+            for _ in 0..motion {
+                content.perform(text_editor::Action::Move(
+                    text_editor::Motion::Right,
+                ));
+            }
+        } else {
+            content.perform(text_editor::Action::Move(
+                text_editor::Motion::DocumentEnd,
+            ));
+            for _ in 0..-motion {
+                content.perform(text_editor::Action::Move(
+                    text_editor::Motion::Left,
+                ));
+            }
+        }
+
+        if select > 0 {
+            for _ in 0..select {
+                content.perform(text_editor::Action::Select(
+                    text_editor::Motion::Right,
+                ));
+            }
+        } else {
+            for _ in 0..-select {
+                content.perform(text_editor::Action::Select(
+                    text_editor::Motion::Left,
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn cursor_after_ghost_replaced_with_url() {
+        let tests = [
+            (
+                "hello world",
+                2,
+                "\nI will tell you what Royalty is\nit is a continuous cutting motion",
+                "https://example.com/image.jpg",
+                -40,
+                10,
+            ),
+            (
+                "hello world",
+                2,
+                "\nI will tell you what Royalty is\nit is a continuous cutting motion",
+                "https://🗺.example.com/image.jpg",
+                -12,
+                4,
+            ),
+            (
+                "안녕하세요 여러분\n",
+                1,
+                "\n시간이 쏜 살 같다",
+                "https://example.com/image.jpg",
+                -2,
+                -2,
+            ),
+            (
+                "안녕하세요 여러분\n",
+                1,
+                "\n시간이 쏜 살 같다",
+                "https://🗺.example.com/image.jpg",
+                5,
+                -2,
+            ),
+            (
+                "👩🏾‍🚒 (",
+                1,
+                ") 💬👋🏾🗺️",
+                "https://example.com/image.jpg",
+                -2,
+                1,
+            ),
+        ];
+
+        for (ghost_prefix, id, ghost_suffix, url, motion, select) in tests {
+            let ghost = upload_ghost(id);
+
+            let mut content: text_editor::Content =
+                text_editor::Content::with_text(&format!(
+                    "{ghost_prefix}{ghost}{ghost_suffix}"
+                ));
+
+            set_cursor(&mut content, motion, select);
+
+            replace_ghost_with_url(
+                &mut content,
+                ghost.clone(),
+                Some(url.to_string()),
+            );
+
+            let adjusted_cursor = content.cursor();
+
+            content = text_editor::Content::with_text(&format!(
+                "{ghost_prefix}{url}{ghost_suffix}"
+            ));
+
+            set_cursor(&mut content, motion, select);
+
+            let cursor = content.cursor();
+
+            assert_eq!(
+                adjusted_cursor, cursor,
+                "text: {ghost_prefix}{ghost}{ghost_suffix} url: {url} motion: {motion}"
+            );
+        }
     }
 }

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -2862,9 +2862,9 @@ fn macos_clipboard_file() -> Option<std::path::PathBuf> {
 
 fn upload_ghost(id: u32) -> String {
     if id <= 1 {
-        String::from("(Uploading...)")
+        String::from("[Uploading...]")
     } else {
-        format!("(Uploading...{id})")
+        format!("[Uploading...{id}]")
     }
 }
 

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -1248,6 +1248,10 @@ impl State {
                     for &id in &upload_ids {
                         self.insert_upload_ghost(id);
                     }
+                    history.record_draft(RawInput {
+                        buffer: buffer.clone(),
+                        text: self.input_content.text(),
+                    });
                 }
 
                 let (handles, registrations): (Vec<_>, Vec<_>) = file_paths
@@ -1346,11 +1350,6 @@ impl State {
                                 ),
                             );
                         }
-
-                        history.record_draft(RawInput {
-                            buffer: buffer.clone(),
-                            text: self.input_content.text(),
-                        });
                     }
                     None => {
                         // upload failed or cancelled
@@ -1386,6 +1385,11 @@ impl State {
                         }
                     }
                 }
+
+                history.record_draft(RawInput {
+                    buffer: buffer.clone(),
+                    text: self.input_content.text(),
+                });
 
                 (Task::none(), None)
             }
@@ -2257,6 +2261,10 @@ impl State {
                         let id = self.next_upload_id;
                         if buffer.target().is_some() {
                             self.insert_upload_ghost(id);
+                            history.record_draft(RawInput {
+                                buffer: buffer.clone(),
+                                text: self.input_content.text(),
+                            });
                         }
                         let anim = was_idle
                             .then(Self::schedule_anim_tick)

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -1599,19 +1599,23 @@ impl State {
 
         // if the ghost would be inserted directly adjacent to a word,
         // pad it with a space so it doesn't run into surrounding text.
-        let prefix = if cursor_char > 0 {
-            let ch = content.chars().nth(cursor_char - 1);
-            if ch.is_some_and(|c| !c.is_whitespace()) {
-                " "
-            } else {
-                ""
-            }
+        let prefix = if self.input_content.cursor().selection.is_none()
+            && cursor_char > 0
+            && content
+                .chars()
+                .nth(cursor_char - 1)
+                .is_some_and(|c| !c.is_whitespace())
+        {
+            " "
         } else {
             ""
         };
 
-        let suffix = if let Some(ch) = content.chars().nth(cursor_char) {
-            if !ch.is_whitespace() { " " } else { "" }
+        let suffix = if self.input_content.cursor().selection.is_none()
+            && let Some(ch) = content.chars().nth(cursor_char)
+            && !ch.is_whitespace()
+        {
+            " "
         } else {
             ""
         };
@@ -1621,17 +1625,6 @@ impl State {
         self.input_content.perform(text_editor::Action::Edit(
             text_editor::Edit::Paste(std::sync::Arc::new(insert)),
         ));
-
-        // place the cursor at the end of the ghost so that adjust_char_pos
-        // considers it "inside" the ghost when the upload finishes,
-        // which ensures the cursor follows the replacement correctly.
-        self.input_content.move_to(text_editor::Cursor {
-            position: char_to_line_col(
-                &self.input_content.text(),
-                cursor_char + prefix.chars().count() + ghost.chars().count(),
-            ),
-            selection: None,
-        });
     }
 
     fn schedule_anim_tick() -> Task<Message> {

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -65,6 +65,7 @@ pub enum Event {
         server: Server,
         target: Option<Target>,
         file_paths: Vec<std::path::PathBuf>,
+        upload_ids: Vec<u32>,
         abort_registrations: Vec<futures::future::AbortRegistration>,
     },
 }
@@ -104,7 +105,10 @@ pub enum Message {
     Cut,
     UploadFile,
     FilesSelected(Vec<std::path::PathBuf>),
-    FilehostUrlReady(String),
+    FilehostUploadDone {
+        id: u32,
+        url: Option<String>,
+    },
     UploadAnimTick,
     CancelUploads,
     SpinnerHovered(bool),
@@ -723,6 +727,7 @@ pub struct State {
     selected_history: Option<usize>,
     last_typing_at: Option<Instant>,
     uploading: usize,
+    next_upload_id: u32,
     upload_anim: f32,
     spinner_hovered: bool,
     upload_abort_handles: Vec<futures::future::AbortHandle>,
@@ -748,6 +753,7 @@ impl State {
             selected_history: None,
             last_typing_at: None,
             uploading: 0,
+            next_upload_id: 0,
             upload_anim: 0.0,
             spinner_hovered: false,
             upload_abort_handles: Vec::new(),
@@ -1230,6 +1236,20 @@ impl State {
                 let was_idle = self.uploading == 0;
                 self.uploading += file_paths.len();
 
+                let upload_ids: Vec<u32> = file_paths
+                    .iter()
+                    .map(|_| {
+                        self.next_upload_id += 1;
+                        self.next_upload_id
+                    })
+                    .collect();
+
+                if buffer.target().is_some() {
+                    for &id in &upload_ids {
+                        self.insert_upload_ghost(id);
+                    }
+                }
+
                 let (handles, registrations): (Vec<_>, Vec<_>) = file_paths
                     .iter()
                     .map(|_| futures::future::AbortHandle::new_pair())
@@ -1241,6 +1261,7 @@ impl State {
                     server: buffer.server().clone(),
                     target: buffer.target(),
                     file_paths,
+                    upload_ids,
                     abort_registrations: registrations,
                 };
                 let anim = was_idle
@@ -1263,6 +1284,7 @@ impl State {
                     handle.abort();
                 }
                 self.uploading = 0;
+                self.next_upload_id = 0;
                 self.spinner_hovered = false;
                 (Task::none(), None)
             }
@@ -1270,33 +1292,101 @@ impl State {
                 self.spinner_hovered = hovered;
                 (Task::none(), None)
             }
-            Message::FilehostUrlReady(url)
-                if !url.is_empty() && self.uploading > 0 =>
-            {
+            Message::FilehostUploadDone { id, url } => {
                 self.uploading = self.uploading.saturating_sub(1);
-                // Append the URL to the end of whatever the user has typed.
-                self.input_content.perform(text_editor::Action::Move(
-                    text_editor::Motion::DocumentEnd,
-                ));
-                // Add a space separator if the buffer already has content.
-                if !self.input_content.text().trim_end().is_empty() {
-                    self.input_content.perform(text_editor::Action::Edit(
-                        text_editor::Edit::Insert(' '),
-                    ));
+                // ids are sequential per upload batch — resetting when idle
+                if self.uploading == 0 {
+                    self.next_upload_id = 0;
                 }
-                self.input_content.perform(text_editor::Action::Edit(
-                    text_editor::Edit::Paste(std::sync::Arc::new(url)),
-                ));
-                history.record_draft(RawInput {
-                    buffer: buffer.clone(),
-                    text: self.input_content.text(),
-                });
+
+                let ghost = upload_ghost(id);
+                let content = self.input_content.text();
+
+                match url {
+                    Some(url) => {
+                        if content.contains(&ghost) {
+                            let ghost_char_pos = content
+                                [..content.find(&ghost).unwrap()]
+                                .chars()
+                                .count();
+                            let replaced = content.replacen(&ghost, &url, 1);
+                            let delta = url.chars().count() as i64
+                                - ghost.chars().count() as i64;
+                            let cursor = adjust_cursor(
+                                &self.input_content,
+                                &replaced,
+                                ghost_char_pos,
+                                ghost.chars().count(),
+                                delta,
+                            );
+                            self.input_content =
+                                text_editor::Content::with_text(&replaced);
+                            self.input_content.move_to(cursor);
+                        } else {
+                            // the user edited the ghost away while uploading — append it rather than losing it
+                            self.input_content.perform(
+                                text_editor::Action::Move(
+                                    text_editor::Motion::DocumentEnd,
+                                ),
+                            );
+                            if !self.input_content.text().trim_end().is_empty()
+                            {
+                                self.input_content.perform(
+                                    text_editor::Action::Edit(
+                                        text_editor::Edit::Insert(' '),
+                                    ),
+                                );
+                            }
+                            self.input_content.perform(
+                                text_editor::Action::Edit(
+                                    text_editor::Edit::Paste(
+                                        std::sync::Arc::new(url),
+                                    ),
+                                ),
+                            );
+                        }
+
+                        history.record_draft(RawInput {
+                            buffer: buffer.clone(),
+                            text: self.input_content.text(),
+                        });
+                    }
+                    None => {
+                        // upload failed or cancelled
+
+                        // the ghost may have inserted surrounding spaces; try widest match
+                        // first so we don't leave a stray space behind.
+                        let search = [
+                            format!(" {ghost} "),
+                            format!(" {ghost}"),
+                            format!("{ghost} "),
+                            ghost.clone(),
+                        ]
+                        .into_iter()
+                        .find(|s| content.contains(s.as_str()));
+
+                        if let Some(search) = search {
+                            let ghost_char_pos = content
+                                [..content.find(&search).unwrap()]
+                                .chars()
+                                .count();
+                            let replaced = content.replacen(&search, "", 1);
+                            let delta = -(search.chars().count() as i64);
+                            let cursor = adjust_cursor(
+                                &self.input_content,
+                                &replaced,
+                                ghost_char_pos,
+                                search.chars().count(),
+                                delta,
+                            );
+                            self.input_content =
+                                text_editor::Content::with_text(&replaced);
+                            self.input_content.move_to(cursor);
+                        }
+                    }
+                }
+
                 (Task::none(), None)
-            }
-            Message::FilehostUrlReady(_) => {
-                // Failed or cancelled — decrement only if not already zeroed.
-                self.uploading = self.uploading.saturating_sub(1);
-                (self.focus(), None)
             }
             Message::DeleteWordBackward(save_to_clipboard) => {
                 self.input_content.perform(text_editor::Action::Select(
@@ -1570,6 +1660,52 @@ impl State {
                 Some(parsed)
             })
             .collect();
+    }
+
+    fn insert_upload_ghost(&mut self, id: u32) {
+        let ghost = upload_ghost(id);
+        let content = self.input_content.text();
+        let cursor_char = line_col_to_char(
+            &self.input_content,
+            self.input_content.cursor().position.line,
+            self.input_content.cursor().position.column,
+        );
+
+        // if the ghost would be inserted directly adjacent to a word,
+        // pad it with a space so it doesn't run into surrounding text.
+        let prefix = if cursor_char > 0 {
+            let ch = content.chars().nth(cursor_char - 1);
+            if ch.is_some_and(|c| !c.is_whitespace()) {
+                " "
+            } else {
+                ""
+            }
+        } else {
+            ""
+        };
+
+        let suffix = if let Some(ch) = content.chars().nth(cursor_char) {
+            if !ch.is_whitespace() { " " } else { "" }
+        } else {
+            ""
+        };
+
+        let insert = format!("{prefix}{ghost}{suffix}");
+
+        self.input_content.perform(text_editor::Action::Edit(
+            text_editor::Edit::Paste(std::sync::Arc::new(insert)),
+        ));
+
+        // place the cursor at the end of the ghost so that adjust_char_pos
+        // considers it "inside" the ghost when the upload finishes,
+        // which ensures the cursor follows the replacement correctly.
+        self.input_content.move_to(text_editor::Cursor {
+            position: char_to_line_col(
+                &self.input_content.text(),
+                cursor_char + prefix.chars().count() + ghost.chars().count(),
+            ),
+            selection: None,
+        });
     }
 
     fn schedule_anim_tick() -> Task<Message> {
@@ -2116,6 +2252,11 @@ impl State {
                         self.upload_abort_handles.push(handle);
                         let was_idle = self.uploading == 0;
                         self.uploading += 1;
+                        self.next_upload_id += 1;
+                        let id = self.next_upload_id;
+                        if buffer.target().is_some() {
+                            self.insert_upload_ghost(id);
+                        }
                         let anim = was_idle
                             .then(Self::schedule_anim_tick)
                             .unwrap_or_else(Task::none);
@@ -2123,6 +2264,7 @@ impl State {
                             server: buffer.server().clone(),
                             target: buffer.target(),
                             file_paths: vec![file_path],
+                            upload_ids: vec![id],
                             abort_registrations: vec![registration],
                         };
                         return (anim, Some(event));
@@ -2715,4 +2857,187 @@ fn macos_clipboard_file() -> Option<std::path::PathBuf> {
 
     let path = std::path::PathBuf::from(path_str);
     path.is_file().then_some(path)
+}
+
+fn upload_ghost(id: u32) -> String {
+    if id <= 1 {
+        String::from("(Uploading...)")
+    } else {
+        format!("(Uploading...{id})")
+    }
+}
+
+/// Converts a `(line, col)` position to a flat char offset.
+///
+/// `text_editor::Content` uses 2D positions, but offset arithmetic requires a
+/// flat char index.
+fn line_col_to_char(
+    content: &text_editor::Content,
+    line: usize,
+    col: usize,
+) -> usize {
+    let mut chars = 0;
+    for i in 0..line {
+        chars += content.line(i).map_or(0, |l| l.text.chars().count()) + 1;
+    }
+    chars += col;
+    chars
+}
+
+/// Converts a flat char offset back to a `(line, col)` position.
+///
+/// Inverse of [`line_col_to_char`]. Used after offset arithmetic to produce a
+/// position suitable for `move_to`.
+fn char_to_line_col(text: &str, char_pos: usize) -> text_editor::Position {
+    let mut remaining = char_pos;
+    for (i, line) in text.lines().enumerate() {
+        let line_char_count = line.chars().count();
+        if remaining <= line_char_count {
+            return text_editor::Position {
+                line: i,
+                column: remaining,
+            };
+        }
+        remaining -= line_char_count + 1;
+    }
+    let last_line = text.lines().count().saturating_sub(1);
+    let last_col = text.lines().last().map_or(0, |l| l.chars().count());
+    text_editor::Position {
+        line: last_line,
+        column: last_col,
+    }
+}
+
+/// Adjusts a flat char offset around a text replacement.
+///
+/// `replace_start..replace_start+replace_len` is the replaced region; `delta`
+/// is the signed change in length. Offsets before the region are unchanged,
+/// offsets inside it clamp to the end of the replacement, and offsets after it
+/// are shifted by `delta`.
+fn adjust_char_pos(
+    char_pos: usize,
+    replace_start: usize,
+    replace_len: usize,
+    delta: i64,
+) -> usize {
+    if char_pos > replace_start + replace_len {
+        // cursor was after the replaced region — shift it by how much the content changed
+        (char_pos as i64 + delta).max(0) as usize
+    } else if char_pos >= replace_start {
+        // cursor was inside the replaced region — land at the end of whatever replaced it.
+        ((replace_start + replace_len) as i64 + delta).max(0) as usize
+    } else {
+        char_pos
+    }
+}
+
+/// Adjusts the cursor (position and selection) of `content` for a text replacement.
+///
+/// `replaced` is the new text after replacement; `replace_start`, `replace_len`,
+/// and `delta` describe the replaced region, as in [`adjust_char_pos`].
+fn adjust_cursor(
+    content: &text_editor::Content,
+    replaced: &str,
+    replace_start: usize,
+    replace_len: usize,
+    delta: i64,
+) -> text_editor::Cursor {
+    let cursor = content.cursor();
+    text_editor::Cursor {
+        position: char_to_line_col(
+            replaced,
+            adjust_char_pos(
+                line_col_to_char(
+                    content,
+                    cursor.position.line,
+                    cursor.position.column,
+                ),
+                replace_start,
+                replace_len,
+                delta,
+            ),
+        ),
+        selection: cursor.selection.map(|sel| {
+            char_to_line_col(
+                replaced,
+                adjust_char_pos(
+                    line_col_to_char(content, sel.line, sel.column),
+                    replace_start,
+                    replace_len,
+                    delta,
+                ),
+            )
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn char_to_line_col_single_line() {
+        let pos = char_to_line_col("hello", 3);
+        assert_eq!(pos.line, 0);
+        assert_eq!(pos.column, 3);
+    }
+
+    #[test]
+    fn char_to_line_col_second_line() {
+        let pos = char_to_line_col("hello\nworld", 7);
+        assert_eq!(pos.line, 1);
+        assert_eq!(pos.column, 1);
+    }
+
+    #[test]
+    fn char_to_line_col_start_of_second_line() {
+        let pos = char_to_line_col("hello\nworld", 6);
+        assert_eq!(pos.line, 1);
+        assert_eq!(pos.column, 0);
+    }
+
+    #[test]
+    fn char_to_line_col_past_end_clamps() {
+        let pos = char_to_line_col("hello", 100);
+        assert_eq!(pos.line, 0);
+        assert_eq!(pos.column, 5);
+    }
+
+    #[test]
+    fn char_to_line_col_empty_string() {
+        let pos = char_to_line_col("", 0);
+        assert_eq!(pos.line, 0);
+        assert_eq!(pos.column, 0);
+    }
+
+    #[test]
+    fn adjust_char_pos_before_region_unchanged() {
+        // cursor at 2, region at 5..8 — unaffected
+        assert_eq!(adjust_char_pos(2, 5, 3, -3), 2);
+    }
+
+    #[test]
+    fn adjust_char_pos_after_region_shifts() {
+        // cursor at 10, region at 5..8, replaced with 1 char (delta -2)
+        assert_eq!(adjust_char_pos(10, 5, 3, -2), 8);
+    }
+
+    #[test]
+    fn adjust_char_pos_inside_region_clamps_to_end_of_replacement() {
+        // cursor at 6, region at 5..8, replaced with 1 char (delta -2)
+        // end of replacement = 5 + 3 - 2 = 6
+        assert_eq!(adjust_char_pos(6, 5, 3, -2), 6);
+    }
+
+    #[test]
+    fn adjust_char_pos_at_region_start_treated_as_inside() {
+        // cursor exactly at replace_start is inside
+        assert_eq!(adjust_char_pos(5, 5, 3, -2), 6);
+    }
+
+    #[test]
+    fn adjust_char_pos_positive_delta() {
+        // region at 5..8 replaced with 6 chars (delta +3), cursor at 10
+        assert_eq!(adjust_char_pos(10, 5, 3, 3), 13);
+    }
 }

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -1309,10 +1309,11 @@ impl State {
                 match url {
                     Some(url) => {
                         if content.contains(&ghost) {
-                            let ghost_char_pos = content
-                                [..content.find(&ghost).unwrap()]
-                                .chars()
-                                .count();
+                            let ghost_char_pos = UnicodeSegmentation::graphemes(
+                                &content[..content.find(&ghost).unwrap()],
+                                true,
+                            )
+                            .count();
                             let replaced = content.replacen(&ghost, &url, 1);
                             let delta = url.chars().count() as i64
                                 - ghost.chars().count() as i64;
@@ -1366,10 +1367,11 @@ impl State {
                         .find(|s| content.contains(s.as_str()));
 
                         if let Some(search) = search {
-                            let ghost_char_pos = content
-                                [..content.find(&search).unwrap()]
-                                .chars()
-                                .count();
+                            let ghost_char_pos = UnicodeSegmentation::graphemes(
+                                &content[..content.find(&search).unwrap()],
+                                true,
+                            )
+                            .count();
                             let replaced = content.replacen(&search, "", 1);
                             let delta = -(search.chars().count() as i64);
                             let cursor = adjust_cursor(
@@ -2885,36 +2887,55 @@ fn line_col_to_char(
     line: usize,
     col: usize,
 ) -> usize {
-    let mut chars = 0;
-    for i in 0..line {
-        chars += content.line(i).map_or(0, |l| l.text.chars().count()) + 1;
+    let text = content.text();
+    let mut pos = 0;
+    for (i, l) in text.lines().enumerate() {
+        if i == line {
+            let mut byte_offset = 0;
+            for grapheme in UnicodeSegmentation::graphemes(l, true) {
+                if byte_offset >= col {
+                    break;
+                }
+                byte_offset += grapheme.len();
+                pos += 1;
+            }
+            return pos;
+        }
+        pos += UnicodeSegmentation::graphemes(l, true).count() + 1;
     }
-    chars += col;
-    chars
+    pos
 }
 
-/// Converts a flat char offset back to a `(line, col)` position.
+/// Converts a flat grapheme-cluster offset back to a `(line, col)` position.
+///
+/// `start_pos` is the number of grapheme clusters from the start of `text`.
+/// The returned `column` is a byte offset within the line, matching how
+/// `text_editor::Position` encodes column.
 ///
 /// Inverse of [`line_col_to_char`]. Used after offset arithmetic to produce a
 /// position suitable for `move_to`.
-fn char_to_line_col(text: &str, char_pos: usize) -> text_editor::Position {
-    let mut remaining = char_pos;
+fn char_to_line_col(text: &str, start_pos: usize) -> text_editor::Position {
+    let mut remaining = start_pos;
+    let mut fallback = text_editor::Position { line: 0, column: 0 };
     for (i, line) in text.lines().enumerate() {
-        let line_char_count = line.chars().count();
-        if remaining <= line_char_count {
-            return text_editor::Position {
-                line: i,
-                column: remaining,
-            };
+        let mut count = 0;
+        let mut byte_col = 0;
+        for grapheme in UnicodeSegmentation::graphemes(line, true) {
+            if count >= remaining {
+                break;
+            }
+            byte_col += grapheme.len();
+            count += 1;
         }
-        remaining -= line_char_count + 1;
+        if count == remaining {
+            return text_editor::Position { line: i, column: byte_col };
+        }
+        remaining -= count + 1;
+        // track the end of the last seen line so that an out-of-bounds
+        // start_pos clamps to the end of the text
+        fallback = text_editor::Position { line: i, column: line.len() };
     }
-    let last_line = text.lines().count().saturating_sub(1);
-    let last_col = text.lines().last().map_or(0, |l| l.chars().count());
-    text_editor::Position {
-        line: last_line,
-        column: last_col,
-    }
+    fallback
 }
 
 /// Adjusts a flat char offset around a text replacement.

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -2399,17 +2399,13 @@ impl State {
                 history.get_reroute_rules(),
             ) {
                 for message in messages {
-                    history_tasks.extend(
-                        history
-                            .record_input_message(
-                                message,
-                                labeled_response_context.clone(),
-                                buffer.server(),
-                                casemapping,
-                                config,
-                            )
-                            .into_iter(),
-                    );
+                    history_tasks.extend(history.record_input_message(
+                        message,
+                        labeled_response_context.clone(),
+                        buffer.server(),
+                        casemapping,
+                        config,
+                    ));
                 }
             }
 
@@ -2767,7 +2763,9 @@ impl State {
 
     fn set_notice(&mut self, line: usize) {
         match self.parsed.get(line) {
-            Some(Err(error)) => {
+            Some(Err(error)) =>
+            {
+                #[allow(clippy::collapsible_match)]
                 if show_while_typing(error) {
                     self.notice = Some(Notice::Error(error.to_string()));
                 }

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -2986,16 +2986,56 @@ mod tests {
 
     #[test]
     fn char_to_line_col_single_line() {
-        let pos = char_to_line_col("hello", 3);
-        assert_eq!(pos.line, 0);
-        assert_eq!(pos.column, 3);
+        let tests = [("hello", 3), ("안녕하세요", 3), ("👩🏾‍🚒 💬👋🏾🗺️", 3)];
+
+        for (text, chars_to_the_right) in tests {
+            let mut content: text_editor::Content =
+                text_editor::Content::with_text(text);
+
+            for _ in 0..chars_to_the_right {
+                content.perform(text_editor::Action::Move(
+                    text_editor::Motion::Right,
+                ));
+            }
+
+            let content_pos = content.cursor().position;
+
+            let pos = char_to_line_col(text, chars_to_the_right);
+
+            assert_eq!(
+                pos, content_pos,
+                "text: {text:?} chars_to_the_right: {chars_to_the_right}"
+            );
+        }
     }
 
     #[test]
     fn char_to_line_col_second_line() {
-        let pos = char_to_line_col("hello\nworld", 7);
-        assert_eq!(pos.line, 1);
-        assert_eq!(pos.column, 1);
+        let tests = [
+            ("hello\nworld", 7),
+            ("안녕하세요\n여러분", 7),
+            ("👩🏾‍🚒 💬👋🏾\n🗺️", 6),
+        ];
+
+        for (text, chars_to_the_right) in tests {
+            let mut content: text_editor::Content =
+                text_editor::Content::with_text(text);
+
+            for _ in 0..chars_to_the_right {
+                content.perform(text_editor::Action::Move(
+                    text_editor::Motion::Right,
+                ));
+            }
+
+            let content_pos = content.cursor().position;
+
+            let pos = char_to_line_col(text, chars_to_the_right);
+
+            assert_eq!(
+                pos, content_pos,
+                "text: {text:?} chars_to_the_right: {chars_to_the_right}"
+            );
+        }
     }
 
     #[test]

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -1308,9 +1308,9 @@ impl State {
 
                 match url {
                     Some(url) => {
-                        if content.contains(&ghost) {
+                        if let Some(ghost_byte_pos) = content.find(&ghost) {
                             let ghost_char_pos = UnicodeSegmentation::graphemes(
-                                &content[..content.find(&ghost).unwrap()],
+                                &content[..ghost_byte_pos],
                                 true,
                             )
                             .count();
@@ -1357,18 +1357,18 @@ impl State {
 
                         // the ghost may have inserted surrounding spaces; try widest match
                         // first so we don't leave a stray space behind.
-                        let search = [
+                        let found = [
                             format!(" {ghost} "),
                             format!(" {ghost}"),
                             format!("{ghost} "),
                             ghost.clone(),
                         ]
                         .into_iter()
-                        .find(|s| content.contains(s.as_str()));
+                        .find_map(|s| content.find(&s).map(|pos| (s, pos)));
 
-                        if let Some(search) = search {
+                        if let Some((search, ghost_byte_pos)) = found {
                             let ghost_char_pos = UnicodeSegmentation::graphemes(
-                                &content[..content.find(&search).unwrap()],
+                                &content[..ghost_byte_pos],
                                 true,
                             )
                             .count();

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -21,7 +21,7 @@ use crate::window::Window;
 pub enum Message {
     ScrollView(scroll_view::Message),
     InputView(input_view::Message),
-    FilehostUrlReady(String),
+    FilehostUploadDone { id: u32, url: Option<String> },
     FilesDropped(Vec<std::path::PathBuf>),
 }
 
@@ -49,6 +49,7 @@ pub enum Event {
         server: Server,
         target: Option<Target>,
         file_paths: Vec<std::path::PathBuf>,
+        upload_ids: Vec<u32>,
         abort_registrations: Vec<futures::future::AbortRegistration>,
     },
 }
@@ -339,6 +340,7 @@ impl Query {
                         server,
                         target,
                         file_paths,
+                        upload_ids,
                         abort_registrations,
                     }) => (
                         command,
@@ -346,15 +348,16 @@ impl Query {
                             server,
                             target,
                             file_paths,
+                            upload_ids,
                             abort_registrations,
                         }),
                     ),
                     None => (command, None),
                 }
             }
-            Message::FilehostUrlReady(url) => {
+            Message::FilehostUploadDone { id, url } => {
                 let (task, _) = self.input_view.update(
-                    input_view::Message::FilehostUrlReady(url),
+                    input_view::Message::FilehostUploadDone { id, url },
                     &self.buffer,
                     clients,
                     history,
@@ -379,11 +382,13 @@ impl Query {
                             server,
                             target,
                             file_paths,
+                            upload_ids,
                             abort_registrations,
                         } => Some(Event::FilehostUpload {
                             server,
                             target,
                             file_paths,
+                            upload_ids,
                             abort_registrations,
                         }),
                         _ => None,

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -40,7 +40,7 @@ fn row_with_timestamp_and_nick<'a>(
 pub enum Message {
     ScrollView(scroll_view::Message),
     InputView(input_view::Message),
-    FilehostUrlReady(String),
+    FilehostUploadDone { id: u32, url: Option<String> },
     FilesDropped(Vec<std::path::PathBuf>),
 }
 
@@ -65,6 +65,7 @@ pub enum Event {
         server: data::server::Server,
         target: Option<Target>,
         file_paths: Vec<std::path::PathBuf>,
+        upload_ids: Vec<u32>,
         abort_registrations: Vec<futures::future::AbortRegistration>,
     },
 }
@@ -457,6 +458,7 @@ impl Server {
                         server,
                         target,
                         file_paths,
+                        upload_ids,
                         abort_registrations,
                     }) => (
                         command,
@@ -464,15 +466,16 @@ impl Server {
                             server,
                             target,
                             file_paths,
+                            upload_ids,
                             abort_registrations,
                         }),
                     ),
                     None => (command, None),
                 }
             }
-            Message::FilehostUrlReady(url) => {
+            Message::FilehostUploadDone { id, url } => {
                 let (task, _) = self.input_view.update(
-                    input_view::Message::FilehostUrlReady(url),
+                    input_view::Message::FilehostUploadDone { id, url },
                     &self.buffer,
                     clients,
                     history,
@@ -497,11 +500,13 @@ impl Server {
                             server,
                             target,
                             file_paths,
+                            upload_ids,
                             abort_registrations,
                         } => Some(Event::FilehostUpload {
                             server,
                             target,
                             file_paths,
+                            upload_ids,
                             abort_registrations,
                         }),
                         _ => None,

--- a/src/filehost.rs
+++ b/src/filehost.rs
@@ -15,6 +15,7 @@ pub enum Message {
         window: window::Id,
         pane_id: pane_grid::Pane,
         target: Option<Target>,
+        id: u32,
         url: String,
     },
     UploadFailed {
@@ -22,6 +23,7 @@ pub enum Message {
         pane_id: pane_grid::Pane,
         server: data::Server,
         target: Option<Target>,
+        id: u32,
         error: String,
     },
     KnownSaved(Result<(), data::known_filehosts::Error>),
@@ -35,6 +37,7 @@ pub struct PendingUpload {
     pub upload_url: String,
     pub has_credentials: bool,
     pub file_paths: Vec<PathBuf>,
+    pub upload_ids: Vec<u32>,
     pub abort_registrations: Vec<futures::future::AbortRegistration>,
 }
 
@@ -183,6 +186,7 @@ impl Manager {
                         window: p.window,
                         pane_id: p.pane_id,
                         target: p.target.clone(),
+                        id: 0,
                         url: String::new(),
                     })
                 })
@@ -208,13 +212,15 @@ fn start_tasks(
         upload_url,
         has_credentials: _,
         file_paths,
+        upload_ids,
         abort_registrations,
     } = pending;
 
     let tasks: Vec<_> = file_paths
         .into_iter()
+        .zip(upload_ids)
         .zip(abort_registrations)
-        .map(|(file_path, registration)| {
+        .map(|((file_path, id), registration)| {
             let upload_url = upload_url.clone();
             let auth = clients.get_filehost_auth(&server);
             let http_client = http_client.clone();
@@ -239,6 +245,7 @@ fn start_tasks(
                         window,
                         pane_id,
                         target,
+                        id,
                         url,
                     },
                     Ok(Err(e)) => {
@@ -248,6 +255,7 @@ fn start_tasks(
                             pane_id,
                             server,
                             target,
+                            id,
                             error: e.to_string(),
                         }
                     }
@@ -255,6 +263,7 @@ fn start_tasks(
                         window,
                         pane_id,
                         target,
+                        id,
                         url: String::new(),
                     },
                 },

--- a/src/filehost.rs
+++ b/src/filehost.rs
@@ -16,7 +16,7 @@ pub enum Message {
         pane_id: pane_grid::Pane,
         target: Option<Target>,
         id: u32,
-        url: String,
+        url: Option<String>,
     },
     UploadFailed {
         window: window::Id,
@@ -187,7 +187,7 @@ impl Manager {
                         pane_id: p.pane_id,
                         target: p.target.clone(),
                         id,
-                        url: String::new(),
+                        url: None,
                     })
                 })
             })
@@ -246,7 +246,7 @@ fn start_tasks(
                         pane_id,
                         target,
                         id,
-                        url,
+                        url: Some(url),
                     },
                     Ok(Err(e)) => {
                         log::warn!("filehost upload failed: {e}");
@@ -264,7 +264,7 @@ fn start_tasks(
                         pane_id,
                         target,
                         id,
-                        url: String::new(),
+                        url: None,
                     },
                 },
             )

--- a/src/filehost.rs
+++ b/src/filehost.rs
@@ -11,7 +11,7 @@ use crate::window;
 
 #[derive(Debug)]
 pub enum Message {
-    UrlReady {
+    UploadDone {
         window: window::Id,
         pane_id: pane_grid::Pane,
         target: Option<Target>,
@@ -181,12 +181,12 @@ impl Manager {
         let tasks: Vec<_> = pending
             .into_iter()
             .flat_map(|p| {
-                (0..p.file_paths.len()).map(move |_| {
-                    Task::done(Message::UrlReady {
+                p.upload_ids.into_iter().map(move |id| {
+                    Task::done(Message::UploadDone {
                         window: p.window,
                         pane_id: p.pane_id,
                         target: p.target.clone(),
-                        id: 0,
+                        id,
                         url: String::new(),
                     })
                 })
@@ -241,7 +241,7 @@ fn start_tasks(
                     futures::future::Abortable::new(fut, registration).await
                 },
                 move |result| match result {
-                    Ok(Ok(url)) => Message::UrlReady {
+                    Ok(Ok(url)) => Message::UploadDone {
                         window,
                         pane_id,
                         target,
@@ -259,7 +259,7 @@ fn start_tasks(
                             error: e.to_string(),
                         }
                     }
-                    Err(_aborted) => Message::UrlReady {
+                    Err(_aborted) => Message::UploadDone {
                         window,
                         pane_id,
                         target,

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -2634,20 +2634,14 @@ impl Dashboard {
                     Some(Target::Channel(_)) => buffer::Message::Channel(
                         buffer::channel::Message::FilehostUploadDone {
                             id,
-                            url: Some(url),
+                            url,
                         },
                     ),
                     Some(Target::Query(_)) => buffer::Message::Query(
-                        buffer::query::Message::FilehostUploadDone {
-                            id,
-                            url: Some(url),
-                        },
+                        buffer::query::Message::FilehostUploadDone { id, url },
                     ),
                     None => buffer::Message::Server(
-                        buffer::server::Message::FilehostUploadDone {
-                            id,
-                            url: Some(url),
-                        },
+                        buffer::server::Message::FilehostUploadDone { id, url },
                     ),
                 };
                 Task::done(Message::Pane(

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -2623,7 +2623,7 @@ impl Dashboard {
         config: &Config,
     ) -> Task<Message> {
         match msg {
-            filehost::Message::UrlReady {
+            filehost::Message::UploadDone {
                 window,
                 pane_id,
                 target,

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -2547,6 +2547,7 @@ impl Dashboard {
                 server,
                 target,
                 file_paths,
+                upload_ids,
                 abort_registrations,
             } => {
                 let Some(upload_url) =
@@ -2579,6 +2580,7 @@ impl Dashboard {
                     target,
                     upload_url,
                     file_paths,
+                    upload_ids,
                     abort_registrations,
                 };
 
@@ -2625,17 +2627,27 @@ impl Dashboard {
                 window,
                 pane_id,
                 target,
+                id,
                 url,
             } => {
                 let buf_msg = match &target {
                     Some(Target::Channel(_)) => buffer::Message::Channel(
-                        buffer::channel::Message::FilehostUrlReady(url),
+                        buffer::channel::Message::FilehostUploadDone {
+                            id,
+                            url: Some(url),
+                        },
                     ),
                     Some(Target::Query(_)) => buffer::Message::Query(
-                        buffer::query::Message::FilehostUrlReady(url),
+                        buffer::query::Message::FilehostUploadDone {
+                            id,
+                            url: Some(url),
+                        },
                     ),
                     None => buffer::Message::Server(
-                        buffer::server::Message::FilehostUrlReady(url),
+                        buffer::server::Message::FilehostUploadDone {
+                            id,
+                            url: Some(url),
+                        },
                     ),
                 };
                 Task::done(Message::Pane(
@@ -2648,6 +2660,7 @@ impl Dashboard {
                 pane_id,
                 server,
                 target,
+                id,
                 error,
             } => {
                 let casemapping =
@@ -2664,15 +2677,22 @@ impl Dashboard {
                 );
                 let decrement_msg = match &target {
                     Some(Target::Channel(_)) => buffer::Message::Channel(
-                        buffer::channel::Message::FilehostUrlReady(
-                            String::new(),
-                        ),
+                        buffer::channel::Message::FilehostUploadDone {
+                            id,
+                            url: None,
+                        },
                     ),
                     Some(Target::Query(_)) => buffer::Message::Query(
-                        buffer::query::Message::FilehostUrlReady(String::new()),
+                        buffer::query::Message::FilehostUploadDone {
+                            id,
+                            url: None,
+                        },
                     ),
                     None => buffer::Message::Server(
-                        buffer::server::Message::FilehostUrlReady(String::new()),
+                        buffer::server::Message::FilehostUploadDone {
+                            id,
+                            url: None,
+                        },
                     ),
                 };
                 let decrement_task = Task::done(Message::Pane(


### PR DESCRIPTION
possible fix to #1764

shows a string like (uploading...) where the upload is going to be, and then replaces it with the url once done. preserves cursor position like the user may expect.

uploads are now inserted where the cursor is, not at the end of the input