### PR TITLE
display urls (almost) like browsers do

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1635,6 +1635,7 @@ dependencies = [
  "iced",
  "iced_core",
  "iced_wgpu",
+ "idna",
  "image",
  "indexmap 2.13.0",
  "infer",
@@ -1664,6 +1665,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "toml 1.1.1+spec-1.1.0",
+ "unicode-security",
  "unicode-segmentation",
  "url",
  "walkdir",
@@ -9158,6 +9160,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9168,6 +9179,16 @@ name = "unicode-script"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
+name = "unicode-security"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e4ddba1535dd35ed8b61c52166b7155d7f4e4b8847cec6f48e71dc66d8b5e50"
+dependencies = [
+ "unicode-normalization",
+ "unicode-script",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -72,6 +72,8 @@ infer = "0.16"
 sys-locale = "0.3"
 mime_guess = "2.0.5"
 any_ascii = "0.3.3"
+idna = "1.1.0"
+unicode-security = "0.1.2"
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/data/src/url.rs
+++ b/data/src/url.rs
@@ -194,7 +194,7 @@ pub enum Error {
 /// If hosts don't pass a specific validation criteria, they are displayed as punycode.
 /// The path segment of a URL is always `percent-encoding` decoded.
 ///
-/// We apply a best effort to handle international domain names in a way that matches browser 
+/// We apply a best effort to handle international domain names in a way that matches browser
 /// status-quo; The host is rendered according to UTS #46 when it passes UTS #39 "Highly Restrictive"
 /// level, and its skeleton is not pure ASCII (which guards against homograph attacks).
 ///

--- a/data/src/url.rs
+++ b/data/src/url.rs
@@ -1,7 +1,10 @@
 use std::str::FromStr;
 
 use fancy_regex::Regex;
+use idna::uts46::{AsciiDenyList, Hyphens, Uts46};
 use percent_encoding::percent_decode_str;
+use unicode_security::confusable_detection::skeleton;
+use unicode_security::{RestrictionLevel, RestrictionLevelDetection};
 
 use crate::appearance::theme;
 use crate::server::ServerName;
@@ -186,6 +189,47 @@ pub enum Error {
     ParseEncodedTheme(#[from] theme::Error),
 }
 
+/// Returns the human-readable form of a URL.
+///
+/// If hosts don't pass a specific validation criteria, they are displayed as punycode.
+/// The path segment of a URL is always `percent-encoding` decoded.
+///
+/// We apply a best effort to handle international domain names in a way that matches browser 
+/// status-quo; The host is rendered according to UTS #46 when it passes UTS #39 "Highly Restrictive"
+/// level, and its skeleton is not pure ASCII (which guards against homograph attacks).
+///
+/// See https://unicode.org/reports/tr46/ and https://www.unicode.org/reports/tr39/ for
+/// motivations. https://chromium.googlesource.com/chromium/src/+/main/docs/idn.md
+/// is not a bad read either - though note that IRC clients have very different threat
+/// models than browsers.
+///
+pub fn display(u: &url::Url) -> String {
+    u.host_str()
+        .and_then(|host| {
+            let (host_str, _) = Uts46::new().to_user_interface(
+                host.as_bytes(),
+                AsciiDenyList::EMPTY,
+                Hyphens::Allow,
+                |label, _tld, _is_bidi| {
+                    let label_str: String = label.iter().collect();
+                    let s = label_str.as_str();
+                    // reject mixed-script confusables
+                    s.check_restriction_level(RestrictionLevel::HighlyRestrictive)
+                        // OR if every character maps to an ASCII confusable prototype;
+                        // not something the spec mandates, but browsers do this
+                        && !skeleton(s).all(|c| c.is_ascii())
+                },
+            );
+            u.as_str().split_once(host).map(|(scheme, path)| {
+                // https://ja.wikipedia.org/wiki/%E9%87%8D%E9%9F%B3%E3%83%86%E3%83%88
+                // -> https://ja.wikipedia.org/wiki/重音テト
+                let path = percent_decode_str(path).decode_utf8_lossy();
+                format!("{scheme}{host_str}{path}")
+            })
+        })
+        .unwrap_or_else(|| u.as_str().to_owned())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -306,5 +350,44 @@ mod tests {
             &["#ops[test]{dev}^foo", "#foo%bar"],
             false,
         );
+    }
+
+    #[test]
+    fn display_latin_umlaut() {
+        // bücher.de — latin with umlaut, safe to show as unicode according to UTS #46 and #39
+        let u = url::Url::parse("https://bücher.de/").unwrap();
+        assert_eq!(display(&u), "https://bücher.de/");
+    }
+
+    #[test]
+    fn display_percent_encoded_path() {
+        // ASCII host, percent-encoded unicode path. path should be percent-decoded.
+        let u = url::Url::parse(
+            "https://ja.wikipedia.org/wiki/%E9%87%8D%E9%9F%B3%E3%83%86%E3%83%88",
+        )
+        .unwrap();
+        assert_eq!(display(&u), "https://ja.wikipedia.org/wiki/重音テト");
+    }
+
+    #[test]
+    fn display_homograph_attack_stays_punycode() {
+        // all-cyrillic that looks identical to apple.com.
+        // got famous in 2017 and made browsers change their logic!
+        let u = url::Url::parse("https://www.аррӏе.com").unwrap();
+        assert_eq!(display(&u), "https://www.xn--80ak6aa92e.com/");
+    }
+
+    #[test]
+    fn display_mixed_script_stays_punycode() {
+        // cyrillic 'а' mixed with latin 'pple'
+        let u = url::Url::parse("https://аpple.com/").unwrap();
+        assert_eq!(display(&u), "https://xn--pple-43d.com/");
+    }
+
+    #[test]
+    fn display_japanese_domain() {
+        // CJK characters have no ASCII-confusable prototypes
+        let u = url::Url::parse("https://日本語.jp/").unwrap();
+        assert_eq!(display(&u), "https://日本語.jp/");
     }
 }

--- a/data/src/url.rs
+++ b/data/src/url.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::str::FromStr;
 
 use fancy_regex::Regex;
@@ -203,7 +204,7 @@ pub enum Error {
 /// is not a bad read either - though note that IRC clients have very different threat
 /// models than browsers.
 ///
-pub fn display(u: &url::Url) -> String {
+pub fn display(u: &url::Url) -> Cow<'_, str> {
     u.host_str()
         .and_then(|host| {
             let (host_str, _) = Uts46::new().to_user_interface(
@@ -224,10 +225,10 @@ pub fn display(u: &url::Url) -> String {
                 // https://ja.wikipedia.org/wiki/%E9%87%8D%E9%9F%B3%E3%83%86%E3%83%88
                 // -> https://ja.wikipedia.org/wiki/重音テト
                 let path = percent_decode_str(path).decode_utf8_lossy();
-                format!("{scheme}{host_str}{path}")
+                Cow::Owned(format!("{scheme}{host_str}{path}"))
             })
         })
-        .unwrap_or_else(|| u.as_str().to_owned())
+        .unwrap_or(Cow::Borrowed(u.as_str()))
 }
 
 #[cfg(test)]

--- a/src/widget/message_content.rs
+++ b/src/widget/message_content.rs
@@ -3,7 +3,6 @@ use data::{Config, Server, isupport, message, target};
 use iced::widget::span;
 use iced::widget::text::Span;
 use iced::{Color, Length, border};
-use percent_encoding::percent_decode_str;
 use unicode_segmentation::UnicodeSegmentation;
 
 use super::{Element, Renderer, selectable_rich_text, selectable_text};
@@ -217,25 +216,7 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
                                 .display
                                 .decode_urls
                             {
-                                // Preserve IDNA-compliant encoded host returned
-                                // by Url::host_str, but percent-decode the path
-                                // and later components of the URL for
-                                // legibility.  If the process fails for any
-                                // reason, return the IDNA-compliant encoding
-                                // provided by Url::as_str.
-                                u.host_str()
-                                    .and_then(|host_str| {
-                                        u.as_str().split_once(host_str).map(
-                                            |(prefix, suffix)| {
-                                                span(format!(
-                                                    "{prefix}{host_str}{}",
-                                                    percent_decode_str(suffix)
-                                                        .decode_utf8_lossy()
-                                                ))
-                                            },
-                                        )
-                                    })
-                                    .unwrap_or(span(u.as_str()))
+                                span(data::url::display(u))
                             } else {
                                 span(s.as_str())
                             }


### PR DESCRIPTION
follow up to #1812. specifically, [this comment](https://github.com/squidowl/halloy/pull/1812#issuecomment-4240624647)

this should match the 2026 status-quo for how browsers parse URLs: rendering the host part as UTS #46 when it passes UTS #39 "Highly Restrictive" level with mixed-script confusable detection. this avoids homograph attacks, like the famous [`www.apple.com` spoof](https://9to5mac.com/2017/04/20/how-to-spot-a-phishing-attempt-fake-apple-site/) and provides a good balance between flexibility and security.

based on research done in https://www.unicode.org/reports/tr39/ and https://unicode.org/reports/tr46/, with cherry-picked points from https://chromium.googlesource.com/chromium/src/+/main/docs/idn.md as browsers have very different security requirements than an IRC client