### PR TITLE
Moved `typing` headings one level up to align with config.

### DIFF
--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -885,11 +885,11 @@ The path to PEM encoded PKCS#8 private key for external auth (optional).[^1] [^2
 key = "/path/to/your/private_key.pem"
 ```
 
-### `typing`
+## `typing`
 
 Typing settings for channel and query buffers on server.
 
-#### `share`
+### `share`
 
 Control whether Halloy shares your typing status with other users on the server.
 
@@ -902,7 +902,7 @@ Control whether Halloy shares your typing status with other users on the server.
 share = false
 ```
 
-#### `show`
+### `show`
 
 Control whether Halloy shows typing status from other users on the server.
 


### PR DESCRIPTION
This PR moves the `typing` section was at the correct level in the `servers` config.

| Before | After |
|--------|--------|
| <img width="897" height="991" alt="Screenshot_20260414_110506" src="https://github.com/user-attachments/assets/64a78e64-a3d9-4a6b-939b-0848e6e1c3b9" /> | <img width="888" height="986" alt="Screenshot_20260414_110435" src="https://github.com/user-attachments/assets/04a92d19-c165-42dc-aee1-60218ba66e4f" /> | 

*hint: it was under the `filehost` heading (or the `confirm_message_delivery` in the current release)