### PR TITLE
Display URLs Percent Decoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Removed:
 
 Thanks:
 
-- Contributions: @furudean, @omentic, @KaiKorla, @achille, @classabbyamp, @ncfavier, @englut
+- Contributions: @furudean, @omentic, @KaiKorla, @achille, @classabbyamp, @ncfavier, @englut, @WinnerWind
 - Bug reports: sebbu, @whitequark, @SnoopJ, esden, @miyukoc, @ld-cd, @achille, @classabbyamp, vignoux, @esden, @ncfavier, @englut
 - Feature requests: @omentic, @classabbyamp, @ncfavier
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Changed:
 - Colons, semicolons and double quotes are no longer considered part of channel names
 - Backslash escapes are now only interpreted when escaping markdown formatting characters
 - Tooltips will be shown for all commands, with an error tooltip shown if the server does not support the command
+- Parsed URLs will be displayed with IDN encoded domains (to avoid domain spoofing) and percent-decoded path & later components (for legibility) by default (`display.decode_urls`)
 
 Fixed:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2935,6 +2935,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "open",
  "palette",
+ "percent-encoding",
  "rand 0.10.0",
  "rand_chacha 0.10.0",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ tokio-util = { version = "0.7", features = ["io"] }
 const_format = "0.2.32"
 iced = { version = "0.15.0-dev", default-features = false }
 nom = "8.0"
+percent-encoding = "2.3.2"
 
 [dependencies]
 tokio = { workspace = true, features = ["rt", "fs", "process"] }
@@ -83,6 +84,7 @@ iced = { workspace = true, features = [
     "crisp",
     "web-colors",
 ] }
+percent-encoding = { workspace = true }
 
 data = { version = "0.1.0", path = "data" }
 ipc = { version = "0.1.0", path = "ipc" }

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -46,13 +46,13 @@ iced = { workspace = true, features = [
     "wayland",
 ] }
 nom = { workspace = true }
+percent-encoding = { workspace = true }
 
 base64 = "0.22.1"
 dirs-next = "2.0.0"
 xdg = "3.0.0"
 flate2 = "1.0"
 hex = "0.4.3"
-percent-encoding = "2.3.2"
 iced_core = "0.15.0-dev"
 iced_wgpu = "0.15.0-dev"
 indexmap = { version = "2.13", features = ["std", "serde"] }

--- a/data/src/config/display.rs
+++ b/data/src/config/display.rs
@@ -1,10 +1,19 @@
 use serde::Deserialize;
 
-#[derive(Debug, Clone, Deserialize, Default)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct Display {
     pub direction_arrows: DirectionArrows,
     pub decode_urls: bool,
+}
+
+impl Default for Display {
+    fn default() -> Self {
+        Self {
+            direction_arrows: DirectionArrows::default(),
+            decode_urls: true,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/data/src/config/display.rs
+++ b/data/src/config/display.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 #[serde(default)]
 pub struct Display {
     pub direction_arrows: DirectionArrows,
+    pub decode_urls: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/docs/configuration/display.md
+++ b/docs/configuration/display.md
@@ -31,3 +31,16 @@ Arrow shown for right-facing events.
 [display]
 direction_arrows = { right = ">" }
 ```
+
+### `decode_urls`
+
+Whether to automatically decode percent-encoded urls in messages.  E.g. when enabled `https://ja.wikipedia.org/wiki/%E9%87%8D%E9%9F%B3%E3%83%86%E3%83%88` will be displayed as `https://ja.wikipedia.org/wiki/重音テト`.
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: false
+
+[display]
+decode_urls = false
+```

--- a/docs/configuration/display.md
+++ b/docs/configuration/display.md
@@ -34,12 +34,15 @@ direction_arrows = { right = ">" }
 
 ### `decode_urls`
 
-Whether to automatically decode percent-encoded urls in messages.  E.g. when enabled `https://ja.wikipedia.org/wiki/%E9%87%8D%E9%9F%B3%E3%83%86%E3%83%88` will be displayed as `https://ja.wikipedia.org/wiki/重音テト`.
+Whether to automatically decode urls in messages, otherwise the URLs
+will appear exactly as sent.  E.g. when enabled `https://bücher.de` will appear as `https://bücher.de`
+`https://ja.wikipedia.org/wiki/%E9%87%8D%E9%9F%B3%E3%83%86%E3%83%88`
+will be displayed as `https://ja.wikipedia.org/wiki/重音テト`.
 
 ```toml
 # Type: boolean
 # Values: true, false
-# Default: false
+# Default: true
 
 [display]
 decode_urls = false

--- a/src/widget/message_content.rs
+++ b/src/widget/message_content.rs
@@ -213,14 +213,29 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
                                     ))
                                     .background(theme.styles().buffer.highlight)
                             }
-                            data::message::Fragment::Url(_, s) => if config
+                            data::message::Fragment::Url(u, s) => if config
                                 .display
                                 .decode_urls
                             {
-                                span(
-                                    percent_decode_str(s.as_str())
-                                        .decode_utf8_lossy(),
-                                )
+                                // Preserve IDNA-compliant encoded host returned
+                                // by Url::host_str, but percent-decode the path
+                                // and later components of the URL for
+                                // legibility.  If the process fails for any
+                                // reason, return the IDNA-compliant encoding
+                                // provided by Url::as_str.
+                                u.host_str()
+                                    .and_then(|host_str| {
+                                        u.as_str().split_once(host_str).map(
+                                            |(prefix, suffix)| {
+                                                span(format!(
+                                                    "{prefix}{host_str}{}",
+                                                    percent_decode_str(suffix)
+                                                        .decode_utf8_lossy()
+                                                ))
+                                            },
+                                        )
+                                    })
+                                    .unwrap_or(span(u.as_str()))
                             } else {
                                 span(s.as_str())
                             }
@@ -235,7 +250,8 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
                             .color(transform_color(
                                 theme.styles().buffer.url.color,
                             ))
-                            .link(message::Link::Url(s.as_str().to_string())),
+                            // Copy to clipboard in IDNA-compliant encoding.
+                            .link(message::Link::Url(u.as_str().to_string())),
                             data::message::Fragment::Formatted {
                                 text,
                                 formatting,

--- a/src/widget/message_content.rs
+++ b/src/widget/message_content.rs
@@ -3,6 +3,7 @@ use data::{Config, Server, isupport, message, target};
 use iced::widget::span;
 use iced::widget::text::Span;
 use iced::{Color, Length, border};
+use percent_encoding::percent_decode_str;
 use unicode_segmentation::UnicodeSegmentation;
 
 use super::{Element, Renderer, selectable_rich_text, selectable_text};
@@ -212,23 +213,29 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
                                     ))
                                     .background(theme.styles().buffer.highlight)
                             }
-                            data::message::Fragment::Url(_, s) => {
+                            data::message::Fragment::Url(_, s) => if config
+                                .display
+                                .decode_urls
+                            {
+                                span(
+                                    percent_decode_str(s.as_str())
+                                        .decode_utf8_lossy(),
+                                )
+                            } else {
                                 span(s.as_str())
-                                    .font_maybe(
-                                        theme
-                                            .styles()
-                                            .buffer
-                                            .url
-                                            .font_style
-                                            .map(font::get),
-                                    )
-                                    .color(transform_color(
-                                        theme.styles().buffer.url.color,
-                                    ))
-                                    .link(message::Link::Url(
-                                        s.as_str().to_string(),
-                                    ))
                             }
+                            .font_maybe(
+                                theme
+                                    .styles()
+                                    .buffer
+                                    .url
+                                    .font_style
+                                    .map(font::get),
+                            )
+                            .color(transform_color(
+                                theme.styles().buffer.url.color,
+                            ))
+                            .link(message::Link::Url(s.as_str().to_string())),
                             data::message::Fragment::Formatted {
                                 text,
                                 formatting,


### PR DESCRIPTION
Adds a setting to automatically decode percent-encoded urls when displaying them.

Closes #1714.