### PR TITLE
Update rand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
  "libc",
  "once_cell",
  "postage",
- "rand 0.9.2",
+ "rand 0.9.4",
  "safelog",
  "serde",
  "tempfile",
@@ -352,7 +352,7 @@ dependencies = [
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand 0.9.2",
+ "rand 0.9.4",
  "raw-window-handle",
  "serde",
  "serde_repr",
@@ -1647,7 +1647,7 @@ dependencies = [
  "nucleo-matcher",
  "palette",
  "percent-encoding",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "reqwest",
  "seahash",
@@ -1726,7 +1726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "284db66a66f03c3dafbe17360d959eb76b83f77cfe191677e2a7899c0da291f3"
 dependencies = [
  "derive-deftly-macros",
- "heck 0.5.0",
+ "heck 0.4.1",
 ]
 
 [[package]]
@@ -1735,8 +1735,8 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caef6056a5788d05d173cdc3c562ac28ae093828f851f69378b74e4e3d578e41"
 dependencies = [
- "heck 0.5.0",
- "indexmap 2.13.0",
+ "heck 0.4.1",
+ "indexmap 1.9.3",
  "itertools",
  "proc-macro-crate",
  "proc-macro2",
@@ -2938,7 +2938,7 @@ dependencies = [
  "open",
  "palette",
  "percent-encoding",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "reqwest",
  "rfd",
@@ -3720,7 +3720,7 @@ dependencies = [
  "futures",
  "interprocess",
  "log",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "thiserror 2.0.18",
  "tokio",
@@ -5731,7 +5731,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
@@ -5796,9 +5796,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -5806,9 +5806,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -5919,7 +5919,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",
@@ -7925,7 +7925,7 @@ dependencies = [
  "itertools",
  "libc",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "serde",
  "slab",
@@ -7968,7 +7968,7 @@ dependencies = [
  "educe",
  "itertools",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.4",
  "smallvec",
  "thiserror 2.0.18",
  "tor-basic-utils",
@@ -8020,7 +8020,7 @@ dependencies = [
  "oneshot-fused-workaround",
  "percent-encoding",
  "postage",
- "rand 0.9.2",
+ "rand 0.9.4",
  "safelog",
  "serde",
  "serde_with",
@@ -8079,7 +8079,7 @@ dependencies = [
  "once_cell",
  "oneshot-fused-workaround",
  "pin-project",
- "rand 0.9.2",
+ "rand 0.9.4",
  "retry-error",
  "safelog",
  "serde",
@@ -8247,7 +8247,7 @@ dependencies = [
  "oneshot-fused-workaround",
  "paste",
  "postage",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rusqlite",
  "safelog",
  "scopeguard",
@@ -8330,7 +8330,7 @@ dependencies = [
  "oneshot-fused-workaround",
  "pin-project",
  "postage",
- "rand 0.9.2",
+ "rand 0.9.4",
  "safelog",
  "serde",
  "strum 0.28.0",
@@ -8368,7 +8368,7 @@ dependencies = [
  "itertools",
  "oneshot-fused-workaround",
  "postage",
- "rand 0.9.2",
+ "rand 0.9.4",
  "retry-error",
  "safelog",
  "slotmap-careful",
@@ -8412,7 +8412,7 @@ dependencies = [
  "humantime",
  "itertools",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.4",
  "safelog",
  "serde",
  "signature",
@@ -8439,7 +8439,7 @@ dependencies = [
  "derive_more",
  "downcast-rs 2.0.2",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rsa",
  "signature",
  "ssh-key-fork-arti",
@@ -8470,7 +8470,7 @@ dependencies = [
  "humantime",
  "inventory",
  "itertools",
- "rand 0.9.2",
+ "rand 0.9.4",
  "safelog",
  "serde",
  "signature",
@@ -8539,7 +8539,7 @@ dependencies = [
  "getrandom 0.3.4",
  "getrandom 0.4.2",
  "hex",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_core 0.6.4",
  "rand_core 0.9.5",
@@ -8635,7 +8635,7 @@ dependencies = [
  "humantime",
  "itertools",
  "num_enum",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "strum 0.28.0",
  "thiserror 2.0.18",
@@ -8674,7 +8674,7 @@ dependencies = [
  "memchr",
  "paste",
  "phf 0.13.1",
- "rand 0.9.2",
+ "rand 0.9.4",
  "saturating-time",
  "serde",
  "serde_with",
@@ -8759,7 +8759,7 @@ dependencies = [
  "oneshot-fused-workaround",
  "pin-project",
  "postage",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_core 0.9.5",
  "safelog",
  "slotmap-careful",
@@ -8835,7 +8835,7 @@ version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3110742f2a9e071c7f6c9278cd37e0bae0995d7171516fe4efb2de675645667e"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "tor-basic-utils",
  "tor-linkspec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ timeago = "0.6.0"
 itertools = "0.14.0"
 emojis = "0.8.0"
 unicode-segmentation = "1.13.2"
-rand = "0.10.0"
+rand = "0.10.1"
 rand_chacha = "0.10.0"
 palette = "0.7.4"
 log = { version = "0.4.26", features = ['std'] }


### PR DESCRIPTION
Update rand in response to [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html).  Two of the three `rand` dependencies are updated, with the third coming from [`rsa`](https://github.com/RustCrypto/RSA) (only needed for the `tor` feature as far as I can tell) which does not appear to have an update yet.  Closes #1828 and #1829.