### PR TITLE
handle sigint+sigterm (for drafts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -701,6 +701,7 @@ Changed:
 - Unread indicator has changed from a boolean value to a enum. See [configuration](https://halloy.squidowl.org/configuration/sidebar/index.html#unread_indicators).
 - Renamed `sidebar.default_action` to `sidebar.buffer_action`.
 - Auto-completing (with tab) a nickname at the beginning of the input line will append ': ' (colon space). Otherwise, a space is appended to the completion.
+- SIGTERM and SIGINT are now intercepted and trigger the same exit path as a normal window close
 
 Removed:
 

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -17,7 +17,7 @@ use crate::target::{self, Target};
 use crate::user::Nick;
 use crate::{Config, Server, buffer, client, config, input, isupport, server};
 
-const DRAFT_SAVE_AFTER: Duration = Duration::from_secs(3);
+const DRAFT_SAVE_EVERY: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Resource {
@@ -285,7 +285,7 @@ impl Manager {
     ) -> Option<BoxFuture<'static, Message>> {
         let last_changed = self.last_draft_changed?;
 
-        if now.duration_since(last_changed) < DRAFT_SAVE_AFTER {
+        if now.duration_since(last_changed) < DRAFT_SAVE_EVERY {
             return None;
         }
 
@@ -350,7 +350,10 @@ impl Manager {
 
     pub fn record_draft(&mut self, raw_input: input::RawInput) {
         self.data.input.store_draft(raw_input);
-        self.last_draft_changed = Some(tokio::time::Instant::now());
+        // Only set if None, so drafts save on an interval
+        if self.last_draft_changed.is_none() {
+            self.last_draft_changed = Some(tokio::time::Instant::now());
+        }
     }
 
     // The message's blocked state should be determined prior to using this

--- a/src/main.rs
+++ b/src/main.rs
@@ -1202,6 +1202,16 @@ impl Halloy {
                 signal_hook::consts::SIGUSR1 => {
                     Task::perform(Config::load(), Message::ConfigReloaded)
                 }
+                #[cfg(target_family = "unix")]
+                signal_hook::consts::SIGTERM | signal_hook::consts::SIGINT => {
+                    if let Screen::Dashboard(dashboard) = &mut self.screen {
+                        dashboard
+                            .exit(&mut self.clients, &self.config)
+                            .map(Message::Dashboard)
+                    } else {
+                        iced::exit()
+                    }
+                }
                 _ => Task::none(),
             },
         }

--- a/src/unix_signal.rs
+++ b/src/unix_signal.rs
@@ -6,7 +6,7 @@ mod unix_signals {
     use iced::Subscription;
     use iced::advanced::graphics::futures::subscription;
     use iced::advanced::subscription::Hasher;
-    use signal_hook::consts::SIGUSR1;
+    use signal_hook::consts::{SIGINT, SIGTERM, SIGUSR1};
     use signal_hook::iterator::Signals;
 
     struct UnixSignal {
@@ -56,7 +56,7 @@ mod unix_signals {
 
     pub fn subscription() -> Subscription<i32> {
         subscription::from_recipe(UnixSignal {
-            signals: vec![SIGUSR1],
+            signals: vec![SIGUSR1, SIGTERM, SIGINT],
         })
     }
 }


### PR DESCRIPTION
this PR started as me trying to figure out why the drafts functionality seemed inconsistent. i came up with two changes that help:

- sigterm and sigint are now intercepted and trigger the same exit path as a normal window close, meaning history and drafts are saved. previously some things would be lost.
- draft saves on an interval instead of after inactivity, and now saves every 10 seconds