### PR TITLE
Remove Default Reroute

### DIFF
--- a/data/src/config/server/reroute.rs
+++ b/data/src/config/server/reroute.rs
@@ -1,22 +1,10 @@
 use serde::Deserialize;
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
 #[serde(default)]
 pub struct Reroute {
     pub query: Vec<RerouteRule>,
     pub notice: Vec<RerouteRule>,
-}
-
-impl Default for Reroute {
-    fn default() -> Self {
-        Self {
-            query: Vec::default(),
-            notice: vec![RerouteRule {
-                user: "*".to_string(),
-                target: RerouteTarget::Server,
-            }],
-        }
-    }
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]

--- a/docs/configuration/reroute.md
+++ b/docs/configuration/reroute.md
@@ -46,7 +46,7 @@ private and are not visible to other users in the channel.
 
 ```toml
 # Type: array
-# Default: [{ user = "*", target = "server" }]
+# Default: []
 
 [servers.<name>.reroute]
 notice = [


### PR DESCRIPTION
Rerouting direct NOTICEs to the server buffer (intended to make mass-messages appear more similar to WALLOPS) is too disruptive, so this removes it as default.