### PR TITLE
filehost: only support `soju.im/filehost`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Added:
 - `buffer.nickname.color` now supports `{ palette = ["#RRGGBB", ...] }` for nickname colors from a fixed set
 - Right-click context menu on messages now includes "Copy message" to copy the message text to the clipboard
 - `buffer.typing.style` setting with `padded` and `popped` modes for typing indicators
-- Files can be uploaded to server using `soju.im/FILEHOST` and `draft/FILEHOST`
+- Files can be uploaded to server using `soju.im/FILEHOST`.
 - `/massmessage` command to send Ergo/Solanum mass-messages
 - Setting to control whether unread indicators are shown on open buffers (`sidebar.unread_indicator.show_on_open_buffers`)
 - Ability to add optional arguments in custom aliases (`/msg ChanServ op $channel $1?-`)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ We strive to be a leading irc client with a rich ircv3 feature set. currently su
 - [`WHOX`](https://ircv3.net/specs/extensions/whox)
 - [`soju.im/bouncer-networks`](https://codeberg.org/emersion/soju/src/branch/master/doc/ext/bouncer-networks.md)
 - [`soju.im/filehost`](https://codeberg.org/emersion/soju/src/branch/master/doc/ext/filehost.md)
-- [a work-in-progress version of `draft/filehost`](https://github.com/ircv3/ircv3-specifications/pull/562)
 
 ## Why?
 

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -277,11 +277,9 @@ impl FromStr for Operation {
                                 Err("value required")
                             }
                         }
-                        "draft/FILEHOST" | "soju.im/FILEHOST" => {
-                            Ok(Operation::Add(Parameter::FILEHOST(
-                                value.to_owned(),
-                            )))
-                        }
+                        "soju.im/FILEHOST" => Ok(Operation::Add(
+                            Parameter::FILEHOST(value.to_owned()),
+                        )),
                         "ESILENCE" => Ok(Operation::Add(Parameter::ESILENCE(
                             parse_optional_letters(value)?,
                         ))),
@@ -638,7 +636,7 @@ impl Operation {
                 "CNOTICE" => Some(Kind::CNOTICE),
                 "CPRIVMSG" => Some(Kind::CPRIVMSG),
                 "ELIST" => Some(Kind::ELIST),
-                "draft/FILEHOST" | "soju.im/FILEHOST" => Some(Kind::FILEHOST),
+                "soju.im/FILEHOST" => Some(Kind::FILEHOST),
                 "HOSTLEN" => Some(Kind::HOSTLEN),
                 "KEYLEN" => Some(Kind::KEYLEN),
                 "KICKLEN" => Some(Kind::KICKLEN),

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -58,7 +58,7 @@ Aliases are resolved before built-in commands and take precedence when they use 
 | `setname`       |              | Change your realname[^5]                                                                 |
 | `sysinfo`       |              | Send system information (OS, CPU, memory, GPU, uptime)                                   |
 | `topic`         | `t`          | Retrieve the topic of a channel or set a new topic[^1]                                   |
-| `upload`        |              | Upload a file via `draft/FILEHOST`[^12]                                                  |
+| `upload`        |              | Upload a file with the server's filehost[^12]                                                  |
 | `whois`         |              | Retrieve information about user(s) from a specific server[^13]                           |
 
 [^1]: The `channel` argument can be skipped when used in a channel buffer to target the channel in the buffer.
@@ -72,5 +72,5 @@ Aliases are resolved before built-in commands and take precedence when they use 
 [^9]: Channels joined will not be remembered after quitting Halloy (i.e. when next starting Halloy it will not re-join the channels).  Add the channel information to the [channels setting for the server](configuration/servers#channels) in the configuration file.
 [^10]: If not joined to the channel in the buffer, then the `chanlist` argument can be skipped to target the channel in the buffer.
 [^11]: The command is executed locally with `sh -c` on Unix-like systems and `cmd /C` on Windows. Only the first non-empty line of stdout is used. If that line starts with `/`, it is treated as a command; otherwise it is sent as a normal message. `/exec` is disabled by default and must be explicitly enabled in [`buffer.commands.exec`](configuration/buffer#exec).
-[^12]: Requires the server to advertise `draft/FILEHOST` support, or [`filehost.override`](./configuration/servers#filehost) to be set.
+[^12]: Requires the server to advertise `soju.im/filehost`, or [`filehost.override`](./configuration/servers#filehost) to be set.
 [^13]: The server variable refers to the server to poll, and can be set to the nickname being queried in order to auto-select the server. Eg. if you are in Libera chat, and you want to run WHOIS on `hunter2`, `/whois hunter2 hunter2` will try `/whois zinc.libera.chat hunter2` 

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -762,7 +762,7 @@ enabled = true
 
 ### `override_url`
 
-Override the filehost URL advertised by the server via ISUPPORT. The filehost must be compatible with the `draft/FILEHOST` spec.
+Override the filehost URL advertised by the server via ISUPPORT. The filehost must be compatible with the `soju.im/filehost` spec.
 
 ```toml
 # Type: string

--- a/docs/guides/filehost.md
+++ b/docs/guides/filehost.md
@@ -1,6 +1,6 @@
 # File Uploads
 
-Halloy supports file uploads via the `draft/FILEHOST` and [`soju.im/filehost`](https://soju.im/filehost) IRC extensions. When a file is uploaded, the resulting URL is inserted into the message input.
+Halloy supports file uploads via the [`soju.im/filehost`](https://soju.im/filehost) IRC extension. When a file is uploaded, the resulting URL is inserted into the message input.
 
 Uploads can be triggered by:
 
@@ -24,7 +24,7 @@ Ergo supports filehost natively via `additional-isupport`. Add the following to 
 ```yaml
 server:
   additional-isupport:
-    "draft/FILEHOST": "https://your-filehost-url/upload"
+    "soju.im/filehost": "https://your-filehost-url/upload"
 ```
 
 ### soju

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,5 +50,4 @@ We strive to be a leading irc client with a rich ircv3 feature set. currently su
 - [`UTF8ONLY`](https://ircv3.net/specs/extensions/utf8-only)
 - [`WHOX`](https://ircv3.net/specs/extensions/whox)
 - [`soju.im/bouncer-networks`](https://codeberg.org/emersion/soju/src/branch/master/doc/ext/bouncer-networks.md)
-- [`draft/FILEHOST`](https://github.com/progval/ircv3-specifications/blob/filehost/extensions/filehost.md)
 - [`soju.im/FILEHOST`](https://soju.im/filehost)


### PR DESCRIPTION
based on conversation in libera #halloy, we agreed that `draft/filehost` is too unstable to advertise support for. the spec has changed since support was added and we don't support it in its current form. it's problematic to advertise that we support a spec that no longer really exists, and especially since is not even fully merged as an official draft spec. `soju.im/filehost` on the other hand has been stable for a long time, and is unlikely to change.

most ircd setups i've seen advertise both soju.im/filehost and draft/filehost as they used to overlap, so it should not be much be much of a functional change.