### PR TITLE
IRCv3 `no-implicit-names` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ Added:
 - Setting to hide the text of messages that contain only a single URL, when the URL's preview is visible (`preview.hide_url`)
 - Nick and channel completion picker
 - Runtime graphics settings (graphic backend, vsync, and antialiasing)
+- IRCv3 `no-implicit-names` support
 
 Fixed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Added:
 - Improved legibility of the returned values of `MONITOR` list (`/monitor L`)
 - Config option (`preview.card.description_decode_html`) to decode html strings in preview card descriptions
 - Support displaying a larger version of the card images in-app
+- IRCv3 `no-implicit-names` support
 
 Fixed:
 
@@ -95,7 +96,6 @@ Added:
 - Setting to hide the text of messages that contain only a single URL, when the URL's preview is visible (`preview.hide_url`)
 - Nick and channel completion picker
 - Runtime graphics settings (graphic backend, vsync, and antialiasing)
-- IRCv3 `no-implicit-names` support
 
 Fixed:
 

--- a/data/src/capabilities.rs
+++ b/data/src/capabilities.rs
@@ -428,14 +428,12 @@ impl Capabilities {
             requested.push("draft/multiline");
         }
 
+        // TODO(quaff): remove `draft/no-implicit-names` support when ergo & soju have both been upgraded
         if self.pending.contains_key("no-implicit-names")
             && !self.acknowledged(Capability::NoImplicitNames)
         {
             requested.push("no-implicit-names");
-        }
-
-        // TODO(quaff): remove `draft/no-implicit-names` support when ergo & soju have both been upgraded
-        if self.pending.contains_key("draft/no-implicit-names")
+        } else if self.pending.contains_key("draft/no-implicit-names")
             && !self.acknowledged(Capability::NoImplicitNames)
         {
             requested.push("draft/no-implicit-names");

--- a/data/src/capabilities.rs
+++ b/data/src/capabilities.rs
@@ -35,6 +35,7 @@ pub enum Capability {
     Multiline,
     MultiPrefix,
     Metadata,
+    NoImplicitNames,
     ReadMarker,
     Sasl,
     ServerTime,
@@ -64,6 +65,9 @@ impl FromStr for Capability {
             "draft/message-redaction" => Ok(Self::MessageRedaction),
             "multi-prefix" => Ok(Self::MultiPrefix),
             "draft/metadata-2" => Ok(Self::Metadata),
+            "no-implicit-names" => Ok(Self::NoImplicitNames),
+            // TODO(quaff): remove `draft/no-implicit-names` support when ergo & soju have both been upgraded
+            "draft/no-implicit-names" => Ok(Self::NoImplicitNames),
             "server-time" => Ok(Self::ServerTime),
             "setname" => Ok(Self::Setname),
             "soju.im/bouncer-networks" => Ok(Self::BouncerNetworks),
@@ -422,6 +426,19 @@ impl Capabilities {
             && MultilineLimits::from_str(multiline).is_ok()
         {
             requested.push("draft/multiline");
+        }
+
+        if self.pending.contains_key("no-implicit-names")
+            && !self.acknowledged(Capability::NoImplicitNames)
+        {
+            requested.push("no-implicit-names");
+        }
+
+        // TODO(quaff): remove `draft/no-implicit-names` support when ergo & soju have both been upgraded
+        if self.pending.contains_key("draft/no-implicit-names")
+            && !self.acknowledged(Capability::NoImplicitNames)
+        {
+            requested.push("draft/no-implicit-names");
         }
 
         if self.pending.contains_key("draft/metadata-2")

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1944,10 +1944,16 @@ impl Client {
                         self.statusmsg(),
                         casemapping,
                     ));
-                    if let Some(pos) = self
-                        .who_polls
-                        .iter()
-                        .position(|who_poll| who_poll.channel == target_channel)
+                    if let Some(pos) =
+                        self.who_polls.iter().position(|who_poll| {
+                            who_poll.channel == target_channel
+                                && (matches!(
+                                    who_poll.status,
+                                    WhoStatus::Joined
+                                        | WhoStatus::Received
+                                        | WhoStatus::Waiting(_)
+                                ))
+                        })
                     {
                         self.who_polls.remove(pos);
                     }
@@ -2082,10 +2088,6 @@ impl Client {
             }
             Command::Numeric(RPL_WHOREPLY, args) => {
                 let channel = ok!(args.get(1));
-                let user = ok!(args.get(2));
-                let host = ok!(args.get(3));
-                let nick = ok!(args.get(5));
-                let flags = ok!(args.get(6));
 
                 let casemapping = self.casemapping();
 
@@ -2095,19 +2097,42 @@ impl Client {
                     self.statusmsg(),
                     casemapping,
                 ) {
-                    let user_request = self.user_who_request(&target_channel);
-
                     if let Some(client_channel) =
                         self.chanmap.get_mut(&target_channel)
                     {
+                        let nick = ok!(args.get(5));
+                        let flags = ok!(args.get(6));
                         let bot_mode_char =
                             isupport::get_bot_mode_char(&self.isupport);
-                        client_channel.update_user_status(
-                            nick,
-                            flags,
-                            casemapping,
-                            bot_mode_char,
-                        );
+
+                        if self
+                            .capabilities
+                            .acknowledged(Capability::NoImplicitNames)
+                            && let Ok(mut user) = User::parse_from_whoreply(
+                                nick,
+                                flags,
+                                ok!(args.get(2)),
+                                ok!(args.get(3)),
+                                casemapping,
+                                isupport::get_prefix(&self.isupport),
+                            )
+                            && client_channel.users.resolve(&user).is_none()
+                        {
+                            if flags.starts_with('G') {
+                                user.update_away(true);
+                            }
+                            if let Some(bot_char) = bot_mode_char {
+                                user.update_bot(flags.contains(bot_char));
+                            }
+                            client_channel.users.insert(user);
+                        } else {
+                            client_channel.update_user_status(
+                                nick,
+                                flags,
+                                casemapping,
+                                bot_mode_char,
+                            );
+                        }
 
                         if let Some(who_poll) = self
                             .who_polls
@@ -2123,25 +2148,9 @@ impl Client {
                                 self.server
                             );
                         }
-
-                        if let Ok(mut user) = User::parse_from_whoreply(
-                            nick,
-                            flags,
-                            user,
-                            host,
-                            casemapping,
-                            isupport::get_prefix(&self.isupport),
-                        ) {
-                            if flags.starts_with('G') {
-                                user.update_away(true);
-                            }
-                            if let Some(bot_char) = bot_mode_char {
-                                user.update_bot(flags.contains(bot_char));
-                            }
-                            client_channel.users.insert(user);
-                        }
                     }
 
+                    let user_request = self.user_who_request(&target_channel);
                     if !user_request {
                         // User did not request, don't save to history
                         return Ok(vec![]);
@@ -2161,13 +2170,7 @@ impl Client {
                 }
             }
             Command::Numeric(RPL_WHOSPCRPL, args) => {
-                let token = ok!(args.get(1));
                 let channel = ok!(args.get(2));
-                let user = ok!(args.get(3));
-                let host = ok!(args.get(4));
-                let nick = ok!(args.get(5));
-                let flags = ok!(args.get(6));
-                let account = args.get(7);
 
                 let casemapping = self.casemapping();
 
@@ -2194,7 +2197,8 @@ impl Client {
                                 _,
                                 Some(request_token),
                             ) if matches!(source, WhoSource::Poll) => {
-                                if let Ok(token) = token.parse::<WhoToken>()
+                                if let Ok(token) =
+                                    ok!(args.get(1)).parse::<WhoToken>()
                                     && *request_token == token
                                 {
                                     who_poll.status = WhoStatus::Receiving(
@@ -2229,12 +2233,14 @@ impl Client {
                             &who_poll.status
                         {
                             // Check token to ~ensure reply is to poll request
-                            if let Ok(token) = token.parse::<WhoToken>() {
+                            if let Ok(token) =
+                                ok!(args.get(1)).parse::<WhoToken>()
+                            {
                                 if token == WhoXPollParameters::Default.token()
                                 {
                                     client_channel.update_user_status(
-                                        nick,
-                                        flags,
+                                        ok!(args.get(3)),
+                                        ok!(args.get(4)),
                                         casemapping,
                                         bot_mode_char,
                                     );
@@ -2243,39 +2249,50 @@ impl Client {
                                         .token()
                                 {
                                     client_channel.update_user_status(
-                                        nick,
-                                        flags,
+                                        ok!(args.get(3)),
+                                        ok!(args.get(4)),
                                         casemapping,
                                         bot_mode_char,
                                     );
 
                                     client_channel.update_user_accountname(
-                                        nick,
-                                        ok!(account),
+                                        ok!(args.get(3)),
+                                        ok!(args.get(5)),
                                         casemapping,
                                     );
+                                } else if token
+                                    == WhoXPollParameters::InitialJoin.token()
+                                    && let flags = ok!(args.get(6))
+                                    && let Ok(mut user) =
+                                        User::parse_from_whoreply(
+                                            ok!(args.get(5)),
+                                            flags,
+                                            ok!(args.get(3)),
+                                            ok!(args.get(4)),
+                                            casemapping,
+                                            isupport::get_prefix(
+                                                &self.isupport,
+                                            ),
+                                        )
+                                    && client_channel
+                                        .users
+                                        .resolve(&user)
+                                        .is_none()
+                                {
+                                    if let Some(account) = args.get(7) {
+                                        user = user.with_accountname(account);
+                                    }
+                                    if flags.starts_with('G') {
+                                        user.update_away(true);
+                                    }
+                                    if let Some(bot_char) = bot_mode_char {
+                                        user.update_bot(
+                                            flags.contains(bot_char),
+                                        );
+                                    }
+                                    client_channel.users.insert(user);
                                 }
                             }
-                        }
-
-                        if let Ok(mut user) = User::parse_from_whoreply(
-                            nick,
-                            flags,
-                            user,
-                            host,
-                            casemapping,
-                            isupport::get_prefix(&self.isupport),
-                        ) {
-                            if let Some(account) = account {
-                                user = user.with_accountname(account);
-                            }
-                            if flags.starts_with('G') {
-                                user.update_away(true);
-                            }
-                            if let Some(bot_char) = bot_mode_char {
-                                user.update_bot(flags.contains(bot_char));
-                            }
-                            client_channel.users.insert(user);
                         }
                     }
 
@@ -4566,14 +4583,12 @@ impl Client {
             }
 
             let request = match &who_poll.status {
-                WhoStatus::Joined => {
-                    (self.capabilities.acknowledged(Capability::AwayNotify)
-                        || self
-                            .capabilities
-                            .acknowledged(Capability::NoImplicitNames)
-                        || self.config.who_poll_enabled)
-                        .then_some(Request::Poll)
-                }
+                WhoStatus::Joined => (self
+                    .capabilities
+                    .acknowledged(Capability::NoImplicitNames)
+                    || self.capabilities.acknowledged(Capability::AwayNotify)
+                    || self.config.who_poll_enabled)
+                    .then_some(Request::Poll),
                 WhoStatus::Waiting(last) => {
                     if self.capabilities.acknowledged(Capability::AwayNotify) {
                         self.chanmap.get(&who_poll.channel).and_then(
@@ -4622,6 +4637,15 @@ impl Client {
                 let message =
                     if self.isupport.contains_key(&isupport::Kind::WHOX) {
                         let whox_params = if self
+                            .capabilities
+                            .acknowledged(Capability::NoImplicitNames)
+                            && self
+                                .chanmap
+                                .get(&who_poll.channel)
+                                .is_none_or(|channel| !channel.who_init)
+                        {
+                            WhoXPollParameters::InitialJoin
+                        } else if self
                             .capabilities
                             .acknowledged(Capability::AccountNotify)
                         {
@@ -4824,11 +4848,13 @@ impl Client {
     }
 
     pub fn prioritize_joined_who_poll(&mut self, channel: target::Channel) {
-        if let Some(pos) = self
-            .who_polls
-            .iter()
-            .position(|who_poll| who_poll.channel == channel)
-            && pos != 0
+        if let Some(pos) = self.who_polls.iter().position(|who_poll| {
+            who_poll.channel == channel
+                && !matches!(
+                    who_poll.status,
+                    WhoStatus::Received | WhoStatus::Waiting(_)
+                )
+        }) && pos != 0
             && let Some(who_poll) = self.who_polls.remove(pos)
         {
             log::debug!("prioritizing who poll for: {channel:?}");

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -2066,6 +2066,10 @@ impl Client {
             }
             Command::Numeric(RPL_WHOREPLY, args) => {
                 let channel = ok!(args.get(1));
+                let user = ok!(args.get(2));
+                let host = ok!(args.get(3));
+                let nick = ok!(args.get(5));
+                let flags = ok!(args.get(6));
 
                 let casemapping = self.casemapping();
 
@@ -2080,11 +2084,13 @@ impl Client {
                     if let Some(client_channel) =
                         self.chanmap.get_mut(&target_channel)
                     {
+                        let bot_mode_char =
+                            isupport::get_bot_mode_char(&self.isupport);
                         client_channel.update_user_status(
-                            ok!(args.get(5)),
-                            ok!(args.get(6)),
+                            nick,
+                            flags,
                             casemapping,
-                            isupport::get_bot_mode_char(&self.isupport),
+                            bot_mode_char,
                         );
 
                         if let Some(who_poll) = self
@@ -2100,6 +2106,23 @@ impl Client {
                                 "[{}] {channel} - WHO receiving...",
                                 self.server
                             );
+                        }
+
+                        if let Ok(mut user) = User::parse_from_whoreply(
+                            nick,
+                            flags,
+                            user,
+                            host,
+                            casemapping,
+                            isupport::get_prefix(&self.isupport),
+                        ) {
+                            if flags.starts_with('G') {
+                                user.update_away(true);
+                            }
+                            if let Some(bot_char) = bot_mode_char {
+                                user.update_bot(flags.contains(bot_char));
+                            }
+                            client_channel.users.insert(user);
                         }
                     }
 
@@ -2122,7 +2145,13 @@ impl Client {
                 }
             }
             Command::Numeric(RPL_WHOSPCRPL, args) => {
+                let token = ok!(args.get(1));
                 let channel = ok!(args.get(2));
+                let user = ok!(args.get(3));
+                let host = ok!(args.get(4));
+                let nick = ok!(args.get(5));
+                let flags = ok!(args.get(6));
+                let account = args.get(7);
 
                 let casemapping = self.casemapping();
 
@@ -2141,14 +2170,15 @@ impl Client {
                             .iter_mut()
                             .find(|who_poll| who_poll.channel == target_channel)
                     {
+                        let bot_mode_char =
+                            isupport::get_bot_mode_char(&self.isupport);
                         match &who_poll.status {
                             WhoStatus::Requested(
                                 source,
                                 _,
                                 Some(request_token),
                             ) if matches!(source, WhoSource::Poll) => {
-                                if let Ok(token) =
-                                    ok!(args.get(1)).parse::<WhoToken>()
+                                if let Ok(token) = token.parse::<WhoToken>()
                                     && *request_token == token
                                 {
                                     who_poll.status = WhoStatus::Receiving(
@@ -2183,41 +2213,53 @@ impl Client {
                             &who_poll.status
                         {
                             // Check token to ~ensure reply is to poll request
-                            if let Ok(token) =
-                                ok!(args.get(1)).parse::<WhoToken>()
-                            {
+                            if let Ok(token) = token.parse::<WhoToken>() {
                                 if token == WhoXPollParameters::Default.token()
                                 {
                                     client_channel.update_user_status(
-                                        ok!(args.get(3)),
-                                        ok!(args.get(4)),
+                                        nick,
+                                        flags,
                                         casemapping,
-                                        isupport::get_bot_mode_char(
-                                            &self.isupport,
-                                        ),
+                                        bot_mode_char,
                                     );
                                 } else if token
                                     == WhoXPollParameters::WithAccountName
                                         .token()
                                 {
-                                    let user = ok!(args.get(3));
-
                                     client_channel.update_user_status(
-                                        user,
-                                        ok!(args.get(4)),
+                                        nick,
+                                        flags,
                                         casemapping,
-                                        isupport::get_bot_mode_char(
-                                            &self.isupport,
-                                        ),
+                                        bot_mode_char,
                                     );
 
                                     client_channel.update_user_accountname(
-                                        user,
-                                        ok!(args.get(5)),
+                                        nick,
+                                        ok!(account),
                                         casemapping,
                                     );
                                 }
                             }
+                        }
+
+                        if let Ok(mut user) = User::parse_from_whoreply(
+                            nick,
+                            flags,
+                            user,
+                            host,
+                            casemapping,
+                            isupport::get_prefix(&self.isupport),
+                        ) {
+                            if let Some(account) = account {
+                                user = user.with_accountname(account);
+                            }
+                            if flags.starts_with('G') {
+                                user.update_away(true);
+                            }
+                            if let Some(bot_char) = bot_mode_char {
+                                user.update_bot(flags.contains(bot_char));
+                            }
+                            client_channel.users.insert(user);
                         }
                     }
 
@@ -2265,15 +2307,39 @@ impl Client {
                         }
 
                         // Prioritize WHO requests due to joining a channel
-                        if let Some(pos) = self
-                            .who_polls
-                            .iter()
-                            .position(|who_poll| {
-                                matches!(who_poll.status, WhoStatus::Joined)
-                            })
-                            .or(self.who_polls.iter().position(|who_poll| {
-                                matches!(who_poll.status, WhoStatus::Received)
-                            }))
+                        if self
+                            .capabilities
+                            .acknowledged(Capability::NoImplicitNames)
+                            && let Some(pos) =
+                                self.who_polls.iter().position(|who_poll| {
+                                    matches!(
+                                        who_poll.status,
+                                        WhoStatus::Requested(..)
+                                    )
+                                })
+                            && pos != 0
+                            && let Some(who_poll) = self.who_polls.remove(pos)
+                        {
+                            self.who_polls.push_front(who_poll);
+                        }
+
+                        if !self
+                            .capabilities
+                            .acknowledged(Capability::NoImplicitNames)
+                            && let Some(pos) = self
+                                .who_polls
+                                .iter()
+                                .position(|who_poll| {
+                                    matches!(who_poll.status, WhoStatus::Joined)
+                                })
+                                .or(self.who_polls.iter().position(
+                                    |who_poll| {
+                                        matches!(
+                                            who_poll.status,
+                                            WhoStatus::Received
+                                        )
+                                    },
+                                ))
                         {
                             self.who_polls[pos].status =
                                 WhoStatus::Waiting(Instant::now());
@@ -4510,6 +4576,9 @@ impl Client {
             let request = match &who_poll.status {
                 WhoStatus::Joined => {
                     (self.capabilities.acknowledged(Capability::AwayNotify)
+                        || self
+                            .capabilities
+                            .acknowledged(Capability::NoImplicitNames)
                         || self.config.who_poll_enabled)
                         .then_some(Request::Poll)
                 }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -538,7 +538,7 @@ impl Client {
     }
 
     fn quit(&mut self, reason: Option<String>) {
-        self.who_queue.quit();
+        self.who_queue.clear_queues();
 
         if let Err(e) = if let Some(reason) = reason {
             self.handle.try_send(command!("QUIT", reason))
@@ -706,7 +706,7 @@ impl Client {
 
                         if let Some(channel) = channel {
                             self.who_queue
-                                .requested_channel_poll(params, channel);
+                                .user_requested_channel_poll(params, channel);
                         }
                     }
                 }
@@ -1940,7 +1940,7 @@ impl Client {
                     );
 
                     // Add channel to WHO poll queue
-                    self.who_queue.queue_channel_poll(&target_channel);
+                    self.who_queue.queue_joined_who_poll(&target_channel);
 
                     if !self.mode_requests.iter().any(|mode_request| {
                         mode_request.channel == target_channel
@@ -2067,10 +2067,8 @@ impl Client {
                             );
                         }
 
-                        self.who_queue.receiving_channel_poll(
-                            &self.server,
-                            &target_channel,
-                        );
+                        self.who_queue
+                            .receiving_who_poll(&self.server, &target_channel);
 
                         if self
                             .capabilities
@@ -3743,8 +3741,14 @@ impl Client {
     }
 
     fn user_who_request(&self, channel: &target::Channel) -> bool {
-        self.who_queue
-            .any_matching_inflight(|who_poll| who_poll.channel == *channel)
+        self.who_queue.any_matching_inflight(|who_poll| {
+            who_poll.channel == *channel
+                && matches!(
+                    who_poll.status,
+                    WhoStatus::Requested(WhoSource::User, _, _)
+                        | WhoStatus::Receiving(WhoSource::User, _)
+                )
+        })
     }
 
     pub fn is_who_init(&self, channel: &target::Channel) -> bool {
@@ -4585,14 +4589,14 @@ impl Client {
         channel: &target::Channel,
         opened_channels: &Vec<(&Server, &target::Channel)>,
     ) {
-        self.who_queue
-            .prioritize_joined_who_poll(&self.server, channel);
-
         self.who_queue.reprioritize_joined_who_polls(
             &self.server,
             opened_channels,
             channel,
         );
+
+        self.who_queue
+            .prioritize_joined_who_poll(&self.server, channel);
     }
 
     pub fn has_isupport_monitor(&self) -> bool {

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -599,13 +599,7 @@ impl Client {
                     // should be in who_polls and rerouting should be stopped, or it
                     // is treated as part of a rate-limiting response and if there
                     // are any outstanding user requests rerouting should be stopped.
-                    self.who_queue.any_matching(|who_poll| {
-                        matches!(
-                            who_poll.status,
-                            WhoStatus::Requested(WhoSource::User, _, _)
-                                | WhoStatus::Receiving(WhoSource::User, _)
-                        )
-                    })
+                    self.who_queue.has_inflight()
                 } else {
                     let target_channel = target::Channel::from_str(
                         &mask,
@@ -1902,15 +1896,8 @@ impl Client {
                         self.statusmsg(),
                         casemapping,
                     ));
-                    self.who_queue.remove_matching(|who_poll| {
+                    self.who_queue.remove_matching_polls(|who_poll| {
                         who_poll.channel == target_channel
-                            && (matches!(
-                                who_poll.status,
-                                WhoStatus::Joined
-                                    | WhoStatus::PrioritizedJoin
-                                    | WhoStatus::Received
-                                    | WhoStatus::Waiting(_)
-                            ))
                     });
                 } else if let Some(channel) =
                     self.chanmap.get_mut(&context!(target::Channel::parse(
@@ -2084,6 +2071,22 @@ impl Client {
                             &self.server,
                             &target_channel,
                         );
+
+                        if self
+                            .capabilities
+                            .acknowledged(Capability::NoImplicitNames)
+                        {
+                            for (message, priority) in
+                                self.who_queue.process_next_prioritized_join(
+                                    &self.server,
+                                    &self.capabilities,
+                                    &self.chanmap,
+                                    &self.isupport,
+                                )
+                            {
+                                self.send(None, message, priority);
+                            }
+                        }
                     }
 
                     let user_request = self.user_who_request(&target_channel);
@@ -2129,6 +2132,22 @@ impl Client {
                             client_channel,
                             args,
                         );
+
+                        if self
+                            .capabilities
+                            .acknowledged(Capability::NoImplicitNames)
+                        {
+                            for (message, priority) in
+                                self.who_queue.process_next_prioritized_join(
+                                    &self.server,
+                                    &self.capabilities,
+                                    &self.chanmap,
+                                    &self.isupport,
+                                )
+                            {
+                                self.send(None, message, priority);
+                            }
+                        }
                     }
 
                     if !user_request {
@@ -2202,10 +2221,12 @@ impl Client {
                         self.casemapping(),
                     );
 
-                    if !self.who_queue.remove_matching(|who_poll| {
+                    if !self.who_queue.remove_matching_polls(|who_poll| {
                         who_poll.channel == target_channel
-                    }) {
-                        self.who_queue.handle_who_rate_limit();
+                    }) || !self.who_queue.remove_matching_inflight(
+                        |who_poll| who_poll.channel == target_channel,
+                    ) {
+                        self.who_queue.handle_who_rate_limited();
                         return Ok(vec![]);
                     }
                 }
@@ -3050,7 +3071,7 @@ impl Client {
                 let command = ok!(args.get(1));
 
                 if command == "WHO" && self.config.who_poll_enabled {
-                    self.who_queue.interval_too_short();
+                    self.who_queue.who_reply_throttled();
 
                     log::debug!(
                         "[{}] WHO poll interval is too short → duration = {:?}",
@@ -3058,7 +3079,7 @@ impl Client {
                         self.who_queue.interval_duration()
                     );
 
-                    if !self.who_queue.any_matching(|who_poll| {
+                    if !self.who_queue.any_matching_inflight(|who_poll| {
                         matches!(
                             who_poll.status,
                             WhoStatus::Requested(WhoSource::User, _, _)
@@ -3710,14 +3731,8 @@ impl Client {
     }
 
     fn user_who_request(&self, channel: &target::Channel) -> bool {
-        self.who_queue.any_matching(|who_poll| {
-            who_poll.channel == *channel
-                && matches!(
-                    who_poll.status,
-                    WhoStatus::Requested(WhoSource::User, _, _)
-                        | WhoStatus::Receiving(WhoSource::User, _)
-                )
-        })
+        self.who_queue
+            .any_matching_inflight(|who_poll| who_poll.channel == *channel)
     }
 
     pub fn is_who_init(&self, channel: &target::Channel) -> bool {
@@ -4548,13 +4563,17 @@ impl Client {
 
     pub fn prioritize_joined_who_poll(
         &mut self,
-        channel: target::Channel,
-        opened_channels: Vec<(&Server, &target::Channel)>,
+        channel: &target::Channel,
+        opened_channels: &Vec<(&Server, &target::Channel)>,
     ) {
-        self.who_queue.prioritize_joined_who_poll(channel);
-
         self.who_queue
-            .reprioritize_joined_who_polls(&self.server, opened_channels);
+            .prioritize_joined_who_poll(&self.server, channel);
+
+        self.who_queue.reprioritize_joined_who_polls(
+            &self.server,
+            opened_channels,
+            channel,
+        );
     }
 
     pub fn has_isupport_monitor(&self) -> bool {
@@ -5547,8 +5566,8 @@ impl Map {
     pub fn prioritize_channel_who_poll(
         &mut self,
         server: &Server,
-        channel: target::Channel,
-        opened_channels: Vec<(&Server, &target::Channel)>,
+        channel: &target::Channel,
+        opened_channels: &Vec<(&Server, &target::Channel)>,
     ) {
         if let Some(client) = self.client_mut(server) {
             client.prioritize_joined_who_poll(channel, opened_channels);

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -28,7 +28,7 @@ use crate::environment::{SOURCE_WEBSITE, VERSION};
 use crate::features::{self, Features, VersionRequest};
 use crate::history::ReadMarker;
 use crate::isupport::{
-    ChatHistoryState, ChatHistorySubcommand, MessageReference,
+    ChatHistoryState, ChatHistorySubcommand, MessageReference, WhoToken,
     find_target_limit, format_optional_message_reference,
 };
 use crate::message::source;
@@ -44,8 +44,6 @@ use crate::{
 
 pub mod on_connect;
 pub mod who_queue;
-
-use who_queue::{WhoSource, WhoStatus};
 
 const HIGHLIGHT_BLACKOUT_INTERVAL: Duration = Duration::from_secs(5);
 const CLIENT_CHATHISTORY_LIMIT: u16 = 1000;
@@ -294,7 +292,7 @@ impl Client {
             ),
             registration_required_channels: vec![],
             isupport: HashMap::new(),
-            who_queue: who_queue::WhoQueue::new(config.clone()),
+            who_queue: who_queue::WhoQueue::new(&config),
             resolved_netid: None,
             anti_flood: Some(TokenBucket::new(config.anti_flood, 10)),
             mode_requests: Vec::new(),
@@ -530,10 +528,11 @@ impl Client {
             events.push(Event::UpdateIcon);
         }
 
-        self.who_queue.update_config(
-            &self.chanmap,
+        self.who_queue.update(
             &self.capabilities,
+            &self.isupport,
             &config,
+            self.chanmap.keys(),
         );
 
         self.config = config;
@@ -542,8 +541,7 @@ impl Client {
     }
 
     fn quit(&mut self, reason: Option<String>) {
-        self.who_queue
-            .clear_queues(&self.capabilities, &self.config);
+        self.who_queue.clear();
 
         if let Err(e) = if let Some(reason) = reason {
             self.handle.try_send(command!("QUIT", reason))
@@ -596,15 +594,13 @@ impl Client {
                     self.statusmsg(),
                     self.casemapping(),
                 ) {
-                    self.user_who_request(&target_channel)
-                    // Some servers respond with the mask * instead of the requested
-                    // channel name when rate-limiting WHO requests
+                    self.who_queue.is_user_who_request(&target_channel)
                 } else if mask == "*" {
-                    // Either the user requested the mask, in which case the request
-                    // should be in who_polls and rerouting should be stopped, or it
-                    // is treated as part of a rate-limiting response and if there
-                    // are any outstanding user requests rerouting should be stopped.
-                    self.who_queue.has_inflight()
+                    // Some servers respond with the mask * instead of the
+                    // requested channel name when rate-limiting WHO requests.
+                    // If there are any outstanding user WHO requests then
+                    // rerouting should be stopped.
+                    self.who_queue.any_user_who_request()
                 } else {
                     let target_channel = target::Channel::from_str(
                         &mask,
@@ -612,7 +608,7 @@ impl Client {
                         self.casemapping(),
                     );
 
-                    self.user_who_request(&target_channel)
+                    self.who_queue.is_user_who_request(&target_channel)
                 }
             }
             _ => matches!(
@@ -710,8 +706,12 @@ impl Client {
                         };
 
                         if let Some(channel) = channel {
+                            let token = params.get(2).and_then(|token| {
+                                token.parse::<WhoToken>().ok()
+                            });
+
                             self.who_queue
-                                .user_requested_channel_poll(params, channel);
+                                .user_requested_who_poll(channel, token);
                         }
                     }
                 }
@@ -1381,6 +1381,13 @@ impl Client {
                         self.handle.try_send(command!("CAP", "END"))?;
                     }
                 }
+
+                self.who_queue.update(
+                    &self.capabilities,
+                    &self.isupport,
+                    &self.config,
+                    self.chanmap.keys(),
+                );
             }
             Command::CAP(_, sub, a, b) if sub == "NAK" => {
                 let caps = ok!(b.as_ref().or(a.as_ref()));
@@ -1395,6 +1402,13 @@ impl Client {
                     self.registration_step = RegistrationStep::End;
                     self.handle.try_send(command!("CAP", "END"))?;
                 }
+
+                self.who_queue.update(
+                    &self.capabilities,
+                    &self.isupport,
+                    &self.config,
+                    self.chanmap.keys(),
+                );
             }
             Command::CAP(_, sub, a, b) if sub == "NEW" => {
                 let caps = ok!(b.as_ref().or(a.as_ref()));
@@ -1885,25 +1899,16 @@ impl Client {
                 let user = ok!(message.user(casemapping));
 
                 if user.nickname() == self.nickname() {
-                    self.chanmap.shift_remove(&context!(
-                        target::Channel::parse(
-                            channel,
-                            self.chantypes(),
-                            self.statusmsg(),
-                            self.casemapping(),
-                        )
-                    ));
-
-                    // Remove departed channel who polls from queue
                     let target_channel = context!(target::Channel::parse(
                         channel,
                         self.chantypes(),
                         self.statusmsg(),
-                        casemapping,
+                        self.casemapping(),
                     ));
-                    self.who_queue.remove_matching_polls(|who_poll| {
-                        who_poll.channel == target_channel
-                    });
+
+                    self.chanmap.shift_remove(&target_channel);
+
+                    self.who_queue.parted_channel(&target_channel);
                 } else if let Some(channel) =
                     self.chanmap.get_mut(&context!(target::Channel::parse(
                         channel,
@@ -1945,7 +1950,7 @@ impl Client {
                     );
 
                     // Add channel to WHO poll queue
-                    self.who_queue.queue_joined_who_poll(
+                    self.who_queue.queue_join_who_request(
                         &self.capabilities,
                         &target_channel,
                     );
@@ -2041,46 +2046,16 @@ impl Client {
                     if let Some(client_channel) =
                         self.chanmap.get_mut(&target_channel)
                     {
-                        let nick = ok!(args.get(5));
-                        let flags = ok!(args.get(6));
-                        let bot_mode_char =
-                            isupport::get_bot_mode_char(&self.isupport);
-
-                        if self
-                            .capabilities
-                            .acknowledged(Capability::NoImplicitNames)
-                            && let Ok(mut user) = User::parse_from_whoreply(
-                                nick,
-                                flags,
-                                ok!(args.get(2)),
-                                ok!(args.get(3)),
-                                casemapping,
-                                isupport::get_prefix(&self.isupport),
-                            )
-                            && client_channel.users.resolve(&user).is_none()
-                        {
-                            if flags.starts_with('G') {
-                                user.update_away(true);
-                            }
-                            if let Some(bot_char) = bot_mode_char {
-                                user.update_bot(flags.contains(bot_char));
-                            }
-                            client_channel.users.insert(user);
-                        } else {
-                            client_channel.update_user_status(
-                                nick,
-                                flags,
-                                casemapping,
-                                bot_mode_char,
-                            );
-                        }
-
-                        self.who_queue
-                            .receiving_who_poll(&self.server, &target_channel);
+                        self.who_queue.handle_who_reply(
+                            &self.server,
+                            &self.isupport,
+                            &target_channel,
+                            client_channel,
+                            args,
+                        )?;
                     }
 
-                    let user_request = self.user_who_request(&target_channel);
-                    if !user_request {
+                    if !self.who_queue.is_user_who_request(&target_channel) {
                         // User did not request, don't save to history
                         return Ok(vec![]);
                     // Reroute who responses
@@ -2109,23 +2084,20 @@ impl Client {
                     self.statusmsg(),
                     casemapping,
                 ) {
-                    let user_request = self.user_who_request(&target_channel);
-
                     if let Some(client_channel) =
                         self.chanmap.get_mut(&target_channel)
                     {
-                        let _ = self.who_queue.handle_whox_reply(
-                            casemapping,
+                        self.who_queue.handle_whox_reply(
                             &self.server,
                             &self.isupport,
                             &target_channel,
                             client_channel,
                             args,
-                        );
+                        )?;
                     }
 
-                    if !user_request {
-                        // User did not request, don't save to history
+                    // User did not request, don't save to history
+                    if !self.who_queue.is_user_who_request(&target_channel) {
                         return Ok(vec![]);
                     // Reroute who responses
                     } else if let Some(target) = self
@@ -2151,40 +2123,24 @@ impl Client {
                     self.statusmsg(),
                     self.casemapping(),
                 ) {
-                    let user_request = self.user_who_request(&target_channel);
+                    let user_request =
+                        self.who_queue.is_user_who_request(&target_channel);
 
                     self.who_queue.handle_end_who_reply(
-                        &self.chanmap,
-                        &self.config,
-                        &self.capabilities,
                         &target_channel,
+                        self.chanmap.contains_key(&target_channel),
+                        &self.capabilities,
+                        &self.config,
                     );
 
                     log::trace!("[{}] {mask} - WHO done", self.server);
 
-                    if let Some(client_channel) =
-                        self.chanmap.get_mut(&target_channel)
-                        && !client_channel.who_init
-                    {
-                        client_channel.who_init = true;
-
-                        if self
-                            .capabilities
-                            .acknowledged(Capability::NoImplicitNames)
-                            && let Some((subcommand, priority)) = self
-                                .pending_chathistory_requests
-                                .remove(&Target::Channel(target_channel))
-                        {
-                            self.send_chathistory_request(subcommand, priority);
-                        }
-                    }
-
+                    // User did not request, don't save to history
                     if !user_request {
-                        self.who_queue.interval_long_enough();
+                        self.channel_users_received(target_channel);
 
-                        // User did not request, don't save to history
                         return Ok(vec![]);
-                    // Reroute who responses
+                    // Reroute who responses for user requests
                     } else if let Some(target) = self
                         .reroute_responses_to
                         .as_ref()
@@ -2198,26 +2154,11 @@ impl Client {
                         }]);
                     }
                 } else if mask == "*" {
-                    // Some servers respond with the mask * instead of the requested
-                    // channel name when rate-limiting WHO requests
-                    let target_channel = target::Channel::from_str(
-                        mask,
-                        self.chantypes(),
-                        self.casemapping(),
-                    );
-
-                    if !self.who_queue.remove_matching_polls(|who_poll| {
-                        who_poll.channel == target_channel
-                    }) || !self.who_queue.remove_matching_inflight(
-                        |who_poll| who_poll.channel == target_channel,
-                    ) {
-                        log::trace!(
-                            "[{}] - WHO poll rate limited",
-                            &self.server
-                        );
-                        self.who_queue.handle_who_rate_limited();
-                        return Ok(vec![]);
-                    }
+                    // Some servers respond with the mask * instead of the
+                    // requested channel name when rate-limiting WHO requests.
+                    // The rate limiting is handled by RPL_TRYAGAIN, so we can
+                    // ignore it here.
+                    return Ok(vec![]);
                 }
             }
             Command::AWAY(args) => {
@@ -2404,7 +2345,7 @@ impl Client {
                     }
 
                     // Don't save to history if names list was triggered by JOIN
-                    if !channel.names_init {
+                    if !channel.users_init {
                         return Ok(vec![]);
                     }
                 }
@@ -2419,18 +2360,12 @@ impl Client {
                     self.casemapping(),
                 ));
 
-                if !self.capabilities.acknowledged(Capability::NoImplicitNames)
-                    && let Some(channel) = self.chanmap.get_mut(&target)
-                    && !channel.names_init
+                if self
+                    .chanmap
+                    .get(&target)
+                    .is_some_and(|channel| !channel.users_init)
                 {
-                    channel.names_init = true;
-
-                    if let Some((subcommand, priority)) = self
-                        .pending_chathistory_requests
-                        .remove(&Target::Channel(target))
-                    {
-                        self.send_chathistory_request(subcommand, priority);
-                    }
+                    self.channel_users_received(target);
 
                     return Ok(vec![]);
                 }
@@ -2711,7 +2646,12 @@ impl Client {
 
                                                 self.anti_flood = None;
 
-                                                self.who_queue.interval_set_min(self.config.who_poll_interval);
+                                                self.who_queue.update(
+                                                    &self.capabilities,
+                                                    &self.isupport,
+                                                    &self.config,
+                                                    self.chanmap.keys(),
+                                                );
                                             }
                                             isupport::Parameter::BOUNCER_NETID(ref id) => {
                                                 match self.server.bouncer_netid() {
@@ -3060,21 +3000,10 @@ impl Client {
             Command::Numeric(RPL_TRYAGAIN, args) => {
                 let command = ok!(args.get(1));
 
-                if command == "WHO" && self.config.who_poll_enabled {
-                    self.who_queue.who_reply_throttled();
+                if command == "WHO" {
+                    self.who_queue.handle_who_rate_limited(&self.server);
 
-                    log::debug!(
-                        "[{}] WHO poll interval is too short → duration = {:?}",
-                        self.server,
-                        self.who_queue.interval_duration()
-                    );
-
-                    if !self.who_queue.any_matching_inflight(|who_poll| {
-                        matches!(
-                            who_poll.status,
-                            WhoStatus::Requested(WhoSource::User, _, _)
-                        )
-                    }) {
+                    if !self.who_queue.any_user_who_request() {
                         // No user request, rate-limited due to WHO polling
                         return Ok(vec![]);
                     }
@@ -3720,24 +3649,6 @@ impl Client {
         }
     }
 
-    fn user_who_request(&self, channel: &target::Channel) -> bool {
-        self.who_queue.any_matching_inflight(|who_poll| {
-            who_poll.channel == *channel
-                && matches!(
-                    who_poll.status,
-                    WhoStatus::Requested(WhoSource::User, _, _)
-                        | WhoStatus::Receiving(WhoSource::User, _)
-                )
-        })
-    }
-
-    pub fn is_who_init(&self, channel: &target::Channel) -> bool {
-        let Some(client_channel) = self.chanmap.get(channel) else {
-            return false;
-        };
-        client_channel.who_init
-    }
-
     pub fn chathistory_limit(&self) -> u16 {
         if let Some(isupport::Parameter::CHATHISTORY(server_limit)) =
             self.isupport.get(&isupport::Kind::CHATHISTORY)
@@ -3783,22 +3694,16 @@ impl Client {
                     let autorequest = !matches!(priority, TokenPriority::User);
 
                     // If the chathistory request is an automatic request due to
-                    // joining a channel, then we want to wait for the initial,
-                    // implicit NAMES reply to complete before requesting
-                    // chathistory so that we have as much channel state as
-                    // possible when parsing messages.
+                    // joining a channel, then we want to wait for the channel
+                    // users to be initialized (via implicit NAMES on JOIN or
+                    // explicit WHO when no-implicit-names is enabled) before
+                    // requesting chathistory so that we have as much channel
+                    // state as possible when parsing messages.
                     if autorequest
                         && let Some(channel) = target
                             .as_channel()
                             .and_then(|channel| self.chanmap.get_mut(channel))
-                        && ((!self
-                            .capabilities
-                            .acknowledged(Capability::NoImplicitNames)
-                            && !channel.names_init)
-                            || (self
-                                .capabilities
-                                .acknowledged(Capability::NoImplicitNames)
-                                && !channel.who_init))
+                        && !channel.users_init
                     {
                         self.pending_chathistory_requests
                             .insert(target.clone(), (subcommand, priority));
@@ -4162,6 +4067,24 @@ impl Client {
         self.chanmap.keys()
     }
 
+    fn channel_users_received(&mut self, target_channel: target::Channel) {
+        if let Some(client_channel) = self.chanmap.get_mut(&target_channel)
+            && !client_channel.users_init
+        {
+            // If users are not already initialized, then mark as initialized and
+            // send any pending chathistory request.
+
+            client_channel.users_init = true;
+
+            if let Some((subcommand, priority)) = self
+                .pending_chathistory_requests
+                .remove(&Target::Channel(target_channel))
+            {
+                self.send_chathistory_request(subcommand, priority);
+            }
+        }
+    }
+
     fn topic<'a>(&'a self, channel: &target::Channel) -> Option<&'a Topic> {
         self.chanmap.get(channel).map(|channel| &channel.topic)
     }
@@ -4389,10 +4312,8 @@ impl Client {
         for (message, priority) in self.who_queue.tick(
             &self.server,
             &self.capabilities,
-            &self.chanmap,
-            &self.config,
             &self.isupport,
-            now,
+            &now,
         ) {
             self.send(None, message, priority);
         }
@@ -4564,16 +4485,12 @@ impl Client {
         self.capabilities.multiline_limits()
     }
 
-    pub fn prioritize_joined_who_poll(
-        &mut self,
-        channel: &target::Channel,
-        opened_channels: &Vec<(&Server, &target::Channel)>,
-    ) {
-        self.who_queue.reprioritize_joined_who_polls(
-            &self.server,
-            opened_channels,
-            channel,
-        );
+    pub fn prioritize_who_poll(&mut self, channel: &target::Channel) {
+        self.who_queue.prioritize_who_poll(&self.server, channel);
+    }
+
+    pub fn deprioritize_who_poll(&mut self, channel: &target::Channel) {
+        self.who_queue.deprioritize_who_poll(&self.server, channel);
     }
 
     pub fn has_isupport_monitor(&self) -> bool {
@@ -4600,7 +4517,7 @@ impl Client {
     }
 
     pub fn add_monitored_user_automated(&mut self, user: &User) {
-        if self.has_isupport_monitor() {
+        if self.has_isupport_monitor() && !self.is_monitored_user(user) {
             self.monitored_users.insert(
                 user.clone(),
                 MonitoredUser {
@@ -4990,6 +4907,36 @@ impl Map {
     pub fn quit(&mut self, server: &Server, reason: Option<String>) {
         if let Some(client) = self.client_mut(server) {
             client.quit(reason);
+        }
+    }
+
+    pub fn prioritize_who_poll(
+        &mut self,
+        server: &Server,
+        channel: &target::Channel,
+    ) {
+        if let Some(client) = self.client_mut(server) {
+            client.prioritize_who_poll(channel);
+        }
+    }
+
+    pub fn deprioritize_who_poll(
+        &mut self,
+        server: &Server,
+        channel: &target::Channel,
+    ) {
+        if let Some(client) = self.client_mut(server) {
+            client.deprioritize_who_poll(channel);
+        }
+    }
+
+    pub fn add_monitored_user_automated(
+        &mut self,
+        server: &Server,
+        user: &User,
+    ) {
+        if let Some(client) = self.client_mut(server) {
+            client.add_monitored_user_automated(user);
         }
     }
 
@@ -5709,9 +5656,8 @@ enum RegistrationStep {
 #[derive(Debug, Default)]
 pub struct Channel {
     pub users: ChannelUsers,
+    pub users_init: bool,
     pub topic: Topic,
-    pub names_init: bool,
-    pub who_init: bool,
     pub mode: Option<String>,
     pub typing: HashMap<Nick, Instant>,
 }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -530,7 +530,11 @@ impl Client {
             events.push(Event::UpdateIcon);
         }
 
-        self.who_queue.update_config(&self.chanmap, config.clone());
+        self.who_queue.update_config(
+            &self.chanmap,
+            &self.capabilities,
+            &config,
+        );
 
         self.config = config;
 
@@ -538,7 +542,8 @@ impl Client {
     }
 
     fn quit(&mut self, reason: Option<String>) {
-        self.who_queue.clear_queues();
+        self.who_queue
+            .clear_queues(&self.capabilities, &self.config);
 
         if let Err(e) = if let Some(reason) = reason {
             self.handle.try_send(command!("QUIT", reason))
@@ -1940,7 +1945,10 @@ impl Client {
                     );
 
                     // Add channel to WHO poll queue
-                    self.who_queue.queue_joined_who_poll(&target_channel);
+                    self.who_queue.queue_joined_who_poll(
+                        &self.capabilities,
+                        &target_channel,
+                    );
 
                     if !self.mode_requests.iter().any(|mode_request| {
                         mode_request.channel == target_channel
@@ -2069,22 +2077,6 @@ impl Client {
 
                         self.who_queue
                             .receiving_who_poll(&self.server, &target_channel);
-
-                        if self
-                            .capabilities
-                            .acknowledged(Capability::NoImplicitNames)
-                        {
-                            for (message, priority) in
-                                self.who_queue.process_next_prioritized_join(
-                                    &self.server,
-                                    &self.capabilities,
-                                    &self.chanmap,
-                                    &self.isupport,
-                                )
-                            {
-                                self.send(None, message, priority);
-                            }
-                        }
                     }
 
                     let user_request = self.user_who_request(&target_channel);
@@ -2130,22 +2122,6 @@ impl Client {
                             client_channel,
                             args,
                         );
-
-                        if self
-                            .capabilities
-                            .acknowledged(Capability::NoImplicitNames)
-                        {
-                            for (message, priority) in
-                                self.who_queue.process_next_prioritized_join(
-                                    &self.server,
-                                    &self.capabilities,
-                                    &self.chanmap,
-                                    &self.isupport,
-                                )
-                            {
-                                self.send(None, message, priority);
-                            }
-                        }
                     }
 
                     if !user_request {
@@ -2235,6 +2211,10 @@ impl Client {
                     }) || !self.who_queue.remove_matching_inflight(
                         |who_poll| who_poll.channel == target_channel,
                     ) {
+                        log::trace!(
+                            "[{}] - WHO poll rate limited",
+                            &self.server
+                        );
                         self.who_queue.handle_who_rate_limited();
                         return Ok(vec![]);
                     }
@@ -4594,9 +4574,6 @@ impl Client {
             opened_channels,
             channel,
         );
-
-        self.who_queue
-            .prioritize_joined_who_poll(&self.server, channel);
     }
 
     pub fn has_isupport_monitor(&self) -> bool {
@@ -5584,17 +5561,6 @@ impl Map {
                 State::Ready(client) => Some(&client.registry),
             })
             .unwrap_or(metadata::EMPTY)
-    }
-
-    pub fn prioritize_channel_who_poll(
-        &mut self,
-        server: &Server,
-        channel: &target::Channel,
-        opened_channels: &Vec<(&Server, &target::Channel)>,
-    ) {
-        if let Some(client) = self.client_mut(server) {
-            client.prioritize_joined_who_poll(channel, opened_channels);
-        }
     }
 }
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -3720,6 +3720,13 @@ impl Client {
         })
     }
 
+    pub fn is_who_init(&self, channel: &target::Channel) -> bool {
+        let Some(client_channel) = self.chanmap.get(channel) else {
+            return false;
+        };
+        client_channel.who_init
+    }
+
     pub fn chathistory_limit(&self) -> u16 {
         if let Some(isupport::Parameter::CHATHISTORY(server_limit)) =
             self.isupport.get(&isupport::Kind::CHATHISTORY)

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 use std::collections::binary_heap::PeekMut;
-use std::collections::{BTreeMap, BinaryHeap, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, BinaryHeap, HashMap, HashSet};
 use std::mem::take;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -28,11 +28,11 @@ use crate::environment::{SOURCE_WEBSITE, VERSION};
 use crate::features::{self, Features, VersionRequest};
 use crate::history::ReadMarker;
 use crate::isupport::{
-    ChatHistoryState, ChatHistorySubcommand, MessageReference, WhoToken,
-    WhoXPollParameters, find_target_limit, format_optional_message_reference,
+    ChatHistoryState, ChatHistorySubcommand, MessageReference,
+    find_target_limit, format_optional_message_reference,
 };
 use crate::message::source;
-use crate::rate_limit::{BackoffInterval, TokenBucket, TokenPriority};
+use crate::rate_limit::{TokenBucket, TokenPriority};
 use crate::target::{self, Target};
 use crate::time::Posix;
 use crate::user::{ChannelUsers, Nick, NickRef};
@@ -43,6 +43,9 @@ use crate::{
 };
 
 pub mod on_connect;
+pub mod who_queue;
+
+use who_queue::{WhoSource, WhoStatus};
 
 const HIGHLIGHT_BLACKOUT_INTERVAL: Duration = Duration::from_secs(5);
 const CLIENT_CHATHISTORY_LIMIT: u16 = 1000;
@@ -224,8 +227,7 @@ pub struct Client {
     notification_blackout: NotificationBlackout,
     registration_required_channels: Vec<target::Channel>,
     isupport: HashMap<isupport::Kind, isupport::Parameter>,
-    who_polls: VecDeque<WhoPoll>,
-    who_poll_interval: BackoffInterval,
+    who_queue: who_queue::WhoQueue,
     resolved_netid: Option<String>,
     anti_flood: Option<TokenBucket<message::Encoded>>,
     mode_requests: Vec<ModeRequest>,
@@ -292,12 +294,7 @@ impl Client {
             ),
             registration_required_channels: vec![],
             isupport: HashMap::new(),
-            who_polls: VecDeque::new(),
-            who_poll_interval: BackoffInterval::from(
-                config
-                    .who_poll_interval
-                    .min(config.anti_flood.saturating_mul(2)),
-            ),
+            who_queue: who_queue::WhoQueue::new(config.clone()),
             resolved_netid: None,
             anti_flood: Some(TokenBucket::new(config.anti_flood, 10)),
             mode_requests: Vec::new(),
@@ -513,25 +510,6 @@ impl Client {
             return events;
         }
 
-        if self.config.who_poll_enabled != config.who_poll_enabled {
-            if config.who_poll_enabled {
-                for channel in self.chanmap.keys() {
-                    self.who_polls.push_back(WhoPoll {
-                        channel: channel.clone(),
-                        status: WhoStatus::Joined,
-                    });
-                }
-            } else {
-                self.who_polls.retain(|who_poll| {
-                    matches!(
-                        who_poll.status,
-                        WhoStatus::Requested(_, _, _)
-                            | WhoStatus::Receiving(_, _)
-                    )
-                });
-            }
-        }
-
         if self.config.order_channels_by != config.order_channels_by
             || self.config.channels != config.channels
         {
@@ -552,18 +530,15 @@ impl Client {
             events.push(Event::UpdateIcon);
         }
 
+        self.who_queue.update_config(&self.chanmap, config.clone());
+
         self.config = config;
 
         events
     }
 
     fn quit(&mut self, reason: Option<String>) {
-        self.who_polls.retain(|who_poll| {
-            matches!(
-                who_poll.status,
-                WhoStatus::Requested(_, _, _) | WhoStatus::Receiving(_, _)
-            )
-        });
+        self.who_queue.quit();
 
         if let Err(e) = if let Some(reason) = reason {
             self.handle.try_send(command!("QUIT", reason))
@@ -624,7 +599,7 @@ impl Client {
                     // should be in who_polls and rerouting should be stopped, or it
                     // is treated as part of a rate-limiting response and if there
                     // are any outstanding user requests rerouting should be stopped.
-                    self.who_polls.iter().any(|who_poll| {
+                    self.who_queue.any_matching(|who_poll| {
                         matches!(
                             who_poll.status,
                             WhoStatus::Requested(WhoSource::User, _, _)
@@ -736,25 +711,8 @@ impl Client {
                         };
 
                         if let Some(channel) = channel {
-                            // Record user WHO request(s) for reply filtering
-                            let status = WhoStatus::Requested(
-                                WhoSource::User,
-                                Instant::now(),
-                                params.get(2).and_then(|token| {
-                                    token.parse::<WhoToken>().ok()
-                                }),
-                            );
-
-                            if let Some(who_poll) = self
-                                .who_polls
-                                .iter_mut()
-                                .find(|who_poll| who_poll.channel == channel)
-                            {
-                                who_poll.status = status;
-                            } else {
-                                self.who_polls
-                                    .push_front(WhoPoll { channel, status });
-                            }
+                            self.who_queue
+                                .requested_channel_poll(params, channel);
                         }
                     }
                 }
@@ -1944,19 +1902,16 @@ impl Client {
                         self.statusmsg(),
                         casemapping,
                     ));
-                    if let Some(pos) =
-                        self.who_polls.iter().position(|who_poll| {
-                            who_poll.channel == target_channel
-                                && (matches!(
-                                    who_poll.status,
-                                    WhoStatus::Joined
-                                        | WhoStatus::Received
-                                        | WhoStatus::Waiting(_)
-                                ))
-                        })
-                    {
-                        self.who_polls.remove(pos);
-                    }
+                    self.who_queue.remove_matching(|who_poll| {
+                        who_poll.channel == target_channel
+                            && (matches!(
+                                who_poll.status,
+                                WhoStatus::Joined
+                                    | WhoStatus::PrioritizedJoin
+                                    | WhoStatus::Received
+                                    | WhoStatus::Waiting(_)
+                            ))
+                    });
                 } else if let Some(channel) =
                     self.chanmap.get_mut(&context!(target::Channel::parse(
                         channel,
@@ -1998,16 +1953,7 @@ impl Client {
                     );
 
                     // Add channel to WHO poll queue
-                    if !self
-                        .who_polls
-                        .iter()
-                        .any(|who_poll| who_poll.channel == target_channel)
-                    {
-                        self.who_polls.push_front(WhoPoll {
-                            channel: target_channel.clone(),
-                            status: WhoStatus::Joined,
-                        });
-                    }
+                    self.who_queue.queue_channel_poll(&target_channel);
 
                     if !self.mode_requests.iter().any(|mode_request| {
                         mode_request.channel == target_channel
@@ -2134,20 +2080,10 @@ impl Client {
                             );
                         }
 
-                        if let Some(who_poll) = self
-                            .who_polls
-                            .iter_mut()
-                            .find(|who_poll| who_poll.channel == target_channel)
-                            && let WhoStatus::Requested(source, _, None) =
-                                &who_poll.status
-                        {
-                            who_poll.status =
-                                WhoStatus::Receiving(source.clone(), None);
-                            log::trace!(
-                                "[{}] {channel} - WHO receiving...",
-                                self.server
-                            );
-                        }
+                        self.who_queue.receiving_channel_poll(
+                            &self.server,
+                            &target_channel,
+                        );
                     }
 
                     let user_request = self.user_who_request(&target_channel);
@@ -2184,116 +2120,15 @@ impl Client {
 
                     if let Some(client_channel) =
                         self.chanmap.get_mut(&target_channel)
-                        && let Some(who_poll) = self
-                            .who_polls
-                            .iter_mut()
-                            .find(|who_poll| who_poll.channel == target_channel)
                     {
-                        let bot_mode_char =
-                            isupport::get_bot_mode_char(&self.isupport);
-                        match &who_poll.status {
-                            WhoStatus::Requested(
-                                source,
-                                _,
-                                Some(request_token),
-                            ) if matches!(source, WhoSource::Poll) => {
-                                if let Ok(token) =
-                                    ok!(args.get(1)).parse::<WhoToken>()
-                                    && *request_token == token
-                                {
-                                    who_poll.status = WhoStatus::Receiving(
-                                        source.clone(),
-                                        Some(*request_token),
-                                    );
-                                    log::trace!(
-                                        "[{}] {channel} - WHO receiving...",
-                                        self.server
-                                    );
-                                }
-                            }
-                            WhoStatus::Requested(
-                                WhoSource::User,
-                                _,
-                                Some(request_token),
-                            ) => {
-                                who_poll.status = WhoStatus::Receiving(
-                                    WhoSource::User,
-                                    Some(*request_token),
-                                );
-
-                                log::trace!(
-                                    "[{}] {channel} - WHO receiving...",
-                                    self.server
-                                );
-                            }
-                            _ => (),
-                        }
-
-                        if let WhoStatus::Receiving(WhoSource::Poll, Some(_)) =
-                            &who_poll.status
-                        {
-                            // Check token to ~ensure reply is to poll request
-                            if let Ok(token) =
-                                ok!(args.get(1)).parse::<WhoToken>()
-                            {
-                                if token == WhoXPollParameters::Default.token()
-                                {
-                                    client_channel.update_user_status(
-                                        ok!(args.get(3)),
-                                        ok!(args.get(4)),
-                                        casemapping,
-                                        bot_mode_char,
-                                    );
-                                } else if token
-                                    == WhoXPollParameters::WithAccountName
-                                        .token()
-                                {
-                                    client_channel.update_user_status(
-                                        ok!(args.get(3)),
-                                        ok!(args.get(4)),
-                                        casemapping,
-                                        bot_mode_char,
-                                    );
-
-                                    client_channel.update_user_accountname(
-                                        ok!(args.get(3)),
-                                        ok!(args.get(5)),
-                                        casemapping,
-                                    );
-                                } else if token
-                                    == WhoXPollParameters::InitialJoin.token()
-                                    && let flags = ok!(args.get(6))
-                                    && let Ok(mut user) =
-                                        User::parse_from_whoreply(
-                                            ok!(args.get(5)),
-                                            flags,
-                                            ok!(args.get(3)),
-                                            ok!(args.get(4)),
-                                            casemapping,
-                                            isupport::get_prefix(
-                                                &self.isupport,
-                                            ),
-                                        )
-                                    && client_channel
-                                        .users
-                                        .resolve(&user)
-                                        .is_none()
-                                {
-                                    if let Some(account) = args.get(7) {
-                                        user = user.with_accountname(account);
-                                    }
-                                    if flags.starts_with('G') {
-                                        user.update_away(true);
-                                    }
-                                    if let Some(bot_char) = bot_mode_char {
-                                        user.update_bot(
-                                            flags.contains(bot_char),
-                                        );
-                                    }
-                                    client_channel.users.insert(user);
-                                }
-                            }
-                        }
+                        let _ = self.who_queue.handle_whox_reply(
+                            casemapping,
+                            &self.server,
+                            &self.isupport,
+                            &target_channel,
+                            client_channel,
+                            args,
+                        );
                     }
 
                     if !user_request {
@@ -2325,42 +2160,12 @@ impl Client {
                 ) {
                     let user_request = self.user_who_request(&target_channel);
 
-                    if let Some(pos) = self
-                        .who_polls
-                        .iter()
-                        .position(|who_poll| who_poll.channel == target_channel)
-                    {
-                        self.who_polls[pos].status = WhoStatus::Received;
-
-                        if let Some(who_poll) = self.who_polls.remove(pos)
-                            && self.chanmap.contains_key(&target_channel)
-                            && self.config.who_poll_enabled
-                        {
-                            self.who_polls.push_back(who_poll);
-                        }
-
-                        // Prioritize WHO requests due to joining a channel
-                        if let Some(pos) = self
-                            .who_polls
-                            .iter()
-                            .position(|who_poll| {
-                                matches!(who_poll.status, WhoStatus::Joined)
-                            })
-                            .or(self.who_polls.iter().position(|who_poll| {
-                                matches!(who_poll.status, WhoStatus::Received)
-                            }))
-                        {
-                            self.who_polls[pos].status =
-                                WhoStatus::Waiting(Instant::now());
-
-                            if pos != 0
-                                && let Some(who_poll) =
-                                    self.who_polls.remove(pos)
-                            {
-                                self.who_polls.push_front(who_poll);
-                            }
-                        }
-                    }
+                    self.who_queue.handle_end_who_reply(
+                        &self.chanmap,
+                        &self.config,
+                        &self.capabilities,
+                        &target_channel,
+                    );
 
                     log::trace!("[{}] {mask} - WHO done", self.server);
 
@@ -2371,7 +2176,7 @@ impl Client {
                     }
 
                     if !user_request {
-                        self.who_poll_interval.long_enough();
+                        self.who_queue.interval_long_enough();
 
                         // User did not request, don't save to history
                         return Ok(vec![]);
@@ -2397,24 +2202,10 @@ impl Client {
                         self.casemapping(),
                     );
 
-                    if let Some(pos) = self
-                        .who_polls
-                        .iter()
-                        .position(|who_poll| who_poll.channel == target_channel)
-                    {
-                        self.who_polls.remove(pos);
-                    } else {
-                        // User did not request, treat as part of rate-limiting response
-                        // (in conjunction with RPL_TRYAGAIN) and don't save to history.
-                        if let Some(who_poll) = self.who_polls.front_mut() {
-                            who_poll.status =
-                                WhoStatus::Waiting(Instant::now());
-                        }
-
-                        self.who_polls.iter_mut().skip(1).for_each(
-                            |who_poll| who_poll.status = WhoStatus::Received,
-                        );
-
+                    if !self.who_queue.remove_matching(|who_poll| {
+                        who_poll.channel == target_channel
+                    }) {
+                        self.who_queue.handle_who_rate_limit();
                         return Ok(vec![]);
                     }
                 }
@@ -2909,7 +2700,7 @@ impl Client {
 
                                                 self.anti_flood = None;
 
-                                                self.who_poll_interval.set_min(self.config.who_poll_interval);
+                                                self.who_queue.interval_set_min(self.config.who_poll_interval);
                                             }
                                             isupport::Parameter::BOUNCER_NETID(ref id) => {
                                                 match self.server.bouncer_netid() {
@@ -3259,15 +3050,15 @@ impl Client {
                 let command = ok!(args.get(1));
 
                 if command == "WHO" && self.config.who_poll_enabled {
-                    self.who_poll_interval.too_short();
+                    self.who_queue.interval_too_short();
 
                     log::debug!(
                         "[{}] WHO poll interval is too short → duration = {:?}",
                         self.server,
-                        self.who_poll_interval.duration()
+                        self.who_queue.interval_duration()
                     );
 
-                    if !self.who_polls.iter().any(|who_poll| {
+                    if !self.who_queue.any_matching(|who_poll| {
                         matches!(
                             who_poll.status,
                             WhoStatus::Requested(WhoSource::User, _, _)
@@ -3919,19 +3710,14 @@ impl Client {
     }
 
     fn user_who_request(&self, channel: &target::Channel) -> bool {
-        if let Some(who_poll) = self
-            .who_polls
-            .iter()
-            .find(|who_poll| who_poll.channel == *channel)
-        {
-            matches!(
-                who_poll.status,
-                WhoStatus::Requested(WhoSource::User, _, _)
-                    | WhoStatus::Receiving(WhoSource::User, _)
-            )
-        } else {
-            false
-        }
+        self.who_queue.any_matching(|who_poll| {
+            who_poll.channel == *channel
+                && matches!(
+                    who_poll.status,
+                    WhoStatus::Requested(WhoSource::User, _, _)
+                        | WhoStatus::Receiving(WhoSource::User, _)
+                )
+        })
     }
 
     pub fn chathistory_limit(&self) -> u16 {
@@ -4575,109 +4361,15 @@ impl Client {
             .for_each(|channel| prune_expired_typing(&mut channel.typing));
         prune_expired_querymap(&mut self.querymap);
 
-        if let Some(who_poll) = self.who_polls.front_mut() {
-            #[derive(Debug)]
-            enum Request {
-                Poll,
-                Retry,
-            }
-
-            let request = match &who_poll.status {
-                WhoStatus::Joined => (self
-                    .capabilities
-                    .acknowledged(Capability::NoImplicitNames)
-                    || self.capabilities.acknowledged(Capability::AwayNotify)
-                    || self.config.who_poll_enabled)
-                    .then_some(Request::Poll),
-                WhoStatus::Waiting(last) => {
-                    if self.capabilities.acknowledged(Capability::AwayNotify) {
-                        self.chanmap.get(&who_poll.channel).and_then(
-                            |channel| {
-                                (!channel.who_init
-                                    && (now.duration_since(*last)
-                                        >= self.who_poll_interval.duration()))
-                                .then_some(Request::Poll)
-                            },
-                        )
-                    } else {
-                        ((self
-                            .capabilities
-                            .acknowledged(Capability::NoImplicitNames)
-                            || self.config.who_poll_enabled)
-                            && (now.duration_since(*last)
-                                >= self.who_poll_interval.duration()))
-                        .then_some(Request::Poll)
-                    }
-                }
-                WhoStatus::Requested(source, requested, _) => {
-                    if matches!(source, WhoSource::Poll)
-                        && !self.config.who_poll_enabled
-                    {
-                        None
-                    } else {
-                        (now.duration_since(*requested)
-                            >= 5 * self.who_poll_interval.duration())
-                        .then_some(Request::Retry)
-                    }
-                }
-                _ => None,
-            };
-
-            if let Some(request) = request {
-                log::trace!(
-                    "[{}] {} - WHO {}",
-                    self.server,
-                    who_poll.channel,
-                    match request {
-                        Request::Poll => "poll",
-                        Request::Retry => "retry",
-                    }
-                );
-
-                let message =
-                    if self.isupport.contains_key(&isupport::Kind::WHOX) {
-                        let whox_params = if self
-                            .capabilities
-                            .acknowledged(Capability::NoImplicitNames)
-                            && self
-                                .chanmap
-                                .get(&who_poll.channel)
-                                .is_none_or(|channel| !channel.who_init)
-                        {
-                            WhoXPollParameters::InitialJoin
-                        } else if self
-                            .capabilities
-                            .acknowledged(Capability::AccountNotify)
-                        {
-                            WhoXPollParameters::WithAccountName
-                        } else {
-                            WhoXPollParameters::Default
-                        };
-
-                        who_poll.status = WhoStatus::Requested(
-                            WhoSource::Poll,
-                            Instant::now(),
-                            Some(whox_params.token()),
-                        );
-
-                        command!(
-                            "WHO",
-                            who_poll.channel.to_string(),
-                            whox_params.fields().to_string(),
-                            whox_params.token().to_owned()
-                        )
-                    } else {
-                        who_poll.status = WhoStatus::Requested(
-                            WhoSource::Poll,
-                            Instant::now(),
-                            None,
-                        );
-
-                        command!("WHO", who_poll.channel.to_string())
-                    };
-
-                self.send(None, message.into(), TokenPriority::Low);
-            }
+        for (message, priority) in self.who_queue.tick(
+            &self.server,
+            &self.capabilities,
+            &self.chanmap,
+            &self.config,
+            &self.isupport,
+            now,
+        ) {
+            self.send(None, message, priority);
         }
 
         self.mode_requests.retain(|mode_request| {
@@ -4848,18 +4540,7 @@ impl Client {
     }
 
     pub fn prioritize_joined_who_poll(&mut self, channel: target::Channel) {
-        if let Some(pos) = self.who_polls.iter().position(|who_poll| {
-            who_poll.channel == channel
-                && !matches!(
-                    who_poll.status,
-                    WhoStatus::Received | WhoStatus::Waiting(_)
-                )
-        }) && pos != 0
-            && let Some(who_poll) = self.who_polls.remove(pos)
-        {
-            log::debug!("prioritizing who poll for: {channel:?}");
-            self.who_polls.push_front(who_poll);
-        }
+        self.who_queue.prioritize_joined_who_poll(channel);
     }
 
     pub fn has_isupport_monitor(&self) -> bool {
@@ -5848,6 +5529,16 @@ impl Map {
             })
             .unwrap_or(metadata::EMPTY)
     }
+
+    pub fn prioritize_channel_who_poll(
+        &mut self,
+        server: &Server,
+        channel: target::Channel,
+    ) {
+        if let Some(client) = self.client_mut(server) {
+            client.prioritize_joined_who_poll(channel);
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -6063,27 +5754,6 @@ pub struct Topic {
     pub content: Option<message::Content>,
     pub who: Option<User>,
     pub time: Option<DateTime<Utc>>,
-}
-
-#[derive(Debug, Clone)]
-pub struct WhoPoll {
-    pub channel: target::Channel,
-    pub status: WhoStatus,
-}
-
-#[derive(Debug, Clone)]
-pub enum WhoStatus {
-    Requested(WhoSource, Instant, Option<WhoToken>),
-    Receiving(WhoSource, Option<WhoToken>),
-    Received,
-    Waiting(Instant),
-    Joined,
-}
-
-#[derive(Debug, Clone)]
-pub enum WhoSource {
-    User,
-    Poll,
 }
 
 #[derive(Debug, Clone)]

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -4546,8 +4546,15 @@ impl Client {
         self.capabilities.multiline_limits()
     }
 
-    pub fn prioritize_joined_who_poll(&mut self, channel: target::Channel) {
+    pub fn prioritize_joined_who_poll(
+        &mut self,
+        channel: target::Channel,
+        opened_channels: Vec<(&Server, &target::Channel)>,
+    ) {
         self.who_queue.prioritize_joined_who_poll(channel);
+
+        self.who_queue
+            .reprioritize_joined_who_polls(&self.server, opened_channels);
     }
 
     pub fn has_isupport_monitor(&self) -> bool {
@@ -5541,9 +5548,10 @@ impl Map {
         &mut self,
         server: &Server,
         channel: target::Channel,
+        opened_channels: Vec<(&Server, &target::Channel)>,
     ) {
         if let Some(client) = self.client_mut(server) {
-            client.prioritize_joined_who_poll(channel);
+            client.prioritize_joined_who_poll(channel, opened_channels);
         }
     }
 }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -2190,8 +2190,19 @@ impl Client {
 
                     if let Some(client_channel) =
                         self.chanmap.get_mut(&target_channel)
+                        && !client_channel.who_init
                     {
                         client_channel.who_init = true;
+
+                        if self
+                            .capabilities
+                            .acknowledged(Capability::NoImplicitNames)
+                            && let Some((subcommand, priority)) = self
+                                .pending_chathistory_requests
+                                .remove(&Target::Channel(target_channel))
+                        {
+                            self.send_chathistory_request(subcommand, priority);
+                        }
                     }
 
                     if !user_request {
@@ -2430,7 +2441,8 @@ impl Client {
                     self.casemapping(),
                 ));
 
-                if let Some(channel) = self.chanmap.get_mut(&target)
+                if !self.capabilities.acknowledged(Capability::NoImplicitNames)
+                    && let Some(channel) = self.chanmap.get_mut(&target)
                     && !channel.names_init
                 {
                     channel.names_init = true;
@@ -3795,7 +3807,14 @@ impl Client {
                         && let Some(channel) = target
                             .as_channel()
                             .and_then(|channel| self.chanmap.get_mut(channel))
-                        && !channel.names_init
+                        && ((!self
+                            .capabilities
+                            .acknowledged(Capability::NoImplicitNames)
+                            && !channel.names_init)
+                            || (self
+                                .capabilities
+                                .acknowledged(Capability::NoImplicitNames)
+                                && !channel.who_init))
                     {
                         self.pending_chathistory_requests
                             .insert(target.clone(), (subcommand, priority));

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1924,7 +1924,8 @@ impl Client {
                 })]);
             }
             Command::PART(channel, _) => {
-                let user = ok!(message.user(self.casemapping()));
+                let casemapping = self.casemapping();
+                let user = ok!(message.user(casemapping));
 
                 if user.nickname() == self.nickname() {
                     self.chanmap.shift_remove(&context!(
@@ -1935,6 +1936,21 @@ impl Client {
                             self.casemapping(),
                         )
                     ));
+
+                    // Remove departed channel who polls from queue
+                    let target_channel = context!(target::Channel::parse(
+                        channel,
+                        self.chantypes(),
+                        self.statusmsg(),
+                        casemapping,
+                    ));
+                    if let Some(pos) = self
+                        .who_polls
+                        .iter()
+                        .position(|who_poll| who_poll.channel == target_channel)
+                    {
+                        self.who_polls.remove(pos);
+                    }
                 } else if let Some(channel) =
                     self.chanmap.get_mut(&context!(target::Channel::parse(
                         channel,
@@ -1981,7 +1997,7 @@ impl Client {
                         .iter()
                         .any(|who_poll| who_poll.channel == target_channel)
                     {
-                        self.who_polls.push_back(WhoPoll {
+                        self.who_polls.push_front(WhoPoll {
                             channel: target_channel.clone(),
                             status: WhoStatus::Joined,
                         });
@@ -2307,39 +2323,15 @@ impl Client {
                         }
 
                         // Prioritize WHO requests due to joining a channel
-                        if self
-                            .capabilities
-                            .acknowledged(Capability::NoImplicitNames)
-                            && let Some(pos) =
-                                self.who_polls.iter().position(|who_poll| {
-                                    matches!(
-                                        who_poll.status,
-                                        WhoStatus::Requested(..)
-                                    )
-                                })
-                            && pos != 0
-                            && let Some(who_poll) = self.who_polls.remove(pos)
-                        {
-                            self.who_polls.push_front(who_poll);
-                        }
-
-                        if !self
-                            .capabilities
-                            .acknowledged(Capability::NoImplicitNames)
-                            && let Some(pos) = self
-                                .who_polls
-                                .iter()
-                                .position(|who_poll| {
-                                    matches!(who_poll.status, WhoStatus::Joined)
-                                })
-                                .or(self.who_polls.iter().position(
-                                    |who_poll| {
-                                        matches!(
-                                            who_poll.status,
-                                            WhoStatus::Received
-                                        )
-                                    },
-                                ))
+                        if let Some(pos) = self
+                            .who_polls
+                            .iter()
+                            .position(|who_poll| {
+                                matches!(who_poll.status, WhoStatus::Joined)
+                            })
+                            .or(self.who_polls.iter().position(|who_poll| {
+                                matches!(who_poll.status, WhoStatus::Received)
+                            }))
                         {
                             self.who_polls[pos].status =
                                 WhoStatus::Waiting(Instant::now());
@@ -4593,7 +4585,10 @@ impl Client {
                             },
                         )
                     } else {
-                        (self.config.who_poll_enabled
+                        ((self
+                            .capabilities
+                            .acknowledged(Capability::NoImplicitNames)
+                            || self.config.who_poll_enabled)
                             && (now.duration_since(*last)
                                 >= self.who_poll_interval.duration()))
                         .then_some(Request::Poll)
@@ -4826,6 +4821,19 @@ impl Client {
 
     pub fn multiline_limits(&self) -> Option<MultilineLimits> {
         self.capabilities.multiline_limits()
+    }
+
+    pub fn prioritize_joined_who_poll(&mut self, channel: target::Channel) {
+        if let Some(pos) = self
+            .who_polls
+            .iter()
+            .position(|who_poll| who_poll.channel == channel)
+            && pos != 0
+            && let Some(who_poll) = self.who_polls.remove(pos)
+        {
+            log::debug!("prioritizing who poll for: {channel:?}");
+            self.who_polls.push_front(who_poll);
+        }
     }
 
     pub fn has_isupport_monitor(&self) -> bool {

--- a/data/src/client/who_queue.rs
+++ b/data/src/client/who_queue.rs
@@ -1,0 +1,489 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::anyhow;
+use indexmap::IndexMap;
+use irc::proto::command;
+
+use crate::capabilities::{Capabilities, Capability};
+use crate::isupport::{self, WhoToken, WhoXPollParameters};
+use crate::rate_limit::{BackoffInterval, TokenPriority};
+use crate::target::Channel;
+use crate::{User, client, config, message};
+
+#[derive(Debug, Clone)]
+pub struct WhoPoll {
+    pub channel: Channel,
+    pub status: WhoStatus,
+}
+
+#[derive(Debug, Clone)]
+pub enum WhoStatus {
+    Requested(WhoSource, Instant, Option<WhoToken>),
+    Receiving(WhoSource, Option<WhoToken>),
+    Received,
+    Waiting(Instant),
+    Joined,
+    PrioritizedJoin,
+}
+
+#[derive(Debug, Clone)]
+pub enum WhoSource {
+    User,
+    Poll,
+}
+
+#[derive(Debug, Clone)]
+pub struct WhoQueue {
+    config: Arc<config::Server>,
+    polls: VecDeque<WhoPoll>,
+    interval: BackoffInterval,
+}
+
+impl WhoQueue {
+    pub fn new(config: Arc<config::Server>) -> Self {
+        let interval = BackoffInterval::from(
+            config
+                .who_poll_interval
+                .min(config.anti_flood.saturating_mul(2)),
+        );
+
+        Self {
+            config,
+            polls: VecDeque::new(),
+            interval,
+        }
+    }
+
+    pub fn tick(
+        &mut self,
+        server: &client::Server,
+        capabilities: &Capabilities,
+        chanmap: &IndexMap<Channel, client::Channel>,
+        config: &Arc<config::Server>,
+        isupport: &HashMap<isupport::Kind, isupport::Parameter>,
+        now: Instant,
+    ) -> Vec<(message::Encoded, TokenPriority)> {
+        let mut messages: Vec<(message::Encoded, TokenPriority)> = vec![];
+        if let Some(who_poll) = self.polls.front_mut() {
+            #[derive(Debug)]
+            enum Request {
+                Poll,
+                Retry,
+            }
+
+            let request = match &who_poll.status {
+                WhoStatus::Joined | WhoStatus::PrioritizedJoin => (capabilities
+                    .acknowledged(Capability::NoImplicitNames)
+                    || capabilities.acknowledged(Capability::AwayNotify)
+                    || config.who_poll_enabled)
+                    .then_some(Request::Poll),
+                WhoStatus::Waiting(last) => ((capabilities
+                    .acknowledged(Capability::NoImplicitNames)
+                    || config.who_poll_enabled)
+                    && (now.duration_since(*last) >= self.interval.duration()))
+                .then_some(Request::Poll),
+                WhoStatus::Requested(source, requested, _) => {
+                    if matches!(source, WhoSource::Poll)
+                        && !config.who_poll_enabled
+                    {
+                        None
+                    } else {
+                        (now.duration_since(*requested)
+                            >= 5 * self.interval.duration())
+                        .then_some(Request::Retry)
+                    }
+                }
+                _ => None,
+            };
+
+            if let Some(request) = request {
+                log::trace!(
+                    "[{}] {} - WHO {}",
+                    server,
+                    who_poll.channel,
+                    match request {
+                        Request::Poll => "poll",
+                        Request::Retry => "retry",
+                    }
+                );
+
+                let message = if isupport.contains_key(&isupport::Kind::WHOX) {
+                    let whox_params = if capabilities
+                        .acknowledged(Capability::NoImplicitNames)
+                        && chanmap
+                            .get(&who_poll.channel)
+                            .is_none_or(|channel| !channel.who_init)
+                    {
+                        WhoXPollParameters::InitialJoin
+                    } else if capabilities
+                        .acknowledged(Capability::AccountNotify)
+                    {
+                        WhoXPollParameters::WithAccountName
+                    } else {
+                        WhoXPollParameters::Default
+                    };
+
+                    who_poll.status = WhoStatus::Requested(
+                        WhoSource::Poll,
+                        Instant::now(),
+                        Some(whox_params.token()),
+                    );
+
+                    command!(
+                        "WHO",
+                        who_poll.channel.to_string(),
+                        whox_params.fields().to_string(),
+                        whox_params.token().to_owned()
+                    )
+                } else {
+                    who_poll.status = WhoStatus::Requested(
+                        WhoSource::Poll,
+                        Instant::now(),
+                        None,
+                    );
+
+                    command!("WHO", who_poll.channel.to_string())
+                };
+
+                messages.push((message.into(), TokenPriority::Low));
+            }
+        }
+
+        messages
+    }
+
+    pub fn update_config(
+        &mut self,
+        chanmap: &IndexMap<Channel, client::Channel>,
+        config: Arc<config::Server>,
+    ) {
+        if self.config.who_poll_enabled != config.who_poll_enabled {
+            if config.who_poll_enabled {
+                for channel in chanmap.keys() {
+                    self.polls.push_back(WhoPoll {
+                        channel: channel.clone(),
+                        status: WhoStatus::Joined,
+                    });
+                }
+            } else {
+                self.polls.retain(|who_poll| {
+                    matches!(
+                        who_poll.status,
+                        WhoStatus::Requested(_, _, _)
+                            | WhoStatus::Receiving(_, _)
+                    )
+                });
+            }
+        }
+        self.config = config;
+    }
+
+    pub fn quit(&mut self) {
+        self.polls.retain(|who_poll| {
+            matches!(
+                who_poll.status,
+                WhoStatus::Requested(_, _, _) | WhoStatus::Receiving(_, _)
+            )
+        });
+    }
+
+    pub fn any_matching<F>(&self, f: F) -> bool
+    where
+        F: Fn(&WhoPoll) -> bool,
+    {
+        self.polls.iter().any(f)
+    }
+
+    pub fn pos_matching<F>(&self, f: F) -> Option<usize>
+    where
+        F: Fn(&WhoPoll) -> bool,
+    {
+        self.polls.iter().position(f)
+    }
+
+    pub fn remove_matching<F>(&mut self, f: F) -> bool
+    where
+        F: Fn(&WhoPoll) -> bool,
+    {
+        if let Some(pos) = self.pos_matching(f) {
+            self.polls.remove(pos);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn requested_channel_poll(
+        &mut self,
+        params: Vec<String>,
+        channel: Channel,
+    ) {
+        // Record user WHO request(s) for reply filtering
+        let status = WhoStatus::Requested(
+            WhoSource::User,
+            Instant::now(),
+            params
+                .get(2)
+                .and_then(|token| token.parse::<WhoToken>().ok()),
+        );
+
+        if let Some(who_poll) = self
+            .polls
+            .iter_mut()
+            .find(|who_poll| who_poll.channel == channel)
+        {
+            who_poll.status = status;
+        } else {
+            self.polls.push_front(WhoPoll { channel, status });
+        }
+    }
+
+    pub fn queue_channel_poll(&mut self, channel: &Channel) {
+        if !self
+            .polls
+            .iter()
+            .any(|who_poll| who_poll.channel == *channel)
+        {
+            self.polls.push_front(WhoPoll {
+                channel: channel.to_owned(),
+                status: WhoStatus::Joined,
+            });
+        }
+    }
+
+    pub fn receiving_channel_poll(
+        &mut self,
+        server: &client::Server,
+        channel: &Channel,
+    ) {
+        if let Some(who_poll) = self
+            .polls
+            .iter_mut()
+            .find(|who_poll| who_poll.channel == *channel)
+            && let WhoStatus::Requested(source, _, None) = &who_poll.status
+        {
+            who_poll.status = WhoStatus::Receiving(source.clone(), None);
+            log::trace!("[{server}] {channel} - WHO receiving...");
+        }
+    }
+
+    pub fn handle_whox_reply(
+        &mut self,
+        casemapping: isupport::CaseMap,
+        server: &client::Server,
+        isupport: &HashMap<isupport::Kind, isupport::Parameter>,
+        target_channel: &Channel,
+        client_channel: &mut client::Channel,
+        args: &[String],
+    ) -> anyhow::Result<()> {
+        macro_rules! ok {
+            ($option:expr) => {
+                $option.ok_or_else(|| {
+                    anyhow!("[{}] Malformed WHOX reply", server)
+                })?
+            };
+        }
+
+        let bot_mode_char = isupport::get_bot_mode_char(isupport);
+
+        if let Some(who_poll) = self
+            .polls
+            .iter_mut()
+            .find(|who_poll| who_poll.channel == *target_channel)
+        {
+            match &who_poll.status {
+                WhoStatus::Requested(source, _, Some(request_token))
+                    if matches!(source, WhoSource::Poll) =>
+                {
+                    if let Ok(token) = ok!(args.get(1)).parse::<WhoToken>()
+                        && *request_token == token
+                    {
+                        who_poll.status = WhoStatus::Receiving(
+                            source.clone(),
+                            Some(*request_token),
+                        );
+                        log::trace!(
+                            "[{server}] {target_channel} - WHO receiving...",
+                        );
+                    }
+                }
+                WhoStatus::Requested(
+                    WhoSource::User,
+                    _,
+                    Some(request_token),
+                ) => {
+                    who_poll.status = WhoStatus::Receiving(
+                        WhoSource::User,
+                        Some(*request_token),
+                    );
+
+                    log::trace!(
+                        "[{server}] {target_channel} - WHO receiving...",
+                    );
+                }
+                _ => (),
+            }
+
+            if let WhoStatus::Receiving(WhoSource::Poll, Some(_)) =
+                &who_poll.status
+            {
+                // Check token to ~ensure reply is to poll request
+                if let Ok(token) = ok!(args.get(1)).parse::<WhoToken>() {
+                    if token == WhoXPollParameters::Default.token() {
+                        client_channel.update_user_status(
+                            ok!(args.get(3)),
+                            ok!(args.get(4)),
+                            casemapping,
+                            bot_mode_char,
+                        );
+                    } else if token
+                        == WhoXPollParameters::WithAccountName.token()
+                    {
+                        let nick = ok!(args.get(3));
+
+                        client_channel.update_user_status(
+                            nick,
+                            ok!(args.get(4)),
+                            casemapping,
+                            bot_mode_char,
+                        );
+
+                        client_channel.update_user_accountname(
+                            nick,
+                            ok!(args.get(5)),
+                            casemapping,
+                        );
+                    } else if token == WhoXPollParameters::InitialJoin.token()
+                        && let flags = ok!(args.get(6))
+                        && let nick = ok!(args.get(5))
+                        && let Ok(user) = User::parse_from_whoreply(
+                            nick,
+                            flags,
+                            ok!(args.get(3)),
+                            ok!(args.get(4)),
+                            casemapping,
+                            isupport::get_prefix(isupport),
+                        )
+                        && client_channel.users.resolve(&user).is_none()
+                    {
+                        client_channel.users.insert(user);
+
+                        client_channel.update_user_status(
+                            nick,
+                            flags,
+                            casemapping,
+                            bot_mode_char,
+                        );
+
+                        client_channel.update_user_accountname(
+                            nick,
+                            ok!(args.get(7)),
+                            casemapping,
+                        );
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn handle_end_who_reply(
+        &mut self,
+        chanmap: &IndexMap<Channel, client::Channel>,
+        config: &Arc<config::Server>,
+        capabilities: &Capabilities,
+        channel: &Channel,
+    ) {
+        if let Some(pos) = self
+            .polls
+            .iter()
+            .position(|who_poll| who_poll.channel == *channel)
+        {
+            self.polls[pos].status = WhoStatus::Received;
+
+            if let Some(who_poll) = self.polls.remove(pos)
+                && chanmap.contains_key(channel)
+                && config.who_poll_enabled
+                && !capabilities.acknowledged(Capability::AwayNotify)
+            {
+                self.polls.push_back(who_poll);
+            }
+
+            // Prioritize WHO requests due to joining a channel
+            if let Some(pos) = self
+                .polls
+                .iter()
+                .position(|who_poll| {
+                    matches!(who_poll.status, WhoStatus::PrioritizedJoin)
+                })
+                .or(self.polls.iter().position(|who_poll| {
+                    matches!(who_poll.status, WhoStatus::Joined)
+                }))
+                .or(self.polls.iter().position(|who_poll| {
+                    matches!(who_poll.status, WhoStatus::Received)
+                }))
+            {
+                self.polls[pos].status = WhoStatus::Waiting(Instant::now());
+
+                if pos != 0
+                    && let Some(who_poll) = self.polls.remove(pos)
+                {
+                    self.polls.push_front(who_poll);
+                }
+            }
+        }
+    }
+
+    pub fn interval_long_enough(&mut self) {
+        self.interval.long_enough();
+    }
+
+    pub fn interval_set_min(&mut self, interval: Duration) {
+        self.interval.set_min(interval);
+    }
+
+    pub fn interval_too_short(&mut self) {
+        self.interval.too_short();
+    }
+
+    pub fn interval_duration(&self) -> Duration {
+        self.interval.duration()
+    }
+
+    // User did not request, treat as part of rate-limiting response
+    // (in conjunction with RPL_TRYAGAIN) and don't save to history.
+    pub fn handle_who_rate_limit(&mut self) {
+        if let Some(who_poll) = self.polls.front_mut() {
+            who_poll.status = WhoStatus::Waiting(Instant::now());
+        }
+
+        self.polls
+            .iter_mut()
+            .skip(1)
+            .for_each(|who_poll| who_poll.status = WhoStatus::Received);
+    }
+
+    pub fn prioritize_joined_who_poll(&mut self, channel: Channel) {
+        if let Some(pos) = self.polls.iter().position(|who_poll| {
+            who_poll.channel == channel
+                && matches!(
+                    who_poll.status,
+                    WhoStatus::Joined
+                        | WhoStatus::PrioritizedJoin
+                        | WhoStatus::Waiting(_)
+                )
+        }) && pos != 0
+            && let Some(mut who_poll) = self.polls.remove(pos)
+        {
+            if matches!(who_poll.status, WhoStatus::Joined) {
+                who_poll.status = WhoStatus::PrioritizedJoin;
+            }
+
+            log::debug!("prioritizing who poll for: {channel:?}");
+            self.polls.push_front(who_poll);
+        }
+    }
+}

--- a/data/src/client/who_queue.rs
+++ b/data/src/client/who_queue.rs
@@ -1,9 +1,9 @@
+use std::cmp::Ordering;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::anyhow;
-use indexmap::IndexMap;
 use irc::proto::command;
 
 use crate::capabilities::{Capabilities, Capability};
@@ -17,55 +17,132 @@ use crate::{User, client, config, message};
 pub struct WhoPoll {
     pub channel: Channel,
     pub status: WhoStatus,
+    pub source: WhoSource,
 }
 
 #[derive(Debug, Clone)]
 pub enum WhoStatus {
-    Requested(WhoSource, Instant, Option<WhoToken>),
-    Receiving(WhoSource, Option<WhoToken>),
-    Received,
-    Waiting(Option<Instant>),
+    Requested {
+        at: Instant,
+        token: Option<WhoToken>,
+    },
+    Receiving {
+        last_received: Instant,
+        token: Option<WhoToken>,
+    },
+    Waiting {
+        immediate: bool,
+    },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum WhoSource {
     User,
+    Join { priority: bool },
     Poll,
 }
 
-#[derive(Debug, Clone)]
-pub enum WhoRequest {
-    Poll,
-    Retry,
+impl Ord for WhoSource {
+    fn cmp(&self, other: &Self) -> Ordering {
+        if self == other {
+            Ordering::Equal
+        } else {
+            match (self, other) {
+                (WhoSource::User, _) => Ordering::Less,
+                (WhoSource::Join { .. }, WhoSource::User) => Ordering::Greater,
+                (WhoSource::Join { priority }, WhoSource::Join { .. }) => {
+                    if *priority {
+                        Ordering::Less
+                    } else {
+                        Ordering::Greater
+                    }
+                }
+                (WhoSource::Join { .. }, _) => Ordering::Less,
+                (WhoSource::Poll, _) => Ordering::Greater,
+            }
+        }
+    }
+}
+
+impl PartialOrd for WhoSource {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct WhoQueue {
-    config: Arc<config::Server>,
-    poll_queue: VecDeque<WhoPoll>,
-    join_queue: VecDeque<WhoPoll>,
-    priority_join_queue: VecDeque<WhoPoll>,
-    inflight: Vec<WhoPoll>,
+    queue: VecDeque<WhoPoll>,
+    in_flight: Vec<WhoPoll>,
+    in_flight_limit: usize,
     interval: BackoffInterval,
-    last_throttled: Option<Instant>,
+    reference_time: Option<Instant>,
 }
 
 impl WhoQueue {
-    pub fn new(config: Arc<config::Server>) -> Self {
+    pub fn new(config: &Arc<config::Server>) -> Self {
+        // Prevent the poll interval from being too short compared to the
+        // anti-flood rate, to avoid overfilling the send queue with WHO polls.
         let interval = BackoffInterval::from(
             config
                 .who_poll_interval
-                .min(config.anti_flood.saturating_mul(2)),
+                .max(config.anti_flood.saturating_mul(2)),
         );
 
         Self {
-            config,
-            poll_queue: VecDeque::new(),
-            join_queue: VecDeque::new(),
-            priority_join_queue: VecDeque::new(),
-            inflight: Vec::new(),
+            queue: VecDeque::new(),
+            in_flight: Vec::new(),
+            in_flight_limit: 1,
             interval,
-            last_throttled: None,
+            reference_time: None,
+        }
+    }
+
+    pub fn update<'a>(
+        &mut self,
+        capabilities: &Capabilities,
+        isupport: &HashMap<isupport::Kind, isupport::Parameter>,
+        config: &Arc<config::Server>,
+        joined_channels: impl Iterator<Item = &'a Channel>,
+    ) {
+        if capabilities.acknowledged(Capability::NoImplicitNames) {
+            self.in_flight_limit = 64;
+        } else {
+            self.in_flight_limit = 1;
+        }
+
+        if isupport.contains_key(&isupport::Kind::SAFELIST) {
+            self.interval.set_min(config.who_poll_interval);
+        } else {
+            self.interval.set_min(
+                config
+                    .who_poll_interval
+                    .max(config.anti_flood.saturating_mul(2)),
+            );
+        }
+
+        if config.who_poll_enabled
+            && !capabilities.acknowledged(Capability::AwayNotify)
+        {
+            for channel in joined_channels {
+                if !self
+                    .in_flight
+                    .iter()
+                    .chain(self.queue.iter())
+                    .any(|who_poll| who_poll.channel == *channel)
+                {
+                    let who_poll = WhoPoll {
+                        channel: channel.clone(),
+                        source: WhoSource::Poll,
+                        status: WhoStatus::Waiting { immediate: false },
+                    };
+
+                    self.insert_towards_back(who_poll);
+                }
+            }
+        } else {
+            self.queue
+                .retain(|who_poll| !matches!(who_poll.source, WhoSource::Poll));
         }
     }
 
@@ -73,280 +150,160 @@ impl WhoQueue {
         &mut self,
         server: &client::Server,
         capabilities: &Capabilities,
-        chanmap: &IndexMap<Channel, client::Channel>,
-        config: &Arc<config::Server>,
         isupport: &HashMap<isupport::Kind, isupport::Parameter>,
-        now: Instant,
+        now: &Instant,
     ) -> Vec<(message::Encoded, TokenPriority)> {
-        let mut messages: Vec<(message::Encoded, TokenPriority)> = vec![];
+        let interval_duration = self.interval.duration();
+        let reference_time = self.reference_time;
 
-        if !self.priority_join_queue.is_empty() || !self.join_queue.is_empty() {
-            const DEFAULT_PARALLEL_POLLS: usize = 1;
+        // Find any timed out polls and return them in the queue.
 
-            let is_throttled = if let Some(last_throttled) = self.last_throttled
-                && now.duration_since(last_throttled)
-                    >= self.interval.duration()
-            {
-                true
+        let timed_out_polls: Vec<_> = self
+            .in_flight
+            .extract_if(.., |who_poll| {
+                can_send_who_poll(
+                    false,
+                    &interval_duration,
+                    &reference_time,
+                    now,
+                    who_poll,
+                )
+            })
+            .collect();
+
+        for who_poll in timed_out_polls.into_iter() {
+            self.insert_towards_front(who_poll);
+        }
+
+        // Prepare polls to be sent during this tick.
+
+        let mut who_polls_to_send = vec![];
+
+        for _ in 0..self.in_flight_limit.saturating_sub(self.in_flight.len()) {
+            if let Some(who_poll) = self.queue.pop_front_if(|who_poll| {
+                can_send_who_poll(
+                    self.in_flight.is_empty() && who_polls_to_send.is_empty(),
+                    &interval_duration,
+                    &reference_time,
+                    now,
+                    who_poll,
+                )
+            }) {
+                who_polls_to_send.push(who_poll);
             } else {
-                false
-            };
-            // no-implicit-names support SHOULD allow 1 free WHO per channel joined.
-            let max_parallel_polls = if capabilities
-                .acknowledged(Capability::NoImplicitNames)
-                && !is_throttled
-            {
-                chanmap.len()
-            } else {
-                DEFAULT_PARALLEL_POLLS
-            };
-
-            let mut execute_polls = vec![];
-            for _ in 0..max_parallel_polls {
-                let duration = self.interval.duration();
-                if let Some(who_poll) = self.priority_join_queue.pop_front() {
-                    if is_safe_poll_interval(duration, &now, &who_poll) {
-                        execute_polls.push(who_poll);
-                    } else {
-                        self.priority_join_queue.push_back(who_poll);
-                    }
-                } else if let Some(who_poll) = self.join_queue.pop_front() {
-                    if is_safe_poll_interval(duration, &now, &who_poll) {
-                        execute_polls.push(who_poll);
-                    } else {
-                        self.join_queue.push_back(who_poll);
-                    }
-                } else {
-                    break;
-                }
+                break;
             }
-            // if there's room, take 1 from the poll_queue
-            if execute_polls.len() < max_parallel_polls
-                && (capabilities.acknowledged(Capability::NoImplicitNames)
-                    || config.who_poll_enabled)
-                && let Some(who_poll) =
-                    self.poll_queue.pop_front_if(|who_poll| {
-                        is_safe_poll_interval(
-                            self.interval.duration(),
-                            &now,
-                            who_poll,
-                        )
-                    })
-            {
-                execute_polls.push(who_poll);
-            }
+        }
 
-            log::trace!(
-                "[{server}] - WHO polls parallel running {} of {}",
-                execute_polls.len(),
-                max_parallel_polls
-            );
-            for mut who_poll in execute_polls {
-                tick_who_poll_request(
-                    capabilities,
-                    chanmap,
-                    isupport,
-                    server,
-                    WhoRequest::Poll,
-                    &mut who_poll,
-                    &mut messages,
-                    Some(&mut self.inflight),
+        // If any polls will be sent, then update the reference time used for
+        // determining if polls can be sent (and thus also for throttling).
+        if !who_polls_to_send.is_empty() {
+            self.reference_time = Some(*now);
+        }
+
+        let number_of_who_polls = who_polls_to_send.len();
+
+        who_polls_to_send
+            .into_iter()
+            .enumerate()
+            .map(|(request_number, who_poll)| {
+                log::trace!(
+                    "[{server}] {} - WHO {}{}",
+                    who_poll.channel,
+                    if matches!(who_poll.status, WhoStatus::Waiting { .. }) {
+                        "request"
+                    } else {
+                        "retry"
+                    },
+                    if number_of_who_polls > 1 {
+                        format!(" ({request_number} of {number_of_who_polls})")
+                    } else {
+                        String::new()
+                    }
                 );
-            }
-        } else if config.who_poll_enabled
-            && let Some(mut who_poll) =
-                self.poll_queue.pop_front_if(|who_poll| {
-                    is_safe_poll_interval(
-                        self.interval.duration(),
-                        &now,
-                        who_poll,
-                    )
-                })
+
+                self.send_who_poll(capabilities, isupport, who_poll)
+            })
+            .collect()
+    }
+
+    pub fn clear(&mut self) {
+        self.queue.clear();
+    }
+
+    pub fn is_user_who_request(&self, channel: &Channel) -> bool {
+        self.in_flight.iter().any(|who_poll| {
+            who_poll.channel == *channel
+                && matches!(who_poll.source, WhoSource::User)
+        })
+    }
+
+    pub fn any_user_who_request(&self) -> bool {
+        self.in_flight
+            .iter()
+            .any(|who_poll| matches!(who_poll.source, WhoSource::User))
+    }
+
+    pub fn parted_channel(&mut self, channel: &Channel) {
+        if let Some(pos) = self
+            .queue
+            .iter()
+            .position(|who_poll| who_poll.channel == *channel)
         {
-            tick_who_poll_request(
-                capabilities,
-                chanmap,
-                isupport,
-                server,
-                WhoRequest::Poll,
-                &mut who_poll,
-                &mut messages,
-                Some(&mut self.inflight),
-            );
-        } else if let Some(who_poll) = self.inflight.first_mut()
-            && let WhoStatus::Requested(source, requested, _) = &who_poll.status
-            && (!matches!(source, WhoSource::Poll) || config.who_poll_enabled)
-            && (now.duration_since(*requested) >= 5 * self.interval.duration())
-        {
-            tick_who_poll_request(
-                capabilities,
-                chanmap,
-                isupport,
-                server,
-                WhoRequest::Poll,
-                who_poll,
-                &mut messages,
-                None,
-            );
+            self.queue.remove(pos);
         }
-
-        messages
     }
 
-    pub fn update_config(
+    // Record user WHO request(s) for reply filtering.
+    pub fn user_requested_who_poll(
         &mut self,
-        chanmap: &IndexMap<Channel, client::Channel>,
-        capabilities: &Capabilities,
-        config: &Arc<config::Server>,
-    ) {
-        if self.config.who_poll_enabled != config.who_poll_enabled {
-            self.clear_queues(capabilities, config);
-
-            if config.who_poll_enabled {
-                for channel in chanmap.keys() {
-                    self.join_queue.push_back(WhoPoll {
-                        channel: channel.clone(),
-                        status: WhoStatus::Waiting(default_waiting_option(
-                            capabilities,
-                        )),
-                    });
-                }
-            }
-        }
-        self.config = config.clone();
-    }
-
-    pub fn clear_queues(
-        &mut self,
-        capabilities: &Capabilities,
-        config: &Arc<config::Server>,
-    ) {
-        if is_join_queue_enabled(capabilities, config) {
-            self.priority_join_queue.truncate(0);
-            self.join_queue.truncate(0);
-        }
-        if config.who_poll_enabled {
-            self.poll_queue.truncate(0);
-        }
-    }
-
-    pub fn any_matching_inflight<F>(&self, f: F) -> bool
-    where
-        F: Fn(&WhoPoll) -> bool,
-    {
-        self.inflight.iter().any(f)
-    }
-
-    pub fn has_inflight(&self) -> bool {
-        !self.inflight.is_empty()
-    }
-
-    pub fn remove_matching_polls<F>(&mut self, f: F) -> bool
-    where
-        F: Fn(&WhoPoll) -> bool,
-    {
-        let mut removed = false;
-        if let Some(pos) = self.poll_queue.iter().position(&f) {
-            self.poll_queue.remove(pos);
-            removed = true;
-        }
-        if let Some(pos) = self.join_queue.iter().position(&f) {
-            self.join_queue.remove(pos);
-            removed = true;
-        }
-        if let Some(pos) = self.priority_join_queue.iter().position(&f) {
-            self.priority_join_queue.remove(pos);
-            removed = true;
-        }
-        removed
-    }
-
-    pub fn remove_matching_inflight<F>(&mut self, f: F) -> bool
-    where
-        F: Fn(&WhoPoll) -> bool,
-    {
-        if let Some(pos) = self.inflight.iter().position(f) {
-            self.inflight.remove(pos);
-            true
-        } else {
-            false
-        }
-    }
-
-    pub fn user_requested_channel_poll(
-        &mut self,
-        params: Vec<String>,
         channel: Channel,
+        token: Option<WhoToken>,
     ) {
-        // Record user WHO request(s) for reply filtering
-        let status = WhoStatus::Requested(
-            WhoSource::User,
-            Instant::now(),
-            params
-                .get(2)
-                .and_then(|token| token.parse::<WhoToken>().ok()),
-        );
+        let who_poll = WhoPoll {
+            channel,
+            status: WhoStatus::Requested {
+                at: Instant::now(),
+                token,
+            },
+            source: WhoSource::User,
+        };
 
         if let Some(pos) = self
-            .priority_join_queue
+            .queue
             .iter()
-            .position(|who_poll| who_poll.channel == channel)
-            && let Some(mut who_poll) = self.priority_join_queue.remove(pos)
+            .position(|queued_poll| queued_poll.channel == who_poll.channel)
         {
-            who_poll.status = status;
-            self.inflight.push(who_poll);
-        } else if self.priority_join_queue.is_empty()
-            && let Some(pos) = self
-                .join_queue
-                .iter()
-                .position(|who_poll| who_poll.channel == channel)
-            && let Some(mut who_poll) = self.join_queue.remove(pos)
-        {
-            who_poll.status = status;
-            self.inflight.push(who_poll);
-        } else if self.join_queue.is_empty()
-            && let Some(pos) = self
-                .poll_queue
-                .iter()
-                .position(|who_poll| who_poll.channel == channel)
-            && let Some(mut who_poll) = self.poll_queue.remove(pos)
-        {
-            who_poll.status = status;
-            self.inflight.push(who_poll);
-        } else {
-            self.inflight.push(WhoPoll { channel, status });
+            self.queue.remove(pos);
         }
+
+        self.in_flight.push(who_poll);
     }
 
-    pub fn queue_joined_who_poll(
+    pub fn queue_join_who_request(
         &mut self,
         capabilities: &Capabilities,
         channel: &Channel,
     ) {
-        if !self
-            .priority_join_queue
+        let who_poll = if let Some(pos) = self
+            .queue
             .iter()
-            .any(|who_poll| who_poll.channel == *channel)
-            && !self
-                .join_queue
-                .iter()
-                .any(|who_poll| who_poll.channel == *channel)
-            && !self
-                .poll_queue
-                .iter()
-                .any(|who_poll| who_poll.channel == *channel)
-            && !self
-                .inflight
-                .iter()
-                .any(|who_poll| who_poll.channel == *channel)
+            .position(|who_poll| who_poll.channel == *channel)
+            && let Some(who_poll) = self.queue.remove(pos)
         {
-            self.join_queue.push_front(WhoPoll {
-                channel: channel.to_owned(),
-                status: WhoStatus::Waiting(default_waiting_option(
-                    capabilities,
-                )),
-            });
-        }
+            who_poll
+        } else {
+            WhoPoll {
+                channel: channel.clone(),
+                source: WhoSource::Join { priority: false },
+                status: WhoStatus::Waiting {
+                    immediate: capabilities
+                        .acknowledged(Capability::NoImplicitNames),
+                },
+            }
+        };
+
+        self.insert_towards_back(who_poll);
     }
 
     pub fn receiving_who_poll(
@@ -355,19 +312,96 @@ impl WhoQueue {
         channel: &Channel,
     ) {
         if let Some(who_poll) = self
-            .inflight
+            .in_flight
             .iter_mut()
             .find(|who_poll| who_poll.channel == *channel)
-            && let WhoStatus::Requested(source, _, None) = &who_poll.status
+            && let WhoStatus::Requested { token, .. } = who_poll.status
         {
-            who_poll.status = WhoStatus::Receiving(source.clone(), None);
+            who_poll.status = WhoStatus::Receiving {
+                last_received: Instant::now(),
+                token,
+            };
+
             log::trace!("[{server}] {channel} - WHO receiving...");
         }
     }
 
+    pub fn handle_who_reply(
+        &mut self,
+        server: &client::Server,
+        isupport: &HashMap<isupport::Kind, isupport::Parameter>,
+        target_channel: &Channel,
+        client_channel: &mut client::Channel,
+        args: &[String],
+    ) -> anyhow::Result<()> {
+        macro_rules! ok {
+            ($option:expr) => {
+                $option.ok_or_else(|| {
+                    anyhow!("[{}] Malformed WHO reply", server)
+                })?
+            };
+        }
+
+        if let Some(who_poll) = self
+            .in_flight
+            .iter_mut()
+            .find(|who_poll| who_poll.channel == *target_channel)
+        {
+            match &mut who_poll.status {
+                WhoStatus::Receiving { last_received, .. } => {
+                    *last_received = Instant::now();
+                }
+                WhoStatus::Requested { token: None, .. } => {
+                    who_poll.status = WhoStatus::Receiving {
+                        last_received: Instant::now(),
+                        token: None,
+                    };
+
+                    log::trace!("[{server}] {target_channel} - receiving WHO",);
+                }
+                WhoStatus::Requested { token: Some(_), .. }
+                | WhoStatus::Waiting { .. } => {
+                    log::debug!(
+                        "[{server}] {target_channel} - receiving unexpected WHO",
+                    );
+                }
+            }
+        }
+
+        let casemapping = isupport::get_casemapping_or_default(isupport);
+        let bot_mode_char = isupport::get_bot_mode_char(isupport);
+
+        let nick = ok!(args.get(5));
+        let flags = ok!(args.get(6));
+        let username = ok!(args.get(2));
+        let hostname = ok!(args.get(3));
+
+        let user = User::from_whoreply(
+            nick,
+            flags,
+            username,
+            hostname,
+            None,
+            casemapping,
+            bot_mode_char,
+        );
+
+        if client_channel.users.contains(&user) {
+            client_channel.update_user_status(
+                nick,
+                flags,
+                casemapping,
+                bot_mode_char,
+            );
+        } else {
+            client_channel.users.insert(user);
+        }
+
+        Ok(())
+    }
+
     pub fn handle_whox_reply(
         &mut self,
-        casemapping: isupport::CaseMap,
         server: &client::Server,
         isupport: &HashMap<isupport::Kind, isupport::Parameter>,
         target_channel: &Channel,
@@ -382,55 +416,65 @@ impl WhoQueue {
             };
         }
 
-        let bot_mode_char = isupport::get_bot_mode_char(isupport);
-
         if let Some(who_poll) = self
-            .inflight
+            .in_flight
             .iter_mut()
             .find(|who_poll| who_poll.channel == *target_channel)
         {
-            match &who_poll.status {
-                WhoStatus::Requested(source, _, Some(request_token))
-                    if matches!(source, WhoSource::Poll) =>
-                {
-                    if let Ok(token) = ok!(args.get(1)).parse::<WhoToken>()
+            match &mut who_poll.status {
+                WhoStatus::Receiving { last_received, .. } => {
+                    *last_received = Instant::now();
+                }
+                WhoStatus::Requested {
+                    token: Some(request_token),
+                    ..
+                } => {
+                    if matches!(who_poll.source, WhoSource::User) {
+                        who_poll.status = WhoStatus::Receiving {
+                            last_received: Instant::now(),
+                            token: Some(*request_token),
+                        };
+                    } else if let Ok(token) =
+                        ok!(args.get(1)).parse::<WhoToken>()
                         && *request_token == token
                     {
-                        who_poll.status = WhoStatus::Receiving(
-                            source.clone(),
-                            Some(*request_token),
-                        );
+                        who_poll.status = WhoStatus::Receiving {
+                            last_received: Instant::now(),
+                            token: Some(*request_token),
+                        };
+
                         log::trace!(
-                            "[{server}] {target_channel} - WHO receiving...",
+                            "[{server}] {target_channel} - receiving WHO",
                         );
                     }
                 }
-                WhoStatus::Requested(
-                    WhoSource::User,
-                    _,
-                    Some(request_token),
-                ) => {
-                    who_poll.status = WhoStatus::Receiving(
-                        WhoSource::User,
-                        Some(*request_token),
-                    );
-
-                    log::trace!(
-                        "[{server}] {target_channel} - WHO receiving...",
+                WhoStatus::Requested { token: None, .. }
+                | WhoStatus::Waiting { .. } => {
+                    log::debug!(
+                        "[{server}] {target_channel} - receiving unexpected WHO",
                     );
                 }
-                _ => (),
             }
 
-            if let WhoStatus::Receiving(WhoSource::Poll, Some(_)) =
-                &who_poll.status
-            {
+            // Don't bother trying to parse user-initiated WHO requests since we
+            // do not currently track user WHO poll request parameters.
+            if matches!(
+                who_poll.source,
+                WhoSource::Poll | WhoSource::Join { .. }
+            ) {
+                let casemapping =
+                    isupport::get_casemapping_or_default(isupport);
+                let bot_mode_char = isupport::get_bot_mode_char(isupport);
+
                 // Check token to ~ensure reply is to poll request
                 if let Ok(token) = ok!(args.get(1)).parse::<WhoToken>() {
                     if token == WhoXPollParameters::Default.token() {
+                        let nick = ok!(args.get(3));
+                        let flags = ok!(args.get(4));
+
                         client_channel.update_user_status(
-                            ok!(args.get(3)),
-                            ok!(args.get(4)),
+                            nick,
+                            flags,
                             casemapping,
                             bot_mode_char,
                         );
@@ -438,33 +482,7 @@ impl WhoQueue {
                         == WhoXPollParameters::WithAccountName.token()
                     {
                         let nick = ok!(args.get(3));
-
-                        client_channel.update_user_status(
-                            nick,
-                            ok!(args.get(4)),
-                            casemapping,
-                            bot_mode_char,
-                        );
-
-                        client_channel.update_user_accountname(
-                            nick,
-                            ok!(args.get(5)),
-                            casemapping,
-                        );
-                    } else if token == WhoXPollParameters::InitialJoin.token()
-                        && let flags = ok!(args.get(6))
-                        && let nick = ok!(args.get(5))
-                        && let Ok(user) = User::parse_from_whoreply(
-                            nick,
-                            flags,
-                            ok!(args.get(3)),
-                            ok!(args.get(4)),
-                            casemapping,
-                            isupport::get_prefix(isupport),
-                        )
-                        && client_channel.users.resolve(&user).is_none()
-                    {
-                        client_channel.users.insert(user);
+                        let flags = ok!(args.get(4));
 
                         client_channel.update_user_status(
                             nick,
@@ -473,11 +491,46 @@ impl WhoQueue {
                             bot_mode_char,
                         );
 
+                        let accountname = ok!(args.get(5));
+
                         client_channel.update_user_accountname(
                             nick,
-                            ok!(args.get(7)),
+                            accountname,
                             casemapping,
                         );
+                    } else if token == WhoXPollParameters::InitialJoin.token() {
+                        let flags = ok!(args.get(6));
+                        let nick = ok!(args.get(5));
+                        let username = ok!(args.get(3));
+                        let hostname = ok!(args.get(4));
+                        let accountname = ok!(args.get(7));
+
+                        let user = User::from_whoreply(
+                            nick,
+                            flags,
+                            username,
+                            hostname,
+                            Some(accountname),
+                            casemapping,
+                            isupport::get_bot_mode_char(isupport),
+                        );
+
+                        if client_channel.users.contains(&user) {
+                            client_channel.update_user_status(
+                                nick,
+                                flags,
+                                casemapping,
+                                bot_mode_char,
+                            );
+
+                            client_channel.update_user_accountname(
+                                nick,
+                                accountname,
+                                casemapping,
+                            );
+                        } else {
+                            client_channel.users.insert(user);
+                        }
                     }
                 }
             }
@@ -488,222 +541,181 @@ impl WhoQueue {
 
     pub fn handle_end_who_reply(
         &mut self,
-        chanmap: &IndexMap<Channel, client::Channel>,
-        config: &Arc<config::Server>,
-        capabilities: &Capabilities,
         channel: &Channel,
+        is_joined: bool,
+        capabilities: &Capabilities,
+        config: &Arc<config::Server>,
     ) {
         if let Some(pos) = self
-            .inflight
+            .in_flight
             .iter()
             .position(|who_poll| who_poll.channel == *channel)
         {
-            let mut who_poll = self.inflight.remove(pos);
-            if chanmap.contains_key(channel)
-                && config.who_poll_enabled
+            let who_poll = self.in_flight.remove(pos);
+
+            let user_request = matches!(who_poll.source, WhoSource::User);
+
+            // Check whether the WHO polling is enabled & needed (for updating
+            // away state of a joined channel).
+            if config.who_poll_enabled
                 && !capabilities.acknowledged(Capability::AwayNotify)
+                && is_joined
+                && !self
+                    .queue
+                    .iter()
+                    .any(|queued_poll| queued_poll.channel == who_poll.channel)
             {
-                who_poll.status = WhoStatus::Received;
-                self.poll_queue.push_back(who_poll);
+                self.insert_towards_back(WhoPoll {
+                    status: WhoStatus::Waiting { immediate: false },
+                    source: WhoSource::Poll,
+                    ..who_poll
+                });
             }
 
-            // Prioritize WHO poll requests due to joining a channel
-            if let Some(pos) = self.poll_queue.iter().position(|who_poll| {
-                matches!(who_poll.status, WhoStatus::Received)
-            }) {
-                self.poll_queue[pos].status =
-                    WhoStatus::Waiting(default_waiting_option(capabilities));
-
-                if pos != 0
-                    && let Some(who_poll) = self.poll_queue.remove(pos)
-                {
-                    self.poll_queue.push_front(who_poll);
-                }
+            if !user_request {
+                self.interval.long_enough();
             }
         }
-    }
-
-    pub fn interval_long_enough(&mut self) {
-        self.interval.long_enough();
-    }
-
-    pub fn interval_set_min(&mut self, interval: Duration) {
-        self.interval.set_min(interval);
-    }
-
-    pub fn who_reply_throttled(&mut self) {
-        self.last_throttled = Some(Instant::now());
-
-        self.interval.too_short();
-    }
-
-    pub fn interval_duration(&self) -> Duration {
-        self.interval.duration()
     }
 
     // User did not request, treat as part of rate-limiting response
     // (in conjunction with RPL_TRYAGAIN) and don't save to history.
-    pub fn handle_who_rate_limited(&mut self) {
-        if let Some(who_poll) = self.poll_queue.front_mut() {
-            who_poll.status = WhoStatus::Waiting(Some(Instant::now()));
+    pub fn handle_who_rate_limited(&mut self, server: &client::Server) {
+        self.interval.too_short();
+
+        self.reference_time = Some(Instant::now());
+
+        for who_poll in self.queue.iter_mut() {
+            who_poll.status = WhoStatus::Waiting { immediate: false };
         }
-        self.poll_queue
-            .iter_mut()
-            .skip(1)
-            .for_each(|who_poll| who_poll.status = WhoStatus::Received);
+
+        log::debug!(
+            "[{server}] WHO poll interval is too short → duration = {:?}",
+            self.interval.duration()
+        );
     }
 
-    pub fn prioritize_joined_who_poll(
+    pub fn prioritize_who_poll(&mut self, server: &Server, channel: &Channel) {
+        if let Some(pos) = self.queue.iter().position(|who_poll| {
+            who_poll.channel == *channel
+                && matches!(who_poll.source, WhoSource::Join { .. })
+        }) && let Some(mut who_poll) = self.queue.remove(pos)
+        {
+            log::trace!("[{server}] {channel} - prioritizing WHO poll",);
+
+            who_poll.source = WhoSource::Join { priority: true };
+
+            self.insert_towards_front(who_poll);
+        }
+    }
+
+    pub fn deprioritize_who_poll(
         &mut self,
         server: &Server,
         channel: &Channel,
     ) {
-        if let Some(pos) = self
-            .join_queue
-            .iter()
-            .position(|who_poll| &who_poll.channel == channel)
-            && let Some(who_poll) = self.join_queue.remove(pos)
+        if let Some(pos) = self.queue.iter().position(|who_poll| {
+            who_poll.channel == *channel
+                && matches!(who_poll.source, WhoSource::Join { priority: true })
+        }) && let Some(mut who_poll) = self.queue.remove(pos)
         {
-            log::trace!(
-                "[{}] {} - WHO poll prioritizing join",
-                server,
-                channel.as_normalized_str(),
-            );
-            self.priority_join_queue.push_front(who_poll);
+            log::trace!("[{server}] {channel} - deprioritizing WHO poll",);
+
+            who_poll.source = WhoSource::Join { priority: false };
+
+            self.insert_towards_front(who_poll);
         }
     }
 
-    pub fn deprioritize_joined_who_poll(
+    fn send_who_poll(
         &mut self,
-        server: &Server,
-        channel: Channel,
-    ) {
-        if let Some(pos) = self
-            .priority_join_queue
-            .iter()
-            .position(|who_poll| who_poll.channel == channel)
-            && let Some(who_poll) = self.join_queue.remove(pos)
-        {
-            log::trace!(
-                "[{}] {} - WHO poll deprioritizing join",
-                server,
-                channel.as_normalized_str()
-            );
+        capabilities: &Capabilities,
+        isupport: &HashMap<isupport::Kind, isupport::Parameter>,
+        mut who_poll: WhoPoll,
+    ) -> (message::Encoded, TokenPriority) {
+        let message = if isupport.contains_key(&isupport::Kind::WHOX) {
+            let whox_params = if capabilities
+                .acknowledged(Capability::NoImplicitNames)
+                && matches!(who_poll.source, WhoSource::Join { .. })
+            {
+                WhoXPollParameters::InitialJoin
+            } else if capabilities.acknowledged(Capability::AccountNotify) {
+                WhoXPollParameters::WithAccountName
+            } else {
+                WhoXPollParameters::Default
+            };
 
-            self.join_queue.push_front(who_poll);
-        }
-    }
+            who_poll.status = WhoStatus::Requested {
+                at: Instant::now(),
+                token: Some(whox_params.token()),
+            };
 
-    pub fn reprioritize_joined_who_polls(
-        &mut self,
-        server: &Server,
-        opened_channels: &Vec<(&Server, &Channel)>,
-        prioritize_channel: &Channel,
-    ) {
-        let channels_to_deprioritize: Vec<Channel> = self
-            .priority_join_queue
-            .iter()
-            .filter(|who_poll| {
-                who_poll.channel != *prioritize_channel
-                    && !opened_channels
-                        .iter()
-                        .any(|(s, c)| *s == server && *c == &who_poll.channel)
-            })
-            .map(|who_poll| who_poll.channel.to_owned())
-            .collect();
-
-        for channel in channels_to_deprioritize {
-            self.deprioritize_joined_who_poll(server, channel);
-        }
-
-        self.prioritize_joined_who_poll(server, prioritize_channel);
-    }
-}
-
-fn tick_who_poll_request(
-    capabilities: &Capabilities,
-    chanmap: &IndexMap<Channel, client::Channel>,
-    isupport: &HashMap<isupport::Kind, isupport::Parameter>,
-    server: &Server,
-    request: WhoRequest,
-    who_poll: &mut WhoPoll,
-    messages: &mut Vec<(message::Encoded, TokenPriority)>,
-    inflight: Option<&mut Vec<WhoPoll>>,
-) {
-    log::trace!(
-        "[{server}] {} - WHO {}",
-        who_poll.channel,
-        match request {
-            WhoRequest::Poll => "poll",
-            WhoRequest::Retry => "retry",
-        }
-    );
-    let message = if isupport.contains_key(&isupport::Kind::WHOX) {
-        let whox_params = if capabilities
-            .acknowledged(Capability::NoImplicitNames)
-            && chanmap
-                .get(&who_poll.channel)
-                .is_none_or(|channel| !channel.who_init)
-        {
-            WhoXPollParameters::InitialJoin
-        } else if capabilities.acknowledged(Capability::AccountNotify) {
-            WhoXPollParameters::WithAccountName
+            command!(
+                "WHO",
+                who_poll.channel.to_string(),
+                whox_params.fields().to_string(),
+                whox_params.token().to_owned()
+            )
         } else {
-            WhoXPollParameters::Default
+            who_poll.status = WhoStatus::Requested {
+                at: Instant::now(),
+                token: None,
+            };
+
+            command!("WHO", who_poll.channel.to_string())
         };
 
-        who_poll.status = WhoStatus::Requested(
-            WhoSource::Poll,
-            Instant::now(),
-            Some(whox_params.token()),
-        );
+        self.in_flight.push(who_poll);
 
-        command!(
-            "WHO",
-            who_poll.channel.to_string(),
-            whox_params.fields().to_string(),
-            whox_params.token().to_owned()
-        )
-    } else {
-        who_poll.status =
-            WhoStatus::Requested(WhoSource::Poll, Instant::now(), None);
+        (message.into(), TokenPriority::Low)
+    }
 
-        command!("WHO", who_poll.channel.to_string())
-    };
-    messages.push((message.into(), TokenPriority::Low));
-    if let Some(inflight) = inflight {
-        inflight.push(who_poll.to_owned());
+    // Insert poll based on sort order, at the back of its sort category.
+    fn insert_towards_back(&mut self, who_poll: WhoPoll) {
+        let at = self.queue.partition_point(|queued_poll| {
+            who_poll.source <= queued_poll.source
+        });
+        self.queue.insert(at, who_poll);
+    }
+
+    // Insert poll based on sort order, at the front of its sort category.
+    fn insert_towards_front(&mut self, who_poll: WhoPoll) {
+        let at = self.queue.partition_point(|queued_poll| {
+            who_poll.source < queued_poll.source
+        });
+        self.queue.insert(at, who_poll);
     }
 }
 
-fn is_join_queue_enabled(
-    capabilities: &Capabilities,
-    config: &Arc<config::Server>,
-) -> bool {
-    capabilities.acknowledged(Capability::NoImplicitNames)
-        || capabilities.acknowledged(Capability::AwayNotify)
-        || config.who_poll_enabled
-}
-
-fn default_waiting_option(capabilities: &Capabilities) -> Option<Instant> {
-    if !capabilities.acknowledged(Capability::NoImplicitNames)
-        && !capabilities.acknowledged(Capability::AwayNotify)
-    {
-        return Some(Instant::now());
-    }
-
-    None
-}
-
-fn is_safe_poll_interval(
-    duration: Duration,
+fn can_send_who_poll(
+    no_polls_in_flight_or_to_send: bool,
+    interval_duration: &Duration,
+    reference_time: &Option<Instant>,
     now: &Instant,
     who_poll: &WhoPoll,
 ) -> bool {
-    if let WhoStatus::Waiting(Some(last)) = who_poll.status
-        && now.duration_since(last) < duration
+    if matches!(who_poll.source, WhoSource::Poll)
+        && matches!(who_poll.status, WhoStatus::Waiting { .. })
+        && !no_polls_in_flight_or_to_send
     {
         return false;
     }
-    true
+
+    match who_poll.status {
+        WhoStatus::Waiting { immediate } => {
+            if immediate {
+                true
+            } else if let Some(reference_time) = reference_time {
+                now.duration_since(*reference_time) > *interval_duration
+            } else {
+                true
+            }
+        }
+        WhoStatus::Requested { at, .. } => {
+            now.duration_since(at) > 5 * *interval_duration
+        }
+        WhoStatus::Receiving { last_received, .. } => {
+            now.duration_since(last_received) > 5 * *interval_duration
+        }
+    }
 }

--- a/data/src/client/who_queue.rs
+++ b/data/src/client/who_queue.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::anyhow;
 use indexmap::IndexMap;
-use irc::proto::{Message, command};
+use irc::proto::command;
 
 use crate::capabilities::{Capabilities, Capability};
 use crate::isupport::{self, WhoToken, WhoXPollParameters};
@@ -21,18 +21,22 @@ pub struct WhoPoll {
 
 #[derive(Debug, Clone)]
 pub enum WhoStatus {
-    Requested(WhoSource, Instant, Option<WhoToken>), // inflight
-    Receiving(WhoSource, Option<WhoToken>),          // inflight
-    Received,                                        // poll
-    Waiting(Instant),                                // poll
-    Joined,                                          // join
-    PrioritizedJoin,                                 // priority_join
+    Requested(WhoSource, Instant, Option<WhoToken>),
+    Receiving(WhoSource, Option<WhoToken>),
+    Received,
+    Waiting(Option<Instant>),
 }
 
 #[derive(Debug, Clone)]
 pub enum WhoSource {
     User,
     Poll,
+}
+
+#[derive(Debug, Clone)]
+pub enum WhoRequest {
+    Poll,
+    Retry,
 }
 
 #[derive(Debug, Clone)]
@@ -76,100 +80,114 @@ impl WhoQueue {
     ) -> Vec<(message::Encoded, TokenPriority)> {
         let mut messages: Vec<(message::Encoded, TokenPriority)> = vec![];
 
-        if let Some(mut who_poll) = self.priority_join_queue.pop_front() {
-            if capabilities.acknowledged(Capability::NoImplicitNames)
-                || capabilities.acknowledged(Capability::AwayNotify)
-                || config.who_poll_enabled
+        if !self.priority_join_queue.is_empty() || !self.join_queue.is_empty() {
+            const DEFAULT_PARALLEL_POLLS: usize = 1;
+
+            let is_throttled = if let Some(last_throttled) = self.last_throttled
+                && now.duration_since(last_throttled)
+                    >= self.interval.duration()
             {
-                log::trace!(
-                    "[{}] {} - WHO poll - priority join queue",
-                    server,
-                    who_poll.channel
-                );
-
-                let message = tick_who_poll_request(
-                    &mut who_poll,
-                    capabilities,
-                    chanmap,
-                    isupport,
-                );
-                self.inflight.push(who_poll);
-
-                messages.push((message.into(), TokenPriority::Low));
+                true
             } else {
-                self.priority_join_queue.push_back(who_poll);
-            }
-        } else if self.priority_join_queue.is_empty()
-            && let Some(mut who_poll) = self.join_queue.pop_front()
-        {
-            if capabilities.acknowledged(Capability::NoImplicitNames)
-                || capabilities.acknowledged(Capability::AwayNotify)
-                || config.who_poll_enabled
+                false
+            };
+            // no-implicit-names support SHOULD allow 1 free WHO per channel joined.
+            let max_parallel_polls = if capabilities
+                .acknowledged(Capability::NoImplicitNames)
+                && !is_throttled
             {
-                log::trace!(
-                    "[{}] {} - WHO poll - join queue",
-                    server,
-                    who_poll.channel
-                );
-
-                let message = tick_who_poll_request(
-                    &mut who_poll,
-                    capabilities,
-                    chanmap,
-                    isupport,
-                );
-                self.inflight.push(who_poll);
-
-                messages.push((message.into(), TokenPriority::Low));
+                chanmap.len()
             } else {
-                self.join_queue.push_back(who_poll);
+                DEFAULT_PARALLEL_POLLS
+            };
+
+            let mut execute_polls = vec![];
+            for _ in 0..max_parallel_polls {
+                let duration = self.interval.duration();
+                if let Some(who_poll) = self.priority_join_queue.pop_front() {
+                    if is_safe_poll_interval(duration, &now, &who_poll) {
+                        execute_polls.push(who_poll);
+                    } else {
+                        self.priority_join_queue.push_back(who_poll);
+                    }
+                } else if let Some(who_poll) = self.join_queue.pop_front() {
+                    if is_safe_poll_interval(duration, &now, &who_poll) {
+                        execute_polls.push(who_poll);
+                    } else {
+                        self.join_queue.push_back(who_poll);
+                    }
+                } else {
+                    break;
+                }
             }
-        } else if self.join_queue.is_empty()
-            && let Some(mut who_poll) = self.poll_queue.pop_front()
-        {
-            if let WhoStatus::Waiting(last) = &who_poll.status
-                && ((capabilities.acknowledged(Capability::NoImplicitNames)
+            // if there's room, take 1 from the poll_queue
+            if execute_polls.len() < max_parallel_polls
+                && (capabilities.acknowledged(Capability::NoImplicitNames)
                     || config.who_poll_enabled)
-                    && (now.duration_since(*last) >= self.interval.duration()))
+                && let Some(who_poll) =
+                    self.poll_queue.pop_front_if(|who_poll| {
+                        is_safe_poll_interval(
+                            self.interval.duration(),
+                            &now,
+                            who_poll,
+                        )
+                    })
             {
-                log::trace!(
-                    "[{}] {} - WHO poll - poll queue",
-                    server,
-                    who_poll.channel
-                );
+                execute_polls.push(who_poll);
+            }
 
-                let message = tick_who_poll_request(
-                    &mut who_poll,
+            log::trace!(
+                "[{server}] - WHO polls parallel running {} of {}",
+                execute_polls.len(),
+                max_parallel_polls
+            );
+            for mut who_poll in execute_polls {
+                tick_who_poll_request(
                     capabilities,
                     chanmap,
                     isupport,
+                    server,
+                    WhoRequest::Poll,
+                    &mut who_poll,
+                    &mut messages,
+                    Some(&mut self.inflight),
                 );
-                self.inflight.push(who_poll);
-
-                messages.push((message.into(), TokenPriority::Low));
-            } else {
-                self.poll_queue.push_back(who_poll);
             }
-        } else if self.poll_queue.is_empty()
-            && let Some(who_poll) = self.inflight.first_mut()
+        } else if config.who_poll_enabled
+            && let Some(mut who_poll) =
+                self.poll_queue.pop_front_if(|who_poll| {
+                    is_safe_poll_interval(
+                        self.interval.duration(),
+                        &now,
+                        who_poll,
+                    )
+                })
+        {
+            tick_who_poll_request(
+                capabilities,
+                chanmap,
+                isupport,
+                server,
+                WhoRequest::Poll,
+                &mut who_poll,
+                &mut messages,
+                Some(&mut self.inflight),
+            );
+        } else if let Some(who_poll) = self.inflight.first_mut()
             && let WhoStatus::Requested(source, requested, _) = &who_poll.status
             && (!matches!(source, WhoSource::Poll) || config.who_poll_enabled)
             && (now.duration_since(*requested) >= 5 * self.interval.duration())
         {
-            log::trace!(
-                "[{}] {} - WHO retry - inflight queue",
-                server,
-                who_poll.channel
-            );
-
-            let message = tick_who_poll_request(
-                who_poll,
+            tick_who_poll_request(
                 capabilities,
                 chanmap,
                 isupport,
+                server,
+                WhoRequest::Poll,
+                who_poll,
+                &mut messages,
+                None,
             );
-
-            messages.push((message.into(), TokenPriority::Low));
         }
 
         messages
@@ -178,27 +196,38 @@ impl WhoQueue {
     pub fn update_config(
         &mut self,
         chanmap: &IndexMap<Channel, client::Channel>,
-        config: Arc<config::Server>,
+        capabilities: &Capabilities,
+        config: &Arc<config::Server>,
     ) {
         if self.config.who_poll_enabled != config.who_poll_enabled {
-            self.clear_queues();
+            self.clear_queues(capabilities, config);
 
             if config.who_poll_enabled {
                 for channel in chanmap.keys() {
                     self.join_queue.push_back(WhoPoll {
                         channel: channel.clone(),
-                        status: WhoStatus::Joined,
+                        status: WhoStatus::Waiting(default_waiting_option(
+                            capabilities,
+                        )),
                     });
                 }
             }
         }
-        self.config = config;
+        self.config = config.clone();
     }
 
-    pub fn clear_queues(&mut self) {
-        self.priority_join_queue.truncate(0);
-        self.join_queue.truncate(0);
-        self.poll_queue.truncate(0);
+    pub fn clear_queues(
+        &mut self,
+        capabilities: &Capabilities,
+        config: &Arc<config::Server>,
+    ) {
+        if is_join_queue_enabled(capabilities, config) {
+            self.priority_join_queue.truncate(0);
+            self.join_queue.truncate(0);
+        }
+        if config.who_poll_enabled {
+            self.poll_queue.truncate(0);
+        }
     }
 
     pub fn any_matching_inflight<F>(&self, f: F) -> bool
@@ -289,7 +318,11 @@ impl WhoQueue {
         }
     }
 
-    pub fn queue_joined_who_poll(&mut self, channel: &Channel) {
+    pub fn queue_joined_who_poll(
+        &mut self,
+        capabilities: &Capabilities,
+        channel: &Channel,
+    ) {
         if !self
             .priority_join_queue
             .iter()
@@ -309,7 +342,9 @@ impl WhoQueue {
         {
             self.join_queue.push_front(WhoPoll {
                 channel: channel.to_owned(),
-                status: WhoStatus::Joined,
+                status: WhoStatus::Waiting(default_waiting_option(
+                    capabilities,
+                )),
             });
         }
     }
@@ -472,26 +507,12 @@ impl WhoQueue {
                 self.poll_queue.push_back(who_poll);
             }
 
-            // Prioritize next WHO request due to joining a channel
-            if let Some(mut priority_join_poll) =
-                self.priority_join_queue.pop_front()
-            {
-                priority_join_poll.status = WhoStatus::Waiting(Instant::now());
-
-                self.poll_queue.push_front(priority_join_poll);
-            } else if self.priority_join_queue.is_empty()
-                && let Some(mut poll) = self.join_queue.pop_front()
-            {
-                poll.status = WhoStatus::Waiting(Instant::now());
-
-                self.poll_queue.push_front(poll);
-            } else if self.poll_queue.is_empty()
-                && let Some(pos) = self.poll_queue.iter().position(|who_poll| {
-                    matches!(who_poll.status, WhoStatus::Received)
-                })
-            {
+            // Prioritize WHO poll requests due to joining a channel
+            if let Some(pos) = self.poll_queue.iter().position(|who_poll| {
+                matches!(who_poll.status, WhoStatus::Received)
+            }) {
                 self.poll_queue[pos].status =
-                    WhoStatus::Waiting(Instant::now());
+                    WhoStatus::Waiting(default_waiting_option(capabilities));
 
                 if pos != 0
                     && let Some(who_poll) = self.poll_queue.remove(pos)
@@ -523,18 +544,9 @@ impl WhoQueue {
     // User did not request, treat as part of rate-limiting response
     // (in conjunction with RPL_TRYAGAIN) and don't save to history.
     pub fn handle_who_rate_limited(&mut self) {
-        if let Some(who_poll) = self.priority_join_queue.front_mut() {
-            who_poll.status = WhoStatus::Waiting(Instant::now());
-        } else if self.priority_join_queue.is_empty()
-            && let Some(who_poll) = self.join_queue.front_mut()
-        {
-            who_poll.status = WhoStatus::Waiting(Instant::now());
-        } else if self.join_queue.is_empty()
-            && let Some(who_poll) = self.poll_queue.front_mut()
-        {
-            who_poll.status = WhoStatus::Waiting(Instant::now());
+        if let Some(who_poll) = self.poll_queue.front_mut() {
+            who_poll.status = WhoStatus::Waiting(Some(Instant::now()));
         }
-
         self.poll_queue
             .iter_mut()
             .skip(1)
@@ -550,10 +562,8 @@ impl WhoQueue {
             .join_queue
             .iter()
             .position(|who_poll| &who_poll.channel == channel)
-            && let Some(mut who_poll) = self.join_queue.remove(pos)
+            && let Some(who_poll) = self.join_queue.remove(pos)
         {
-            who_poll.status = WhoStatus::PrioritizedJoin;
-
             log::trace!(
                 "[{}] {} - WHO poll prioritizing join",
                 server,
@@ -572,14 +582,13 @@ impl WhoQueue {
             .priority_join_queue
             .iter()
             .position(|who_poll| who_poll.channel == channel)
-            && let Some(mut who_poll) = self.join_queue.remove(pos)
+            && let Some(who_poll) = self.join_queue.remove(pos)
         {
             log::trace!(
                 "[{}] {} - WHO poll deprioritizing join",
                 server,
                 channel.as_normalized_str()
             );
-            who_poll.status = WhoStatus::Joined;
 
             self.join_queue.push_front(who_poll);
         }
@@ -589,13 +598,13 @@ impl WhoQueue {
         &mut self,
         server: &Server,
         opened_channels: &Vec<(&Server, &Channel)>,
-        exclude_channel: &Channel,
+        prioritize_channel: &Channel,
     ) {
         let channels_to_deprioritize: Vec<Channel> = self
             .priority_join_queue
             .iter()
             .filter(|who_poll| {
-                who_poll.channel != *exclude_channel
+                who_poll.channel != *prioritize_channel
                     && !opened_channels
                         .iter()
                         .any(|(s, c)| *s == server && *c == &who_poll.channel)
@@ -606,55 +615,30 @@ impl WhoQueue {
         for channel in channels_to_deprioritize {
             self.deprioritize_joined_who_poll(server, channel);
         }
-    }
 
-    pub fn process_next_prioritized_join(
-        &mut self,
-        server: &client::Server,
-        capabilities: &Capabilities,
-        chanmap: &IndexMap<Channel, client::Channel>,
-        isupport: &HashMap<isupport::Kind, isupport::Parameter>,
-    ) -> Vec<(message::Encoded, TokenPriority)> {
-        let mut messages: Vec<(message::Encoded, TokenPriority)> = vec![];
-
-        let now = Instant::now();
-        if let Some(last_throttled) = self.last_throttled
-            && now.duration_since(last_throttled) < self.interval.duration()
-        {
-            log::trace!(
-                "[{server}] - WHO poll throttled, end next prioritizing"
-            );
-            return messages;
-        }
-
-        if let Some(mut who_poll) = self.priority_join_queue.pop_front() {
-            log::trace!(
-                "[{}] {} - WHO poll processing next prioritized join",
-                server,
-                who_poll.channel
-            );
-
-            let message = tick_who_poll_request(
-                &mut who_poll,
-                capabilities,
-                chanmap,
-                isupport,
-            );
-            self.inflight.push(who_poll);
-
-            messages.push((message.into(), TokenPriority::Low));
-        }
-        messages
+        self.prioritize_joined_who_poll(server, prioritize_channel);
     }
 }
 
 fn tick_who_poll_request(
-    who_poll: &mut WhoPoll,
     capabilities: &Capabilities,
     chanmap: &IndexMap<Channel, client::Channel>,
     isupport: &HashMap<isupport::Kind, isupport::Parameter>,
-) -> Message {
-    if isupport.contains_key(&isupport::Kind::WHOX) {
+    server: &Server,
+    request: WhoRequest,
+    who_poll: &mut WhoPoll,
+    messages: &mut Vec<(message::Encoded, TokenPriority)>,
+    inflight: Option<&mut Vec<WhoPoll>>,
+) {
+    log::trace!(
+        "[{server}] {} - WHO {}",
+        who_poll.channel,
+        match request {
+            WhoRequest::Poll => "poll",
+            WhoRequest::Retry => "retry",
+        }
+    );
+    let message = if isupport.contains_key(&isupport::Kind::WHOX) {
         let whox_params = if capabilities
             .acknowledged(Capability::NoImplicitNames)
             && chanmap
@@ -685,5 +669,41 @@ fn tick_who_poll_request(
             WhoStatus::Requested(WhoSource::Poll, Instant::now(), None);
 
         command!("WHO", who_poll.channel.to_string())
+    };
+    messages.push((message.into(), TokenPriority::Low));
+    if let Some(inflight) = inflight {
+        inflight.push(who_poll.to_owned());
     }
+}
+
+fn is_join_queue_enabled(
+    capabilities: &Capabilities,
+    config: &Arc<config::Server>,
+) -> bool {
+    capabilities.acknowledged(Capability::NoImplicitNames)
+        || capabilities.acknowledged(Capability::AwayNotify)
+        || config.who_poll_enabled
+}
+
+fn default_waiting_option(capabilities: &Capabilities) -> Option<Instant> {
+    if !capabilities.acknowledged(Capability::NoImplicitNames)
+        && !capabilities.acknowledged(Capability::AwayNotify)
+    {
+        return Some(Instant::now());
+    }
+
+    None
+}
+
+fn is_safe_poll_interval(
+    duration: Duration,
+    now: &Instant,
+    who_poll: &WhoPoll,
+) -> bool {
+    if let WhoStatus::Waiting(Some(last)) = who_poll.status
+        && now.duration_since(last) < duration
+    {
+        return false;
+    }
+    true
 }

--- a/data/src/client/who_queue.rs
+++ b/data/src/client/who_queue.rs
@@ -9,6 +9,7 @@ use irc::proto::command;
 use crate::capabilities::{Capabilities, Capability};
 use crate::isupport::{self, WhoToken, WhoXPollParameters};
 use crate::rate_limit::{BackoffInterval, TokenPriority};
+use crate::server::Server;
 use crate::target::Channel;
 use crate::{User, client, config, message};
 
@@ -484,6 +485,38 @@ impl WhoQueue {
 
             log::debug!("prioritizing who poll for: {channel:?}");
             self.polls.push_front(who_poll);
+        }
+    }
+
+    pub fn deprioritize_joined_who_poll(&mut self, channel: Channel) {
+        if let Some(pos) = self.polls.iter().position(|who_poll| {
+            who_poll.channel == channel
+                && matches!(who_poll.status, WhoStatus::PrioritizedJoin)
+        }) {
+            log::debug!("deprioritizing who poll for: {channel:?}");
+            self.polls[pos].status = WhoStatus::Joined;
+        }
+    }
+
+    pub fn reprioritize_joined_who_polls(
+        &mut self,
+        server: &Server,
+        opened_channels: Vec<(&Server, &Channel)>,
+    ) {
+        let channels_to_deprioritize: Vec<Channel> = self
+            .polls
+            .iter()
+            .filter(|who_poll| {
+                matches!(who_poll.status, WhoStatus::PrioritizedJoin)
+                    && !opened_channels
+                        .iter()
+                        .any(|(s, c)| *s == server && *c == &who_poll.channel)
+            })
+            .map(|who_poll| who_poll.channel.clone())
+            .collect();
+
+        for channel in channels_to_deprioritize {
+            self.deprioritize_joined_who_poll(channel);
         }
     }
 }

--- a/data/src/client/who_queue.rs
+++ b/data/src/client/who_queue.rs
@@ -156,9 +156,11 @@ impl WhoQueue {
         let interval_duration = self.interval.duration();
         let reference_time = self.reference_time;
 
-        // Find any timed out polls and return them in the queue.
+        // Find any in flight polls that stopped before completing, and
+        // return them to the front of their respective section in the
+        // queue to be re-tried.
 
-        let timed_out_polls: Vec<_> = self
+        let stalled_polls: Vec<_> = self
             .in_flight
             .extract_if(.., |who_poll| {
                 can_send_who_poll(
@@ -171,11 +173,11 @@ impl WhoQueue {
             })
             .collect();
 
-        for who_poll in timed_out_polls.into_iter() {
+        for who_poll in stalled_polls.into_iter() {
             self.insert_towards_front(who_poll);
         }
 
-        // Prepare polls to be sent during this tick.
+        // Prepare poll(s) to be sent during this tick.
 
         let mut who_polls_to_send = vec![];
 
@@ -216,7 +218,10 @@ impl WhoQueue {
                         "retry"
                     },
                     if number_of_who_polls > 1 {
-                        format!(" ({request_number} of {number_of_who_polls})")
+                        format!(
+                            " ({} of {number_of_who_polls})",
+                            request_number + 1
+                        )
                     } else {
                         String::new()
                     }
@@ -512,7 +517,7 @@ impl WhoQueue {
                             hostname,
                             Some(accountname),
                             casemapping,
-                            isupport::get_bot_mode_char(isupport),
+                            bot_mode_char,
                         );
 
                         if client_channel.users.contains(&user) {

--- a/data/src/client/who_queue.rs
+++ b/data/src/client/who_queue.rs
@@ -21,12 +21,12 @@ pub struct WhoPoll {
 
 #[derive(Debug, Clone)]
 pub enum WhoStatus {
-    Requested(WhoSource, Instant, Option<WhoToken>),
-    Receiving(WhoSource, Option<WhoToken>),
-    Received,
-    Waiting(Instant),
-    Joined,
-    PrioritizedJoin,
+    Requested(WhoSource, Instant, Option<WhoToken>), // inflight
+    Receiving(WhoSource, Option<WhoToken>),          // inflight
+    Received,                                        // poll
+    Waiting(Instant),                                // poll
+    Joined,                                          // join
+    PrioritizedJoin,                                 // priority_join
 }
 
 #[derive(Debug, Clone)]
@@ -38,15 +38,12 @@ pub enum WhoSource {
 #[derive(Debug, Clone)]
 pub struct WhoQueue {
     config: Arc<config::Server>,
-    queue: VecDeque<WhoPoll>,
+    poll_queue: VecDeque<WhoPoll>,
+    join_queue: VecDeque<WhoPoll>,
+    priority_join_queue: VecDeque<WhoPoll>,
     inflight: Vec<WhoPoll>,
     interval: BackoffInterval,
     last_throttled: Option<Instant>,
-}
-#[derive(Debug)]
-enum WhoRequest {
-    Poll,
-    Retry,
 }
 
 impl WhoQueue {
@@ -59,7 +56,9 @@ impl WhoQueue {
 
         Self {
             config,
-            queue: VecDeque::new(),
+            poll_queue: VecDeque::new(),
+            join_queue: VecDeque::new(),
+            priority_join_queue: VecDeque::new(),
             inflight: Vec::new(),
             interval,
             last_throttled: None,
@@ -77,23 +76,16 @@ impl WhoQueue {
     ) -> Vec<(message::Encoded, TokenPriority)> {
         let mut messages: Vec<(message::Encoded, TokenPriority)> = vec![];
 
-        if let Some(mut who_poll) = self.queue.pop_front() {
-            let request = match &who_poll.status {
-                WhoStatus::Joined | WhoStatus::PrioritizedJoin => (capabilities
-                    .acknowledged(Capability::NoImplicitNames)
-                    || capabilities.acknowledged(Capability::AwayNotify)
-                    || config.who_poll_enabled)
-                    .then_some(WhoRequest::Poll),
-                WhoStatus::Waiting(last) => ((capabilities
-                    .acknowledged(Capability::NoImplicitNames)
-                    || config.who_poll_enabled)
-                    && (now.duration_since(*last) >= self.interval.duration()))
-                .then_some(WhoRequest::Poll),
-                _ => None,
-            };
-
-            if request.is_some() {
-                log::trace!("[{}] {} - WHO poll", server, who_poll.channel);
+        if let Some(mut who_poll) = self.priority_join_queue.pop_front() {
+            if capabilities.acknowledged(Capability::NoImplicitNames)
+                || capabilities.acknowledged(Capability::AwayNotify)
+                || config.who_poll_enabled
+            {
+                log::trace!(
+                    "[{}] {} - WHO poll - priority join queue",
+                    server,
+                    who_poll.channel
+                );
 
                 let message = tick_who_poll_request(
                     &mut who_poll,
@@ -105,38 +97,79 @@ impl WhoQueue {
 
                 messages.push((message.into(), TokenPriority::Low));
             } else {
-                self.queue.push_back(who_poll);
+                self.priority_join_queue.push_back(who_poll);
             }
-        }
-
-        if let Some(who_poll) = self.inflight.first_mut() {
-            let request = match &who_poll.status {
-                WhoStatus::Requested(source, requested, _) => {
-                    if matches!(source, WhoSource::Poll)
-                        && !config.who_poll_enabled
-                    {
-                        None
-                    } else {
-                        (now.duration_since(*requested)
-                            >= 5 * self.interval.duration())
-                        .then_some(WhoRequest::Retry)
-                    }
-                }
-                _ => None,
-            };
-
-            if request.is_some() {
-                log::trace!("[{}] {} - WHO retry", server, who_poll.channel);
+        } else if self.priority_join_queue.is_empty()
+            && let Some(mut who_poll) = self.join_queue.pop_front()
+        {
+            if capabilities.acknowledged(Capability::NoImplicitNames)
+                || capabilities.acknowledged(Capability::AwayNotify)
+                || config.who_poll_enabled
+            {
+                log::trace!(
+                    "[{}] {} - WHO poll - join queue",
+                    server,
+                    who_poll.channel
+                );
 
                 let message = tick_who_poll_request(
-                    who_poll,
+                    &mut who_poll,
                     capabilities,
                     chanmap,
                     isupport,
                 );
+                self.inflight.push(who_poll);
 
                 messages.push((message.into(), TokenPriority::Low));
+            } else {
+                self.join_queue.push_back(who_poll);
             }
+        } else if self.join_queue.is_empty()
+            && let Some(mut who_poll) = self.poll_queue.pop_front()
+        {
+            if let WhoStatus::Waiting(last) = &who_poll.status
+                && ((capabilities.acknowledged(Capability::NoImplicitNames)
+                    || config.who_poll_enabled)
+                    && (now.duration_since(*last) >= self.interval.duration()))
+            {
+                log::trace!(
+                    "[{}] {} - WHO poll - poll queue",
+                    server,
+                    who_poll.channel
+                );
+
+                let message = tick_who_poll_request(
+                    &mut who_poll,
+                    capabilities,
+                    chanmap,
+                    isupport,
+                );
+                self.inflight.push(who_poll);
+
+                messages.push((message.into(), TokenPriority::Low));
+            } else {
+                self.poll_queue.push_back(who_poll);
+            }
+        } else if self.poll_queue.is_empty()
+            && let Some(who_poll) = self.inflight.first_mut()
+            && let WhoStatus::Requested(source, requested, _) = &who_poll.status
+            && (!matches!(source, WhoSource::Poll) || config.who_poll_enabled)
+            && (now.duration_since(*requested) >= 5 * self.interval.duration())
+        {
+            log::trace!(
+                "[{}] {} - WHO retry - inflight queue",
+                server,
+                who_poll.channel
+            );
+
+            let message = tick_who_poll_request(
+                who_poll,
+                capabilities,
+                chanmap,
+                isupport,
+            );
+
+            messages.push((message.into(), TokenPriority::Low));
         }
 
         messages
@@ -148,81 +181,70 @@ impl WhoQueue {
         config: Arc<config::Server>,
     ) {
         if self.config.who_poll_enabled != config.who_poll_enabled {
+            self.clear_queues();
+
             if config.who_poll_enabled {
                 for channel in chanmap.keys() {
-                    self.queue.push_back(WhoPoll {
+                    self.join_queue.push_back(WhoPoll {
                         channel: channel.clone(),
                         status: WhoStatus::Joined,
                     });
                 }
-            } else {
-                self.queue.truncate(0);
             }
         }
         self.config = config;
     }
 
-    pub fn quit(&mut self) {
-        self.queue.truncate(0);
-    }
-
-    pub fn any_matching_polls<F>(&self, f: F) -> bool
-    where
-        F: Fn(&WhoPoll) -> bool,
-    {
-        self.queue.iter().any(f)
+    pub fn clear_queues(&mut self) {
+        self.priority_join_queue.truncate(0);
+        self.join_queue.truncate(0);
+        self.poll_queue.truncate(0);
     }
 
     pub fn any_matching_inflight<F>(&self, f: F) -> bool
     where
         F: Fn(&WhoPoll) -> bool,
     {
-        self.queue.iter().any(f)
+        self.inflight.iter().any(f)
     }
 
     pub fn has_inflight(&self) -> bool {
         !self.inflight.is_empty()
     }
 
-    pub fn pos_matching_polls<F>(&self, f: F) -> Option<usize>
-    where
-        F: Fn(&WhoPoll) -> bool,
-    {
-        self.queue.iter().position(f)
-    }
-
     pub fn remove_matching_polls<F>(&mut self, f: F) -> bool
     where
         F: Fn(&WhoPoll) -> bool,
     {
-        if let Some(pos) = self.pos_matching_polls(f) {
-            self.queue.remove(pos);
-            true
-        } else {
-            false
+        let mut removed = false;
+        if let Some(pos) = self.poll_queue.iter().position(&f) {
+            self.poll_queue.remove(pos);
+            removed = true;
         }
-    }
-
-    pub fn pos_matching_inflight<F>(&self, f: F) -> Option<usize>
-    where
-        F: Fn(&WhoPoll) -> bool,
-    {
-        self.queue.iter().position(f)
+        if let Some(pos) = self.join_queue.iter().position(&f) {
+            self.join_queue.remove(pos);
+            removed = true;
+        }
+        if let Some(pos) = self.priority_join_queue.iter().position(&f) {
+            self.priority_join_queue.remove(pos);
+            removed = true;
+        }
+        removed
     }
 
     pub fn remove_matching_inflight<F>(&mut self, f: F) -> bool
     where
         F: Fn(&WhoPoll) -> bool,
     {
-        if let Some(pos) = self.pos_matching_inflight(f) {
-            self.queue.remove(pos);
+        if let Some(pos) = self.inflight.iter().position(f) {
+            self.inflight.remove(pos);
             true
         } else {
             false
         }
     }
 
-    pub fn requested_channel_poll(
+    pub fn user_requested_channel_poll(
         &mut self,
         params: Vec<String>,
         channel: Channel,
@@ -237,10 +259,28 @@ impl WhoQueue {
         );
 
         if let Some(pos) = self
-            .queue
+            .priority_join_queue
             .iter()
             .position(|who_poll| who_poll.channel == channel)
-            && let Some(mut who_poll) = self.queue.remove(pos)
+            && let Some(mut who_poll) = self.priority_join_queue.remove(pos)
+        {
+            who_poll.status = status;
+            self.inflight.push(who_poll);
+        } else if self.priority_join_queue.is_empty()
+            && let Some(pos) = self
+                .join_queue
+                .iter()
+                .position(|who_poll| who_poll.channel == channel)
+            && let Some(mut who_poll) = self.join_queue.remove(pos)
+        {
+            who_poll.status = status;
+            self.inflight.push(who_poll);
+        } else if self.join_queue.is_empty()
+            && let Some(pos) = self
+                .poll_queue
+                .iter()
+                .position(|who_poll| who_poll.channel == channel)
+            && let Some(mut who_poll) = self.poll_queue.remove(pos)
         {
             who_poll.status = status;
             self.inflight.push(who_poll);
@@ -249,24 +289,32 @@ impl WhoQueue {
         }
     }
 
-    pub fn queue_channel_poll(&mut self, channel: &Channel) {
+    pub fn queue_joined_who_poll(&mut self, channel: &Channel) {
         if !self
-            .queue
+            .priority_join_queue
             .iter()
             .any(|who_poll| who_poll.channel == *channel)
+            && !self
+                .join_queue
+                .iter()
+                .any(|who_poll| who_poll.channel == *channel)
+            && !self
+                .poll_queue
+                .iter()
+                .any(|who_poll| who_poll.channel == *channel)
             && !self
                 .inflight
                 .iter()
                 .any(|who_poll| who_poll.channel == *channel)
         {
-            self.queue.push_front(WhoPoll {
+            self.join_queue.push_front(WhoPoll {
                 channel: channel.to_owned(),
                 status: WhoStatus::Joined,
             });
         }
     }
 
-    pub fn receiving_channel_poll(
+    pub fn receiving_who_poll(
         &mut self,
         server: &client::Server,
         channel: &Channel,
@@ -421,29 +469,34 @@ impl WhoQueue {
                 && !capabilities.acknowledged(Capability::AwayNotify)
             {
                 who_poll.status = WhoStatus::Received;
-                self.queue.push_back(who_poll);
+                self.poll_queue.push_back(who_poll);
             }
 
             // Prioritize next WHO request due to joining a channel
-            if let Some(pos) = self
-                .queue
-                .iter()
-                .position(|who_poll| {
-                    matches!(who_poll.status, WhoStatus::PrioritizedJoin)
-                })
-                .or(self.queue.iter().position(|who_poll| {
-                    matches!(who_poll.status, WhoStatus::Joined)
-                }))
-                .or(self.queue.iter().position(|who_poll| {
-                    matches!(who_poll.status, WhoStatus::Received)
-                }))
+            if let Some(mut priority_join_poll) =
+                self.priority_join_queue.pop_front()
             {
-                self.queue[pos].status = WhoStatus::Waiting(Instant::now());
+                priority_join_poll.status = WhoStatus::Waiting(Instant::now());
+
+                self.poll_queue.push_front(priority_join_poll);
+            } else if self.priority_join_queue.is_empty()
+                && let Some(mut poll) = self.join_queue.pop_front()
+            {
+                poll.status = WhoStatus::Waiting(Instant::now());
+
+                self.poll_queue.push_front(poll);
+            } else if self.poll_queue.is_empty()
+                && let Some(pos) = self.poll_queue.iter().position(|who_poll| {
+                    matches!(who_poll.status, WhoStatus::Received)
+                })
+            {
+                self.poll_queue[pos].status =
+                    WhoStatus::Waiting(Instant::now());
 
                 if pos != 0
-                    && let Some(who_poll) = self.queue.remove(pos)
+                    && let Some(who_poll) = self.poll_queue.remove(pos)
                 {
-                    self.queue.push_front(who_poll);
+                    self.poll_queue.push_front(who_poll);
                 }
             }
         }
@@ -470,11 +523,19 @@ impl WhoQueue {
     // User did not request, treat as part of rate-limiting response
     // (in conjunction with RPL_TRYAGAIN) and don't save to history.
     pub fn handle_who_rate_limited(&mut self) {
-        if let Some(who_poll) = self.queue.front_mut() {
+        if let Some(who_poll) = self.priority_join_queue.front_mut() {
+            who_poll.status = WhoStatus::Waiting(Instant::now());
+        } else if self.priority_join_queue.is_empty()
+            && let Some(who_poll) = self.join_queue.front_mut()
+        {
+            who_poll.status = WhoStatus::Waiting(Instant::now());
+        } else if self.join_queue.is_empty()
+            && let Some(who_poll) = self.poll_queue.front_mut()
+        {
             who_poll.status = WhoStatus::Waiting(Instant::now());
         }
 
-        self.queue
+        self.poll_queue
             .iter_mut()
             .skip(1)
             .for_each(|who_poll| who_poll.status = WhoStatus::Received);
@@ -486,22 +547,19 @@ impl WhoQueue {
         channel: &Channel,
     ) {
         if let Some(pos) = self
-            .queue
+            .join_queue
             .iter()
             .position(|who_poll| &who_poll.channel == channel)
-            && pos != 0
-            && let Some(mut who_poll) = self.queue.remove(pos)
+            && let Some(mut who_poll) = self.join_queue.remove(pos)
         {
-            if matches!(who_poll.status, WhoStatus::Joined) {
-                who_poll.status = WhoStatus::PrioritizedJoin;
-            }
+            who_poll.status = WhoStatus::PrioritizedJoin;
 
             log::trace!(
                 "[{}] {} - WHO poll prioritizing join",
                 server,
                 channel.as_normalized_str(),
             );
-            self.queue.push_front(who_poll);
+            self.priority_join_queue.push_front(who_poll);
         }
     }
 
@@ -510,16 +568,20 @@ impl WhoQueue {
         server: &Server,
         channel: Channel,
     ) {
-        if let Some(pos) = self.queue.iter().position(|who_poll| {
-            who_poll.channel == channel
-                && matches!(who_poll.status, WhoStatus::PrioritizedJoin)
-        }) {
+        if let Some(pos) = self
+            .priority_join_queue
+            .iter()
+            .position(|who_poll| who_poll.channel == channel)
+            && let Some(mut who_poll) = self.join_queue.remove(pos)
+        {
             log::trace!(
                 "[{}] {} - WHO poll deprioritizing join",
                 server,
                 channel.as_normalized_str()
             );
-            self.queue[pos].status = WhoStatus::Joined;
+            who_poll.status = WhoStatus::Joined;
+
+            self.join_queue.push_front(who_poll);
         }
     }
 
@@ -530,11 +592,10 @@ impl WhoQueue {
         exclude_channel: &Channel,
     ) {
         let channels_to_deprioritize: Vec<Channel> = self
-            .queue
+            .priority_join_queue
             .iter()
             .filter(|who_poll| {
-                matches!(who_poll.status, WhoStatus::PrioritizedJoin)
-                    && who_poll.channel != *exclude_channel
+                who_poll.channel != *exclude_channel
                     && !opened_channels
                         .iter()
                         .any(|(s, c)| *s == server && *c == &who_poll.channel)
@@ -566,10 +627,7 @@ impl WhoQueue {
             return messages;
         }
 
-        if let Some(pos) = self.queue.iter().position(|who_poll| {
-            matches!(who_poll.status, WhoStatus::PrioritizedJoin)
-        }) && let Some(mut who_poll) = self.queue.remove(pos)
-        {
+        if let Some(mut who_poll) = self.priority_join_queue.pop_front() {
             log::trace!(
                 "[{}] {} - WHO poll processing next prioritized join",
                 server,

--- a/data/src/client/who_queue.rs
+++ b/data/src/client/who_queue.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::anyhow;
 use indexmap::IndexMap;
-use irc::proto::command;
+use irc::proto::{Message, command};
 
 use crate::capabilities::{Capabilities, Capability};
 use crate::isupport::{self, WhoToken, WhoXPollParameters};
@@ -38,8 +38,15 @@ pub enum WhoSource {
 #[derive(Debug, Clone)]
 pub struct WhoQueue {
     config: Arc<config::Server>,
-    polls: VecDeque<WhoPoll>,
+    queue: VecDeque<WhoPoll>,
+    inflight: Vec<WhoPoll>,
     interval: BackoffInterval,
+    last_throttled: Option<Instant>,
+}
+#[derive(Debug)]
+enum WhoRequest {
+    Poll,
+    Retry,
 }
 
 impl WhoQueue {
@@ -52,8 +59,10 @@ impl WhoQueue {
 
         Self {
             config,
-            polls: VecDeque::new(),
+            queue: VecDeque::new(),
+            inflight: Vec::new(),
             interval,
+            last_throttled: None,
         }
     }
 
@@ -67,24 +76,41 @@ impl WhoQueue {
         now: Instant,
     ) -> Vec<(message::Encoded, TokenPriority)> {
         let mut messages: Vec<(message::Encoded, TokenPriority)> = vec![];
-        if let Some(who_poll) = self.polls.front_mut() {
-            #[derive(Debug)]
-            enum Request {
-                Poll,
-                Retry,
-            }
 
+        if let Some(mut who_poll) = self.queue.pop_front() {
             let request = match &who_poll.status {
                 WhoStatus::Joined | WhoStatus::PrioritizedJoin => (capabilities
                     .acknowledged(Capability::NoImplicitNames)
                     || capabilities.acknowledged(Capability::AwayNotify)
                     || config.who_poll_enabled)
-                    .then_some(Request::Poll),
+                    .then_some(WhoRequest::Poll),
                 WhoStatus::Waiting(last) => ((capabilities
                     .acknowledged(Capability::NoImplicitNames)
                     || config.who_poll_enabled)
                     && (now.duration_since(*last) >= self.interval.duration()))
-                .then_some(Request::Poll),
+                .then_some(WhoRequest::Poll),
+                _ => None,
+            };
+
+            if request.is_some() {
+                log::trace!("[{}] {} - WHO poll", server, who_poll.channel);
+
+                let message = tick_who_poll_request(
+                    &mut who_poll,
+                    capabilities,
+                    chanmap,
+                    isupport,
+                );
+                self.inflight.push(who_poll);
+
+                messages.push((message.into(), TokenPriority::Low));
+            } else {
+                self.queue.push_back(who_poll);
+            }
+        }
+
+        if let Some(who_poll) = self.inflight.first_mut() {
+            let request = match &who_poll.status {
                 WhoStatus::Requested(source, requested, _) => {
                     if matches!(source, WhoSource::Poll)
                         && !config.who_poll_enabled
@@ -93,60 +119,21 @@ impl WhoQueue {
                     } else {
                         (now.duration_since(*requested)
                             >= 5 * self.interval.duration())
-                        .then_some(Request::Retry)
+                        .then_some(WhoRequest::Retry)
                     }
                 }
                 _ => None,
             };
 
-            if let Some(request) = request {
-                log::trace!(
-                    "[{}] {} - WHO {}",
-                    server,
-                    who_poll.channel,
-                    match request {
-                        Request::Poll => "poll",
-                        Request::Retry => "retry",
-                    }
+            if request.is_some() {
+                log::trace!("[{}] {} - WHO retry", server, who_poll.channel);
+
+                let message = tick_who_poll_request(
+                    who_poll,
+                    capabilities,
+                    chanmap,
+                    isupport,
                 );
-
-                let message = if isupport.contains_key(&isupport::Kind::WHOX) {
-                    let whox_params = if capabilities
-                        .acknowledged(Capability::NoImplicitNames)
-                        && chanmap
-                            .get(&who_poll.channel)
-                            .is_none_or(|channel| !channel.who_init)
-                    {
-                        WhoXPollParameters::InitialJoin
-                    } else if capabilities
-                        .acknowledged(Capability::AccountNotify)
-                    {
-                        WhoXPollParameters::WithAccountName
-                    } else {
-                        WhoXPollParameters::Default
-                    };
-
-                    who_poll.status = WhoStatus::Requested(
-                        WhoSource::Poll,
-                        Instant::now(),
-                        Some(whox_params.token()),
-                    );
-
-                    command!(
-                        "WHO",
-                        who_poll.channel.to_string(),
-                        whox_params.fields().to_string(),
-                        whox_params.token().to_owned()
-                    )
-                } else {
-                    who_poll.status = WhoStatus::Requested(
-                        WhoSource::Poll,
-                        Instant::now(),
-                        None,
-                    );
-
-                    command!("WHO", who_poll.channel.to_string())
-                };
 
                 messages.push((message.into(), TokenPriority::Low));
             }
@@ -163,53 +150,72 @@ impl WhoQueue {
         if self.config.who_poll_enabled != config.who_poll_enabled {
             if config.who_poll_enabled {
                 for channel in chanmap.keys() {
-                    self.polls.push_back(WhoPoll {
+                    self.queue.push_back(WhoPoll {
                         channel: channel.clone(),
                         status: WhoStatus::Joined,
                     });
                 }
             } else {
-                self.polls.retain(|who_poll| {
-                    matches!(
-                        who_poll.status,
-                        WhoStatus::Requested(_, _, _)
-                            | WhoStatus::Receiving(_, _)
-                    )
-                });
+                self.queue.truncate(0);
             }
         }
         self.config = config;
     }
 
     pub fn quit(&mut self) {
-        self.polls.retain(|who_poll| {
-            matches!(
-                who_poll.status,
-                WhoStatus::Requested(_, _, _) | WhoStatus::Receiving(_, _)
-            )
-        });
+        self.queue.truncate(0);
     }
 
-    pub fn any_matching<F>(&self, f: F) -> bool
+    pub fn any_matching_polls<F>(&self, f: F) -> bool
     where
         F: Fn(&WhoPoll) -> bool,
     {
-        self.polls.iter().any(f)
+        self.queue.iter().any(f)
     }
 
-    pub fn pos_matching<F>(&self, f: F) -> Option<usize>
+    pub fn any_matching_inflight<F>(&self, f: F) -> bool
     where
         F: Fn(&WhoPoll) -> bool,
     {
-        self.polls.iter().position(f)
+        self.queue.iter().any(f)
     }
 
-    pub fn remove_matching<F>(&mut self, f: F) -> bool
+    pub fn has_inflight(&self) -> bool {
+        !self.inflight.is_empty()
+    }
+
+    pub fn pos_matching_polls<F>(&self, f: F) -> Option<usize>
     where
         F: Fn(&WhoPoll) -> bool,
     {
-        if let Some(pos) = self.pos_matching(f) {
-            self.polls.remove(pos);
+        self.queue.iter().position(f)
+    }
+
+    pub fn remove_matching_polls<F>(&mut self, f: F) -> bool
+    where
+        F: Fn(&WhoPoll) -> bool,
+    {
+        if let Some(pos) = self.pos_matching_polls(f) {
+            self.queue.remove(pos);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn pos_matching_inflight<F>(&self, f: F) -> Option<usize>
+    where
+        F: Fn(&WhoPoll) -> bool,
+    {
+        self.queue.iter().position(f)
+    }
+
+    pub fn remove_matching_inflight<F>(&mut self, f: F) -> bool
+    where
+        F: Fn(&WhoPoll) -> bool,
+    {
+        if let Some(pos) = self.pos_matching_inflight(f) {
+            self.queue.remove(pos);
             true
         } else {
             false
@@ -230,24 +236,30 @@ impl WhoQueue {
                 .and_then(|token| token.parse::<WhoToken>().ok()),
         );
 
-        if let Some(who_poll) = self
-            .polls
-            .iter_mut()
-            .find(|who_poll| who_poll.channel == channel)
+        if let Some(pos) = self
+            .queue
+            .iter()
+            .position(|who_poll| who_poll.channel == channel)
+            && let Some(mut who_poll) = self.queue.remove(pos)
         {
             who_poll.status = status;
+            self.inflight.push(who_poll);
         } else {
-            self.polls.push_front(WhoPoll { channel, status });
+            self.inflight.push(WhoPoll { channel, status });
         }
     }
 
     pub fn queue_channel_poll(&mut self, channel: &Channel) {
         if !self
-            .polls
+            .queue
             .iter()
             .any(|who_poll| who_poll.channel == *channel)
+            && !self
+                .inflight
+                .iter()
+                .any(|who_poll| who_poll.channel == *channel)
         {
-            self.polls.push_front(WhoPoll {
+            self.queue.push_front(WhoPoll {
                 channel: channel.to_owned(),
                 status: WhoStatus::Joined,
             });
@@ -260,7 +272,7 @@ impl WhoQueue {
         channel: &Channel,
     ) {
         if let Some(who_poll) = self
-            .polls
+            .inflight
             .iter_mut()
             .find(|who_poll| who_poll.channel == *channel)
             && let WhoStatus::Requested(source, _, None) = &who_poll.status
@@ -290,7 +302,7 @@ impl WhoQueue {
         let bot_mode_char = isupport::get_bot_mode_char(isupport);
 
         if let Some(who_poll) = self
-            .polls
+            .inflight
             .iter_mut()
             .find(|who_poll| who_poll.channel == *target_channel)
         {
@@ -399,40 +411,39 @@ impl WhoQueue {
         channel: &Channel,
     ) {
         if let Some(pos) = self
-            .polls
+            .inflight
             .iter()
             .position(|who_poll| who_poll.channel == *channel)
         {
-            self.polls[pos].status = WhoStatus::Received;
-
-            if let Some(who_poll) = self.polls.remove(pos)
-                && chanmap.contains_key(channel)
+            let mut who_poll = self.inflight.remove(pos);
+            if chanmap.contains_key(channel)
                 && config.who_poll_enabled
                 && !capabilities.acknowledged(Capability::AwayNotify)
             {
-                self.polls.push_back(who_poll);
+                who_poll.status = WhoStatus::Received;
+                self.queue.push_back(who_poll);
             }
 
-            // Prioritize WHO requests due to joining a channel
+            // Prioritize next WHO request due to joining a channel
             if let Some(pos) = self
-                .polls
+                .queue
                 .iter()
                 .position(|who_poll| {
                     matches!(who_poll.status, WhoStatus::PrioritizedJoin)
                 })
-                .or(self.polls.iter().position(|who_poll| {
+                .or(self.queue.iter().position(|who_poll| {
                     matches!(who_poll.status, WhoStatus::Joined)
                 }))
-                .or(self.polls.iter().position(|who_poll| {
+                .or(self.queue.iter().position(|who_poll| {
                     matches!(who_poll.status, WhoStatus::Received)
                 }))
             {
-                self.polls[pos].status = WhoStatus::Waiting(Instant::now());
+                self.queue[pos].status = WhoStatus::Waiting(Instant::now());
 
                 if pos != 0
-                    && let Some(who_poll) = self.polls.remove(pos)
+                    && let Some(who_poll) = self.queue.remove(pos)
                 {
-                    self.polls.push_front(who_poll);
+                    self.queue.push_front(who_poll);
                 }
             }
         }
@@ -446,7 +457,9 @@ impl WhoQueue {
         self.interval.set_min(interval);
     }
 
-    pub fn interval_too_short(&mut self) {
+    pub fn who_reply_throttled(&mut self) {
+        self.last_throttled = Some(Instant::now());
+
         self.interval.too_short();
     }
 
@@ -456,67 +469,163 @@ impl WhoQueue {
 
     // User did not request, treat as part of rate-limiting response
     // (in conjunction with RPL_TRYAGAIN) and don't save to history.
-    pub fn handle_who_rate_limit(&mut self) {
-        if let Some(who_poll) = self.polls.front_mut() {
+    pub fn handle_who_rate_limited(&mut self) {
+        if let Some(who_poll) = self.queue.front_mut() {
             who_poll.status = WhoStatus::Waiting(Instant::now());
         }
 
-        self.polls
+        self.queue
             .iter_mut()
             .skip(1)
             .for_each(|who_poll| who_poll.status = WhoStatus::Received);
     }
 
-    pub fn prioritize_joined_who_poll(&mut self, channel: Channel) {
-        if let Some(pos) = self.polls.iter().position(|who_poll| {
-            who_poll.channel == channel
-                && matches!(
-                    who_poll.status,
-                    WhoStatus::Joined
-                        | WhoStatus::PrioritizedJoin
-                        | WhoStatus::Waiting(_)
-                )
-        }) && pos != 0
-            && let Some(mut who_poll) = self.polls.remove(pos)
+    pub fn prioritize_joined_who_poll(
+        &mut self,
+        server: &Server,
+        channel: &Channel,
+    ) {
+        if let Some(pos) = self
+            .queue
+            .iter()
+            .position(|who_poll| &who_poll.channel == channel)
+            && pos != 0
+            && let Some(mut who_poll) = self.queue.remove(pos)
         {
             if matches!(who_poll.status, WhoStatus::Joined) {
                 who_poll.status = WhoStatus::PrioritizedJoin;
             }
 
-            log::debug!("prioritizing who poll for: {channel:?}");
-            self.polls.push_front(who_poll);
+            log::trace!(
+                "[{}] {} - WHO poll prioritizing join",
+                server,
+                channel.as_normalized_str(),
+            );
+            self.queue.push_front(who_poll);
         }
     }
 
-    pub fn deprioritize_joined_who_poll(&mut self, channel: Channel) {
-        if let Some(pos) = self.polls.iter().position(|who_poll| {
+    pub fn deprioritize_joined_who_poll(
+        &mut self,
+        server: &Server,
+        channel: Channel,
+    ) {
+        if let Some(pos) = self.queue.iter().position(|who_poll| {
             who_poll.channel == channel
                 && matches!(who_poll.status, WhoStatus::PrioritizedJoin)
         }) {
-            log::debug!("deprioritizing who poll for: {channel:?}");
-            self.polls[pos].status = WhoStatus::Joined;
+            log::trace!(
+                "[{}] {} - WHO poll deprioritizing join",
+                server,
+                channel.as_normalized_str()
+            );
+            self.queue[pos].status = WhoStatus::Joined;
         }
     }
 
     pub fn reprioritize_joined_who_polls(
         &mut self,
         server: &Server,
-        opened_channels: Vec<(&Server, &Channel)>,
+        opened_channels: &Vec<(&Server, &Channel)>,
+        exclude_channel: &Channel,
     ) {
         let channels_to_deprioritize: Vec<Channel> = self
-            .polls
+            .queue
             .iter()
             .filter(|who_poll| {
                 matches!(who_poll.status, WhoStatus::PrioritizedJoin)
+                    && who_poll.channel != *exclude_channel
                     && !opened_channels
                         .iter()
                         .any(|(s, c)| *s == server && *c == &who_poll.channel)
             })
-            .map(|who_poll| who_poll.channel.clone())
+            .map(|who_poll| who_poll.channel.to_owned())
             .collect();
 
         for channel in channels_to_deprioritize {
-            self.deprioritize_joined_who_poll(channel);
+            self.deprioritize_joined_who_poll(server, channel);
         }
+    }
+
+    pub fn process_next_prioritized_join(
+        &mut self,
+        server: &client::Server,
+        capabilities: &Capabilities,
+        chanmap: &IndexMap<Channel, client::Channel>,
+        isupport: &HashMap<isupport::Kind, isupport::Parameter>,
+    ) -> Vec<(message::Encoded, TokenPriority)> {
+        let mut messages: Vec<(message::Encoded, TokenPriority)> = vec![];
+
+        let now = Instant::now();
+        if let Some(last_throttled) = self.last_throttled
+            && now.duration_since(last_throttled) < self.interval.duration()
+        {
+            log::trace!(
+                "[{server}] - WHO poll throttled, end next prioritizing"
+            );
+            return messages;
+        }
+
+        if let Some(pos) = self.queue.iter().position(|who_poll| {
+            matches!(who_poll.status, WhoStatus::PrioritizedJoin)
+        }) && let Some(mut who_poll) = self.queue.remove(pos)
+        {
+            log::trace!(
+                "[{}] {} - WHO poll processing next prioritized join",
+                server,
+                who_poll.channel
+            );
+
+            let message = tick_who_poll_request(
+                &mut who_poll,
+                capabilities,
+                chanmap,
+                isupport,
+            );
+            self.inflight.push(who_poll);
+
+            messages.push((message.into(), TokenPriority::Low));
+        }
+        messages
+    }
+}
+
+fn tick_who_poll_request(
+    who_poll: &mut WhoPoll,
+    capabilities: &Capabilities,
+    chanmap: &IndexMap<Channel, client::Channel>,
+    isupport: &HashMap<isupport::Kind, isupport::Parameter>,
+) -> Message {
+    if isupport.contains_key(&isupport::Kind::WHOX) {
+        let whox_params = if capabilities
+            .acknowledged(Capability::NoImplicitNames)
+            && chanmap
+                .get(&who_poll.channel)
+                .is_none_or(|channel| !channel.who_init)
+        {
+            WhoXPollParameters::InitialJoin
+        } else if capabilities.acknowledged(Capability::AccountNotify) {
+            WhoXPollParameters::WithAccountName
+        } else {
+            WhoXPollParameters::Default
+        };
+
+        who_poll.status = WhoStatus::Requested(
+            WhoSource::Poll,
+            Instant::now(),
+            Some(whox_params.token()),
+        );
+
+        command!(
+            "WHO",
+            who_poll.channel.to_string(),
+            whox_params.fields().to_string(),
+            whox_params.token().to_owned()
+        )
+    } else {
+        who_poll.status =
+            WhoStatus::Requested(WhoSource::Poll, Instant::now(), None);
+
+        command!("WHO", who_poll.channel.to_string())
     }
 }

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -1148,8 +1148,8 @@ pub enum WhoXPollParameters {
 impl WhoXPollParameters {
     pub fn fields(&self) -> &'static str {
         match self {
-            WhoXPollParameters::Default => "tcnf",
-            WhoXPollParameters::WithAccountName => "tcnfa",
+            WhoXPollParameters::Default => "tcnfuh",
+            WhoXPollParameters::WithAccountName => "tcnfuha",
         }
     }
 

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -1151,7 +1151,7 @@ impl WhoXPollParameters {
         match self {
             WhoXPollParameters::Default => "tcnf",
             WhoXPollParameters::WithAccountName => "tcnfa",
-            WhoXPollParameters::InitialJoin => "tcnfuha",
+            WhoXPollParameters::InitialJoin => "tcuhnfa",
         }
     }
 

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -1147,6 +1147,10 @@ pub enum WhoXPollParameters {
 }
 
 impl WhoXPollParameters {
+    // Fields are listed in return order here for ease of reference, but
+    // return order is not dependent on the order provided in a WHOX
+    // request.  Returned field ordering is defined by the WHOX
+    // specification: https://ircv3.net/specs/extensions/whox
     pub fn fields(&self) -> &'static str {
         match self {
             WhoXPollParameters::Default => "tcnf",

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -1143,13 +1143,15 @@ impl FromStr for WhoToken {
 pub enum WhoXPollParameters {
     Default,
     WithAccountName,
+    InitialJoin,
 }
 
 impl WhoXPollParameters {
     pub fn fields(&self) -> &'static str {
         match self {
-            WhoXPollParameters::Default => "tcnfuh",
-            WhoXPollParameters::WithAccountName => "tcnfuha",
+            WhoXPollParameters::Default => "tcnf",
+            WhoXPollParameters::WithAccountName => "tcnfa",
+            WhoXPollParameters::InitialJoin => "tcnfuha",
         }
     }
 
@@ -1160,6 +1162,9 @@ impl WhoXPollParameters {
             },
             WhoXPollParameters::WithAccountName => WhoToken {
                 digits: ['9', '9', '\0'],
+            },
+            WhoXPollParameters::InitialJoin => WhoToken {
+                digits: ['9', '9', '9'],
             },
         }
     }

--- a/data/src/rate_limit.rs
+++ b/data/src/rate_limit.rs
@@ -2,6 +2,7 @@ use std::collections::VecDeque;
 
 use tokio::time::{Duration, Instant};
 
+#[derive(Debug, Clone)]
 pub struct BackoffInterval {
     duration: Duration,
     previous: Duration,
@@ -9,6 +10,7 @@ pub struct BackoffInterval {
     mode: BackoffMode,
 }
 
+#[derive(Debug, Clone)]
 enum BackoffMode {
     Set,
     BackingOff(usize),

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -99,6 +99,10 @@ impl ChannelUsers {
         self.0.is_empty()
     }
 
+    pub fn contains(&self, user: &User) -> bool {
+        self.0.contains(user)
+    }
+
     // Any modifications to this procedure MUST ensure that no
     // modifications are made to the user's hash.
     pub fn update_user(
@@ -447,29 +451,33 @@ impl User {
         })
     }
 
-    pub fn parse_from_whoreply(
-        nick: &String,
+    pub fn from_whoreply(
+        nick: &str,
         flags: &str,
-        user: &String,
-        host: &String,
+        user: &str,
+        host: &str,
+        account: Option<&str>,
         casemapping: isupport::CaseMap,
-        prefix: Option<&[isupport::PrefixMap]>,
-    ) -> Result<Self, ParseUserError> {
-        let access_level: String = flags[1..]
+        bot_mode_char: Option<char>,
+    ) -> Self {
+        let access_levels = flags
             .chars()
-            .filter(|c| {
-                if let Some(prefix) = prefix {
-                    prefix.iter().any(|p| p.prefix == *c)
-                } else {
-                    AccessLevel::try_from(*c).is_ok()
-                }
-            })
-            .collect();
-        User::parse(
-            format!("{access_level}{nick}!{user}@{host}").as_str(),
-            casemapping,
-            prefix,
-        )
+            .skip(1)
+            .filter_map(|c| AccessLevel::try_from(c).ok())
+            .collect::<BTreeSet<_>>();
+        let away = flags.starts_with('G');
+        let bot =
+            bot_mode_char.is_some_and(|bot_char| flags.contains(bot_char));
+
+        User {
+            nickname: Nick::from_str(nick, casemapping),
+            username: Some(user.to_string()),
+            hostname: Some(host.to_string()),
+            accountname: account.map(ToString::to_string),
+            access_levels,
+            away,
+            bot,
+        }
     }
 
     pub fn parse_or_force(

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -447,6 +447,31 @@ impl User {
         })
     }
 
+    pub fn parse_from_whoreply(
+        nick: &String,
+        flags: &str,
+        user: &String,
+        host: &String,
+        casemapping: isupport::CaseMap,
+        prefix: Option<&[isupport::PrefixMap]>,
+    ) -> Result<Self, ParseUserError> {
+        let access_level: String = flags[1..]
+            .chars()
+            .filter(|c| {
+                if let Some(prefix) = prefix {
+                    prefix.iter().any(|p| p.prefix == *c)
+                } else {
+                    AccessLevel::try_from(*c).is_ok()
+                }
+            })
+            .collect();
+        User::parse(
+            format!("{access_level}{nick}!{user}@{host}").as_str(),
+            casemapping,
+            prefix,
+        )
+    }
+
     pub fn parse_or_force(
         value: &str,
         casemapping: isupport::CaseMap,

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,7 @@ We strive to be a leading irc client with a rich IRCv3 feature set. Currently su
 - [multi-prefix](https://ircv3.net/specs/extensions/multi-prefix)
 - [multiline](https://ircv3.net/specs/extensions/multiline)
 - [network-icon](https://ircv3.net/specs/extensions/network-icon)
+- [no-implicit-names](https://ircv3.net/specs/extensions/no-implicit-names)
 - [react](https://ircv3.net/specs/client-tags/react.html)
 - [read-marker](https://ircv3.net/specs/extensions/read-marker)
 - [reply](https://ircv3.net/specs/client-tags/reply)

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use data::capabilities::Capability;
 use data::dashboard::BufferAction;
 use data::history::filter::FilterChain;
 use data::preview::{self, Previews};
@@ -223,8 +224,17 @@ pub fn view<'a>(
             settings.channel.nicklist.enabled
         });
 
+    let is_nicklist_ready: bool = !clients
+        .get_capabilities_ref(server)
+        .acknowledged(Capability::NoImplicitNames)
+        || clients
+            .client(server)
+            .is_some_and(|client| client.is_who_init(channel));
+
+    let show_nicklist = nicklist_enabled && is_nicklist_ready;
+
     let content =
-        match (nicklist_enabled, config.buffer.channel.nicklist.position) {
+        match (show_nicklist, config.buffer.channel.nicklist.position) {
             (true, data::channel::Position::Left) => row![nick_list, content],
             (true, data::channel::Position::Right) => row![content, nick_list],
             (false, _) => { row![content] }.height(Length::Fill),

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -1,5 +1,4 @@
 use chrono::{DateTime, Utc};
-use data::capabilities::Capability;
 use data::dashboard::BufferAction;
 use data::history::filter::FilterChain;
 use data::preview::{self, Previews};
@@ -219,19 +218,10 @@ pub fn view<'a>(
 
     let content = column![topic, messages];
 
-    let nicklist_enabled = settings
+    let show_nicklist = settings
         .map_or(config.buffer.channel.nicklist.enabled, |settings| {
             settings.channel.nicklist.enabled
         });
-
-    let is_nicklist_ready: bool = !clients
-        .get_capabilities_ref(server)
-        .acknowledged(Capability::NoImplicitNames)
-        || clients
-            .client(server)
-            .is_some_and(|client| client.is_who_init(channel));
-
-    let show_nicklist = nicklist_enabled && is_nicklist_ready;
 
     let content =
         match (show_nicklist, config.buffer.channel.nicklist.position) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1820,9 +1820,14 @@ fn handle_client_events(
                         )
                         .map(Message::Dashboard),
                 );
-
-                if dashboard.has_open_channel_pane(server, &channel) {
-                    clients.prioritize_channel_who_poll(server, channel);
+                let (opened_channels, opened) =
+                    dashboard.has_open_pane_channel(server, &channel);
+                if opened {
+                    clients.prioritize_channel_who_poll(
+                        server,
+                        channel,
+                        opened_channels,
+                    );
                 }
             }
             Event::LoggedIn(server_time) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1814,12 +1814,16 @@ fn handle_client_events(
                         .load_metadata_and_request_newer_chathistory(
                             clients,
                             server.clone(),
-                            Target::Channel(channel),
+                            Target::Channel(channel.to_owned()),
                             server_time,
                             false,
                         )
                         .map(Message::Dashboard),
                 );
+
+                if dashboard.has_open_channel_pane(server, &channel) {
+                    clients.prioritize_channel_who_poll(server, channel);
+                }
             }
             Event::LoggedIn(server_time) => {
                 if clients.get_server_supports_chathistory(server)
@@ -1833,7 +1837,6 @@ fn handle_client_events(
                 {
                     commands.push(command);
                 }
-                dashboard.prioritize_panes_joined_who_polls(server, clients);
             }
             Event::ChatHistoryTargetReceived(target, server_time) => {
                 commands.push(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1828,11 +1828,12 @@ fn handle_client_events(
                         server,
                         &channel.as_normalized_str(),
                     );
-                    clients.prioritize_channel_who_poll(
-                        server,
-                        &channel,
-                        &opened_channels,
-                    );
+                    if let Some(client) = clients.client_mut(server) {
+                        client.prioritize_joined_who_poll(
+                            &channel,
+                            &opened_channels,
+                        );
+                    }
                 }
             }
             Event::LoggedIn(server_time) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1820,20 +1820,9 @@ fn handle_client_events(
                         )
                         .map(Message::Dashboard),
                 );
-                let (opened_channels, opened) =
-                    dashboard.has_open_pane_channel(server, &channel);
-                if opened {
-                    log::trace!(
-                        "[{}] {} - WHO poll open pane prioritize",
-                        server,
-                        &channel.as_normalized_str(),
-                    );
-                    if let Some(client) = clients.client_mut(server) {
-                        client.prioritize_joined_who_poll(
-                            &channel,
-                            &opened_channels,
-                        );
-                    }
+
+                if dashboard.has_open_pane_channel(server, &channel) {
+                    clients.prioritize_who_poll(server, &channel);
                 }
             }
             Event::LoggedIn(server_time) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1823,10 +1823,15 @@ fn handle_client_events(
                 let (opened_channels, opened) =
                     dashboard.has_open_pane_channel(server, &channel);
                 if opened {
+                    log::trace!(
+                        "[{}] {} - WHO poll open pane prioritize",
+                        server,
+                        &channel.as_normalized_str(),
+                    );
                     clients.prioritize_channel_who_poll(
                         server,
-                        channel,
-                        opened_channels,
+                        &channel,
+                        &opened_channels,
                     );
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1833,6 +1833,7 @@ fn handle_client_events(
                 {
                     commands.push(command);
                 }
+                dashboard.prioritize_panes_joined_who_polls(server, clients);
             }
             Event::ChatHistoryTargetReceived(target, server_time) => {
                 commands.push(

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1070,86 +1070,44 @@ impl Dashboard {
                         let all_buffers = all_buffers(clients, &self.history);
                         let open_buffers = open_buffers(self);
 
-                        if let Some((window, pane, state, history)) =
-                            self.get_focused_with_history_mut()
+                        if let Some((_, _, state)) = self.get_focused_mut()
                             && let Some(buffer) = cycle_next_buffer(
                                 state.buffer.upstream(),
                                 all_buffers,
                                 &open_buffers,
                             )
                         {
-                            mark_as_read_on_buffer_close(
-                                &state.buffer,
-                                history,
-                                clients,
-                                config,
+                            return (
+                                self.open_buffer(
+                                    data::Buffer::Upstream(buffer.clone()),
+                                    BufferAction::ReplacePane,
+                                    clients,
+                                    config,
+                                ),
+                                None,
                             );
-
-                            state.buffer = Buffer::from_data(
-                                data::Buffer::Upstream(buffer.clone()),
-                                clients,
-                                history,
-                                state.size,
-                                config,
-                            );
-                            self.last_changed = Some(Instant::now());
-
-                            let server = buffer.server();
-                            if let Some(channel) = buffer.channel()
-                                && let Some(client) = clients.client_mut(server)
-                            {
-                                let opened_channels =
-                                    &self.open_pane_channels();
-                                client.prioritize_joined_who_poll(
-                                    channel,
-                                    opened_channels,
-                                );
-                            }
-
-                            return (self.focus_pane(window, pane), None);
                         }
                     }
                     CyclePreviousBuffer => {
                         let all_buffers = all_buffers(clients, &self.history);
                         let open_buffers = open_buffers(self);
 
-                        if let Some((window, pane, state, history)) =
-                            self.get_focused_with_history_mut()
+                        if let Some((_, _, state)) = self.get_focused_mut()
                             && let Some(buffer) = cycle_previous_buffer(
                                 state.buffer.upstream(),
                                 all_buffers,
                                 &open_buffers,
                             )
                         {
-                            mark_as_read_on_buffer_close(
-                                &state.buffer,
-                                history,
-                                clients,
-                                config,
+                            return (
+                                self.open_buffer(
+                                    data::Buffer::Upstream(buffer.clone()),
+                                    BufferAction::ReplacePane,
+                                    clients,
+                                    config,
+                                ),
+                                None,
                             );
-
-                            state.buffer = Buffer::from_data(
-                                data::Buffer::Upstream(buffer.clone()),
-                                clients,
-                                history,
-                                state.size,
-                                config,
-                            );
-                            self.last_changed = Some(Instant::now());
-
-                            let server = buffer.server();
-                            if let Some(channel) = buffer.channel()
-                                && let Some(client) = clients.client_mut(server)
-                            {
-                                let opened_channels =
-                                    &self.open_pane_channels();
-                                client.prioritize_joined_who_poll(
-                                    channel,
-                                    opened_channels,
-                                );
-                            }
-
-                            return (self.focus_pane(window, pane), None);
                         }
                     }
                     LeaveBuffer => {
@@ -1371,30 +1329,22 @@ impl Dashboard {
                             all_buffers_with_has_unread(clients, &self.history);
                         let open_buffers = open_buffers(self);
 
-                        if let Some((window, pane, state, history)) =
-                            self.get_focused_with_history_mut()
+                        if let Some((_, _, state)) = self.get_focused_mut()
                             && let Some(buffer) = cycle_next_unread_buffer(
                                 state.buffer.upstream(),
                                 all_buffers,
                                 &open_buffers,
                             )
                         {
-                            mark_as_read_on_buffer_close(
-                                &state.buffer,
-                                history,
-                                clients,
-                                config,
+                            return (
+                                self.open_buffer(
+                                    data::Buffer::Upstream(buffer.clone()),
+                                    BufferAction::ReplacePane,
+                                    clients,
+                                    config,
+                                ),
+                                None,
                             );
-
-                            state.buffer = Buffer::from_data(
-                                data::Buffer::Upstream(buffer),
-                                clients,
-                                history,
-                                state.size,
-                                config,
-                            );
-                            self.last_changed = Some(Instant::now());
-                            return (self.focus_pane(window, pane), None);
                         }
                     }
                     CyclePreviousUnreadBuffer => {
@@ -1402,30 +1352,22 @@ impl Dashboard {
                             all_buffers_with_has_unread(clients, &self.history);
                         let open_buffers = open_buffers(self);
 
-                        if let Some((window, pane, state, history)) =
-                            self.get_focused_with_history_mut()
+                        if let Some((_, _, state)) = self.get_focused_mut()
                             && let Some(buffer) = cycle_previous_unread_buffer(
                                 state.buffer.upstream(),
                                 all_buffers,
                                 &open_buffers,
                             )
                         {
-                            mark_as_read_on_buffer_close(
-                                &state.buffer,
-                                history,
-                                clients,
-                                config,
+                            return (
+                                self.open_buffer(
+                                    data::Buffer::Upstream(buffer.clone()),
+                                    BufferAction::ReplacePane,
+                                    clients,
+                                    config,
+                                ),
+                                None,
                             );
-
-                            state.buffer = Buffer::from_data(
-                                data::Buffer::Upstream(buffer),
-                                clients,
-                                history,
-                                state.size,
-                                config,
-                            );
-                            self.last_changed = Some(Instant::now());
-                            return (self.focus_pane(window, pane), None);
                         }
                     }
                     MarkAsRead => {
@@ -3016,20 +2958,16 @@ impl Dashboard {
 
         self.last_changed = Some(Instant::now());
 
-        if let Some(buffer::Upstream::Channel(server, channel)) =
-            buffer.upstream()
-            && let Some(client) = clients.client_mut(server)
-        {
-            let opened_channels = &self.open_pane_channels();
-            client.prioritize_joined_who_poll(channel, opened_channels);
-        }
+        match buffer.upstream() {
+            Some(buffer::Upstream::Channel(server, channel)) => {
+                clients.prioritize_who_poll(server, channel);
+            }
+            Some(buffer::Upstream::Query(server, query)) => {
+                let user = User::from(Nick::from(query));
 
-        if let Some(buffer::Upstream::Query(server, query)) = buffer.upstream()
-            && let Some(client) = clients.client_mut(server)
-            && let user = User::from(Nick::from(query))
-            && !client.is_monitored_user(&user)
-        {
-            client.add_monitored_user_automated(&user);
+                clients.add_monitored_user_automated(server, &user);
+            }
+            Some(buffer::Upstream::Server(..)) | None => (),
         }
 
         match buffer_action {
@@ -3055,6 +2993,12 @@ impl Dashboard {
                         clients,
                         config,
                     );
+
+                    if let Some(buffer::Upstream::Channel(server, channel)) =
+                        state.buffer.upstream()
+                    {
+                        clients.deprioritize_who_poll(server, channel);
+                    }
 
                     state.buffer = Buffer::from_data(
                         buffer,
@@ -4091,6 +4035,12 @@ impl Dashboard {
                 config,
             );
 
+            if let Some(buffer::Upstream::Channel(server, channel)) =
+                state.buffer.upstream()
+            {
+                clients.deprioritize_who_poll(server, channel);
+            }
+
             if config.buffer.close.query.close()
                 && let Some(history::Kind::Query(server, nick)) =
                     state.buffer.data().and_then(history::Kind::from_buffer)
@@ -4961,12 +4911,10 @@ impl Dashboard {
         &self,
         server: &Server,
         channel: &target::Channel,
-    ) -> (Vec<(&Server, &target::Channel)>, bool) {
-        let opened_channels = self.open_pane_channels();
-        let is_channel_opened = &opened_channels
+    ) -> bool {
+        self.open_pane_channels()
             .iter()
-            .any(|(s, c)| *s == server && *c == channel);
-        (opened_channels, *is_channel_opened)
+            .any(|(s, c)| *s == server && *c == channel)
     }
 
     pub fn open_pane_server_queries(

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1098,9 +1098,10 @@ impl Dashboard {
                             if let Some(channel) = buffer.channel()
                                 && let Some(client) = clients.client_mut(server)
                             {
-                                let opened_channels = self.open_pane_channels();
+                                let opened_channels =
+                                    &self.open_pane_channels();
                                 client.prioritize_joined_who_poll(
-                                    channel.to_owned(),
+                                    channel,
                                     opened_channels,
                                 );
                             }
@@ -1140,9 +1141,10 @@ impl Dashboard {
                             if let Some(channel) = buffer.channel()
                                 && let Some(client) = clients.client_mut(server)
                             {
-                                let opened_channels = self.open_pane_channels();
+                                let opened_channels =
+                                    &self.open_pane_channels();
                                 client.prioritize_joined_who_poll(
-                                    channel.to_owned(),
+                                    channel,
                                     opened_channels,
                                 );
                             }
@@ -3019,11 +3021,8 @@ impl Dashboard {
             && let Some(channel) = upstream.channel()
             && let Some(client) = clients.client_mut(server)
         {
-            let opened_channels = self.open_pane_channels();
-            client.prioritize_joined_who_poll(
-                channel.to_owned(),
-                opened_channels,
-            );
+            let opened_channels = &self.open_pane_channels();
+            client.prioritize_joined_who_poll(channel, opened_channels);
         }
 
         if let Some(buffer::Upstream::Query(server, query)) = buffer.upstream()

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1098,8 +1098,10 @@ impl Dashboard {
                             if let Some(channel) = buffer.channel()
                                 && let Some(client) = clients.client_mut(server)
                             {
+                                let opened_channels = self.open_pane_channels();
                                 client.prioritize_joined_who_poll(
                                     channel.to_owned(),
+                                    opened_channels,
                                 );
                             }
 
@@ -1138,8 +1140,10 @@ impl Dashboard {
                             if let Some(channel) = buffer.channel()
                                 && let Some(client) = clients.client_mut(server)
                             {
+                                let opened_channels = self.open_pane_channels();
                                 client.prioritize_joined_who_poll(
                                     channel.to_owned(),
+                                    opened_channels,
                                 );
                             }
 
@@ -3015,7 +3019,11 @@ impl Dashboard {
             && let Some(channel) = upstream.channel()
             && let Some(client) = clients.client_mut(server)
         {
-            client.prioritize_joined_who_poll(channel.to_owned());
+            let opened_channels = self.open_pane_channels();
+            client.prioritize_joined_who_poll(
+                channel.to_owned(),
+                opened_channels,
+            );
         }
 
         if let Some(buffer::Upstream::Query(server, query)) = buffer.upstream()
@@ -4939,17 +4947,28 @@ impl Dashboard {
         }
     }
 
-    pub fn has_open_channel_pane(
+    pub fn open_pane_channels(&self) -> Vec<(&Server, &target::Channel)> {
+        self.panes
+            .iter()
+            .filter_map(|(_, _, pane)| match pane.buffer.upstream() {
+                Some(buffer::Upstream::Channel(server, channel)) => {
+                    Some((server, channel))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    pub fn has_open_pane_channel(
         &self,
         server: &Server,
         channel: &target::Channel,
-    ) -> bool {
-        self.panes.iter().any(|(_, _, pane)| {
-            matches!(
-                pane.buffer.upstream(),
-                Some(buffer::Upstream::Channel(s, c)) if s == server && c == channel
-            )
-        })
+    ) -> (Vec<(&Server, &target::Channel)>, bool) {
+        let opened_channels = self.open_pane_channels();
+        let is_channel_opened = &opened_channels
+            .iter()
+            .any(|(s, c)| *s == server && *c == channel);
+        (opened_channels, *is_channel_opened)
     }
 
     pub fn open_pane_server_queries(

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -4939,22 +4939,17 @@ impl Dashboard {
         }
     }
 
-    pub fn prioritize_panes_joined_who_polls(
+    pub fn has_open_channel_pane(
         &self,
-        server: &data::Server,
-        clients: &mut client::Map,
-    ) {
-        if let Some(client) = clients.client_mut(server) {
-            for (_, _, pane) in self.panes.iter() {
-                if let Some(buffer) = pane.buffer.data()
-                    && let Some(upstream) = buffer.upstream()
-                    && upstream.server() == server
-                    && let Some(channel) = upstream.channel()
-                {
-                    client.prioritize_joined_who_poll(channel.to_owned());
-                }
-            }
-        }
+        server: &Server,
+        channel: &target::Channel,
+    ) -> bool {
+        self.panes.iter().any(|(_, _, pane)| {
+            matches!(
+                pane.buffer.upstream(),
+                Some(buffer::Upstream::Channel(s, c)) if s == server && c == channel
+            )
+        })
     }
 
     pub fn open_pane_server_queries(

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -3016,9 +3016,8 @@ impl Dashboard {
 
         self.last_changed = Some(Instant::now());
 
-        if let Some(upstream) = buffer.upstream()
-            && let server = upstream.server()
-            && let Some(channel) = upstream.channel()
+        if let Some(buffer::Upstream::Channel(server, channel)) =
+            buffer.upstream()
             && let Some(client) = clients.client_mut(server)
         {
             let opened_channels = &self.open_pane_channels();

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1086,13 +1086,23 @@ impl Dashboard {
                             );
 
                             state.buffer = Buffer::from_data(
-                                data::Buffer::Upstream(buffer),
+                                data::Buffer::Upstream(buffer.clone()),
                                 clients,
                                 history,
                                 state.size,
                                 config,
                             );
                             self.last_changed = Some(Instant::now());
+
+                            let server = buffer.server();
+                            if let Some(channel) = buffer.channel()
+                                && let Some(client) = clients.client_mut(server)
+                            {
+                                client.prioritize_joined_who_poll(
+                                    channel.to_owned(),
+                                );
+                            }
+
                             return (self.focus_pane(window, pane), None);
                         }
                     }
@@ -1116,13 +1126,23 @@ impl Dashboard {
                             );
 
                             state.buffer = Buffer::from_data(
-                                data::Buffer::Upstream(buffer),
+                                data::Buffer::Upstream(buffer.clone()),
                                 clients,
                                 history,
                                 state.size,
                                 config,
                             );
                             self.last_changed = Some(Instant::now());
+
+                            let server = buffer.server();
+                            if let Some(channel) = buffer.channel()
+                                && let Some(client) = clients.client_mut(server)
+                            {
+                                client.prioritize_joined_who_poll(
+                                    channel.to_owned(),
+                                );
+                            }
+
                             return (self.focus_pane(window, pane), None);
                         }
                     }
@@ -2989,6 +3009,14 @@ impl Dashboard {
         let panes = self.panes.clone();
 
         self.last_changed = Some(Instant::now());
+
+        if let Some(upstream) = buffer.upstream()
+            && let server = upstream.server()
+            && let Some(channel) = upstream.channel()
+            && let Some(client) = clients.client_mut(server)
+        {
+            client.prioritize_joined_who_poll(channel.to_owned());
+        }
 
         if let Some(buffer::Upstream::Query(server, query)) = buffer.upstream()
             && let Some(client) = clients.client_mut(server)
@@ -4908,6 +4936,24 @@ impl Dashboard {
                 (win == w && !matches!(pane.buffer, Buffer::Empty))
                     .then_some(pane.buffer.to_string())
             })
+        }
+    }
+
+    pub fn prioritize_panes_joined_who_polls(
+        &self,
+        server: &data::Server,
+        clients: &mut client::Map,
+    ) {
+        if let Some(client) = clients.client_mut(server) {
+            for (_, _, pane) in self.panes.iter() {
+                if let Some(buffer) = pane.buffer.data()
+                    && let Some(upstream) = buffer.upstream()
+                    && upstream.server() == server
+                    && let Some(channel) = upstream.channel()
+                {
+                    client.prioritize_joined_who_poll(channel.to_owned());
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Implements [`no-implicit-names`](https://ircv3.net/specs/extensions/no-implicit-names). Added temporary support for `draft/no-implicit-names` since this was ratified recently and I want to make sure we're compatible with soju and ergo both before they've had a chance to upgrade! 

Updated the `/WHO` commands to include filling in the channel's user list. Also, the `/WHO` commands sent on join scenarios have been updated to fire faster when appropriate as well.

~Any keen people want to go make those PRs to soju and ergo??? :eyes:~

[ergo PR](https://github.com/ergochat/ergo/pull/2390) - merged; will be in ergo v2.19
[soju PR](https://codeberg.org/emersion/soju/pulls/388) - merged; will be in soju v0.11.0
