### PR TITLE
Limited Deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,8 @@ Removed:
 Thanks:
 
 - Contributions: @furudean, @omentic, @KaiKorla, @achille, @classabbyamp, @ncfavier, @englut, @WinnerWind
-- Bug reports: sebbu, @whitequark, @SnoopJ, esden, @miyukoc, @ld-cd, @achille, @classabbyamp, vignoux, @esden, @ncfavier, @englut
-- Feature requests: @omentic, @classabbyamp, @ncfavier
+- Bug reports: sebbu, @whitequark, @SnoopJ, esden, @miyukoc, @ld-cd, @achille, @classabbyamp, vignoux, @esden, @ncfavier, @englut, @cyrneko
+- Feature requests: @omentic, @classabbyamp, @ncfavier, @ineeee
 
 # 2026.5 (2026-03-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Fixed:
 - `typing` settings for buffers could get in a stuck state without any way to control them
 - +typing=done should not be sent when the message is sent
 - `/MOTD` will not trigger end-of-registration actions
+- Repeat lines in some MOTDs would be deduplicated
 - Received reactions in queries
 
 Removed:

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -115,10 +115,10 @@ pub enum Message {
 
 #[derive(Debug)]
 pub enum Event {
-    Single(message::Encoded, Nick),
-    PrivOrNotice(message::Encoded, Nick, bool),
+    Single(message::Encoded, Nick, bool),
+    PrivOrNotice(message::Encoded, Nick, bool, bool),
     Reaction(message::Encoded, Nick),
-    WithTarget(message::Encoded, Nick, message::Target),
+    WithTarget(message::Encoded, Nick, message::Target, bool),
     Broadcast(Broadcast),
     FileTransferRequest(file_transfer::ReceiveRequest),
     UpdateReadMarker(Target, ReadMarker),
@@ -1035,6 +1035,7 @@ impl Client {
                         message,
                         self.nickname().to_owned(),
                         source,
+                        false,
                     )]);
                 }
             }
@@ -1067,6 +1068,7 @@ impl Client {
                         message,
                         self.nickname().to_owned(),
                         source,
+                        false,
                     )]);
                 }
             }
@@ -1351,6 +1353,7 @@ impl Client {
                                     message,
                                     self.nickname().to_owned(),
                                     self.notification_blackout.allowed(),
+                                    false,
                                 );
 
                                 return Ok(vec![event]);
@@ -1496,6 +1499,7 @@ impl Client {
                         message.clone(),
                         self.nickname().to_owned(),
                         self.notification_blackout.allowed(),
+                        false,
                     );
 
                     // Event::DirectMessage is currently only used to send a
@@ -1526,8 +1530,11 @@ impl Client {
 
                 let invitee = Nick::from_str(invitee, self.casemapping());
 
-                let event =
-                    Event::Single(message.clone(), self.nickname().to_owned());
+                let event = Event::Single(
+                    message.clone(),
+                    self.nickname().to_owned(),
+                    false,
+                );
 
                 if invitee.as_nickref() == self.nickname() {
                     return Ok(vec![
@@ -1746,7 +1753,11 @@ impl Client {
                                 channel,
                                 sent_time: message.server_time_or_now(),
                             }),
-                            Event::Single(message, self.nickname().to_owned()),
+                            Event::Single(
+                                message,
+                                self.nickname().to_owned(),
+                                false,
+                            ),
                         ]);
                     } else if let Some(channel) = self.chanmap.get_mut(&channel)
                     {
@@ -1808,6 +1819,7 @@ impl Client {
                             message,
                             self.nickname().to_owned(),
                             source,
+                            false,
                         )]);
                     }
                 }
@@ -1919,6 +1931,7 @@ impl Client {
                             message,
                             self.nickname().to_owned(),
                             source,
+                            false,
                         )]);
                     }
                 }
@@ -1994,6 +2007,7 @@ impl Client {
                             message,
                             self.nickname().to_owned(),
                             source,
+                            false,
                         )]);
                     }
                 } else if mask == "*" {
@@ -2638,7 +2652,11 @@ impl Client {
                     .collect::<Vec<_>>();
 
                 return Ok(vec![
-                    Event::Single(message.clone(), self.nickname().to_owned()),
+                    Event::Single(
+                        message.clone(),
+                        self.nickname().to_owned(),
+                        false,
+                    ),
                     Event::MonitoredOnline(targets),
                 ]);
             }
@@ -2649,7 +2667,11 @@ impl Client {
                     .collect::<Vec<_>>();
 
                 return Ok(vec![
-                    Event::Single(message.clone(), self.nickname().to_owned()),
+                    Event::Single(
+                        message.clone(),
+                        self.nickname().to_owned(),
+                        false,
+                    ),
                     Event::MonitoredOffline(targets),
                 ]);
             }
@@ -2700,6 +2722,7 @@ impl Client {
                         events.push(Event::Single(
                             message.clone(),
                             self.nickname().to_owned(),
+                            false,
                         ));
                     }
                 }
@@ -2983,7 +3006,11 @@ impl Client {
             _ => {}
         }
 
-        Ok(vec![Event::Single(message, self.nickname().to_owned())])
+        Ok(vec![Event::Single(
+            message,
+            self.nickname().to_owned(),
+            false,
+        )])
     }
 
     fn handle_chathistory(
@@ -3016,6 +3043,7 @@ impl Client {
                             message,
                             self.nickname().to_owned(),
                             target,
+                            true,
                         )]
                     })
                     .unwrap_or_default(),
@@ -3039,6 +3067,7 @@ impl Client {
                             message,
                             self.nickname().to_owned(),
                             target,
+                            true,
                         )]
                     })
                     .unwrap_or_default(),
@@ -3062,6 +3091,7 @@ impl Client {
                             message,
                             self.nickname().to_owned(),
                             target,
+                            true,
                         )]
                     })
                     .unwrap_or_default(),
@@ -3085,6 +3115,7 @@ impl Client {
                             message,
                             self.nickname().to_owned(),
                             target,
+                            true,
                         )]
                     })
                     .unwrap_or_default(),
@@ -3107,10 +3138,15 @@ impl Client {
                             self.nickname().to_owned(),
                             // Don't allow notifications from history
                             false,
+                            true,
                         )]
                     }
                 }
-                _ => vec![Event::Single(message, self.nickname().to_owned())],
+                _ => vec![Event::Single(
+                    message,
+                    self.nickname().to_owned(),
+                    true,
+                )],
             }
         }
     }
@@ -4148,9 +4184,9 @@ fn continue_chathistory_between(
 ) -> Option<ChatHistorySubcommand> {
     let start_message_reference =
         events.first().and_then(|first_event| match first_event {
-            Event::Single(message, _)
-            | Event::PrivOrNotice(message, _, _)
-            | Event::WithTarget(message, _, _)
+            Event::Single(message, _, _)
+            | Event::PrivOrNotice(message, _, _, _)
+            | Event::WithTarget(message, _, _, _)
             | Event::DirectMessage(message, _, _)
             | Event::Reaction(message, _) => match end_message_reference {
                 MessageReference::MessageId(_) => {
@@ -4197,9 +4233,9 @@ fn continue_chathistory_targets(
             Event::ChatHistoryTargetReceived(_, server_time) => {
                 Some(MessageReference::Timestamp(*server_time))
             }
-            Event::Single(_, _)
-            | Event::PrivOrNotice(_, _, _)
-            | Event::WithTarget(_, _, _)
+            Event::Single(_, _, _)
+            | Event::PrivOrNotice(_, _, _, _)
+            | Event::WithTarget(_, _, _, _)
             | Event::DirectMessage(_, _, _)
             | Event::Reaction(_, _)
             | Event::Broadcast(_)
@@ -5428,7 +5464,7 @@ mod tests {
             priv_events.len()
         );
 
-        if let Event::PrivOrNotice(msg, _, _) = &priv_events[0] {
+        if let Event::PrivOrNotice(msg, _, _, _) = &priv_events[0] {
             match &msg.0.command {
                 Command::PRIVMSG(_, text) => {
                     assert_eq!(

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -1111,7 +1111,9 @@ pub fn insert_message(
                     && message.is_echo;
 
             if (message.id.is_some() && stored.id == message.id)
-                || ((stored.server_time == message.server_time || use_echo_cmp)
+                || (((message.deduplicate
+                    && stored.server_time == message.server_time)
+                    || use_echo_cmp)
                     && has_matching_content(stored, &message, use_echo_cmp))
             {
                 replace_at = Some(current_index);

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -325,6 +325,7 @@ pub struct Message {
     pub command: Option<command::Irc>, // Only relevant if direction == Direction::Sent
     pub reactions: Vec<Reaction>,
     pub rerouted_from: Option<Target>,
+    pub deduplicate: bool,
 }
 
 impl Message {
@@ -408,6 +409,7 @@ impl Message {
     pub fn received<'a>(
         encoded: Encoded,
         our_nick: Nick,
+        deduplicate: bool,
         config: &'a Config,
         reroute_rules: &RerouteRules,
         resolve_attributes: impl Fn(&User, &target::Channel) -> Option<User>,
@@ -465,12 +467,14 @@ impl Message {
             command,
             reactions: vec![],
             rerouted_from,
+            deduplicate,
         })
     }
 
     pub fn received_with_highlight<'a>(
         encoded: Encoded,
         our_nick: Nick,
+        deduplicate: bool,
         config: &'a Config,
         reroute_rules: &RerouteRules,
         resolve_attributes: impl Fn(&User, &target::Channel) -> Option<User>,
@@ -528,6 +532,7 @@ impl Message {
             command,
             reactions: vec![],
             rerouted_from,
+            deduplicate,
         };
 
         let highlight = highlight.and_then(|kind| {
@@ -596,6 +601,7 @@ impl Message {
             command,
             reactions: vec![],
             rerouted_from: None,
+            deduplicate: false,
         }
     }
 
@@ -631,6 +637,7 @@ impl Message {
             command: None,
             reactions: vec![],
             rerouted_from: None,
+            deduplicate: false,
         }
     }
 
@@ -664,6 +671,7 @@ impl Message {
             command: None,
             reactions: vec![],
             rerouted_from: None,
+            deduplicate: false,
         }
     }
 
@@ -716,6 +724,7 @@ impl Message {
             command: None,
             reactions: vec![],
             rerouted_from: None,
+            deduplicate: false,
         }
     }
 
@@ -859,6 +868,7 @@ impl<'de> Deserialize<'de> for Message {
             command,
             reactions,
             rerouted_from,
+            deduplicate: false,
         })
     }
 }
@@ -1051,6 +1061,7 @@ pub fn condense(
             command: None,
             reactions: vec![],
             rerouted_from: None,
+            deduplicate: false,
         }))
     } else {
         None
@@ -4103,6 +4114,7 @@ pub mod tests {
         Message::received_with_highlight(
             Encoded::from(encoded.clone()),
             our_nick.clone(),
+            false,
             &Config::default(),
             &RerouteRules::default(),
             |user: &User, _channel: &target::Channel| {

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -44,6 +44,7 @@ fn expand(
             command: None,
             reactions: vec![],
             rerouted_from: None,
+            deduplicate: false,
         }
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1496,23 +1496,30 @@ fn handle_client_events(
 
     for event in events {
         match event {
-            Event::Single(encoded, our_nick) => {
+            Event::Single(encoded, our_nick, deduplicate) => {
                 handle_single_event(
                     server,
                     encoded,
                     our_nick,
+                    deduplicate,
                     dashboard,
                     &mut commands,
                     clients,
                     config,
                 );
             }
-            Event::PrivOrNotice(encoded, our_nick, notification_enabled) => {
+            Event::PrivOrNotice(
+                encoded,
+                our_nick,
+                notification_enabled,
+                deduplicate,
+            ) => {
                 handle_priv_or_notice(
                     server,
                     encoded,
                     our_nick,
                     notification_enabled,
+                    deduplicate,
                     dashboard,
                     &mut commands,
                     clients,
@@ -1521,12 +1528,13 @@ fn handle_client_events(
                     main_window,
                 );
             }
-            Event::WithTarget(encoded, our_nick, target) => {
+            Event::WithTarget(encoded, our_nick, target, deduplicate) => {
                 handle_with_target_event(
                     server,
                     encoded,
                     our_nick,
                     target,
+                    deduplicate,
                     dashboard,
                     &mut commands,
                     clients,
@@ -1714,6 +1722,7 @@ fn create_message(
     server: &Server,
     encoded: message::Encoded,
     our_nick: data::user::Nick,
+    deduplicate: bool,
     config: &Config,
     clients: &data::client::Map,
     reroute_rules: &RerouteRules,
@@ -1721,6 +1730,7 @@ fn create_message(
     data::Message::received(
         encoded,
         our_nick,
+        deduplicate,
         config,
         reroute_rules,
         |user, channel| {
@@ -1741,6 +1751,7 @@ fn create_message_with_highlight(
     server: &Server,
     encoded: message::Encoded,
     our_nick: data::user::Nick,
+    deduplicate: bool,
     config: &Config,
     clients: &data::client::Map,
     reroute_rules: &RerouteRules,
@@ -1748,6 +1759,7 @@ fn create_message_with_highlight(
     data::Message::received_with_highlight(
         encoded,
         our_nick,
+        deduplicate,
         config,
         reroute_rules,
         |user, channel| {
@@ -1768,6 +1780,7 @@ fn handle_single_event(
     server: &Server,
     encoded: message::Encoded,
     our_nick: data::user::Nick,
+    deduplicate: bool,
     dashboard: &mut screen::Dashboard,
     commands: &mut Vec<Task<Message>>,
     clients: &data::client::Map,
@@ -1777,6 +1790,7 @@ fn handle_single_event(
         server,
         encoded,
         our_nick,
+        deduplicate,
         config,
         clients,
         dashboard.get_reroute_rules(),
@@ -1801,6 +1815,7 @@ fn handle_with_target_event(
     encoded: message::Encoded,
     our_nick: data::user::Nick,
     target: message::Target,
+    deduplicate: bool,
     dashboard: &mut screen::Dashboard,
     commands: &mut Vec<Task<Message>>,
     clients: &data::client::Map,
@@ -1810,6 +1825,7 @@ fn handle_with_target_event(
         server,
         encoded,
         our_nick,
+        deduplicate,
         config,
         clients,
         dashboard.get_reroute_rules(),
@@ -1833,6 +1849,7 @@ fn handle_priv_or_notice(
     server: &Server,
     encoded: message::Encoded,
     our_nick: data::user::Nick,
+    deduplicate: bool,
     notification_enabled: bool,
     dashboard: &mut screen::Dashboard,
     commands: &mut Vec<Task<Message>>,
@@ -1845,6 +1862,7 @@ fn handle_priv_or_notice(
         server,
         encoded,
         our_nick,
+        deduplicate,
         config,
         clients,
         dashboard.get_reroute_rules(),
@@ -2149,6 +2167,7 @@ fn handle_direct_message(
         server,
         encoded,
         our_nick,
+        false,
         config,
         clients,
         dashboard.get_reroute_rules(),


### PR DESCRIPTION
Restricts deduplication to messages received via chathistory, echoes, and messages with the same id.  Fixes #1725.