### PR TITLE
Reaction notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Added:
   - emacs bindings for <kbd>ctrl</kbd> + <kbd>u</kbd> and <kbd>ctrl</kbd> + <kbd>w</kbd>
   - `buffer.text_input.kill_to_clipboard` to control key bindings moving killed text to clipboard
 - Windows MSI installer does not automatically start Halloy during passive or quiet installations
+- Notification for reacts
 
 Changed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Added:
 
 - The default font is not bundled if default feature `iosevka-font` is disabled.
 - Configuration options for font stretch (`font.stretch`)
+- Notification for reacts
 
 Fixed:
 
@@ -12,7 +13,7 @@ Fixed:
 
 Thanks:
 
-- Contributions: @bb010g, @furudean
+- Contributions: @bb010g, @furudean, @englut
 - Bug reports: @bb010g
 
 # 2026.6 (2026-04-21)
@@ -46,7 +47,6 @@ Added:
   - emacs bindings for <kbd>ctrl</kbd> + <kbd>u</kbd> and <kbd>ctrl</kbd> + <kbd>w</kbd>
   - `buffer.text_input.kill_to_clipboard` to control key bindings moving killed text to clipboard
 - Windows MSI installer does not automatically start Halloy during passive or quiet installations
-- Notification for reacts
 
 Changed:
 

--- a/data/src/config/notification.rs
+++ b/data/src/config/notification.rs
@@ -69,6 +69,7 @@ pub struct Notifications {
     pub monitored_offline: Notification,
     #[serde(rename = "channel")]
     pub channels: HashMap<String, Notification>,
+    pub reaction: Notification,
 }
 
 impl Notifications {
@@ -123,6 +124,9 @@ impl Notifications {
             }
         }
         for sound_name in highlight_matches_sounds {
+            load_and_insert(sound_name);
+        }
+        if let Some(sound_name) = self.reaction.sound.as_deref() {
             load_and_insert(sound_name);
         }
 

--- a/data/src/config/notification.rs
+++ b/data/src/config/notification.rs
@@ -118,15 +118,15 @@ impl Notifications {
         if let Some(sound_name) = self.monitored_offline.sound.as_deref() {
             load_and_insert(sound_name);
         }
+        if let Some(sound_name) = self.reaction.sound.as_deref() {
+            load_and_insert(sound_name);
+        }
         for notification in self.channels.values() {
             if let Some(sound_name) = notification.sound.as_deref() {
                 load_and_insert(sound_name);
             }
         }
         for sound_name in highlight_matches_sounds {
-            load_and_insert(sound_name);
-        }
-        if let Some(sound_name) = self.reaction.sound.as_deref() {
             load_and_insert(sound_name);
         }
 

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -278,21 +278,22 @@ pub async fn append(
         if let Some(message) =
             find_reaction_target(&mut all_messages, &id, &pending.server_time)
         {
-            if message.is_echo && message.direction == Direction::Received {
-                if let Ok(target) = Target::try_from(message.target.clone()) {
-                    let message_text = message.text();
-                    for reaction in pending.clone().reactions.into_iter() {
-                        let reaction_to_echo = ReactionToEcho {
-                            reaction: reaction::Context {
-                                inner: reaction,
-                                target: target.clone(),
-                                in_reply_to: id.clone(),
-                                server_time: pending.server_time,
-                            },
-                            message_text: message_text.clone(),
-                        };
-                        pending_reactions_flushed.push(reaction_to_echo);
-                    }
+            if message.is_echo
+                && message.direction == Direction::Received
+                && let Ok(target) = Target::try_from(message.target.clone())
+            {
+                let message_text = message.text();
+                for reaction in pending.clone().reactions.into_iter() {
+                    let reaction_to_echo = ReactionToEcho {
+                        reaction: reaction::Context {
+                            inner: reaction,
+                            target: target.clone(),
+                            in_reply_to: id.clone(),
+                            server_time: pending.server_time,
+                        },
+                        message_text: message_text.clone(),
+                    };
+                    pending_reactions_flushed.push(reaction_to_echo);
                 }
             }
 
@@ -309,9 +310,9 @@ pub async fn append(
         },
     );
 
-    let result = overwrite(kind, &all_messages, read_marker, chathistory_references)
-        .await;
-    result.map(|_| pending_reactions_flushed)
+    overwrite(kind, &all_messages, read_marker, chathistory_references)
+        .await
+        .map(|()| pending_reactions_flushed)
 }
 
 pub async fn delete(kind: &Kind) -> Result<(), Error> {
@@ -754,14 +755,14 @@ impl History {
 
                     return Some(
                         async move {
-                            let result = overwrite(
+                            overwrite(
                                 &kind,
                                 &messages,
                                 read_marker,
                                 chathistory_references,
                             )
-                            .await;
-                            result.map(|_| vec![])
+                            .await
+                            .map(|()| vec![])
                         }
                         .boxed(),
                     );
@@ -837,18 +838,16 @@ impl History {
                 chathistory_references,
                 pending_reactions,
                 ..
-            } => {
-                let result = append(
-                    &kind,
-                    seed,
-                    pending_messages,
-                    read_marker,
-                    chathistory_references,
-                    pending_reactions,
-                )
-                .await;
-                result.map(|_| ())
-            }
+            } => append(
+                &kind,
+                seed,
+                pending_messages,
+                read_marker,
+                chathistory_references,
+                pending_reactions,
+            )
+            .await
+            .map(|_| ()),
             History::Full {
                 kind,
                 messages,

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -10,7 +10,7 @@ use futures::{Future, FutureExt};
 use tokio::fs;
 use tokio::time::Instant;
 
-pub use self::manager::{Manager, Resource};
+pub use self::manager::{Manager, PendingReaction, Resource};
 pub use self::metadata::{Metadata, ReadMarker};
 use crate::capabilities::LabeledResponseContext;
 use crate::message::{self, Direction, MessageReferences, Source};
@@ -267,8 +267,10 @@ pub async fn append(
     read_marker: Option<ReadMarker>,
     chathistory_references: Option<MessageReferences>,
     pending_reactions: HashMap<message::Id, reaction::Pending>,
-) -> Result<(), Error> {
+) -> Result<Vec<PendingReaction>, Error> {
     let loaded = load(kind.clone(), seed).await?;
+
+    let mut pending_reactions_flushed: Vec<PendingReaction> = vec![];
 
     let mut all_messages = loaded.messages;
     // pending reactions should only exist for unloaded history entries
@@ -276,6 +278,33 @@ pub async fn append(
         if let Some(message) =
             find_reaction_target(&mut all_messages, &id, &pending.server_time)
         {
+            if message.is_echo && message.direction == Direction::Received {
+                let target = match message.target.clone() {
+                    message::Target::Channel { channel, source: _ } => {
+                        Some(target::Target::Channel(channel))
+                    }
+                    message::Target::Query { query, source: _ } => {
+                        Some(target::Target::Query(query))
+                    }
+                    _ => None,
+                };
+                if let Some(target) = target {
+                    let message_text = message.text();
+                    for reaction in pending.clone().reactions.into_iter() {
+                        let pending_reaction = PendingReaction {
+                            reaction: reaction::Context {
+                                inner: reaction,
+                                target: target.clone(),
+                                in_reply_to: id.clone(),
+                                server_time: pending.server_time,
+                            },
+                            message_text: message_text.clone(),
+                        };
+                        pending_reactions_flushed.push(pending_reaction);
+                    }
+                }
+            }
+
             message.reactions.append(&mut pending.reactions);
         }
     }
@@ -289,7 +318,10 @@ pub async fn append(
         },
     );
 
-    overwrite(kind, &all_messages, read_marker, chathistory_references).await
+    let _ = overwrite(kind, &all_messages, read_marker, chathistory_references)
+        .await;
+
+    Ok(pending_reactions_flushed)
 }
 
 pub async fn delete(kind: &Kind) -> Result<(), Error> {
@@ -659,7 +691,7 @@ impl History {
         &mut self,
         now: Option<Instant>,
         seed: Option<Seed>,
-    ) -> Option<BoxFuture<'static, Result<(), Error>>> {
+    ) -> Option<BoxFuture<'static, Result<Vec<PendingReaction>, Error>>> {
         match self {
             History::Partial {
                 kind,
@@ -732,13 +764,15 @@ impl History {
 
                     return Some(
                         async move {
-                            overwrite(
+                            let _ = overwrite(
                                 &kind,
                                 &messages,
                                 read_marker,
                                 chathistory_references,
                             )
-                            .await
+                            .await;
+
+                            Ok(vec![])
                         }
                         .boxed(),
                     );
@@ -815,7 +849,7 @@ impl History {
                 pending_reactions,
                 ..
             } => {
-                append(
+                let _ = append(
                     &kind,
                     seed,
                     pending_messages,
@@ -823,7 +857,8 @@ impl History {
                     chathistory_references,
                     pending_reactions,
                 )
-                .await
+                .await;
+                Ok(())
             }
             History::Full {
                 kind,

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -35,6 +35,12 @@ const TRUNC_COUNT: usize = 500;
 const FLUSH_AFTER_LAST_RECEIVED: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ReactionTarget {
+    pub sent_by_self: bool,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Kind {
     Server(Server),
     Channel(Server, target::Channel),
@@ -1053,7 +1059,7 @@ impl History {
         id: message::Id,
         reaction: Reaction,
         server_time: DateTime<Utc>,
-    ) {
+    ) -> Option<ReactionTarget> {
         match self {
             History::Partial {
                 pending_messages,
@@ -1066,7 +1072,12 @@ impl History {
                         (m.id.as_deref() == Some(&*id)).then_some(m)
                     })
                 {
+                    let target = ReactionTarget {
+                        sent_by_self: message.is_echo,
+                        text: message.text(),
+                    };
                     message.reactions.push(reaction);
+                    return Some(target);
                 } else {
                     let pending = pending_reactions
                         .entry(id)
@@ -1084,16 +1095,20 @@ impl History {
                 last_updated_at,
                 ..
             } => {
-                let Some(message) =
-                    find_reaction_target(messages, &id, &server_time)
-                else {
-                    return;
-                };
+                let message =
+                    find_reaction_target(messages, &id, &server_time)?;
                 message.reactions.push(reaction);
 
                 *last_updated_at = Some(Instant::now());
+
+                let target = ReactionTarget {
+                    sent_by_self: message.is_echo,
+                    text: message.text(),
+                };
+                return Some(target);
             }
         }
+        None
     }
 
     pub fn last_seen(&self) -> HashMap<Nick, DateTime<Utc>> {

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -10,7 +10,7 @@ use futures::{Future, FutureExt};
 use tokio::fs;
 use tokio::time::Instant;
 
-pub use self::manager::{Manager, PendingReaction, Resource};
+pub use self::manager::{Manager, ReactionToEcho, Resource};
 pub use self::metadata::{Metadata, ReadMarker};
 use crate::capabilities::LabeledResponseContext;
 use crate::message::{self, Direction, MessageReferences, Source};
@@ -267,10 +267,10 @@ pub async fn append(
     read_marker: Option<ReadMarker>,
     chathistory_references: Option<MessageReferences>,
     pending_reactions: HashMap<message::Id, reaction::Pending>,
-) -> Result<Vec<PendingReaction>, Error> {
+) -> Result<Vec<ReactionToEcho>, Error> {
     let loaded = load(kind.clone(), seed).await?;
 
-    let mut pending_reactions_flushed: Vec<PendingReaction> = vec![];
+    let mut pending_reactions_flushed: Vec<ReactionToEcho> = vec![];
 
     let mut all_messages = loaded.messages;
     // pending reactions should only exist for unloaded history entries
@@ -279,19 +279,10 @@ pub async fn append(
             find_reaction_target(&mut all_messages, &id, &pending.server_time)
         {
             if message.is_echo && message.direction == Direction::Received {
-                let target = match message.target.clone() {
-                    message::Target::Channel { channel, source: _ } => {
-                        Some(target::Target::Channel(channel))
-                    }
-                    message::Target::Query { query, source: _ } => {
-                        Some(target::Target::Query(query))
-                    }
-                    _ => None,
-                };
-                if let Some(target) = target {
+                if let Ok(target) = Target::try_from(message.target.clone()) {
                     let message_text = message.text();
                     for reaction in pending.clone().reactions.into_iter() {
-                        let pending_reaction = PendingReaction {
+                        let reaction_to_echo = ReactionToEcho {
                             reaction: reaction::Context {
                                 inner: reaction,
                                 target: target.clone(),
@@ -300,7 +291,7 @@ pub async fn append(
                             },
                             message_text: message_text.clone(),
                         };
-                        pending_reactions_flushed.push(pending_reaction);
+                        pending_reactions_flushed.push(reaction_to_echo);
                     }
                 }
             }
@@ -318,10 +309,9 @@ pub async fn append(
         },
     );
 
-    let _ = overwrite(kind, &all_messages, read_marker, chathistory_references)
+    let result = overwrite(kind, &all_messages, read_marker, chathistory_references)
         .await;
-
-    Ok(pending_reactions_flushed)
+    result.map(|_| pending_reactions_flushed)
 }
 
 pub async fn delete(kind: &Kind) -> Result<(), Error> {
@@ -691,7 +681,7 @@ impl History {
         &mut self,
         now: Option<Instant>,
         seed: Option<Seed>,
-    ) -> Option<BoxFuture<'static, Result<Vec<PendingReaction>, Error>>> {
+    ) -> Option<BoxFuture<'static, Result<Vec<ReactionToEcho>, Error>>> {
         match self {
             History::Partial {
                 kind,
@@ -764,14 +754,14 @@ impl History {
 
                     return Some(
                         async move {
-                            let _ = overwrite(
+                            let result = overwrite(
                                 &kind,
                                 &messages,
                                 read_marker,
                                 chathistory_references,
                             )
                             .await;
-                            Ok(vec![])
+                            result.map(|_| vec![])
                         }
                         .boxed(),
                     );
@@ -848,7 +838,7 @@ impl History {
                 pending_reactions,
                 ..
             } => {
-                let _ = append(
+                let result = append(
                     &kind,
                     seed,
                     pending_messages,
@@ -857,7 +847,7 @@ impl History {
                     pending_reactions,
                 )
                 .await;
-                Ok(())
+                result.map(|_| ())
             }
             History::Full {
                 kind,
@@ -1085,7 +1075,7 @@ impl History {
     pub fn add_reaction(
         &mut self,
         reaction: reaction::Context,
-    ) -> Option<String> {
+    ) -> Option<ReactionToEcho> {
         match self {
             History::Partial {
                 pending_messages,
@@ -1106,8 +1096,16 @@ impl History {
                     } else {
                         None
                     };
-                    message.reactions.push(reaction.inner);
-                    return message_text;
+                    message.reactions.push(reaction.inner.clone());
+
+                    if let Some(message_text) = message_text {
+                        return Some(ReactionToEcho {
+                            reaction,
+                            message_text,
+                        });
+                    } else {
+                        return None;
+                    }
                 } else {
                     let pending = pending_reactions
                         .entry(reaction.in_reply_to)
@@ -1132,18 +1130,18 @@ impl History {
                     &reaction.in_reply_to,
                     &reaction.server_time,
                 )?;
-                message.reactions.push(reaction.inner);
+                message.reactions.push(reaction.inner.clone());
 
                 *last_updated_at = Some(Instant::now());
 
-                let message_text = if message.is_echo
-                    && message.direction == Direction::Received
-                {
-                    Some(message.text())
+                if message.is_echo && message.direction == Direction::Received {
+                    return Some(ReactionToEcho {
+                        reaction,
+                        message_text: message.text(),
+                    });
                 } else {
-                    None
+                    return None;
                 };
-                return message_text;
             }
         }
         None

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -14,11 +14,11 @@ pub use self::manager::{Manager, Resource};
 pub use self::metadata::{Metadata, ReadMarker};
 use crate::capabilities::LabeledResponseContext;
 use crate::message::{self, MessageReferences, Source};
-use crate::reaction::{self, Reaction};
 use crate::target::{self, Target};
 use crate::user::Nick;
 use crate::{
-    Buffer, Message, Server, buffer, compression, config, environment, isupport,
+    Buffer, Message, Server, buffer, compression, config, environment,
+    isupport, reaction,
 };
 
 pub mod filter;
@@ -1056,9 +1056,7 @@ impl History {
 
     pub fn add_reaction(
         &mut self,
-        id: message::Id,
-        reaction: Reaction,
-        server_time: DateTime<Utc>,
+        reaction: reaction::Context,
     ) -> Option<ReactionTarget> {
         match self {
             History::Partial {
@@ -1069,23 +1067,26 @@ impl History {
             } => {
                 if let Some(message) =
                     pending_messages.iter_mut().rev().find_map(|(m, _)| {
-                        (m.id.as_deref() == Some(&*id)).then_some(m)
+                        (m.id.as_deref() == Some(&*reaction.in_reply_to))
+                            .then_some(m)
                     })
                 {
                     let target = ReactionTarget {
                         sent_by_self: message.is_echo,
                         text: message.text(),
                     };
-                    message.reactions.push(reaction);
+                    message.reactions.push(reaction.inner);
                     return Some(target);
                 } else {
                     let pending = pending_reactions
-                        .entry(id)
-                        .or_insert(reaction::Pending::new(server_time));
+                        .entry(reaction.in_reply_to)
+                        .or_insert(reaction::Pending::new(
+                            reaction.server_time,
+                        ));
 
                     pending.server_time =
-                        (pending.server_time).min(server_time);
-                    pending.reactions.push(reaction);
+                        (pending.server_time).min(reaction.server_time);
+                    pending.reactions.push(reaction.inner);
                 }
 
                 *last_updated_at = Some(Instant::now());
@@ -1095,9 +1096,12 @@ impl History {
                 last_updated_at,
                 ..
             } => {
-                let message =
-                    find_reaction_target(messages, &id, &server_time)?;
-                message.reactions.push(reaction);
+                let message = find_reaction_target(
+                    messages,
+                    &reaction.in_reply_to,
+                    &reaction.server_time,
+                )?;
+                message.reactions.push(reaction.inner);
 
                 *last_updated_at = Some(Instant::now());
 

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -771,7 +771,6 @@ impl History {
                                 chathistory_references,
                             )
                             .await;
-
                             Ok(vec![])
                         }
                         .boxed(),

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -13,7 +13,7 @@ use tokio::time::Instant;
 pub use self::manager::{Manager, Resource};
 pub use self::metadata::{Metadata, ReadMarker};
 use crate::capabilities::LabeledResponseContext;
-use crate::message::{self, MessageReferences, Source};
+use crate::message::{self, Direction, MessageReferences, Source};
 use crate::target::{self, Target};
 use crate::user::Nick;
 use crate::{
@@ -1072,7 +1072,8 @@ impl History {
                     })
                 {
                     let target = ReactionTarget {
-                        sent_by_self: message.is_echo,
+                        sent_by_self: message.is_echo
+                            && message.direction == Direction::Received,
                         text: message.text(),
                     };
                     message.reactions.push(reaction.inner);
@@ -1106,7 +1107,8 @@ impl History {
                 *last_updated_at = Some(Instant::now());
 
                 let target = ReactionTarget {
-                    sent_by_self: message.is_echo,
+                    sent_by_self: message.is_echo
+                        && message.direction == Direction::Received,
                     text: message.text(),
                 };
                 return Some(target);

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -35,12 +35,6 @@ const TRUNC_COUNT: usize = 500;
 const FLUSH_AFTER_LAST_RECEIVED: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ReactionTarget {
-    pub sent_by_self: bool,
-    pub text: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Kind {
     Server(Server),
     Channel(Server, target::Channel),
@@ -1057,7 +1051,7 @@ impl History {
     pub fn add_reaction(
         &mut self,
         reaction: reaction::Context,
-    ) -> Option<ReactionTarget> {
+    ) -> Option<String> {
         match self {
             History::Partial {
                 pending_messages,
@@ -1071,13 +1065,15 @@ impl History {
                             .then_some(m)
                     })
                 {
-                    let target = ReactionTarget {
-                        sent_by_self: message.is_echo
-                            && message.direction == Direction::Received,
-                        text: message.text(),
+                    let message_text = if message.is_echo
+                        && message.direction == Direction::Received
+                    {
+                        Some(message.text())
+                    } else {
+                        None
                     };
                     message.reactions.push(reaction.inner);
-                    return Some(target);
+                    return message_text;
                 } else {
                     let pending = pending_reactions
                         .entry(reaction.in_reply_to)
@@ -1106,12 +1102,14 @@ impl History {
 
                 *last_updated_at = Some(Instant::now());
 
-                let target = ReactionTarget {
-                    sent_by_self: message.is_echo
-                        && message.direction == Direction::Received,
-                    text: message.text(),
+                let message_text = if message.is_echo
+                    && message.direction == Direction::Received
+                {
+                    Some(message.text())
+                } else {
+                    None
                 };
-                return Some(target);
+                return message_text;
             }
         }
         None

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -42,7 +42,7 @@ impl Resource {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct PendingReaction {
+pub struct ReactionToEcho {
     pub reaction: reaction::Context,
     pub message_text: String,
 }
@@ -62,12 +62,12 @@ pub enum Message {
         Result<(), history::Error>,
     ),
     Closed(history::Kind, Result<(), history::Error>),
-    Flushed(history::Kind, Result<Vec<PendingReaction>, history::Error>),
+    Flushed(history::Kind, Result<Vec<ReactionToEcho>, history::Error>),
     Exited(Vec<(history::Kind, Result<(), history::Error>)>),
     SentMessageUpdated(history::Kind, history::ReadMarker),
     ResendMessage(history::Kind, message::Message),
     DraftsSaved,
-    PendingReactions(Server, Vec<PendingReaction>),
+    ReactionsToEcho(Server, Vec<ReactionToEcho>),
 }
 
 pub enum Event {
@@ -75,7 +75,7 @@ pub enum Event {
     Exited,
     SentMessageUpdated(history::Kind, history::ReadMarker),
     ResendMessage(history::Kind, message::Message),
-    PendingReactions(Server, Vec<PendingReaction>),
+    ReactionsToEcho(Server, Vec<ReactionToEcho>),
 }
 
 #[derive(Debug, Default)]
@@ -107,8 +107,10 @@ impl Manager {
             log::debug!("cleared messages for {kind}");
 
             return task.map(move |task| {
-                task.map(move |_| Message::Flushed(kind, Ok(vec![])))
-                    .boxed()
+                task.map(move |result| {
+                    Message::Flushed(kind, result.map(|_| vec![]))
+                })
+                .boxed()
             });
         }
 
@@ -174,17 +176,17 @@ impl Manager {
             Message::Closed(kind, Err(error)) => {
                 log::warn!("failed to close history for {kind}: {error}");
             }
-            Message::Flushed(kind, Ok(pending_reactions)) => {
+            Message::Flushed(kind, Ok(reactions)) => {
                 // Will cause flush loop if we emit a log every time we flush logs
                 if !matches!(kind, history::Kind::Logs) {
                     log::debug!("flushed history for {kind}",);
                 }
-                if !pending_reactions.is_empty()
+                if !reactions.is_empty()
                     && let Some(server) = kind.server()
                 {
-                    return Some(Event::PendingReactions(
+                    return Some(Event::ReactionsToEcho(
                         server.clone(),
-                        pending_reactions,
+                        reactions,
                     ));
                 }
             }
@@ -247,10 +249,10 @@ impl Manager {
                 return Some(Event::ResendMessage(kind, message));
             }
             Message::DraftsSaved => {}
-            Message::PendingReactions(server, pending_reactions) => {
-                return Some(Event::PendingReactions(
+            Message::ReactionsToEcho(server, reactions) => {
+                return Some(Event::ReactionsToEcho(
                     server,
-                    pending_reactions,
+                    reactions,
                 ));
             }
         }
@@ -469,7 +471,7 @@ impl Manager {
         server: &Server,
         reaction: reaction::Context,
     ) -> (
-        Option<String>,
+        Option<ReactionToEcho>,
         Option<impl Future<Output = Message> + use<>>,
     ) {
         self.data.add_reaction(server.clone(), reaction)
@@ -1850,24 +1852,23 @@ impl Data {
         server: Server,
         reaction: reaction::Context,
     ) -> (
-        Option<String>,
+        Option<ReactionToEcho>,
         Option<impl Future<Output = Message> + use<>>,
     ) {
         let kind =
             history::Kind::from_target(server.clone(), reaction.target.clone());
         match self.map.entry(kind.clone()) {
             hash_map::Entry::Occupied(mut entry) => {
-                let message_text =
-                    entry.get_mut().add_reaction(reaction.clone());
-                (message_text, None)
+                let reaction = entry.get_mut().add_reaction(reaction);
+                (reaction, None)
             }
             hash_map::Entry::Vacant(entry) => {
-                let message_text = entry
+                let reaction = entry
                     .insert(History::partial(kind.clone()))
                     .add_reaction(reaction);
 
                 (
-                    message_text,
+                    reaction,
                     Some(
                         async move {
                             let loaded =

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -11,11 +11,9 @@ use tokio::time::Instant;
 use super::filter::{Filter, FilterChain};
 use super::reroute::RerouteRules;
 use crate::capabilities::LabeledResponseContext;
-use crate::history::{
-    self, History, MessageReferences, ReactionTarget, ReadMarker, metadata,
-};
+use crate::history::{self, History, MessageReferences, ReadMarker, metadata};
 use crate::message::broadcast::{self, Broadcast};
-use crate::message::{self, Direction, Limit};
+use crate::message::{self, Limit};
 use crate::target::{self, Target};
 use crate::user::Nick;
 use crate::{
@@ -63,7 +61,7 @@ pub enum Message {
     SentMessageUpdated(history::Kind, history::ReadMarker),
     ResendMessage(history::Kind, message::Message),
     DraftsSaved,
-    PendingReaction(Server, Option<ReactionTarget>, reaction::Context),
+    PendingReaction(Server, reaction::Context, Option<String>),
 }
 
 pub enum Event {
@@ -71,7 +69,7 @@ pub enum Event {
     Exited,
     SentMessageUpdated(history::Kind, history::ReadMarker),
     ResendMessage(history::Kind, message::Message),
-    PendingReaction(Server, Option<ReactionTarget>, reaction::Context),
+    PendingReaction(Server, reaction::Context, Option<String>),
 }
 
 #[derive(Debug, Default)]
@@ -235,8 +233,12 @@ impl Manager {
                 return Some(Event::ResendMessage(kind, message));
             }
             Message::DraftsSaved => {}
-            Message::PendingReaction(server, target, reaction) => {
-                return Some(Event::PendingReaction(server, target, reaction));
+            Message::PendingReaction(server, reaction, message_text) => {
+                return Some(Event::PendingReaction(
+                    server,
+                    reaction,
+                    message_text,
+                ));
             }
         }
 
@@ -451,14 +453,13 @@ impl Manager {
 
     pub fn record_reaction(
         &mut self,
-        clients: &client::Map,
         server: &Server,
         reaction: reaction::Context,
     ) -> (
-        Option<ReactionTarget>,
+        Option<String>,
         Option<impl Future<Output = Message> + use<>>,
     ) {
-        self.data.add_reaction(clients, server.clone(), reaction)
+        self.data.add_reaction(server.clone(), reaction)
     }
 
     pub fn block_and_record_message(
@@ -1833,63 +1834,27 @@ impl Data {
 
     fn add_reaction(
         &mut self,
-        clients: &client::Map,
         server: Server,
         reaction: reaction::Context,
     ) -> (
-        Option<ReactionTarget>,
+        Option<String>,
         Option<impl Future<Output = Message> + use<>>,
     ) {
         let kind =
             history::Kind::from_target(server.clone(), reaction.target.clone());
         match self.map.entry(kind.clone()) {
             hash_map::Entry::Occupied(mut entry) => {
-                let target = entry.get_mut().add_reaction(reaction.clone());
-                let seed = clients.get_seed(&kind);
-
-                if target.is_some() {
-                    (target, None)
-                } else {
-                    (
-                        None,
-                        Some(
-                            async move {
-                                let loaded =
-                                    history::load(kind.clone(), seed).await;
-                                let target = if let Ok(loaded) = loaded {
-                                    loaded
-                                        .messages
-                                        .iter()
-                                        .rev()
-                                        .find(|message| {
-                                            message.id.as_deref()
-                                                == Some(&*reaction.in_reply_to)
-                                        })
-                                        .map(|message| ReactionTarget {
-                                            sent_by_self: message.is_echo
-                                                && message.direction
-                                                    == Direction::Received,
-                                            text: message.text(),
-                                        })
-                                } else {
-                                    None
-                                };
-                                Message::PendingReaction(
-                                    server, target, reaction,
-                                )
-                            }
-                            .boxed(),
-                        ),
-                    )
-                }
+                let message_text =
+                    entry.get_mut().add_reaction(reaction.clone());
+                (message_text, None)
             }
             hash_map::Entry::Vacant(entry) => {
-                let target = entry
+                let message_text = entry
                     .insert(History::partial(kind.clone()))
                     .add_reaction(reaction);
 
                 (
-                    target,
+                    message_text,
                     Some(
                         async move {
                             let loaded =

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -15,7 +15,7 @@ use crate::history::{
     self, History, MessageReferences, ReactionTarget, ReadMarker, metadata,
 };
 use crate::message::broadcast::{self, Broadcast};
-use crate::message::{self, Limit};
+use crate::message::{self, Direction, Limit};
 use crate::target::{self, Target};
 use crate::user::Nick;
 use crate::{
@@ -1865,7 +1865,9 @@ impl Data {
                                                 == Some(&*reaction.in_reply_to)
                                         })
                                         .map(|message| ReactionTarget {
-                                            sent_by_self: message.is_echo,
+                                            sent_by_self: message.is_echo
+                                                && message.direction
+                                                    == Direction::Received,
                                             text: message.text(),
                                         })
                                 } else {

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -250,10 +250,7 @@ impl Manager {
             }
             Message::DraftsSaved => {}
             Message::ReactionsToEcho(server, reactions) => {
-                return Some(Event::ReactionsToEcho(
-                    server,
-                    reactions,
-                ));
+                return Some(Event::ReactionsToEcho(server, reactions));
             }
         }
 
@@ -470,10 +467,7 @@ impl Manager {
         &mut self,
         server: &Server,
         reaction: reaction::Context,
-    ) -> (
-        Option<ReactionToEcho>,
-        Option<impl Future<Output = Message> + use<>>,
-    ) {
+    ) -> Option<impl Future<Output = Message> + use<>> {
         self.data.add_reaction(server.clone(), reaction)
     }
 
@@ -1851,32 +1845,30 @@ impl Data {
         &mut self,
         server: Server,
         reaction: reaction::Context,
-    ) -> (
-        Option<ReactionToEcho>,
-        Option<impl Future<Output = Message> + use<>>,
-    ) {
+    ) -> Option<impl Future<Output = Message> + use<>> {
         let kind =
             history::Kind::from_target(server.clone(), reaction.target.clone());
         match self.map.entry(kind.clone()) {
             hash_map::Entry::Occupied(mut entry) => {
-                let reaction = entry.get_mut().add_reaction(reaction);
-                (reaction, None)
+                entry.get_mut().add_reaction(reaction).map(|reaction| {
+                    async move {
+                        Message::ReactionsToEcho(server, vec![reaction])
+                    }
+                    .boxed()
+                })
             }
             hash_map::Entry::Vacant(entry) => {
-                let reaction = entry
+                entry
                     .insert(History::partial(kind.clone()))
                     .add_reaction(reaction);
 
-                (
-                    reaction,
-                    Some(
-                        async move {
-                            let loaded =
-                                history::metadata::load(kind.clone()).await;
-                            Message::UpdatePartial(kind, loaded)
-                        }
-                        .boxed(),
-                    ),
+                Some(
+                    async move {
+                        let loaded =
+                            history::metadata::load(kind.clone()).await;
+                        Message::UpdatePartial(kind, loaded)
+                    }
+                    .boxed(),
                 )
             }
         }

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -451,13 +451,14 @@ impl Manager {
 
     pub fn record_reaction(
         &mut self,
+        clients: &client::Map,
         server: &Server,
         reaction: reaction::Context,
     ) -> (
         Option<ReactionTarget>,
         Option<impl Future<Output = Message> + use<>>,
     ) {
-        self.data.add_reaction(server.clone(), reaction)
+        self.data.add_reaction(clients, server.clone(), reaction)
     }
 
     pub fn block_and_record_message(
@@ -1832,6 +1833,7 @@ impl Data {
 
     fn add_reaction(
         &mut self,
+        clients: &client::Map,
         server: Server,
         reaction: reaction::Context,
     ) -> (
@@ -1843,6 +1845,7 @@ impl Data {
         match self.map.entry(kind.clone()) {
             hash_map::Entry::Occupied(mut entry) => {
                 let target = entry.get_mut().add_reaction(reaction.clone());
+                let seed = clients.get_seed(&kind);
 
                 if target.is_some() {
                     (target, None)
@@ -1851,12 +1854,11 @@ impl Data {
                         None,
                         Some(
                             async move {
-                                let path = history::path(&kind).await.ok();
-                                let target = if let Some(path) = path {
-                                    let messages = history::read_all(&path)
-                                        .await
-                                        .unwrap_or_default();
-                                    messages
+                                let loaded =
+                                    history::load(kind.clone(), seed).await;
+                                let target = if let Ok(loaded) = loaded {
+                                    loaded
+                                        .messages
                                         .iter()
                                         .rev()
                                         .find(|message| {

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -235,8 +235,8 @@ impl Manager {
                 return Some(Event::ResendMessage(kind, message));
             }
             Message::DraftsSaved => {}
-            Message::PendingReaction(server, target, context) => {
-                return Some(Event::PendingReaction(server, target, context));
+            Message::PendingReaction(server, target, reaction) => {
+                return Some(Event::PendingReaction(server, target, reaction));
             }
         }
 
@@ -457,9 +457,7 @@ impl Manager {
         Option<ReactionTarget>,
         Option<impl Future<Output = Message> + use<>>,
     ) {
-        let kind =
-            history::Kind::from_target(server.clone(), reaction.target.clone());
-        self.data.add_reaction(kind, server.clone(), reaction)
+        self.data.add_reaction(server.clone(), reaction)
     }
 
     pub fn block_and_record_message(
@@ -1834,13 +1832,14 @@ impl Data {
 
     fn add_reaction(
         &mut self,
-        kind: history::Kind,
         server: Server,
         reaction: reaction::Context,
     ) -> (
         Option<ReactionTarget>,
         Option<impl Future<Output = Message> + use<>>,
     ) {
+        let kind =
+            history::Kind::from_target(server.clone(), reaction.target.clone());
         match self.map.entry(kind.clone()) {
             hash_map::Entry::Occupied(mut entry) => {
                 let target = entry.get_mut().add_reaction(reaction.clone());

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -41,6 +41,12 @@ impl Resource {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PendingReaction {
+    pub reaction: reaction::Context,
+    pub message_text: String,
+}
+
 #[derive(Debug)]
 pub enum Message {
     LoadFull(history::Kind, Result<history::Loaded, history::Error>),
@@ -56,12 +62,12 @@ pub enum Message {
         Result<(), history::Error>,
     ),
     Closed(history::Kind, Result<(), history::Error>),
-    Flushed(history::Kind, Result<(), history::Error>),
+    Flushed(history::Kind, Result<Vec<PendingReaction>, history::Error>),
     Exited(Vec<(history::Kind, Result<(), history::Error>)>),
     SentMessageUpdated(history::Kind, history::ReadMarker),
     ResendMessage(history::Kind, message::Message),
     DraftsSaved,
-    PendingReaction(Server, reaction::Context, Option<String>),
+    PendingReactions(Server, Vec<PendingReaction>),
 }
 
 pub enum Event {
@@ -69,7 +75,7 @@ pub enum Event {
     Exited,
     SentMessageUpdated(history::Kind, history::ReadMarker),
     ResendMessage(history::Kind, message::Message),
-    PendingReaction(Server, reaction::Context, Option<String>),
+    PendingReactions(Server, Vec<PendingReaction>),
 }
 
 #[derive(Debug, Default)]
@@ -101,7 +107,7 @@ impl Manager {
             log::debug!("cleared messages for {kind}");
 
             return task.map(move |task| {
-                task.map(move |result| Message::Flushed(kind, result))
+                task.map(move |_| Message::Flushed(kind, Ok(vec![])))
                     .boxed()
             });
         }
@@ -168,10 +174,18 @@ impl Manager {
             Message::Closed(kind, Err(error)) => {
                 log::warn!("failed to close history for {kind}: {error}");
             }
-            Message::Flushed(kind, Ok(())) => {
+            Message::Flushed(kind, Ok(pending_reactions)) => {
                 // Will cause flush loop if we emit a log every time we flush logs
                 if !matches!(kind, history::Kind::Logs) {
                     log::debug!("flushed history for {kind}",);
+                }
+                if !pending_reactions.is_empty()
+                    && let Some(server) = kind.server()
+                {
+                    return Some(Event::PendingReactions(
+                        server.clone(),
+                        pending_reactions,
+                    ));
                 }
             }
             Message::Flushed(kind, Err(error)) => {
@@ -233,11 +247,10 @@ impl Manager {
                 return Some(Event::ResendMessage(kind, message));
             }
             Message::DraftsSaved => {}
-            Message::PendingReaction(server, reaction, message_text) => {
-                return Some(Event::PendingReaction(
+            Message::PendingReactions(server, pending_reactions) => {
+                return Some(Event::PendingReactions(
                     server,
-                    reaction,
-                    message_text,
+                    pending_reactions,
                 ));
             }
         }

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -11,7 +11,9 @@ use tokio::time::Instant;
 use super::filter::{Filter, FilterChain};
 use super::reroute::RerouteRules;
 use crate::capabilities::LabeledResponseContext;
-use crate::history::{self, History, MessageReferences, ReadMarker, metadata};
+use crate::history::{
+    self, History, MessageReferences, ReactionTarget, ReadMarker, metadata,
+};
 use crate::message::broadcast::{self, Broadcast};
 use crate::message::{self, Limit};
 use crate::reaction::{self, Reaction};
@@ -445,7 +447,10 @@ impl Manager {
         &mut self,
         server: &Server,
         reaction: reaction::Context,
-    ) -> Option<impl Future<Output = Message> + use<>> {
+    ) -> (
+        Option<ReactionTarget>,
+        Option<impl Future<Output = Message> + use<>>,
+    ) {
         let kind =
             history::Kind::from_target(server.clone(), reaction.target.clone());
         self.data.add_reaction(
@@ -1832,31 +1837,35 @@ impl Data {
         in_reply_to: message::Id,
         reaction: Reaction,
         server_time: DateTime<Utc>,
-    ) -> Option<impl Future<Output = Message> + use<>> {
+    ) -> (
+        Option<ReactionTarget>,
+        Option<impl Future<Output = Message> + use<>>,
+    ) {
         match self.map.entry(kind.clone()) {
             hash_map::Entry::Occupied(mut entry) => {
-                entry.get_mut().add_reaction(
+                let target = entry.get_mut().add_reaction(
                     in_reply_to,
                     reaction,
                     server_time,
                 );
 
-                None
+                (target, None)
             }
             hash_map::Entry::Vacant(entry) => {
-                entry.insert(History::partial(kind.clone())).add_reaction(
-                    in_reply_to,
-                    reaction,
-                    server_time,
-                );
+                let target = entry
+                    .insert(History::partial(kind.clone()))
+                    .add_reaction(in_reply_to, reaction, server_time);
 
-                Some(
-                    async move {
-                        let loaded =
-                            history::metadata::load(kind.clone()).await;
-                        Message::UpdatePartial(kind, loaded)
-                    }
-                    .boxed(),
+                (
+                    target,
+                    Some(
+                        async move {
+                            let loaded =
+                                history::metadata::load(kind.clone()).await;
+                            Message::UpdatePartial(kind, loaded)
+                        }
+                        .boxed(),
+                    ),
                 )
             }
         }

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -16,10 +16,11 @@ use crate::history::{
 };
 use crate::message::broadcast::{self, Broadcast};
 use crate::message::{self, Limit};
-use crate::reaction::{self, Reaction};
 use crate::target::{self, Target};
 use crate::user::Nick;
-use crate::{Config, Server, buffer, client, config, input, isupport, server};
+use crate::{
+    Config, Server, buffer, client, config, input, isupport, reaction, server,
+};
 
 const DRAFT_SAVE_EVERY: Duration = Duration::from_secs(10);
 
@@ -62,6 +63,7 @@ pub enum Message {
     SentMessageUpdated(history::Kind, history::ReadMarker),
     ResendMessage(history::Kind, message::Message),
     DraftsSaved,
+    PendingReaction(Server, Option<ReactionTarget>, reaction::Context),
 }
 
 pub enum Event {
@@ -69,6 +71,7 @@ pub enum Event {
     Exited,
     SentMessageUpdated(history::Kind, history::ReadMarker),
     ResendMessage(history::Kind, message::Message),
+    PendingReaction(Server, Option<ReactionTarget>, reaction::Context),
 }
 
 #[derive(Debug, Default)]
@@ -232,6 +235,9 @@ impl Manager {
                 return Some(Event::ResendMessage(kind, message));
             }
             Message::DraftsSaved => {}
+            Message::PendingReaction(server, target, context) => {
+                return Some(Event::PendingReaction(server, target, context));
+            }
         }
 
         None
@@ -453,12 +459,7 @@ impl Manager {
     ) {
         let kind =
             history::Kind::from_target(server.clone(), reaction.target.clone());
-        self.data.add_reaction(
-            kind,
-            reaction.in_reply_to,
-            reaction.inner,
-            reaction.server_time,
-        )
+        self.data.add_reaction(kind, server.clone(), reaction)
     }
 
     pub fn block_and_record_message(
@@ -1834,27 +1835,55 @@ impl Data {
     fn add_reaction(
         &mut self,
         kind: history::Kind,
-        in_reply_to: message::Id,
-        reaction: Reaction,
-        server_time: DateTime<Utc>,
+        server: Server,
+        reaction: reaction::Context,
     ) -> (
         Option<ReactionTarget>,
         Option<impl Future<Output = Message> + use<>>,
     ) {
         match self.map.entry(kind.clone()) {
             hash_map::Entry::Occupied(mut entry) => {
-                let target = entry.get_mut().add_reaction(
-                    in_reply_to,
-                    reaction,
-                    server_time,
-                );
+                let target = entry.get_mut().add_reaction(reaction.clone());
 
-                (target, None)
+                if target.is_some() {
+                    (target, None)
+                } else {
+                    (
+                        None,
+                        Some(
+                            async move {
+                                let path = history::path(&kind).await.ok();
+                                let target = if let Some(path) = path {
+                                    let messages = history::read_all(&path)
+                                        .await
+                                        .unwrap_or_default();
+                                    messages
+                                        .iter()
+                                        .rev()
+                                        .find(|message| {
+                                            message.id.as_deref()
+                                                == Some(&*reaction.in_reply_to)
+                                        })
+                                        .map(|message| ReactionTarget {
+                                            sent_by_self: message.is_echo,
+                                            text: message.text(),
+                                        })
+                                } else {
+                                    None
+                                };
+                                Message::PendingReaction(
+                                    server, target, reaction,
+                                )
+                            }
+                            .boxed(),
+                        ),
+                    )
+                }
             }
             hash_map::Entry::Vacant(entry) => {
                 let target = entry
                     .insert(History::partial(kind.clone()))
-                    .add_reaction(in_reply_to, reaction, server_time);
+                    .add_reaction(reaction);
 
                 (
                     target,

--- a/data/src/notification.rs
+++ b/data/src/notification.rs
@@ -1,3 +1,4 @@
+use crate::history::ReactionTarget;
 use crate::target::Channel;
 use crate::user::Nick;
 use crate::{User, isupport, reaction};
@@ -36,6 +37,6 @@ pub enum Notification {
     Reaction {
         casemapping: isupport::CaseMap,
         reaction: reaction::Context,
-        message_text: String,
+        reaction_target: Option<ReactionTarget>,
     },
 }

--- a/data/src/notification.rs
+++ b/data/src/notification.rs
@@ -1,6 +1,6 @@
 use crate::target::Channel;
 use crate::user::Nick;
-use crate::{User, isupport};
+use crate::{User, isupport, reaction};
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum Notification {
@@ -32,5 +32,9 @@ pub enum Notification {
         channel: Channel,
         casemapping: isupport::CaseMap,
         message: String,
+    },
+    Reaction {
+        casemapping: isupport::CaseMap,
+        reaction: reaction::Context,
     },
 }

--- a/data/src/notification.rs
+++ b/data/src/notification.rs
@@ -36,5 +36,6 @@ pub enum Notification {
     Reaction {
         casemapping: isupport::CaseMap,
         reaction: reaction::Context,
+        message_text: String,
     },
 }

--- a/data/src/notification.rs
+++ b/data/src/notification.rs
@@ -1,4 +1,3 @@
-use crate::history::ReactionTarget;
 use crate::target::Channel;
 use crate::user::Nick;
 use crate::{User, isupport, reaction};
@@ -37,6 +36,6 @@ pub enum Notification {
     Reaction {
         casemapping: isupport::CaseMap,
         reaction: reaction::Context,
-        reaction_target: Option<ReactionTarget>,
+        message_text: Option<String>,
     },
 }

--- a/data/src/notification.rs
+++ b/data/src/notification.rs
@@ -36,6 +36,6 @@ pub enum Notification {
     Reaction {
         casemapping: isupport::CaseMap,
         reaction: reaction::Context,
-        message_text: Option<String>,
+        message_text: String,
     },
 }

--- a/data/src/reaction.rs
+++ b/data/src/reaction.rs
@@ -78,7 +78,7 @@ impl Reaction {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Pending {
     pub reactions: Vec<Reaction>,
     pub server_time: DateTime<Utc>,

--- a/data/src/reaction.rs
+++ b/data/src/reaction.rs
@@ -8,14 +8,14 @@ use crate::message::{Encoded, Id};
 use crate::target::Target;
 use crate::user::Nick;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Reaction {
     pub sender: Nick,
     pub text: String,
     pub unreact: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct Context {
     pub inner: Reaction,
     pub target: Target,

--- a/data/src/target.rs
+++ b/data/src/target.rs
@@ -5,9 +5,8 @@ use std::{cmp, fmt};
 use irc::proto;
 use serde::{Deserialize, Serialize};
 
-use crate::isupport;
-use crate::message;
 use crate::user::{Nick, NickRef, User};
+use crate::{isupport, message};
 
 #[derive(Debug, Clone, Copy)]
 pub enum TargetRef<'a> {

--- a/data/src/target.rs
+++ b/data/src/target.rs
@@ -6,6 +6,7 @@ use irc::proto;
 use serde::{Deserialize, Serialize};
 
 use crate::isupport;
+use crate::message;
 use crate::user::{Nick, NickRef, User};
 
 #[derive(Debug, Clone, Copy)]
@@ -226,6 +227,20 @@ impl From<Nick> for Target {
 impl From<NickRef<'_>> for Target {
     fn from(nickref: NickRef) -> Self {
         Target::Query(Query::from(nickref))
+    }
+}
+
+impl TryFrom<message::Target> for Target {
+    type Error = ();
+
+    fn try_from(target: message::Target) -> Result<Self, Self::Error> {
+        Ok(match target {
+            message::Target::Channel { channel, source: _ } => {
+                Target::Channel(channel)
+            }
+            message::Target::Query { query, source: _ } => Target::Query(query),
+            _ => return Err(()),
+        })
     }
 }
 

--- a/docs/configuration/notifications.md
+++ b/docs/configuration/notifications.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable MD033 -->
+
 # Notifications
 
 Customize and enable notifications.
@@ -16,20 +17,21 @@ exclude = { users = ["NickServ"], channels = ["#halloy"] }
 
 Following notifications are available:
 
-| Name                    | Description                                        | Content                           |
-| ----------------------- | -------------------------------------------------- | --------------------------------- |
-| `channel`               | Triggered when a message is received in a channel  | Message text                      |
-| `connected`             | Triggered when a server is connected               | N/A                               |
-| `direct_message`        | Triggered when a direct message is received        | Message text                      |
-| `disconnected`          | Triggered when a server disconnects                | N/A                               |
-| `file_transfer_request` | Triggered when a file transfer request is received | File name                         |
-| `highlight`             | Triggered when you were highlighted in a buffer    | Message text                      |
-| `monitored_online`      | Triggered when a user you're monitoring is online  | N/A                               |
-| `monitored_offline`     | Triggered when a user you're monitoring is offline | N/A                               |
-| `reconnected`           | Triggered when a server reconnects                 | N/A                               |
+| Name                    | Description                                        | Content      |
+| ----------------------- | -------------------------------------------------- | ------------ |
+| `channel`               | Triggered when a message is received in a channel  | Message text |
+| `connected`             | Triggered when a server is connected               | N/A          |
+| `direct_message`        | Triggered when a direct message is received        | Message text |
+| `disconnected`          | Triggered when a server disconnects                | N/A          |
+| `file_transfer_request` | Triggered when a file transfer request is received | File name    |
+| `highlight`             | Triggered when you were highlighted in a buffer    | Message text |
+| `monitored_online`      | Triggered when a user you're monitoring is online  | N/A          |
+| `monitored_offline`     | Triggered when a user you're monitoring is offline | N/A          |
+| `reconnected`           | Triggered when a server reconnects                 | N/A          |
+| `reaction`              | Triggered when another user reacts to your message | Message text |
 
 `channel` is an array of tables, with each entry a notification for a single
-channel.  For example, the following shows a toast notification for every
+channel. For example, the following shows a toast notification for every
 message in `#halloy`:
 
 ```toml
@@ -41,8 +43,8 @@ show_toast = true
 
 The following table shows all available built-in sounds
 
-| Sound Name | Preview                                                                          |
-| ---------- | -------------------------------------------------------------------------------- |
+| Sound Name | Preview                                                                       |
+| ---------- | ----------------------------------------------------------------------------- |
 | `bloop`    | <audio controls><source src="../sounds/bloop.ogg" type="audio/ogg"></audio>   |
 | `bonk`     | <audio controls><source src="../sounds/bonk.ogg" type="audio/ogg"></audio>    |
 | `dong`     | <audio controls><source src="../sounds/dong.ogg" type="audio/ogg"></audio>    |
@@ -85,12 +87,12 @@ show_toast = true
 
 ## `request_attention`
 
-Notification should request user attention for its window (aka urgency).  Exact
+Notification should request user attention for its window (aka urgency). Exact
 behavior is platform specific:
 
-  - macOS: Bounces the dock icon once.
-  - Windows: Flashes the taskbar button until the application is in focus.
-  - Linux: Depends on the desktop environment.
+- macOS: Bounces the dock icon once.
+- Windows: Flashes the taskbar button until the application is in focus.
+- Linux: Depends on the desktop environment.
 
 ```toml
 # Type: boolean

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -1406,7 +1406,6 @@ fn send_reaction(
     if !clients.get_server_supports_echoes(server) {
         let nick = clients.nickname(server)?;
         history.record_reaction(
-            clients,
             server,
             reaction::Context {
                 inner: Reaction {

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -1406,6 +1406,7 @@ fn send_reaction(
     if !clients.get_server_supports_echoes(server) {
         let nick = clients.nickname(server)?;
         history.record_reaction(
+            clients,
             server,
             reaction::Context {
                 inner: Reaction {

--- a/src/main.rs
+++ b/src/main.rs
@@ -602,7 +602,7 @@ impl Halloy {
                                 reactions
                                     .into_iter()
                                     .filter_map(|reaction| {
-                                        notify_reaction(
+                                        handle_reaction_to_echo(
                                             &self.config,
                                             &server,
                                             casemapping,
@@ -1785,17 +1785,23 @@ fn handle_client_events(
                 controllers.disconnect(server, error);
             }
             Event::Reaction(encoded, our_nick) => {
-                handle_reaction(
-                    config,
-                    server,
-                    clients,
-                    dashboard,
-                    main_window,
-                    notifications,
-                    &mut reactions,
+                let casemapping =
+                    clients.get_server_casemapping_or_default(server);
+                let chantypes = clients.get_server_chantypes_or_default(server);
+                let statusmsg = clients.get_server_statusmsg_or_default(server);
+
+                if let Some(reaction) = Reaction::received(
                     encoded,
-                    our_nick,
-                );
+                    our_nick.clone(),
+                    chantypes,
+                    statusmsg,
+                    casemapping,
+                    config.buffer.channel.message.max_reaction_chars,
+                ) {
+                    let task =
+                        dashboard.record_reaction(server, reaction.clone());
+                    reactions.push(task.map(Message::Dashboard));
+                }
             }
         }
     }
@@ -2240,7 +2246,7 @@ fn handle_broadcast(
     commands.push(task.map(Message::Dashboard));
 }
 
-fn notify_reaction(
+fn handle_reaction_to_echo(
     config: &Config,
     server: &Server,
     casemapping: data::isupport::CaseMap,
@@ -2307,52 +2313,6 @@ fn notify_reaction(
     }
 
     None
-}
-
-fn handle_reaction(
-    config: &Config,
-    server: &Server,
-    clients: &data::client::Map,
-    dashboard: &mut screen::Dashboard,
-    main_window: &Window,
-    notifications: &mut Notifications,
-    reactions: &mut Vec<Task<Message>>,
-    encoded: message::Encoded,
-    our_nick: Nick,
-) {
-    let casemapping = clients.get_server_casemapping_or_default(server);
-    let chantypes = clients.get_server_chantypes_or_default(server);
-    let statusmsg = clients.get_server_statusmsg_or_default(server);
-
-    if let Some(reaction) = Reaction::received(
-        encoded,
-        our_nick.clone(),
-        chantypes,
-        statusmsg,
-        casemapping,
-        config.buffer.channel.message.max_reaction_chars,
-    ) {
-        let (reaction, task) =
-            dashboard.record_reaction(server, reaction.clone());
-        reactions.push(task.map(Message::Dashboard));
-
-        if let Some(reaction) = reaction
-            && let Some(task) = notify_reaction(
-                config,
-                server,
-                casemapping,
-                chantypes,
-                statusmsg,
-                dashboard,
-                main_window,
-                reaction,
-                notifications,
-                our_nick,
-            )
-        {
-            reactions.push(task);
-        }
-    }
 }
 
 fn handle_direct_message(

--- a/src/main.rs
+++ b/src/main.rs
@@ -598,19 +598,24 @@ impl Halloy {
                         let statusmsg = self
                             .clients
                             .get_server_statusmsg_or_default(&server);
-                        if let Some(task) = notify_reaction(
-                            &self.config,
-                            &server,
-                            casemapping,
-                            chantypes,
-                            statusmsg,
-                            dashboard,
-                            &self.main_window,
-                            &reaction,
-                            reaction_target.as_ref(),
-                            &mut self.notifications,
-                        ) {
-                            task
+                        if let Some(our_nick) = self.clients.nickname(&server) {
+                            if let Some(task) = notify_reaction(
+                                &self.config,
+                                &server,
+                                casemapping,
+                                chantypes,
+                                statusmsg,
+                                dashboard,
+                                &self.main_window,
+                                &reaction,
+                                reaction_target.as_ref(),
+                                &mut self.notifications,
+                                our_nick.to_owned(),
+                            ) {
+                                task
+                            } else {
+                                Task::none()
+                            }
                         } else {
                             Task::none()
                         }
@@ -2245,11 +2250,14 @@ fn notify_reaction(
     reaction: &reaction::Context,
     reaction_target: Option<&ReactionTarget>,
     notifications: &mut Notifications,
+    our_nick: Nick,
 ) -> Option<Task<Message>> {
     let is_react_to_own_message =
         reaction_target.is_some_and(|t| t.sent_by_self);
 
-    let sender = User::from(reaction.inner.sender.clone());
+    let sender_nick = reaction.inner.sender.clone();
+    let self_reaction = our_nick == sender_nick;
+    let sender = User::from(sender_nick);
     let channel = reaction.target.as_channel();
     let query = match channel {
         None => target::Query::parse(
@@ -2283,6 +2291,7 @@ fn notify_reaction(
     };
 
     if !blocked
+        && !self_reaction
         && !reaction.inner.unreact
         && is_react_to_own_message
         && (message_window.is_none() || !main_window.focused)
@@ -2292,9 +2301,7 @@ fn notify_reaction(
             &Notification::Reaction {
                 casemapping,
                 reaction: reaction.clone(),
-                message_text: reaction_target
-                    .map(|t| t.text.clone())
-                    .unwrap_or_default(),
+                reaction_target: reaction_target.cloned(),
             },
             server,
             message_window.unwrap_or(main_window.id),
@@ -2323,7 +2330,7 @@ fn handle_reaction(
 
     if let Some(reaction) = Reaction::received(
         encoded,
-        our_nick,
+        our_nick.clone(),
         chantypes,
         statusmsg,
         casemapping,
@@ -2344,6 +2351,7 @@ fn handle_reaction(
             &reaction,
             reaction_target.as_ref(),
             notifications,
+            our_nick,
         ) {
             reactions.push(task);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -583,10 +583,9 @@ impl Halloy {
                         });
                         Task::none()
                     }
-                    Some(dashboard::Event::PendingReaction(
+                    Some(dashboard::Event::PendingReactions(
                         server,
-                        reaction,
-                        message_text,
+                        pending_reactions,
                     )) => {
                         let casemapping = self
                             .clients
@@ -598,23 +597,28 @@ impl Halloy {
                             .clients
                             .get_server_statusmsg_or_default(&server);
                         if let Some(our_nick) = self.clients.nickname(&server) {
-                            if let Some(task) = notify_reaction(
-                                &self.config,
-                                &server,
-                                casemapping,
-                                chantypes,
-                                statusmsg,
-                                dashboard,
-                                &self.main_window,
-                                &reaction,
-                                message_text.as_ref(),
-                                &mut self.notifications,
-                                our_nick.to_owned(),
-                            ) {
-                                task
-                            } else {
-                                Task::none()
-                            }
+                            Task::batch(
+                                pending_reactions
+                                    .into_iter()
+                                    .filter_map(|pending_reaction| {
+                                        notify_reaction(
+                                            &self.config,
+                                            &server,
+                                            casemapping,
+                                            chantypes,
+                                            statusmsg,
+                                            dashboard,
+                                            &self.main_window,
+                                            &pending_reaction.reaction,
+                                            Some(
+                                                &pending_reaction.message_text,
+                                            ),
+                                            &mut self.notifications,
+                                            our_nick.to_owned(),
+                                        )
+                                    })
+                                    .collect::<Vec<_>>(),
+                            )
                         } else {
                             Task::none()
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,10 +30,11 @@ use std::{env, mem};
 use appearance::{Theme, theme};
 use data::capabilities::LabeledResponseContext;
 use data::config::{self, Config};
+use data::history::ReactionToEcho;
 use data::history::filter::FilterChain;
 use data::history::reroute::RerouteRules;
 use data::message::{self, Broadcast};
-use data::reaction::{self, Reaction};
+use data::reaction::Reaction;
 use data::target::{self, Target};
 use data::user::Nick;
 use data::version::Version;
@@ -583,9 +584,9 @@ impl Halloy {
                         });
                         Task::none()
                     }
-                    Some(dashboard::Event::PendingReactions(
+                    Some(dashboard::Event::ReactionsToEcho(
                         server,
-                        pending_reactions,
+                        reactions,
                     )) => {
                         let casemapping = self
                             .clients
@@ -598,9 +599,9 @@ impl Halloy {
                             .get_server_statusmsg_or_default(&server);
                         if let Some(our_nick) = self.clients.nickname(&server) {
                             Task::batch(
-                                pending_reactions
+                                reactions
                                     .into_iter()
-                                    .filter_map(|pending_reaction| {
+                                    .filter_map(|reaction| {
                                         notify_reaction(
                                             &self.config,
                                             &server,
@@ -609,8 +610,7 @@ impl Halloy {
                                             statusmsg,
                                             dashboard,
                                             &self.main_window,
-                                            &pending_reaction.reaction,
-                                            pending_reaction.message_text,
+                                            reaction,
                                             &mut self.notifications,
                                             our_nick.to_owned(),
                                         )
@@ -2248,15 +2248,14 @@ fn notify_reaction(
     statusmsg: &[char],
     dashboard: &mut screen::Dashboard,
     main_window: &Window,
-    reaction: &reaction::Context,
-    message_text: String,
+    reaction_to_echo: ReactionToEcho,
     notifications: &mut Notifications,
     our_nick: Nick,
 ) -> Option<Task<Message>> {
-    let sender_nick = reaction.inner.sender.clone();
+    let sender_nick = reaction_to_echo.reaction.inner.sender.clone();
     let self_reaction = our_nick == sender_nick;
     let sender = User::from(sender_nick);
-    let channel = reaction.target.as_channel();
+    let channel = reaction_to_echo.reaction.target.as_channel();
     let query = match channel {
         None => target::Query::parse(
             sender.nickname().as_str(),
@@ -2290,15 +2289,15 @@ fn notify_reaction(
 
     if !blocked
         && !self_reaction
-        && !reaction.inner.unreact
+        && !reaction_to_echo.reaction.inner.unreact
         && (message_window.is_none() || !main_window.focused)
     {
         let request_attention = notifications.notify(
             &config.notifications,
             &Notification::Reaction {
                 casemapping,
-                reaction: reaction.clone(),
-                message_text,
+                reaction: reaction_to_echo.reaction.clone(),
+                message_text: reaction_to_echo.message_text,
             },
             server,
             message_window.unwrap_or(main_window.id),
@@ -2333,11 +2332,11 @@ fn handle_reaction(
         casemapping,
         config.buffer.channel.message.max_reaction_chars,
     ) {
-        let (message_text, task) =
+        let (reaction, task) =
             dashboard.record_reaction(server, reaction.clone());
         reactions.push(task.map(Message::Dashboard));
 
-        if let Some(message_text) = message_text
+        if let Some(reaction) = reaction
             && let Some(task) = notify_reaction(
                 config,
                 server,
@@ -2346,8 +2345,7 @@ fn handle_reaction(
                 statusmsg,
                 dashboard,
                 main_window,
-                &reaction,
-                message_text,
+                reaction,
                 notifications,
                 our_nick,
             )

--- a/src/main.rs
+++ b/src/main.rs
@@ -1785,22 +1785,19 @@ fn handle_client_events(
                 controllers.disconnect(server, error);
             }
             Event::Reaction(encoded, our_nick) => {
-                let casemapping =
-                    clients.get_server_casemapping_or_default(server);
-                let chantypes = clients.get_server_chantypes_or_default(server);
-                let statusmsg = clients.get_server_statusmsg_or_default(server);
-
                 if let Some(reaction) = Reaction::received(
                     encoded,
-                    our_nick.clone(),
-                    chantypes,
-                    statusmsg,
-                    casemapping,
+                    our_nick,
+                    clients.get_server_chantypes_or_default(server),
+                    clients.get_server_statusmsg_or_default(server),
+                    clients.get_server_casemapping_or_default(server),
                     config.buffer.channel.message.max_reaction_chars,
                 ) {
-                    let task =
-                        dashboard.record_reaction(server, reaction.clone());
-                    reactions.push(task.map(Message::Dashboard));
+                    reactions.push(
+                        dashboard
+                            .record_reaction(server, reaction)
+                            .map(Message::Dashboard),
+                    );
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2337,7 +2337,7 @@ fn handle_reaction(
         config.buffer.channel.message.max_reaction_chars,
     ) {
         let (reaction_target, task) =
-            dashboard.record_reaction(server, reaction.clone());
+            dashboard.record_reaction(clients, server, reaction.clone());
         reactions.push(task.map(Message::Dashboard));
 
         if let Some(task) = notify_reaction(

--- a/src/main.rs
+++ b/src/main.rs
@@ -610,9 +610,7 @@ impl Halloy {
                                             dashboard,
                                             &self.main_window,
                                             &pending_reaction.reaction,
-                                            Some(
-                                                &pending_reaction.message_text,
-                                            ),
+                                            pending_reaction.message_text,
                                             &mut self.notifications,
                                             our_nick.to_owned(),
                                         )
@@ -2251,7 +2249,7 @@ fn notify_reaction(
     dashboard: &mut screen::Dashboard,
     main_window: &Window,
     reaction: &reaction::Context,
-    message_text: Option<&String>,
+    message_text: String,
     notifications: &mut Notifications,
     our_nick: Nick,
 ) -> Option<Task<Message>> {
@@ -2293,7 +2291,6 @@ fn notify_reaction(
     if !blocked
         && !self_reaction
         && !reaction.inner.unreact
-        && message_text.is_some()
         && (message_window.is_none() || !main_window.focused)
     {
         let request_attention = notifications.notify(
@@ -2301,7 +2298,7 @@ fn notify_reaction(
             &Notification::Reaction {
                 casemapping,
                 reaction: reaction.clone(),
-                message_text: message_text.cloned(),
+                message_text,
             },
             server,
             message_window.unwrap_or(main_window.id),
@@ -2340,19 +2337,21 @@ fn handle_reaction(
             dashboard.record_reaction(server, reaction.clone());
         reactions.push(task.map(Message::Dashboard));
 
-        if let Some(task) = notify_reaction(
-            config,
-            server,
-            casemapping,
-            chantypes,
-            statusmsg,
-            dashboard,
-            main_window,
-            &reaction,
-            message_text.as_ref(),
-            notifications,
-            our_nick,
-        ) {
+        if let Some(message_text) = message_text
+            && let Some(task) = notify_reaction(
+                config,
+                server,
+                casemapping,
+                chantypes,
+                statusmsg,
+                dashboard,
+                main_window,
+                &reaction,
+                message_text,
+                notifications,
+                our_nick,
+            )
+        {
             reactions.push(task);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,10 +30,11 @@ use std::{env, mem};
 use appearance::{Theme, theme};
 use data::capabilities::LabeledResponseContext;
 use data::config::{self, Config};
+use data::history::ReactionTarget;
 use data::history::filter::FilterChain;
 use data::history::reroute::RerouteRules;
 use data::message::{self, Broadcast};
-use data::reaction::Reaction;
+use data::reaction::{self, Reaction};
 use data::target::{self, Target};
 use data::user::Nick;
 use data::version::Version;
@@ -582,6 +583,26 @@ impl Halloy {
                             window,
                         });
                         Task::none()
+                    }
+                    Some(dashboard::Event::PendingReaction(
+                        server,
+                        reaction_target,
+                        reaction,
+                    )) => {
+                        if let Some(task) = notify_reaction(
+                            &server,
+                            &reaction,
+                            reaction_target.as_ref(),
+                            dashboard,
+                            &self.config,
+                            &self.clients,
+                            &mut self.notifications,
+                            &self.main_window,
+                        ) {
+                            task
+                        } else {
+                            Task::none()
+                        }
                     }
                     None => Task::none(),
                 };
@@ -2202,6 +2223,80 @@ fn handle_broadcast(
     commands.push(task.map(Message::Dashboard));
 }
 
+fn notify_reaction(
+    server: &Server,
+    reaction: &reaction::Context,
+    reaction_target: Option<&ReactionTarget>,
+    dashboard: &mut screen::Dashboard,
+    config: &Config,
+    clients: &data::client::Map,
+    notifications: &mut Notifications,
+    main_window: &Window,
+) -> Option<Task<Message>> {
+    let is_react_to_own_message =
+        reaction_target.is_some_and(|t| t.sent_by_self);
+
+    let casemapping = clients.get_server_casemapping_or_default(server);
+    let chantypes = clients.get_server_chantypes_or_default(server);
+    let statusmsg = clients.get_server_statusmsg_or_default(server);
+
+    let sender = User::from(reaction.inner.sender.clone());
+    let channel = reaction.target.as_channel();
+    let query = match channel {
+        None => target::Query::parse(
+            sender.nickname().as_str(),
+            chantypes,
+            statusmsg,
+            casemapping,
+        )
+        .ok(),
+        Some(_) => None,
+    };
+
+    let kind = match channel {
+        Some(channel) => Some(history::Kind::Channel(
+            server.to_owned(),
+            channel.to_owned(),
+        )),
+        None => query
+            .to_owned()
+            .map(|query| history::Kind::Query(server.to_owned(), query)),
+    };
+    let message_window =
+        kind.and_then(|kind| dashboard.find_window_with_history(&kind));
+
+    let blocked = match (channel, query) {
+        (Some(channel), None) => FilterChain::borrow(dashboard.get_filters())
+            .filter_user(&sender, Some(channel), server),
+        (None, Some(query)) => FilterChain::borrow(dashboard.get_filters())
+            .filter_query(&query, server),
+        _ => false,
+    };
+
+    if !blocked
+        && !reaction.inner.unreact
+        && is_react_to_own_message
+        && (message_window.is_none() || !main_window.focused)
+    {
+        let request_attention = notifications.notify(
+            &config.notifications,
+            &Notification::Reaction {
+                casemapping,
+                reaction: reaction.clone(),
+                message_text: reaction_target
+                    .map(|t| t.text.clone())
+                    .unwrap_or_default(),
+            },
+            server,
+            message_window.unwrap_or(main_window.id),
+        );
+
+        return request_attention;
+    }
+
+    None
+}
+
 fn handle_reaction(
     server: &Server,
     encoded: message::Encoded,
@@ -2229,66 +2324,17 @@ fn handle_reaction(
             dashboard.record_reaction(server, reaction.clone());
         reactions.push(task.map(Message::Dashboard));
 
-        let is_react_to_own_message =
-            reaction_target.as_ref().is_some_and(|t| t.sent_by_self);
-
-        let sender = User::from(reaction.inner.sender.clone());
-        let channel = reaction.target.as_channel();
-        let query = match channel {
-            None => target::Query::parse(
-                sender.nickname().as_str(),
-                chantypes,
-                statusmsg,
-                casemapping,
-            )
-            .ok(),
-            Some(_) => None,
-        };
-
-        let kind = match channel {
-            Some(channel) => Some(history::Kind::Channel(
-                server.to_owned(),
-                channel.to_owned(),
-            )),
-            None => query
-                .to_owned()
-                .map(|query| history::Kind::Query(server.to_owned(), query)),
-        };
-        let message_window =
-            kind.and_then(|kind| dashboard.find_window_with_history(&kind));
-
-        let blocked = match (channel, query) {
-            (Some(channel), None) => FilterChain::borrow(
-                dashboard.get_filters(),
-            )
-            .filter_user(&sender, Some(channel), server),
-            (None, Some(query)) => FilterChain::borrow(dashboard.get_filters())
-                .filter_query(&query, server),
-            _ => false,
-        };
-
-        if !blocked
-            && !reaction.inner.unreact
-            && is_react_to_own_message
-            && (message_window.is_none() || !main_window.focused)
-        {
-            let request_attention = notifications.notify(
-                &config.notifications,
-                &Notification::Reaction {
-                    casemapping,
-                    reaction,
-                    message_text: reaction_target
-                        .as_ref()
-                        .map(|t| t.text.clone())
-                        .unwrap_or_default(),
-                },
-                server,
-                message_window.unwrap_or(main_window.id),
-            );
-
-            if let Some(request_attention) = request_attention {
-                reactions.push(request_attention);
-            }
+        if let Some(task) = notify_reaction(
+            server,
+            &reaction,
+            reaction_target.as_ref(),
+            dashboard,
+            config,
+            clients,
+            notifications,
+            main_window,
+        ) {
+            reactions.push(task);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -589,15 +589,26 @@ impl Halloy {
                         reaction_target,
                         reaction,
                     )) => {
+                        let casemapping = self
+                            .clients
+                            .get_server_casemapping_or_default(&server);
+                        let chantypes = self
+                            .clients
+                            .get_server_chantypes_or_default(&server);
+                        let statusmsg = self
+                            .clients
+                            .get_server_statusmsg_or_default(&server);
                         if let Some(task) = notify_reaction(
+                            &self.config,
                             &server,
+                            casemapping,
+                            chantypes,
+                            statusmsg,
+                            dashboard,
+                            &self.main_window,
                             &reaction,
                             reaction_target.as_ref(),
-                            dashboard,
-                            &self.config,
-                            &self.clients,
                             &mut self.notifications,
-                            &self.main_window,
                         ) {
                             task
                         } else {
@@ -1769,15 +1780,15 @@ fn handle_client_events(
             }
             Event::Reaction(encoded, our_nick) => {
                 handle_reaction(
+                    config,
                     server,
+                    clients,
+                    dashboard,
+                    main_window,
+                    notifications,
+                    &mut reactions,
                     encoded,
                     our_nick,
-                    dashboard,
-                    config,
-                    clients,
-                    &mut reactions,
-                    notifications,
-                    main_window,
                 );
             }
         }
@@ -2224,21 +2235,19 @@ fn handle_broadcast(
 }
 
 fn notify_reaction(
+    config: &Config,
     server: &Server,
+    casemapping: data::isupport::CaseMap,
+    chantypes: &[char],
+    statusmsg: &[char],
+    dashboard: &mut screen::Dashboard,
+    main_window: &Window,
     reaction: &reaction::Context,
     reaction_target: Option<&ReactionTarget>,
-    dashboard: &mut screen::Dashboard,
-    config: &Config,
-    clients: &data::client::Map,
     notifications: &mut Notifications,
-    main_window: &Window,
 ) -> Option<Task<Message>> {
     let is_react_to_own_message =
         reaction_target.is_some_and(|t| t.sent_by_self);
-
-    let casemapping = clients.get_server_casemapping_or_default(server);
-    let chantypes = clients.get_server_chantypes_or_default(server);
-    let statusmsg = clients.get_server_statusmsg_or_default(server);
 
     let sender = User::from(reaction.inner.sender.clone());
     let channel = reaction.target.as_channel();
@@ -2298,15 +2307,15 @@ fn notify_reaction(
 }
 
 fn handle_reaction(
+    config: &Config,
     server: &Server,
+    clients: &data::client::Map,
+    dashboard: &mut screen::Dashboard,
+    main_window: &Window,
+    notifications: &mut Notifications,
+    reactions: &mut Vec<Task<Message>>,
     encoded: message::Encoded,
     our_nick: Nick,
-    dashboard: &mut screen::Dashboard,
-    config: &Config,
-    clients: &data::client::Map,
-    reactions: &mut Vec<Task<Message>>,
-    notifications: &mut Notifications,
-    main_window: &Window,
 ) {
     let casemapping = clients.get_server_casemapping_or_default(server);
     let chantypes = clients.get_server_chantypes_or_default(server);
@@ -2325,14 +2334,16 @@ fn handle_reaction(
         reactions.push(task.map(Message::Dashboard));
 
         if let Some(task) = notify_reaction(
+            config,
             server,
+            casemapping,
+            chantypes,
+            statusmsg,
+            dashboard,
+            main_window,
             &reaction,
             reaction_target.as_ref(),
-            dashboard,
-            config,
-            clients,
             notifications,
-            main_window,
         ) {
             reactions.push(task);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2217,15 +2217,6 @@ fn handle_reaction(
     let chantypes = clients.get_server_chantypes_or_default(server);
     let statusmsg = clients.get_server_statusmsg_or_default(server);
 
-    // Going to assume that there'll be something in `encoded` that gives
-    // us access to the original message directly. using user() as placeholder
-    let is_react_to_own_message =
-        if let Some(message_sender) = &encoded.user(casemapping.to_owned()) {
-            message_sender.nickname() != our_nick // just setting to true for now
-        } else {
-            false
-        };
-
     if let Some(reaction) = Reaction::received(
         encoded,
         our_nick,
@@ -2234,11 +2225,12 @@ fn handle_reaction(
         casemapping,
         config.buffer.channel.message.max_reaction_chars,
     ) {
-        reactions.push(
-            dashboard
-                .record_reaction(server, reaction.clone())
-                .map(Message::Dashboard),
-        );
+        let (reaction_target, task) =
+            dashboard.record_reaction(server, reaction.clone());
+        reactions.push(task.map(Message::Dashboard));
+
+        let is_react_to_own_message =
+            reaction_target.as_ref().is_some_and(|t| t.sent_by_self);
 
         let sender = User::from(reaction.inner.sender.clone());
         let channel = reaction.target.as_channel();
@@ -2285,6 +2277,10 @@ fn handle_reaction(
                 &Notification::Reaction {
                     casemapping,
                     reaction,
+                    message_text: reaction_target
+                        .as_ref()
+                        .map(|t| t.text.clone())
+                        .unwrap_or_default(),
                 },
                 server,
                 message_window.unwrap_or(main_window.id),

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,6 @@ use std::{env, mem};
 use appearance::{Theme, theme};
 use data::capabilities::LabeledResponseContext;
 use data::config::{self, Config};
-use data::history::ReactionTarget;
 use data::history::filter::FilterChain;
 use data::history::reroute::RerouteRules;
 use data::message::{self, Broadcast};
@@ -586,8 +585,8 @@ impl Halloy {
                     }
                     Some(dashboard::Event::PendingReaction(
                         server,
-                        reaction_target,
                         reaction,
+                        message_text,
                     )) => {
                         let casemapping = self
                             .clients
@@ -608,7 +607,7 @@ impl Halloy {
                                 dashboard,
                                 &self.main_window,
                                 &reaction,
-                                reaction_target.as_ref(),
+                                message_text.as_ref(),
                                 &mut self.notifications,
                                 our_nick.to_owned(),
                             ) {
@@ -2248,13 +2247,10 @@ fn notify_reaction(
     dashboard: &mut screen::Dashboard,
     main_window: &Window,
     reaction: &reaction::Context,
-    reaction_target: Option<&ReactionTarget>,
+    message_text: Option<&String>,
     notifications: &mut Notifications,
     our_nick: Nick,
 ) -> Option<Task<Message>> {
-    let is_react_to_own_message =
-        reaction_target.is_some_and(|t| t.sent_by_self);
-
     let sender_nick = reaction.inner.sender.clone();
     let self_reaction = our_nick == sender_nick;
     let sender = User::from(sender_nick);
@@ -2293,7 +2289,7 @@ fn notify_reaction(
     if !blocked
         && !self_reaction
         && !reaction.inner.unreact
-        && is_react_to_own_message
+        && message_text.is_some()
         && (message_window.is_none() || !main_window.focused)
     {
         let request_attention = notifications.notify(
@@ -2301,7 +2297,7 @@ fn notify_reaction(
             &Notification::Reaction {
                 casemapping,
                 reaction: reaction.clone(),
-                reaction_target: reaction_target.cloned(),
+                message_text: message_text.cloned(),
             },
             server,
             message_window.unwrap_or(main_window.id),
@@ -2336,8 +2332,8 @@ fn handle_reaction(
         casemapping,
         config.buffer.channel.message.max_reaction_chars,
     ) {
-        let (reaction_target, task) =
-            dashboard.record_reaction(clients, server, reaction.clone());
+        let (message_text, task) =
+            dashboard.record_reaction(server, reaction.clone());
         reactions.push(task.map(Message::Dashboard));
 
         if let Some(task) = notify_reaction(
@@ -2349,7 +2345,7 @@ fn handle_reaction(
             dashboard,
             main_window,
             &reaction,
-            reaction_target.as_ref(),
+            message_text.as_ref(),
             notifications,
             our_nick,
         ) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ use data::history::reroute::RerouteRules;
 use data::message::{self, Broadcast};
 use data::reaction::Reaction;
 use data::target::{self, Target};
+use data::user::Nick;
 use data::version::Version;
 use data::{
     Notification, Server, Url, User, client, environment, history, server,
@@ -1746,20 +1747,17 @@ fn handle_client_events(
                 controllers.disconnect(server, error);
             }
             Event::Reaction(encoded, our_nick) => {
-                if let Some(reaction) = Reaction::received(
+                handle_reaction(
+                    server,
                     encoded,
                     our_nick,
-                    clients.get_server_chantypes_or_default(server),
-                    clients.get_server_statusmsg_or_default(server),
-                    clients.get_server_casemapping_or_default(server),
-                    config.buffer.channel.message.max_reaction_chars,
-                ) {
-                    reactions.push(
-                        dashboard
-                            .record_reaction(server, reaction)
-                            .map(Message::Dashboard),
-                    );
-                }
+                    dashboard,
+                    config,
+                    clients,
+                    &mut reactions,
+                    notifications,
+                    main_window,
+                );
             }
         }
     }
@@ -2202,6 +2200,101 @@ fn handle_broadcast(
     };
 
     commands.push(task.map(Message::Dashboard));
+}
+
+fn handle_reaction(
+    server: &Server,
+    encoded: message::Encoded,
+    our_nick: Nick,
+    dashboard: &mut screen::Dashboard,
+    config: &Config,
+    clients: &data::client::Map,
+    reactions: &mut Vec<Task<Message>>,
+    notifications: &mut Notifications,
+    main_window: &Window,
+) {
+    let casemapping = clients.get_server_casemapping_or_default(server);
+    let chantypes = clients.get_server_chantypes_or_default(server);
+    let statusmsg = clients.get_server_statusmsg_or_default(server);
+
+    // Going to assume that there'll be something in `encoded` that gives
+    // us access to the original message directly. using user() as placeholder
+    let is_react_to_own_message =
+        if let Some(message_sender) = &encoded.user(casemapping.to_owned()) {
+            message_sender.nickname() != our_nick // just setting to true for now
+        } else {
+            false
+        };
+
+    if let Some(reaction) = Reaction::received(
+        encoded,
+        our_nick,
+        chantypes,
+        statusmsg,
+        casemapping,
+        config.buffer.channel.message.max_reaction_chars,
+    ) {
+        reactions.push(
+            dashboard
+                .record_reaction(server, reaction.clone())
+                .map(Message::Dashboard),
+        );
+
+        let sender = User::from(reaction.inner.sender.clone());
+        let channel = reaction.target.as_channel();
+        let query = match channel {
+            None => target::Query::parse(
+                sender.nickname().as_str(),
+                chantypes,
+                statusmsg,
+                casemapping,
+            )
+            .ok(),
+            Some(_) => None,
+        };
+
+        let kind = match channel {
+            Some(channel) => Some(history::Kind::Channel(
+                server.to_owned(),
+                channel.to_owned(),
+            )),
+            None => query
+                .to_owned()
+                .map(|query| history::Kind::Query(server.to_owned(), query)),
+        };
+        let message_window =
+            kind.and_then(|kind| dashboard.find_window_with_history(&kind));
+
+        let blocked = match (channel, query) {
+            (Some(channel), None) => FilterChain::borrow(
+                dashboard.get_filters(),
+            )
+            .filter_user(&sender, Some(channel), server),
+            (None, Some(query)) => FilterChain::borrow(dashboard.get_filters())
+                .filter_query(&query, server),
+            _ => false,
+        };
+
+        if !blocked
+            && !reaction.inner.unreact
+            && is_react_to_own_message
+            && (message_window.is_none() || !main_window.focused)
+        {
+            let request_attention = notifications.notify(
+                &config.notifications,
+                &Notification::Reaction {
+                    casemapping,
+                    reaction,
+                },
+                server,
+                message_window.unwrap_or(main_window.id),
+            );
+
+            if let Some(request_attention) = request_attention {
+                reactions.push(request_attention);
+            }
+        }
+    }
 }
 
 fn handle_direct_message(

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -345,6 +345,7 @@ impl Notifications {
             Notification::Reaction {
                 casemapping,
                 reaction,
+                message_text,
             } => {
                 let channel_option = reaction.target.clone().to_channel();
                 let channel = channel_option.as_ref();
@@ -366,11 +367,11 @@ impl Notifications {
                     ) = if config.reaction.show_content {
                         (
                             reaction.inner.sender.to_string(),
-                            None,
-                            format!(
+                            Some(format!(
                                 "Reacted {} to your message in {react_sent_in}",
                                 reaction.inner.text
-                            ),
+                            )),
+                            message_text.to_string(),
                         )
                     } else {
                         (

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -24,6 +24,7 @@ enum NotificationDelayKey {
     MonitoredOnline,
     MonitoredOffline,
     Channel(Box<str>),
+    Reaction,
 }
 
 impl From<&Notification> for NotificationDelayKey {
@@ -58,6 +59,7 @@ impl From<&Notification> for NotificationDelayKey {
                     channel.as_normalized_str().into(),
                 )
             }
+            Notification::Reaction { .. } => NotificationDelayKey::Reaction,
         }
     }
 }
@@ -336,6 +338,60 @@ impl Notifications {
 
                         notification_config.request_attention
                     }
+                } else {
+                    false
+                }
+            }
+            Notification::Reaction {
+                casemapping,
+                reaction,
+            } => {
+                let channel_option = reaction.target.clone().to_channel();
+                let channel = channel_option.as_ref();
+                if config.reaction.should_notify(
+                    &User::from(reaction.inner.sender.clone()),
+                    channel,
+                    server,
+                    *casemapping,
+                ) {
+                    let react_sent_in = match channel {
+                        Some(channel) => channel.as_normalized_str(),
+                        _ => "a direct message",
+                    };
+
+                    let (title, subtitle, body): (
+                        String,
+                        Option<String>,
+                        String,
+                    ) = if config.reaction.show_content {
+                        (
+                            reaction.inner.sender.to_string(),
+                            None,
+                            format!(
+                                "Reacted {} to your message in {react_sent_in}",
+                                reaction.inner.text
+                            ),
+                        )
+                    } else {
+                        (
+                            reaction.inner.sender.to_string(),
+                            None,
+                            format!(
+                                "Reacted to your message in {react_sent_in}",
+                            ),
+                        )
+                    };
+
+                    self.execute(
+                        &config.reaction,
+                        notification,
+                        title.as_str(),
+                        subtitle.as_deref(),
+                        body.as_str(),
+                        None,
+                    );
+
+                    config.reaction.request_attention
                 } else {
                     false
                 }

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -356,8 +356,24 @@ impl Notifications {
                     *casemapping,
                 ) {
                     let react_sent_in = match channel {
-                        Some(channel) => channel.as_normalized_str(),
-                        _ => "your direct message",
+                        Some(channel) => {
+                            if cfg!(target_os = "macos")
+                                || !config.reaction.show_content
+                            {
+                                format!("{channel} ({server})")
+                            } else {
+                                format!("{channel}, {server}")
+                            }
+                        }
+                        None => {
+                            if cfg!(target_os = "macos")
+                                || !config.reaction.show_content
+                            {
+                                format!("query ({server})")
+                            } else {
+                                format!("query, {server}")
+                            }
+                        }
                     };
 
                     let (title, subtitle, body): (
@@ -367,19 +383,17 @@ impl Notifications {
                     ) = if config.reaction.show_content {
                         (
                             reaction.inner.sender.to_string(),
-                            Some(format!(
-                                "Reacted {} to your message in {react_sent_in}",
+                            Some(react_sent_in.to_string()),
+                            format!(
+                                "Reacted {} to your message: {message_text}",
                                 reaction.inner.text
-                            )),
-                            message_text.to_string(),
+                            ),
                         )
                     } else {
                         (
                             reaction.inner.sender.to_string(),
-                            None,
-                            format!(
-                                "Reacted to your message in {react_sent_in}",
-                            ),
+                            Some(react_sent_in.to_string()),
+                            format!("Reacted to your message",),
                         )
                     };
 

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -357,10 +357,8 @@ impl Notifications {
                 ) {
                     let react_sent_in = match channel {
                         Some(channel) => channel.as_normalized_str(),
-                        _ => "a direct message",
+                        _ => "your direct message",
                     };
-                    let owner_display_text =
-                        if message_text.is_some() { "your" } else { "a" };
 
                     let (title, subtitle, body): (
                         String,
@@ -370,17 +368,17 @@ impl Notifications {
                         (
                             reaction.inner.sender.to_string(),
                             Some(format!(
-                                "Reacted {} to {owner_display_text} message in {react_sent_in}",
+                                "Reacted {} to your message in {react_sent_in}",
                                 reaction.inner.text
                             )),
-                            message_text.clone().unwrap_or_default(),
+                            message_text.to_string(),
                         )
                     } else {
                         (
                             reaction.inner.sender.to_string(),
                             None,
                             format!(
-                                "Reacted to {owner_display_text} message in {react_sent_in}",
+                                "Reacted to your message in {react_sent_in}",
                             ),
                         )
                     };

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -345,7 +345,7 @@ impl Notifications {
             Notification::Reaction {
                 casemapping,
                 reaction,
-                reaction_target,
+                message_text,
             } => {
                 let channel_option = reaction.target.clone().to_channel();
                 let channel = channel_option.as_ref();
@@ -359,18 +359,8 @@ impl Notifications {
                         Some(channel) => channel.as_normalized_str(),
                         _ => "a direct message",
                     };
-                    let message_text = reaction_target
-                        .clone()
-                        .map(|t| t.text)
-                        .unwrap_or_default();
-                    let owner_display_text = if let Some(reaction_target) =
-                        reaction_target
-                        && reaction_target.sent_by_self
-                    {
-                        "your"
-                    } else {
-                        "a"
-                    };
+                    let owner_display_text =
+                        if message_text.is_some() { "your" } else { "a" };
 
                     let (title, subtitle, body): (
                         String,
@@ -383,7 +373,7 @@ impl Notifications {
                                 "Reacted {} to {owner_display_text} message in {react_sent_in}",
                                 reaction.inner.text
                             )),
-                            message_text.to_string(),
+                            message_text.clone().unwrap_or_default(),
                         )
                     } else {
                         (

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -393,7 +393,7 @@ impl Notifications {
                         (
                             reaction.inner.sender.to_string(),
                             Some(react_sent_in.to_string()),
-                            format!("Reacted to your message",),
+                            "Reacted to your message".to_string(),
                         )
                     };
 

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -345,7 +345,7 @@ impl Notifications {
             Notification::Reaction {
                 casemapping,
                 reaction,
-                message_text,
+                reaction_target,
             } => {
                 let channel_option = reaction.target.clone().to_channel();
                 let channel = channel_option.as_ref();
@@ -359,6 +359,18 @@ impl Notifications {
                         Some(channel) => channel.as_normalized_str(),
                         _ => "a direct message",
                     };
+                    let message_text = reaction_target
+                        .clone()
+                        .map(|t| t.text)
+                        .unwrap_or_default();
+                    let owner_display_text = if let Some(reaction_target) =
+                        reaction_target
+                        && reaction_target.sent_by_self
+                    {
+                        "your"
+                    } else {
+                        "a"
+                    };
 
                     let (title, subtitle, body): (
                         String,
@@ -368,7 +380,7 @@ impl Notifications {
                         (
                             reaction.inner.sender.to_string(),
                             Some(format!(
-                                "Reacted {} to your message in {react_sent_in}",
+                                "Reacted {} to {owner_display_text} message in {react_sent_in}",
                                 reaction.inner.text
                             )),
                             message_text.to_string(),
@@ -378,7 +390,7 @@ impl Notifications {
                             reaction.inner.sender.to_string(),
                             None,
                             format!(
-                                "Reacted to your message in {react_sent_in}",
+                                "Reacted to {owner_display_text} message in {react_sent_in}",
                             ),
                         )
                     };

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -3206,10 +3206,12 @@ impl Dashboard {
 
     pub fn record_reaction(
         &mut self,
+        clients: &client::Map,
         server: &Server,
         reaction: reaction::Context,
     ) -> (Option<ReactionTarget>, Task<Message>) {
-        let (target, future) = self.history.record_reaction(server, reaction);
+        let (target, future) =
+            self.history.record_reaction(clients, server, reaction);
         let task = if let Some(f) = future {
             Task::perform(f, Message::History)
         } else {

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -13,7 +13,7 @@ use data::dashboard::{self, BufferAction};
 use data::environment::{RELEASE_WEBSITE, WIKI_WEBSITE};
 use data::history::ReadMarker;
 use data::history::filter::Filter;
-use data::history::manager::PendingReaction;
+use data::history::manager::ReactionToEcho;
 use data::history::reroute::RerouteRules;
 use data::isupport::{self, ChatHistorySubcommand, MessageReference};
 use data::message::{self, Broadcast};
@@ -116,7 +116,7 @@ pub enum Event {
         has_credentials: bool,
         window: window::Id,
     },
-    PendingReactions(Server, Vec<PendingReaction>),
+    ReactionsToEcho(Server, Vec<ReactionToEcho>),
 }
 
 impl Dashboard {
@@ -987,16 +987,13 @@ impl Dashboard {
                                 }
                             }
                         }
-                        history::manager::Event::PendingReactions(
+                        history::manager::Event::ReactionsToEcho(
                             server,
-                            pending_reactions,
+                            reactions,
                         ) => {
                             return (
                                 Task::none(),
-                                Some(Event::PendingReactions(
-                                    server,
-                                    pending_reactions,
-                                )),
+                                Some(Event::ReactionsToEcho(server, reactions)),
                             );
                         }
                     }
@@ -3209,15 +3206,15 @@ impl Dashboard {
         &mut self,
         server: &Server,
         reaction: reaction::Context,
-    ) -> (Option<String>, Task<Message>) {
-        let (message_text, future) =
+    ) -> (Option<ReactionToEcho>, Task<Message>) {
+        let (reaction_to_echo, future) =
             self.history.record_reaction(server, reaction);
         let task = if let Some(f) = future {
             Task::perform(f, Message::History)
         } else {
             Task::none()
         };
-        (message_text, task)
+        (reaction_to_echo, task)
     }
 
     pub fn is_focused_and_at_bottom(

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -13,6 +13,7 @@ use data::dashboard::{self, BufferAction};
 use data::environment::{RELEASE_WEBSITE, WIKI_WEBSITE};
 use data::history::ReadMarker;
 use data::history::filter::Filter;
+use data::history::manager::PendingReaction;
 use data::history::reroute::RerouteRules;
 use data::isupport::{self, ChatHistorySubcommand, MessageReference};
 use data::message::{self, Broadcast};
@@ -115,7 +116,7 @@ pub enum Event {
         has_credentials: bool,
         window: window::Id,
     },
-    PendingReaction(Server, reaction::Context, Option<String>),
+    PendingReactions(Server, Vec<PendingReaction>),
 }
 
 impl Dashboard {
@@ -986,17 +987,15 @@ impl Dashboard {
                                 }
                             }
                         }
-                        history::manager::Event::PendingReaction(
+                        history::manager::Event::PendingReactions(
                             server,
-                            context,
-                            message_text,
+                            pending_reactions,
                         ) => {
                             return (
                                 Task::none(),
-                                Some(Event::PendingReaction(
+                                Some(Event::PendingReactions(
                                     server,
-                                    context,
-                                    message_text,
+                                    pending_reactions,
                                 )),
                             );
                         }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -11,9 +11,9 @@ use data::capabilities::{
 use data::config::buffer::{ScrollPosition, UsernameFormat};
 use data::dashboard::{self, BufferAction};
 use data::environment::{RELEASE_WEBSITE, WIKI_WEBSITE};
-use data::history::ReadMarker;
 use data::history::filter::Filter;
 use data::history::reroute::RerouteRules;
+use data::history::{ReactionTarget, ReadMarker};
 use data::isupport::{self, ChatHistorySubcommand, MessageReference};
 use data::message::{self, Broadcast};
 use data::rate_limit::TokenPriority;
@@ -3195,12 +3195,14 @@ impl Dashboard {
         &mut self,
         server: &Server,
         reaction: reaction::Context,
-    ) -> Task<Message> {
-        if let Some(task) = self.history.record_reaction(server, reaction) {
-            Task::perform(task, Message::History)
+    ) -> (Option<ReactionTarget>, Task<Message>) {
+        let (target, future) = self.history.record_reaction(server, reaction);
+        let task = if let Some(f) = future {
+            Task::perform(f, Message::History)
         } else {
             Task::none()
-        }
+        };
+        (target, task)
     }
 
     pub fn is_focused_and_at_bottom(

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -3206,15 +3206,13 @@ impl Dashboard {
         &mut self,
         server: &Server,
         reaction: reaction::Context,
-    ) -> (Option<ReactionToEcho>, Task<Message>) {
-        let (reaction_to_echo, future) =
-            self.history.record_reaction(server, reaction);
-        let task = if let Some(f) = future {
+    ) -> Task<Message> {
+        let future = self.history.record_reaction(server, reaction);
+        if let Some(f) = future {
             Task::perform(f, Message::History)
         } else {
             Task::none()
-        };
-        (reaction_to_echo, task)
+        }
     }
 
     pub fn is_focused_and_at_bottom(

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -115,6 +115,7 @@ pub enum Event {
         has_credentials: bool,
         window: window::Id,
     },
+    PendingReaction(Server, Option<ReactionTarget>, reaction::Context),
 }
 
 impl Dashboard {
@@ -984,6 +985,18 @@ impl Dashboard {
                                     );
                                 }
                             }
+                        }
+                        history::manager::Event::PendingReaction(
+                            server,
+                            target,
+                            context,
+                        ) => {
+                            return (
+                                Task::none(),
+                                Some(Event::PendingReaction(
+                                    server, target, context,
+                                )),
+                            );
                         }
                     }
                 }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -11,9 +11,9 @@ use data::capabilities::{
 use data::config::buffer::{ScrollPosition, UsernameFormat};
 use data::dashboard::{self, BufferAction};
 use data::environment::{RELEASE_WEBSITE, WIKI_WEBSITE};
+use data::history::ReadMarker;
 use data::history::filter::Filter;
 use data::history::reroute::RerouteRules;
-use data::history::{ReactionTarget, ReadMarker};
 use data::isupport::{self, ChatHistorySubcommand, MessageReference};
 use data::message::{self, Broadcast};
 use data::rate_limit::TokenPriority;
@@ -115,7 +115,7 @@ pub enum Event {
         has_credentials: bool,
         window: window::Id,
     },
-    PendingReaction(Server, Option<ReactionTarget>, reaction::Context),
+    PendingReaction(Server, reaction::Context, Option<String>),
 }
 
 impl Dashboard {
@@ -988,13 +988,15 @@ impl Dashboard {
                         }
                         history::manager::Event::PendingReaction(
                             server,
-                            target,
                             context,
+                            message_text,
                         ) => {
                             return (
                                 Task::none(),
                                 Some(Event::PendingReaction(
-                                    server, target, context,
+                                    server,
+                                    context,
+                                    message_text,
                                 )),
                             );
                         }
@@ -3206,18 +3208,17 @@ impl Dashboard {
 
     pub fn record_reaction(
         &mut self,
-        clients: &client::Map,
         server: &Server,
         reaction: reaction::Context,
-    ) -> (Option<ReactionTarget>, Task<Message>) {
-        let (target, future) =
-            self.history.record_reaction(clients, server, reaction);
+    ) -> (Option<String>, Task<Message>) {
+        let (message_text, future) =
+            self.history.record_reaction(server, reaction);
         let task = if let Some(f) = future {
             Task::perform(f, Message::History)
         } else {
             Task::none()
         };
-        (target, task)
+        (message_text, task)
     }
 
     pub fn is_focused_and_at_bottom(


### PR DESCRIPTION
Adds notifications for reactions!

- unreacts don't fire off notifications
- notifications are sent if:
  - window is unfocused
  - reaction's buffer (channel or query) is not the current open buffer.
  - react is by non-self
  - reacted to message is originally sent by you

~There's still one more scenario that needs solving, but may require a bit more consideration:~

- ~notifying only when reacts are on your own messages~

~Currently, this isn't obvious how I can achieve this. I think I would need to attach the original message to the reaction context.~

~Leaving this in draft until that is sorted.~