### PR TITLE
Expand Tooltip Setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Added:
 - Unread indicators for queries can be hidden via `sidebar.unread_indicator.exclude`
 - Settings to reroute direct PRIVMSG and/or NOTICE messages to another buffer (`servers.<name>.reroute.query` and `servers.<name>.reroute.notice`)
 - `channel-context` support
+- Expanded `tooltips` setting to allow hiding auto-complete tooltips
 
 Changed:
 
@@ -54,7 +55,7 @@ Removed:
 Thanks:
 
 - Contributions: @furudean, @omentic, @KaiKorla, @achille, @classabbyamp, @ncfavier, @englut, @WinnerWind
-- Bug reports: sebbu, @whitequark, @SnoopJ, esden, @miyukoc, @ld-cd, @achille, @classabbyamp, vignoux, @esden, @ncfavier, @englut, @cyrneko
+- Bug reports: sebbu, @whitequark, @SnoopJ, esden, @miyukoc, @ld-cd, @achille, @classabbyamp, vignoux, @esden, @ncfavier, @englut, @cyrneko, @jeffharrell1
 - Feature requests: @omentic, @classabbyamp, @ncfavier, @ineeee, @4e554c4c
 
 # 2026.5 (2026-03-21)

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -124,7 +124,7 @@ impl Default for Config {
 pub enum Tooltips {
     #[default]
     All,
-    AutocompleteOnly,
+    Autocomplete,
     None,
 }
 
@@ -137,7 +137,7 @@ impl<'de> Deserialize<'de> for Tooltips {
         #[serde(rename_all = "kebab-case")]
         pub enum Data {
             All,
-            AutocompleteOnly,
+            Autocomplete,
             None,
         }
 
@@ -158,7 +158,7 @@ impl<'de> Deserialize<'de> for Tooltips {
             }
             Inner::Enum(data) => match data {
                 Data::All => Ok(Tooltips::All),
-                Data::AutocompleteOnly => Ok(Tooltips::AutocompleteOnly),
+                Data::Autocomplete => Ok(Tooltips::Autocomplete),
                 Data::None => Ok(Tooltips::None),
             },
         }
@@ -169,13 +169,13 @@ impl Tooltips {
     pub fn show_for_buttons(&self) -> bool {
         match self {
             Self::All => true,
-            Self::AutocompleteOnly | Self::None => false,
+            Self::Autocomplete | Self::None => false,
         }
     }
 
     pub fn show_for_autocomplete(&self) -> bool {
         match self {
-            Self::All | Self::AutocompleteOnly => true,
+            Self::All | Self::Autocomplete => true,
             Self::None => false,
         }
     }

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -78,7 +78,7 @@ pub struct Config {
     pub notifications: Notifications,
     pub file_transfer: FileTransfer,
     pub filehost: Filehost,
-    pub tooltips: bool,
+    pub tooltips: Tooltips,
     pub window: Window,
     pub preview: Preview,
     pub highlights: Highlights,
@@ -106,7 +106,7 @@ impl Default for Config {
             notifications: Notifications::default(),
             file_transfer: FileTransfer::default(),
             filehost: Filehost::default(),
-            tooltips: true,
+            tooltips: Tooltips::default(),
             window: Window::default(),
             preview: Preview::default(),
             highlights: Highlights::default(),
@@ -116,6 +116,67 @@ impl Default for Config {
             logs: Logs::default(),
             platform_specific: PlatformSpecific::default(),
             check_for_update_on_launch: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub enum Tooltips {
+    #[default]
+    All,
+    AutocompleteOnly,
+    None,
+}
+
+impl<'de> Deserialize<'de> for Tooltips {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "kebab-case")]
+        pub enum Data {
+            All,
+            AutocompleteOnly,
+            None,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Inner {
+            Boolean(bool),
+            Enum(Data),
+        }
+
+        match Inner::deserialize(deserializer)? {
+            Inner::Boolean(b) => {
+                if b {
+                    Ok(Tooltips::All)
+                } else {
+                    Ok(Tooltips::None)
+                }
+            }
+            Inner::Enum(data) => match data {
+                Data::All => Ok(Tooltips::All),
+                Data::AutocompleteOnly => Ok(Tooltips::AutocompleteOnly),
+                Data::None => Ok(Tooltips::None),
+            },
+        }
+    }
+}
+
+impl Tooltips {
+    pub fn show_for_buttons(&self) -> bool {
+        match self {
+            Self::All => true,
+            Self::AutocompleteOnly | Self::None => false,
+        }
+    }
+
+    pub fn show_for_autocomplete(&self) -> bool {
+        match self {
+            Self::All | Self::AutocompleteOnly => true,
+            Self::None => false,
         }
     }
 }
@@ -367,7 +428,7 @@ impl Config {
             pub notifications: Notifications,
             pub file_transfer: FileTransfer,
             pub filehost: Filehost,
-            pub tooltips: bool,
+            pub tooltips: Tooltips,
             pub window: Window,
             pub preview: Preview,
             pub highlights: Highlights,
@@ -395,7 +456,7 @@ impl Config {
                     notifications: Notifications::default(),
                     file_transfer: FileTransfer::default(),
                     filehost: Filehost::default(),
-                    tooltips: true,
+                    tooltips: Tooltips::default(),
                     window: Window::default(),
                     preview: Preview::default(),
                     highlights: Highlights::default(),

--- a/docs/configuration/tooltips.md
+++ b/docs/configuration/tooltips.md
@@ -1,6 +1,6 @@
 # Tooltips
 
-Control if tooltips are displayed or not.
+Control which tooltips are displayed.
 
 ## `tooltips`
 
@@ -8,10 +8,11 @@ Control if tooltips are displayed or not.
 `tooltips` is a root key, so it must be placed before any section.
 :::
 
-```toml
-# Type: boolean
-# Values: true, false
-# Default: true
 
-tooltips = true
+```toml
+# Type: String
+# Values: "all", "autocomplete-only", "none"
+# Default: "all"
+
+tooltips = "none"
 ```

--- a/docs/configuration/tooltips.md
+++ b/docs/configuration/tooltips.md
@@ -11,7 +11,7 @@ Control which tooltips are displayed.
 
 ```toml
 # Type: String
-# Values: "all", "autocomplete-only", "none"
+# Values: "all", "autocomplete", "none"
 # Default: "all"
 
 tooltips = "none"

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -640,7 +640,7 @@ pub fn view<'a>(
                         theme::button::secondary(theme, status, false)
                     })
                     .on_press(Message::UploadFile),
-                Some("Upload file"),
+                config.tooltips.show_for_buttons().then_some("Upload file"),
                 tooltip::Position::Top,
                 theme,
             )

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -668,23 +668,32 @@ pub fn view<'a>(
     .spacing(4)
     .padding(padding::top(4));
 
-    let overlay = column![
-        state.completion.view(
-            state.input_content.text().as_str(),
-            server,
-            config,
-            theme,
-            Message::SelectCompletion,
-        ),
-        state
-            .notice
-            .as_ref()
-            .map(|notice| notice_view(notice, theme)),
-    ]
-    .padding([0, 8])
-    .spacing(4);
+    if config.tooltips.show_for_autocomplete() {
+        let overlay = column![
+            state.completion.view(
+                state.input_content.text().as_str(),
+                server,
+                config,
+                theme,
+                Message::SelectCompletion,
+            ),
+            state
+                .notice
+                .as_ref()
+                .map(|notice| notice_view(notice, theme)),
+        ]
+        .padding([0, 8])
+        .spacing(4);
 
-    anchored_overlay(content, overlay, anchored_overlay::Anchor::AboveTop, 4.0)
+        anchored_overlay(
+            content,
+            overlay,
+            anchored_overlay::Anchor::AboveTop,
+            4.0,
+        )
+    } else {
+        content.into()
+    }
 }
 
 fn notice_view<'a, 'b, Message: 'a>(

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -692,7 +692,7 @@ pub fn view<'a>(
             4.0,
         )
     } else {
-        content.into()
+        column![content].into()
     }
 }
 

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -347,6 +347,8 @@ impl<'a> ChannelQueryLayout<'a> {
             on_react,
             on_unreact,
             on_open_picker,
+            self.config.tooltips.show_for_buttons(),
+            self.theme,
         ))
     }
 

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -2028,7 +2028,7 @@ fn preview_row<'a>(
                 .style(|theme, status| {
                     theme::button::secondary(theme, status, false)
                 }),
-            config.tooltips.then_some("Hide Preview"),
+            config.tooltips.show_for_buttons().then_some("Hide Preview"),
             tooltip::Position::Top,
             theme,
         ))

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -135,7 +135,7 @@ impl Pane {
             clients,
             settings,
             self.modal.is_none(),
-            config.tooltips && self.modal.is_none(),
+            config.tooltips.show_for_buttons() && self.modal.is_none(),
             is_popout,
             config,
             theme,

--- a/src/widget/reaction_row.rs
+++ b/src/widget/reaction_row.rs
@@ -8,8 +8,8 @@ use iced::{alignment, padding};
 use unicode_segmentation::UnicodeSegmentation;
 
 use super::{Column, Element, Row};
-use crate::widget::text;
-use crate::{icon, theme};
+use crate::widget::{text, tooltip};
+use crate::{Theme, icon, theme};
 
 const REACTION_TOOLTIP_MAX_NAMES: usize = 10;
 
@@ -25,6 +25,8 @@ pub fn reaction_row<'a, M, F1, F2>(
     on_react: Option<F1>,
     on_unreact: Option<F2>,
     on_open_picker: Option<M>,
+    show_tooltips_for_buttons: bool,
+    theme: &'a Theme,
 ) -> Element<'a, M>
 where
     M: 'a + Clone,
@@ -102,7 +104,7 @@ where
     if !m.is_empty()
         && let Some(on_open_picker) = on_open_picker
     {
-        let open_picker = iced::widget::tooltip(
+        let open_picker = tooltip(
             button(
                 icon::plus()
                     .size(emoji_size + 4.0)
@@ -113,10 +115,9 @@ where
                 theme::button::secondary(theme, status, false)
             })
             .on_press(on_open_picker),
-            container(text("Add reaction").style(theme::text::secondary))
-                .style(theme::container::tooltip)
-                .padding(8),
+            show_tooltips_for_buttons.then_some("Add reaction"),
             Position::Bottom,
+            theme,
         );
 
         row = row.push(open_picker);


### PR DESCRIPTION
Expands tooltip setting into an enum to allow more detailed control of which tooltips are displayed and allow autocomplete tooltips to be hidden.

Fixes #1837.