### PR TITLE
Stricter Deduplication

### DIFF
--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -1119,7 +1119,9 @@ pub fn insert_message(
                     && message.is_echo;
 
             if (message.id.is_some() && stored.id == message.id)
-                || (((message.deduplicate
+                || (((message.id.is_none()
+                    && stored.id.is_none()
+                    && message.deduplicate
                     && stored.server_time == message.server_time)
                     || use_echo_cmp)
                     && has_matching_content(stored, &message, use_echo_cmp))


### PR DESCRIPTION
Don't deduplicate non-echoes via server-time unless neither message has a message id.  This is to prevent false positives when a server/bouncer has coarse timestamps and message ids.

Closes #1819.