### PR TITLE
Utilize `labeled-response` to Match Echoes 

### DIFF
--- a/data/src/capabilities.rs
+++ b/data/src/capabilities.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use std::string::ToString;
 use std::sync::LazyLock;
 
+use chrono::{DateTime, Utc};
 use irc::proto::{self, Tags, command, format};
 
 use crate::message::formatting::{Modifier, update_formatting_with_modifier};
@@ -404,5 +405,21 @@ impl Capabilities {
 
     pub fn contains_multiline_limits(&self) -> bool {
         self.multiline_limits().is_some()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LabeledResponseContext {
+    pub label_as_id: message::Id,
+    pub server_time: DateTime<Utc>,
+}
+
+impl LabeledResponseContext {
+    pub fn new(message: &message::Encoded, label: &str) -> Self {
+        Self {
+            // Prefix ':' to ensure it cannot match any valid message id
+            label_as_id: format!(":label={label}").into(),
+            server_time: message.server_time_or_now(),
+        }
     }
 }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -915,7 +915,7 @@ impl Client {
 
                                 finished.events.extend(self.handle(
                                     encoded,
-                                    context.clone(),
+                                    finished.context.clone(),
                                     config,
                                 )?);
                             }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -18,8 +18,8 @@ use tokio::fs;
 pub use self::on_connect::on_connect;
 use crate::bouncer::{self, BouncerNetwork};
 use crate::capabilities::{
-    self, Capabilities, Capability, MultilineBatchKind, MultilineLimits,
-    multiline_concat_lines, multiline_encoded,
+    self, Capabilities, Capability, LabeledResponseContext, MultilineBatchKind,
+    MultilineLimits, multiline_concat_lines, multiline_encoded,
 };
 use crate::config::server::filehost;
 use crate::environment::{SOURCE_WEBSITE, VERSION};
@@ -115,10 +115,25 @@ pub enum Message {
 
 #[derive(Debug)]
 pub enum Event {
-    Single(message::Encoded, Nick, bool),
-    PrivOrNotice(message::Encoded, Nick, bool, bool),
+    Single {
+        message: message::Encoded,
+        our_nick: Nick,
+        deduplicate: bool,
+    },
+    PrivOrNotice {
+        message: message::Encoded,
+        our_nick: Nick,
+        notification_enabled: bool,
+        deduplicate: bool,
+        labeled_response_context: Option<LabeledResponseContext>,
+    },
     Reaction(message::Encoded, Nick),
-    WithTarget(message::Encoded, Nick, message::Target, bool),
+    WithTarget {
+        message: message::Encoded,
+        our_nick: Nick,
+        target: message::Target,
+        deduplicate: bool,
+    },
     Broadcast(Broadcast),
     FileTransferRequest(file_transfer::ReceiveRequest),
     UpdateReadMarker(Target, ReadMarker),
@@ -513,26 +528,49 @@ impl Client {
         }
     }
 
-    fn send(
+    fn set_labeled_response_context(
         &mut self,
         buffer: Option<&buffer::Upstream>,
-        mut message: message::Encoded,
-        priority: TokenPriority,
-    ) {
-        if let Some(buffer) = buffer {
-            if self.capabilities.acknowledged(Capability::LabeledResponse) {
+        message: &mut message::Encoded,
+    ) -> Option<LabeledResponseContext> {
+        buffer.and_then(|buffer| {
+            let labeled_response_context = if self
+                .capabilities
+                .acknowledged(Capability::LabeledResponse)
+            {
                 let label = generate_label();
-                let context = Context::new(&message, buffer.clone());
+
+                let context =
+                    Context::new(message, buffer.clone(), Some(&label));
+
+                let labeled_response_context =
+                    context.labeled_response_context().cloned();
 
                 self.labels.insert(label.clone(), context);
 
                 // IRC: Encode tags
                 message.tags.insert("label".to_string(), label);
-            }
+
+                labeled_response_context
+            } else {
+                None
+            };
 
             self.reroute_responses_to =
                 self.start_reroute(&message.command).then(|| buffer.clone());
-        }
+
+            labeled_response_context
+        })
+    }
+
+    fn send(
+        &mut self,
+        buffer: Option<&buffer::Upstream>,
+        mut message: message::Encoded,
+        priority: TokenPriority,
+    ) -> Option<LabeledResponseContext> {
+        let labeled_response_context =
+            self.set_labeled_response_context(buffer, &mut message);
 
         if matches!(priority, TokenPriority::User) {
             match &message.command {
@@ -594,6 +632,8 @@ impl Client {
         } else if let Err(e) = self.handle.try_send(message.into()) {
             log::warn!("[{}] Error sending message: {e}", self.server);
         }
+
+        labeled_response_context
     }
 
     fn send_multiline_batch(
@@ -601,7 +641,7 @@ impl Client {
         buffer: &buffer::Upstream,
         mut messages: Vec<message::Encoded>,
         priority: TokenPriority,
-    ) {
+    ) -> Option<LabeledResponseContext> {
         if let Some(multiline_limits) = self.multiline_limits()
             && let Some(batch_kind) =
                 messages.first().and_then(|message| match message.command {
@@ -621,15 +661,8 @@ impl Client {
             )
             .into();
 
-            if self.capabilities.acknowledged(Capability::LabeledResponse) {
-                let label = generate_label();
-                let context = Context::new(&opening_batch, buffer.clone());
-
-                self.labels.insert(label.clone(), context);
-
-                // IRC: Encode tags
-                opening_batch.tags.insert("label".to_string(), label);
-            }
+            let labeled_response_context = self
+                .set_labeled_response_context(Some(buffer), &mut opening_batch);
 
             // Overwrite any existing tags, since messages in the batch can only
             // have draft/multiline-concat and batch tags
@@ -721,11 +754,15 @@ impl Client {
                     }
                 }
             }
+
+            labeled_response_context
         } else {
             log::warn!(
                 "[{}] unable to send messages as IRCv3 draft/multiline batch; capability not supported: {messages:?}",
                 self.server
             );
+
+            None
         }
     }
 
@@ -756,22 +793,19 @@ impl Client {
         use irc::proto::command::Numeric::*;
 
         let label_tag = message.tags.remove("label");
+
         let batch_tag = message.tags.remove("batch");
 
-        let context = parent_context.or_else(|| {
-            label_tag
-                .as_ref()
-                // Remove context associated to label if we get resp for it
-                .and_then(|label| self.labels.remove(label))
-                // Otherwise if we're in a batch, get it's context
-                .or_else(|| {
-                    batch_tag.as_ref().and_then(|batch| {
-                        self.batches
-                            .get(batch)
-                            .and_then(|batch| batch.context.clone())
-                    })
-                })
-        });
+        let context = parent_context.or(label_tag
+            .as_ref()
+            // Remove context associated to label if we get resp for it
+            .and_then(|label| self.labels.remove(label))
+            // Otherwise if we're in a batch, get its context
+            .or(batch_tag.as_ref().and_then(|batch| {
+                self.batches
+                    .get(batch)
+                    .and_then(|batch| batch.context.clone())
+            })));
 
         macro_rules! ok {
             ($option:expr) => {
@@ -1031,12 +1065,12 @@ impl Client {
                     .map(Context::buffer)
                     .map(|buffer| buffer.server_message_target(None))
                 {
-                    return Ok(vec![Event::WithTarget(
+                    return Ok(vec![Event::WithTarget {
                         message,
-                        self.nickname().to_owned(),
-                        source,
-                        false,
-                    )]);
+                        our_nick: self.nickname().to_owned(),
+                        target: source,
+                        deduplicate: false,
+                    }]);
                 }
             }
             _ if is_reaction(&message) => {
@@ -1064,12 +1098,12 @@ impl Client {
                     .clone()
                     .map(|buffer| buffer.server_message_target(None))
                 {
-                    return Ok(vec![Event::WithTarget(
+                    return Ok(vec![Event::WithTarget {
                         message,
-                        self.nickname().to_owned(),
-                        source,
-                        false,
-                    )]);
+                        our_nick: self.nickname().to_owned(),
+                        target: source,
+                        deduplicate: false,
+                    }]);
                 }
             }
             Command::BOUNCER(subcommand, params) if subcommand == "NETWORK" => {
@@ -1349,12 +1383,15 @@ impl Client {
                             // Response to us sending a CTCP request to another client
                             if matches!(&message.command, Command::NOTICE(_, _))
                             {
-                                let event = Event::PrivOrNotice(
+                                let event = Event::PrivOrNotice {
                                     message,
-                                    self.nickname().to_owned(),
-                                    self.notification_blackout.allowed(),
-                                    false,
-                                );
+                                    our_nick: self.nickname().to_owned(),
+                                    notification_enabled: self
+                                        .notification_blackout
+                                        .allowed(),
+                                    deduplicate: false,
+                                    labeled_response_context: None,
+                                };
 
                                 return Ok(vec![event]);
                             }
@@ -1495,12 +1532,15 @@ impl Client {
                         self.record_query(&user_query);
                     }
 
-                    let event = Event::PrivOrNotice(
-                        message.clone(),
-                        self.nickname().to_owned(),
-                        self.notification_blackout.allowed(),
-                        false,
-                    );
+                    let event = Event::PrivOrNotice {
+                        message: message.clone(),
+                        our_nick: self.nickname().to_owned(),
+                        notification_enabled: self
+                            .notification_blackout
+                            .allowed(),
+                        deduplicate: false,
+                        labeled_response_context: context.and_then(Into::into),
+                    };
 
                     // Event::DirectMessage is currently only used to send a
                     // notification, so only return the event it notifications
@@ -1530,11 +1570,11 @@ impl Client {
 
                 let invitee = Nick::from_str(invitee, self.casemapping());
 
-                let event = Event::Single(
-                    message.clone(),
-                    self.nickname().to_owned(),
-                    false,
-                );
+                let event = Event::Single {
+                    message: message.clone(),
+                    our_nick: self.nickname().to_owned(),
+                    deduplicate: false,
+                };
 
                 if invitee.as_nickref() == self.nickname() {
                     return Ok(vec![
@@ -1753,11 +1793,11 @@ impl Client {
                                 channel,
                                 sent_time: message.server_time_or_now(),
                             }),
-                            Event::Single(
+                            Event::Single {
                                 message,
-                                self.nickname().to_owned(),
-                                false,
-                            ),
+                                our_nick: self.nickname().to_owned(),
+                                deduplicate: false,
+                            },
                         ]);
                     } else if let Some(channel) = self.chanmap.get_mut(&channel)
                     {
@@ -1815,12 +1855,12 @@ impl Client {
                         .clone()
                         .map(|buffer| buffer.server_message_target(None))
                     {
-                        return Ok(vec![Event::WithTarget(
+                        return Ok(vec![Event::WithTarget {
                             message,
-                            self.nickname().to_owned(),
-                            source,
-                            false,
-                        )]);
+                            our_nick: self.nickname().to_owned(),
+                            target: source,
+                            deduplicate: false,
+                        }]);
                     }
                 }
             }
@@ -1927,12 +1967,12 @@ impl Client {
                         .clone()
                         .map(|buffer| buffer.server_message_target(None))
                     {
-                        return Ok(vec![Event::WithTarget(
+                        return Ok(vec![Event::WithTarget {
                             message,
-                            self.nickname().to_owned(),
-                            source,
-                            false,
-                        )]);
+                            our_nick: self.nickname().to_owned(),
+                            target: source,
+                            deduplicate: false,
+                        }]);
                     }
                 }
             }
@@ -2003,12 +2043,12 @@ impl Client {
                         .clone()
                         .map(|buffer| buffer.server_message_target(None))
                     {
-                        return Ok(vec![Event::WithTarget(
+                        return Ok(vec![Event::WithTarget {
                             message,
-                            self.nickname().to_owned(),
-                            source,
-                            false,
-                        )]);
+                            our_nick: self.nickname().to_owned(),
+                            target: source,
+                            deduplicate: false,
+                        }]);
                     }
                 } else if mask == "*" {
                     // Some servers respond with the mask * instead of the requested
@@ -2652,11 +2692,11 @@ impl Client {
                     .collect::<Vec<_>>();
 
                 return Ok(vec![
-                    Event::Single(
-                        message.clone(),
-                        self.nickname().to_owned(),
-                        false,
-                    ),
+                    Event::Single {
+                        message: message.clone(),
+                        our_nick: self.nickname().to_owned(),
+                        deduplicate: false,
+                    },
                     Event::MonitoredOnline(targets),
                 ]);
             }
@@ -2667,11 +2707,11 @@ impl Client {
                     .collect::<Vec<_>>();
 
                 return Ok(vec![
-                    Event::Single(
-                        message.clone(),
-                        self.nickname().to_owned(),
-                        false,
-                    ),
+                    Event::Single {
+                        message: message.clone(),
+                        our_nick: self.nickname().to_owned(),
+                        deduplicate: false,
+                    },
                     Event::MonitoredOffline(targets),
                 ]);
             }
@@ -2719,11 +2759,11 @@ impl Client {
 
                     if self.chathistory_targets_request.is_none() {
                         // User requested, save to history
-                        events.push(Event::Single(
-                            message.clone(),
-                            self.nickname().to_owned(),
-                            false,
-                        ));
+                        events.push(Event::Single {
+                            message: message.clone(),
+                            our_nick: self.nickname().to_owned(),
+                            deduplicate: false,
+                        });
                     }
                 }
 
@@ -3006,11 +3046,11 @@ impl Client {
             _ => {}
         }
 
-        Ok(vec![Event::Single(
+        Ok(vec![Event::Single {
             message,
-            self.nickname().to_owned(),
-            false,
-        )])
+            our_nick: self.nickname().to_owned(),
+            deduplicate: false,
+        }])
     }
 
     fn handle_chathistory(
@@ -3039,12 +3079,12 @@ impl Client {
                             source: source::Source::Server(None),
                         };
 
-                        vec![Event::WithTarget(
+                        vec![Event::WithTarget {
                             message,
-                            self.nickname().to_owned(),
+                            our_nick: self.nickname().to_owned(),
                             target,
-                            true,
-                        )]
+                            deduplicate: true,
+                        }]
                     })
                     .unwrap_or_default(),
                 Command::JOIN(_, _) => batch_target
@@ -3063,12 +3103,12 @@ impl Client {
                             )),
                         };
 
-                        vec![Event::WithTarget(
+                        vec![Event::WithTarget {
                             message,
-                            self.nickname().to_owned(),
+                            our_nick: self.nickname().to_owned(),
                             target,
-                            true,
-                        )]
+                            deduplicate: true,
+                        }]
                     })
                     .unwrap_or_default(),
                 Command::PART(_, _) => batch_target
@@ -3087,12 +3127,12 @@ impl Client {
                             )),
                         };
 
-                        vec![Event::WithTarget(
+                        vec![Event::WithTarget {
                             message,
-                            self.nickname().to_owned(),
+                            our_nick: self.nickname().to_owned(),
                             target,
-                            true,
-                        )]
+                            deduplicate: true,
+                        }]
                     })
                     .unwrap_or_default(),
                 Command::QUIT(_) => batch_target
@@ -3111,12 +3151,12 @@ impl Client {
                             )),
                         };
 
-                        vec![Event::WithTarget(
+                        vec![Event::WithTarget {
                             message,
-                            self.nickname().to_owned(),
+                            our_nick: self.nickname().to_owned(),
                             target,
-                            true,
-                        )]
+                            deduplicate: true,
+                        }]
                     })
                     .unwrap_or_default(),
                 Command::PRIVMSG(target, text)
@@ -3133,20 +3173,21 @@ impl Client {
                             }
                         }
 
-                        vec![Event::PrivOrNotice(
+                        vec![Event::PrivOrNotice {
                             message,
-                            self.nickname().to_owned(),
+                            our_nick: self.nickname().to_owned(),
                             // Don't allow notifications from history
-                            false,
-                            true,
-                        )]
+                            notification_enabled: false,
+                            deduplicate: true,
+                            labeled_response_context: None,
+                        }]
                     }
                 }
-                _ => vec![Event::Single(
+                _ => vec![Event::Single {
                     message,
-                    self.nickname().to_owned(),
-                    true,
-                )],
+                    our_nick: self.nickname().to_owned(),
+                    deduplicate: true,
+                }],
             }
         }
     }
@@ -4184,9 +4225,9 @@ fn continue_chathistory_between(
 ) -> Option<ChatHistorySubcommand> {
     let start_message_reference =
         events.first().and_then(|first_event| match first_event {
-            Event::Single(message, _, _)
-            | Event::PrivOrNotice(message, _, _, _)
-            | Event::WithTarget(message, _, _, _)
+            Event::Single { message, .. }
+            | Event::PrivOrNotice { message, .. }
+            | Event::WithTarget { message, .. }
             | Event::DirectMessage(message, _, _)
             | Event::Reaction(message, _) => match end_message_reference {
                 MessageReference::MessageId(_) => {
@@ -4233,9 +4274,9 @@ fn continue_chathistory_targets(
             Event::ChatHistoryTargetReceived(_, server_time) => {
                 Some(MessageReference::Timestamp(*server_time))
             }
-            Event::Single(_, _, _)
-            | Event::PrivOrNotice(_, _, _, _)
-            | Event::WithTarget(_, _, _, _)
+            Event::Single { .. }
+            | Event::PrivOrNotice { .. }
+            | Event::WithTarget { .. }
             | Event::DirectMessage(_, _, _)
             | Event::Reaction(_, _)
             | Event::Broadcast(_)
@@ -4394,10 +4435,9 @@ impl Map {
         buffer: &buffer::Upstream,
         message: message::Encoded,
         priority: TokenPriority,
-    ) {
-        if let Some(client) = self.client_mut(buffer.server()) {
-            client.send(Some(buffer), message, priority);
-        }
+    ) -> Option<LabeledResponseContext> {
+        self.client_mut(buffer.server())
+            .and_then(|client| client.send(Some(buffer), message, priority))
     }
 
     pub fn send_multiline_batch(
@@ -4405,10 +4445,10 @@ impl Map {
         buffer: &buffer::Upstream,
         messages: Vec<message::Encoded>,
         priority: TokenPriority,
-    ) {
-        if let Some(client) = self.client_mut(buffer.server()) {
-            client.send_multiline_batch(buffer, messages, priority);
-        }
+    ) -> Option<LabeledResponseContext> {
+        self.client_mut(buffer.server()).and_then(|client| {
+            client.send_multiline_batch(buffer, messages, priority)
+        })
     }
 
     pub fn send_markread(
@@ -4927,15 +4967,37 @@ impl Map {
 #[derive(Debug, Clone)]
 pub enum Context {
     Buffer(buffer::Upstream),
+    PrivOrNotice(buffer::Upstream, Option<LabeledResponseContext>),
     Whois(buffer::Upstream),
 }
 
 impl Context {
-    fn new(message: &message::Encoded, buffer: buffer::Upstream) -> Self {
-        if let Command::WHOIS(_, _) = message.command {
-            Self::Whois(buffer)
-        } else {
-            Self::Buffer(buffer)
+    fn new(
+        message: &message::Encoded,
+        buffer: buffer::Upstream,
+        label: Option<&str>,
+    ) -> Self {
+        match &message.command {
+            Command::WHOIS(_, _) => Self::Whois(buffer),
+            Command::PRIVMSG(_, _) | Command::NOTICE(_, _) => {
+                Self::PrivOrNotice(
+                    buffer,
+                    label.map(|label| {
+                        LabeledResponseContext::new(message, label)
+                    }),
+                )
+            }
+            Command::BATCH(_, params)
+                if params.iter().any(|param| param == "draft/multiline") =>
+            {
+                Self::PrivOrNotice(
+                    buffer,
+                    label.map(|label| {
+                        LabeledResponseContext::new(message, label)
+                    }),
+                )
+            }
+            _ => Self::Buffer(buffer),
         }
     }
 
@@ -4946,7 +5008,28 @@ impl Context {
     fn buffer(self) -> buffer::Upstream {
         match self {
             Context::Buffer(buffer) => buffer,
+            Context::PrivOrNotice(buffer, _) => buffer,
             Context::Whois(buffer) => buffer,
+        }
+    }
+
+    fn labeled_response_context(&self) -> Option<&LabeledResponseContext> {
+        match self {
+            Context::PrivOrNotice(_, labeled_response_context) => {
+                labeled_response_context.as_ref()
+            }
+            Context::Buffer(_) | Context::Whois(_) => None,
+        }
+    }
+}
+
+impl From<Context> for Option<LabeledResponseContext> {
+    fn from(context: Context) -> Option<LabeledResponseContext> {
+        match context {
+            Context::PrivOrNotice(_, labeled_response_context) => {
+                labeled_response_context
+            }
+            Context::Buffer(_) | Context::Whois(_) => None,
         }
     }
 }
@@ -5454,7 +5537,7 @@ mod tests {
         // with combined text "line one\nline two"
         let priv_events: Vec<_> = events
             .iter()
-            .filter(|e| matches!(e, Event::PrivOrNotice(..)))
+            .filter(|e| matches!(e, Event::PrivOrNotice { .. }))
             .collect();
 
         assert_eq!(
@@ -5464,8 +5547,8 @@ mod tests {
             priv_events.len()
         );
 
-        if let Event::PrivOrNotice(msg, _, _, _) = &priv_events[0] {
-            match &msg.0.command {
+        if let Event::PrivOrNotice { message, .. } = &priv_events[0] {
+            match &message.0.command {
                 Command::PRIVMSG(_, text) => {
                     assert_eq!(
                         text, "line one\nline two",

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -12,6 +12,7 @@ use tokio::time::Instant;
 
 pub use self::manager::{Manager, Resource};
 pub use self::metadata::{Metadata, ReadMarker};
+use crate::capabilities::LabeledResponseContext;
 use crate::message::{self, MessageReferences, Source};
 use crate::reaction::{self, Reaction};
 use crate::target::{self, Target};
@@ -202,7 +203,7 @@ pub async fn load(kind: Kind, seed: Option<Seed>) -> Result<Loaded, Error> {
     if let Some(seed) = seed {
         // TODO: Utilize DeserializeSeed (or equivalent) so proper normalization
         // happens inside read_all, rather than having to renormalize afterward
-        renormalize_messages(&mut messages, seed);
+        renormalize_messages(messages.iter_mut(), seed);
     }
 
     let metadata = metadata::load(kind).await.unwrap_or_default();
@@ -210,10 +211,13 @@ pub async fn load(kind: Kind, seed: Option<Seed>) -> Result<Loaded, Error> {
     Ok(Loaded { messages, metadata })
 }
 
-pub fn renormalize_messages(messages: &mut [Message], seed: Seed) {
+fn renormalize_messages<'a>(
+    messages: impl Iterator<Item = &'a mut Message>,
+    seed: Seed,
+) {
     match seed {
         Seed::Multiple(casemappings) => {
-            messages.iter_mut().for_each(|message| {
+            messages.for_each(|message| {
                 if let message::Target::Highlights { server, .. } =
                     &message.target
                     && let Some(casemapping) = casemappings.get(server)
@@ -223,9 +227,7 @@ pub fn renormalize_messages(messages: &mut [Message], seed: Seed) {
             });
         }
         Seed::Single(casemapping) => {
-            messages
-                .iter_mut()
-                .for_each(|message| message.renormalize(casemapping));
+            messages.for_each(|message| message.renormalize(casemapping));
         }
     }
 }
@@ -261,7 +263,7 @@ pub async fn overwrite(
 pub async fn append(
     kind: &Kind,
     seed: Option<Seed>,
-    mut messages: Vec<Message>,
+    pending_messages: Vec<(Message, Option<LabeledResponseContext>)>,
     read_marker: Option<ReadMarker>,
     chathistory_references: Option<MessageReferences>,
     pending_reactions: HashMap<message::Id, reaction::Pending>,
@@ -272,14 +274,20 @@ pub async fn append(
     // pending reactions should only exist for unloaded history entries
     for (id, mut pending) in pending_reactions.into_iter() {
         if let Some(message) =
-            find_reaction_target(&mut messages, &id, &pending.server_time)
+            find_reaction_target(&mut all_messages, &id, &pending.server_time)
         {
             message.reactions.append(&mut pending.reactions);
         }
     }
-    messages.into_iter().for_each(|message| {
-        insert_message(&mut all_messages, message);
-    });
+    pending_messages.into_iter().for_each(
+        |(message, labeled_response_context)| {
+            insert_message(
+                &mut all_messages,
+                message,
+                labeled_response_context,
+            );
+        },
+    );
 
     overwrite(kind, &all_messages, read_marker, chathistory_references).await
 }
@@ -333,7 +341,7 @@ async fn path(kind: &Kind) -> Result<PathBuf, Error> {
 pub enum History {
     Partial {
         kind: Kind,
-        messages: Vec<Message>,
+        pending_messages: Vec<(Message, Option<LabeledResponseContext>)>, // Unordered
         last_updated_at: Option<Instant>,
         max_triggers_unread: Option<DateTime<Utc>>,
         max_triggers_highlight: Option<DateTime<Utc>>,
@@ -345,7 +353,7 @@ pub enum History {
     },
     Full {
         kind: Kind,
-        messages: Vec<Message>,
+        messages: Vec<Message>, // Sorted by Message.server_time
         last_updated_at: Option<Instant>,
         read_marker: Option<ReadMarker>,
         display_read_marker: Option<ReadMarker>,
@@ -359,7 +367,7 @@ impl History {
     fn partial(kind: Kind) -> Self {
         Self::Partial {
             kind,
-            messages: vec![],
+            pending_messages: vec![],
             last_updated_at: None,
             max_triggers_unread: None,
             max_triggers_highlight: None,
@@ -459,7 +467,11 @@ impl History {
         }
     }
 
-    fn add_message(&mut self, message: Message) -> Option<ReadMarker> {
+    fn add_message(
+        &mut self,
+        message: Message,
+        labeled_response_context: Option<LabeledResponseContext>,
+    ) -> Option<ReadMarker> {
         if let History::Partial {
             show_in_sidebar,
             max_triggers_unread,
@@ -497,13 +509,11 @@ impl History {
 
         match self {
             History::Partial {
-                messages,
                 last_updated_at,
                 last_seen,
                 ..
             }
             | History::Full {
-                messages,
                 last_updated_at,
                 last_seen,
                 ..
@@ -511,8 +521,19 @@ impl History {
                 *last_updated_at = Some(Instant::now());
 
                 update_last_seen(last_seen, &message);
+            }
+        }
 
-                insert_message(messages, message)
+        match self {
+            History::Partial {
+                pending_messages, ..
+            } => {
+                pending_messages.push((message, labeled_response_context));
+
+                None
+            }
+            History::Full { messages, .. } => {
+                insert_message(messages, message, labeled_response_context)
             }
         }
     }
@@ -523,8 +544,16 @@ impl History {
         hash: message::Hash,
     ) -> Option<Message> {
         match self {
-            History::Partial { messages, .. }
-            | History::Full { messages, .. } => {
+            History::Partial {
+                pending_messages, ..
+            } => pending_messages
+                .iter()
+                .position(|(message, _)| message.hash == hash)
+                .map(|index| {
+                    let (message, _) = pending_messages.remove(index);
+                    message
+                }),
+            History::Full { messages, .. } => {
                 if messages.is_empty() {
                     return None;
                 }
@@ -549,12 +578,10 @@ impl History {
 
                 messages[start_index..end_index]
                     .iter()
-                    .enumerate()
-                    .find_map(|(slice_index, message)| {
-                        (message.hash == hash)
-                            .then_some(start_index + slice_index)
+                    .position(|message| message.hash == hash)
+                    .map(|slice_index| {
+                        messages.remove(start_index + slice_index)
                     })
-                    .map(|index| messages.remove(index))
             }
         }
     }
@@ -568,8 +595,8 @@ impl History {
         config: &config::buffer::Condensation,
     ) -> Vec<&mut Message> {
         match self {
-            History::Partial { messages, .. }
-            | History::Full { messages, .. } => {
+            History::Partial { .. } => vec![],
+            History::Full { messages, .. } => {
                 if messages.is_empty() {
                     return vec![];
                 }
@@ -636,7 +663,7 @@ impl History {
         match self {
             History::Partial {
                 kind,
-                messages,
+                pending_messages,
                 last_updated_at,
                 read_marker,
                 chathistory_references,
@@ -650,7 +677,7 @@ impl History {
                     })
                 {
                     let kind = kind.clone();
-                    let messages = std::mem::take(messages);
+                    let pending_messages = std::mem::take(pending_messages);
                     let read_marker = *read_marker;
                     let chathistory_references = chathistory_references.clone();
                     let pending_reactions = std::mem::take(pending_reactions);
@@ -662,7 +689,7 @@ impl History {
                             append(
                                 &kind,
                                 seed,
-                                messages,
+                                pending_messages,
                                 read_marker,
                                 chathistory_references,
                                 pending_reactions,
@@ -750,7 +777,7 @@ impl History {
                     self,
                     Self::Partial {
                         kind,
-                        messages: vec![],
+                        pending_messages: vec![],
                         last_updated_at: None,
                         read_marker,
                         max_triggers_unread,
@@ -762,20 +789,18 @@ impl History {
                     },
                 );
 
-                let (kind, messages) = match full_history {
-                    History::Partial { kind, messages, .. }
-                    | History::Full { kind, messages, .. } => (kind, messages),
-                };
-
-                Some(async move {
-                    overwrite(
-                        &kind,
-                        &messages,
-                        read_marker,
-                        chathistory_references,
-                    )
-                    .await
-                })
+                match full_history {
+                    History::Partial { .. } => None,
+                    History::Full { kind, messages, .. } => Some(async move {
+                        overwrite(
+                            &kind,
+                            &messages,
+                            read_marker,
+                            chathistory_references,
+                        )
+                        .await
+                    }),
+                }
             }
         }
     }
@@ -784,7 +809,7 @@ impl History {
         match self {
             History::Partial {
                 kind,
-                messages,
+                pending_messages,
                 read_marker,
                 chathistory_references,
                 pending_reactions,
@@ -793,7 +818,7 @@ impl History {
                 append(
                     &kind,
                     seed,
-                    messages,
+                    pending_messages,
                     read_marker,
                     chathistory_references,
                     pending_reactions,
@@ -854,12 +879,18 @@ impl History {
     }
 
     pub fn first_can_reference(&self) -> Option<&Message> {
+        let can_reference = |message: &Message| {
+            message.can_reference() && !message.is_rerouted()
+        };
+
         match self {
-            History::Partial { messages, .. }
-            | History::Full { messages, .. } => {
-                messages.iter().find(|message| {
-                    message.can_reference() && !message.is_rerouted()
-                })
+            History::Partial {
+                pending_messages, ..
+            } => pending_messages.iter().find_map(|(message, _)| {
+                can_reference(message).then_some(message)
+            }),
+            History::Full { messages, .. } => {
+                messages.iter().find(|message| can_reference(message))
             }
         }
     }
@@ -868,39 +899,44 @@ impl History {
         &self,
         server_time: DateTime<Utc>,
     ) -> Option<MessageReferences> {
-        let (messages, chathistory_references) = match self {
+        let can_reference = |message: &Message| {
+            message.can_reference()
+                && !message.is_rerouted()
+                && message.server_time < server_time
+        };
+
+        let (message, chathistory_references) = match self {
             History::Partial {
-                messages,
+                pending_messages,
                 chathistory_references,
                 ..
-            } => (messages, chathistory_references),
+            } => (
+                pending_messages.iter().rev().find_map(|(message, _)| {
+                    can_reference(message).then_some(message)
+                }),
+                chathistory_references,
+            ),
             History::Full {
                 messages,
                 chathistory_references,
                 ..
-            } => (messages, chathistory_references),
+            } => (
+                messages.iter().rev().find(|message| can_reference(message)),
+                chathistory_references,
+            ),
         };
 
-        messages
-            .iter()
-            .rev()
-            .find(|message| {
-                message.can_reference()
-                    && !message.is_rerouted()
-                    && message.server_time < server_time
-            })
-            .map(Message::references)
-            .max(
-                if chathistory_references.as_ref().is_some_and(
-                    |chathistory_references| {
-                        chathistory_references.timestamp < server_time
-                    },
-                ) {
-                    chathistory_references.clone()
-                } else {
-                    None
+        message.map(Message::references).max(
+            if chathistory_references.as_ref().is_some_and(
+                |chathistory_references| {
+                    chathistory_references.timestamp < server_time
                 },
-            )
+            ) {
+                chathistory_references.clone()
+            } else {
+                None
+            },
+        )
     }
 
     pub fn update_chathistory_references(
@@ -1020,15 +1056,15 @@ impl History {
     ) {
         match self {
             History::Partial {
-                messages,
+                pending_messages,
                 last_updated_at,
                 pending_reactions,
                 ..
             } => {
-                if let Some(message) = messages
-                    .iter_mut()
-                    .rev()
-                    .find(|m| m.id.as_deref() == Some(&*id))
+                if let Some(message) =
+                    pending_messages.iter_mut().rev().find_map(|(m, _)| {
+                        (m.id.as_deref() == Some(&*id)).then_some(m)
+                    })
                 {
                     message.reactions.push(reaction);
                 } else {
@@ -1040,6 +1076,7 @@ impl History {
                         (pending.server_time).min(server_time);
                     pending.reactions.push(reaction);
                 }
+
                 *last_updated_at = Some(Instant::now());
             }
             History::Full {
@@ -1065,6 +1102,20 @@ impl History {
             | History::Full { last_seen, .. } => last_seen.clone(),
         }
     }
+
+    pub fn renormalize_messages(&mut self, seed: Seed) {
+        match self {
+            History::Full { messages, .. } => {
+                renormalize_messages(messages.iter_mut(), seed);
+            }
+            History::Partial {
+                pending_messages, ..
+            } => renormalize_messages(
+                pending_messages.iter_mut().map(|(message, _)| message),
+                seed,
+            ),
+        }
+    }
 }
 
 /// Insert the incoming message into the provided vector, sorted
@@ -1080,20 +1131,61 @@ impl History {
 pub fn insert_message(
     messages: &mut Vec<Message>,
     message: Message,
+    labeled_response_context: Option<LabeledResponseContext>,
 ) -> Option<ReadMarker> {
-    let fuzz_seconds =
-        if matches!(message.direction, message::Direction::Received)
-            && message.is_echo
-        {
-            chrono::Duration::seconds(300)
-        } else {
-            chrono::Duration::seconds(1)
-        };
-
     if messages.is_empty() {
         messages.push(message);
 
         return None;
+    }
+
+    let message_is_unlabeled_echo =
+        matches!(message.direction, message::Direction::Received)
+            && message.is_echo
+            && labeled_response_context.is_none();
+
+    let fuzz_seconds = if message_is_unlabeled_echo {
+        chrono::Duration::seconds(300)
+    } else {
+        chrono::Duration::seconds(1)
+    };
+
+    let mut read_marker = None;
+
+    if let Some(labeled_response_context) = &labeled_response_context {
+        let start = labeled_response_context.server_time - fuzz_seconds;
+        let end = labeled_response_context.server_time + fuzz_seconds;
+
+        let start_index = match messages
+            .binary_search_by(|stored| stored.server_time.cmp(&start))
+        {
+            Ok(match_index) => match_index,
+            Err(sorted_insert_index) => sorted_insert_index,
+        };
+        let end_index = match messages
+            .binary_search_by(|stored| stored.server_time.cmp(&end))
+        {
+            Ok(match_index) => match_index,
+            Err(sorted_insert_index) => sorted_insert_index,
+        };
+
+        if let Some(index) = messages[start_index..end_index]
+            .iter()
+            .enumerate()
+            .find_map(|(slice_index, message)| {
+                message
+                    .id
+                    .as_ref()
+                    .is_some_and(|id| {
+                        *id == labeled_response_context.label_as_id
+                    })
+                    .then_some(start_index + slice_index)
+            })
+        {
+            messages.remove(index);
+
+            read_marker = Some(ReadMarker::from(&message));
+        }
     }
 
     let start = message.server_time - fuzz_seconds;
@@ -1117,21 +1209,19 @@ pub fn insert_message(
     let mut replace_at = None;
 
     for stored in &messages[start_index..end_index] {
-        if replace_at.is_none() {
+        if replace_at.is_none() && labeled_response_context.is_none() {
             let use_echo_cmp =
                 matches!(stored.direction, message::Direction::Sent)
-                    && matches!(
-                        message.direction,
-                        message::Direction::Received
-                    )
-                    && message.is_echo;
+                    && message_is_unlabeled_echo;
 
-            if (message.id.is_some() && stored.id == message.id)
-                || (((message.id.is_none()
-                    && stored.id.is_none()
+            let check_for_matching_content = stored.id.is_none()
+                && ((message.id.is_none()
                     && message.deduplicate
                     && stored.server_time == message.server_time)
-                    || use_echo_cmp)
+                    || use_echo_cmp);
+
+            if (message.id.is_some() && stored.id == message.id)
+                || (check_for_matching_content
                     && has_matching_content(stored, &message, use_echo_cmp))
             {
                 replace_at = Some(current_index);
@@ -1155,21 +1245,10 @@ pub fn insert_message(
             } else {
                 messages[index] = message;
             }
-
-            None
         } else {
-            let read_marker = if matches!(
-                messages[index].direction,
-                message::Direction::Sent
-            ) && matches!(
-                message.direction,
-                message::Direction::Received
-            ) && message.is_echo
-            {
-                Some(ReadMarker::from(&message))
-            } else {
-                None
-            };
+            if message_is_unlabeled_echo {
+                read_marker = Some(ReadMarker::from(&message));
+            }
 
             match insert_at.cmp(&index) {
                 Ordering::Less => {
@@ -1182,14 +1261,12 @@ pub fn insert_message(
                     messages.remove(index);
                 }
             }
-
-            read_marker
         }
     } else {
         messages.insert(insert_at, message);
-
-        None
     }
+
+    read_marker
 }
 
 /// The content of JOIN, PART, and QUIT messages may be dependent on how

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -10,6 +10,7 @@ use tokio::time::Instant;
 
 use super::filter::{Filter, FilterChain};
 use super::reroute::RerouteRules;
+use crate::capabilities::LabeledResponseContext;
 use crate::history::{self, History, MessageReferences, ReadMarker, metadata};
 use crate::message::broadcast::{self, Broadcast};
 use crate::message::{self, Limit};
@@ -86,16 +87,12 @@ impl Manager {
         if let Some(history) = self.data.map.get_mut(&kind) {
             let task = history.flush(None, clients.get_seed(&kind));
 
-            match history {
-                History::Full {
-                    messages, cleared, ..
-                } => {
-                    messages.clear();
-                    *cleared = true;
-                }
-                History::Partial { messages, .. } => {
-                    messages.clear();
-                }
+            if let History::Full {
+                messages, cleared, ..
+            } = history
+            {
+                messages.clear();
+                *cleared = true;
             }
 
             log::debug!("cleared messages for {kind}");
@@ -344,11 +341,15 @@ impl Manager {
     pub fn record_input_message(
         &mut self,
         message: message::Message,
+        labeled_response_context: Option<LabeledResponseContext>,
         server: &Server,
         casemapping: isupport::CaseMap,
         config: &Config,
     ) -> Vec<BoxFuture<'static, Message>> {
         let mut tasks = vec![];
+
+        let message =
+            message.with_labeled_response_context(labeled_response_context);
 
         if config.buffer.mark_as_read.on_message_sent
             && let Some(kind) =
@@ -364,6 +365,7 @@ impl Manager {
             server,
             casemapping,
             message,
+            None,
             &config.buffer,
         ));
 
@@ -393,6 +395,7 @@ impl Manager {
         &mut self,
         server: &Server,
         message: crate::Message,
+        labeled_response_context: Option<LabeledResponseContext>,
         buffer_config: &config::Buffer,
     ) -> Vec<BoxFuture<'static, Message>> {
         history::Kind::from_server_message_rerouted_from(server, &message)
@@ -417,7 +420,11 @@ impl Manager {
                         ) && !message.blocked)
                             .then_some((kind.clone(), message.clone()));
 
-                        let future = self.data.add_message(kind, message);
+                        let future = self.data.add_message(
+                            kind,
+                            message,
+                            labeled_response_context,
+                        );
 
                         if let Some((kind, message)) = condensers {
                             self.condense_message(
@@ -454,6 +461,7 @@ impl Manager {
         server: &Server,
         casemapping: isupport::CaseMap,
         mut message: crate::Message,
+        labeled_response_context: Option<LabeledResponseContext>,
         buffer_config: &config::Buffer,
     ) -> Vec<BoxFuture<'static, Message>> {
         if let Some(kind) = history::Kind::from_server_message(server, &message)
@@ -467,15 +475,23 @@ impl Manager {
             );
         }
 
-        self.record_message(server, message, buffer_config)
+        self.record_message(
+            server,
+            message,
+            labeled_response_context,
+            buffer_config,
+        )
     }
 
     pub fn record_log(
         &mut self,
         record: crate::log::Record,
     ) -> Option<impl Future<Output = Message> + use<>> {
-        self.data
-            .add_message(history::Kind::Logs, crate::Message::log(record))
+        self.data.add_message(
+            history::Kind::Logs,
+            crate::Message::log(record),
+            None,
+        )
     }
 
     // Unlike block_and_record_message, the message's blocked status should be
@@ -485,7 +501,8 @@ impl Manager {
         &mut self,
         message: crate::Message,
     ) -> Option<impl Future<Output = Message> + use<>> {
-        self.data.add_message(history::Kind::Highlights, message)
+        self.data
+            .add_message(history::Kind::Highlights, message, None)
     }
 
     pub fn remove_message(
@@ -719,6 +736,7 @@ impl Manager {
                     server,
                     casemapping,
                     message,
+                    None,
                     &config.buffer,
                 )
             })
@@ -798,13 +816,13 @@ impl Manager {
                                 .map(|nick| Nick::from_str(nick, casemapping))
                         }),
                     }
-                && let Some(history) = self.data.map.get(kind)
+                // These blocks are currently only relevant for open panes,
+                // since the associated messages do not trigger UI
+                // (unread/notifications/etc) and will be processed if/when the
+                // pane is opened.
+                && let Some(History::Full { messages, .. }) =
+                    self.data.map.get(kind)
             {
-                let messages = match history {
-                    History::Full { messages, .. } => messages,
-                    History::Partial { messages, .. } => messages,
-                };
-
                 if matches!(source_kind, Some(message::Kind::Away)) {
                     message.blocked = messages
                         .iter()
@@ -990,12 +1008,9 @@ impl Manager {
             Singular,
         }
 
-        if let Some(history) = self.data.map.get_mut(&kind) {
-            let messages = match history {
-                History::Full { messages, .. } => messages,
-                History::Partial { messages, .. } => messages,
-            };
-
+        if let Some(History::Full { messages, .. }) =
+            self.data.map.get_mut(&kind)
+        {
             let mut last_seen = HashMap::<Nick, DateTime<Utc>>::new();
             let mut last_away = HashMap::<Nick, DateTime<Utc>>::new();
 
@@ -1183,12 +1198,7 @@ impl Manager {
         if let Some(history) = self.data.map.get_mut(kind)
             && let Some(seed) = clients.get_seed(kind)
         {
-            let messages = match history {
-                History::Full { messages, .. } => messages,
-                History::Partial { messages, .. } => messages,
-            };
-
-            history::renormalize_messages(messages, seed);
+            history.renormalize_messages(seed);
         }
     }
 }
@@ -1241,7 +1251,7 @@ impl Data {
         match self.map.entry(kind.clone()) {
             hash_map::Entry::Occupied(mut entry) => match entry.get_mut() {
                 History::Partial {
-                    messages: new_messages,
+                    pending_messages,
                     last_updated_at,
                     read_marker: partial_read_marker,
                     chathistory_references: partial_chathistory_references,
@@ -1271,10 +1281,16 @@ impl Data {
                         }
                     }
 
-                    for message in std::mem::take(new_messages) {
+                    for (message, labeled_response_context) in
+                        std::mem::take(pending_messages)
+                    {
                         history::update_last_seen(&mut last_seen, &message);
 
-                        history::insert_message(&mut messages, message);
+                        history::insert_message(
+                            &mut messages,
+                            message,
+                            labeled_response_context,
+                        );
                     }
 
                     entry.insert(History::Full {
@@ -1527,10 +1543,13 @@ impl Data {
         &mut self,
         kind: history::Kind,
         message: crate::Message,
+        labeled_response_context: Option<LabeledResponseContext>,
     ) -> Option<impl Future<Output = Message> + use<>> {
         match self.map.entry(kind.clone()) {
             hash_map::Entry::Occupied(mut entry) => {
-                let read_marker = entry.get_mut().add_message(message);
+                let read_marker = entry
+                    .get_mut()
+                    .add_message(message, labeled_response_context);
 
                 // Update the read marker immediately so the split is correct
                 if let Some(read_marker) = read_marker
@@ -1552,7 +1571,7 @@ impl Data {
             hash_map::Entry::Vacant(entry) => {
                 let _ = entry
                     .insert(History::partial(kind.clone()))
-                    .add_message(message);
+                    .add_message(message, labeled_response_context);
 
                 Some(
                     async move {

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -19,6 +19,7 @@ pub use self::formatting::{Color, Formatting};
 pub use self::highlight::Highlight;
 pub use self::source::Source;
 pub use self::source::server::{Change, Kind, StandardReply};
+use crate::capabilities::LabeledResponseContext;
 use crate::config::buffer::{CondensationFormat, UsernameFormat};
 use crate::config::{self, Highlights};
 use crate::history::reroute::RerouteRules;
@@ -651,6 +652,21 @@ impl Message {
 
     pub fn with_target(self, target: Target) -> Self {
         Self { target, ..self }
+    }
+
+    pub fn with_labeled_response_context(
+        self,
+        labeled_response_context: Option<LabeledResponseContext>,
+    ) -> Self {
+        if let Some(labeled_response_context) = labeled_response_context {
+            Self {
+                server_time: labeled_response_context.server_time,
+                id: Some(labeled_response_context.label_as_id),
+                ..self
+            }
+        } else {
+            self
+        }
     }
 
     pub fn reroute_with_target(self, target: Target) -> Self {

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -1727,10 +1727,16 @@ impl State {
             .filter_map(data::Input::encoded)
             .collect::<Vec<_>>();
 
-        if let Some(last_encoded) = encoded.last() {
+        let labeled_response_context = if let Some(last_encoded) =
+            encoded.last()
+        {
             let sent_time = last_encoded.server_time_or_now();
 
-            clients.send_multiline_batch(buffer, encoded, TokenPriority::User);
+            let labeled_response_context = clients.send_multiline_batch(
+                buffer,
+                encoded,
+                TokenPriority::User,
+            );
 
             let supports_echoes =
                 clients.get_server_supports_echoes(buffer.server());
@@ -1759,7 +1765,11 @@ impl State {
                     }
                 }
             }
-        }
+
+            labeled_response_context
+        } else {
+            None
+        };
 
         let mut history_task = Task::none();
 
@@ -1870,6 +1880,7 @@ impl State {
             {
                 history_tasks.extend(history.record_input_message(
                     message,
+                    labeled_response_context,
                     buffer.server(),
                     casemapping,
                     config,
@@ -2156,10 +2167,11 @@ impl State {
             }
         };
 
-        if let Some(encoded) = input.encoded() {
+        let labeled_response_context = if let Some(encoded) = input.encoded() {
             let sent_time = encoded.server_time_or_now();
 
-            clients.send(buffer, encoded, TokenPriority::User);
+            let labeled_response_context =
+                clients.send(buffer, encoded, TokenPriority::User);
 
             let supports_echoes =
                 clients.get_server_supports_echoes(buffer.server());
@@ -2187,7 +2199,11 @@ impl State {
                     }
                 }
             }
-        }
+
+            labeled_response_context
+        } else {
+            None
+        };
 
         let mut history_task = Task::none();
 
@@ -2232,6 +2248,7 @@ impl State {
                         history
                             .record_input_message(
                                 message,
+                                labeled_response_context.clone(),
                                 buffer.server(),
                                 casemapping,
                                 config,

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ use std::time::{Duration, Instant};
 use std::{env, mem};
 
 use appearance::{Theme, theme};
+use data::capabilities::LabeledResponseContext;
 use data::config::{self, Config};
 use data::history::filter::FilterChain;
 use data::history::reroute::RerouteRules;
@@ -1506,7 +1507,11 @@ fn handle_client_events(
 
     for event in events {
         match event {
-            Event::Single(encoded, our_nick, deduplicate) => {
+            Event::Single {
+                message: encoded,
+                our_nick,
+                deduplicate,
+            } => {
                 handle_single_event(
                     server,
                     encoded,
@@ -1518,17 +1523,19 @@ fn handle_client_events(
                     config,
                 );
             }
-            Event::PrivOrNotice(
-                encoded,
+            Event::PrivOrNotice {
+                message: encoded,
                 our_nick,
                 notification_enabled,
                 deduplicate,
-            ) => {
+                labeled_response_context,
+            } => {
                 handle_priv_or_notice(
                     server,
                     encoded,
                     our_nick,
                     deduplicate,
+                    labeled_response_context,
                     notification_enabled,
                     dashboard,
                     &mut commands,
@@ -1538,7 +1545,12 @@ fn handle_client_events(
                     main_window,
                 );
             }
-            Event::WithTarget(encoded, our_nick, target, deduplicate) => {
+            Event::WithTarget {
+                message: encoded,
+                our_nick,
+                target,
+                deduplicate,
+            } => {
                 handle_with_target_event(
                     server,
                     encoded,
@@ -1814,6 +1826,7 @@ fn handle_single_event(
                 server,
                 clients.get_server_casemapping_or_default(server),
                 message,
+                None,
                 &config.buffer,
             )
             .map(Message::Dashboard),
@@ -1849,6 +1862,7 @@ fn handle_with_target_event(
                 server,
                 clients.get_server_casemapping_or_default(server),
                 message.with_target(target),
+                None,
                 &config.buffer,
             )
             .map(Message::Dashboard),
@@ -1860,6 +1874,7 @@ fn handle_priv_or_notice(
     encoded: message::Encoded,
     our_nick: data::user::Nick,
     deduplicate: bool,
+    labeled_response_context: Option<LabeledResponseContext>,
     notification_enabled: bool,
     dashboard: &mut screen::Dashboard,
     commands: &mut Vec<Task<Message>>,
@@ -1941,7 +1956,12 @@ fn handle_priv_or_notice(
 
     commands.push(
         dashboard
-            .record_message(server, msg, &config.buffer)
+            .record_message(
+                server,
+                msg,
+                labeled_response_context,
+                &config.buffer,
+            )
             .map(Message::Dashboard),
     );
 

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -5,7 +5,9 @@ use std::time::{Duration, Instant};
 use std::{convert, slice};
 
 use chrono::{DateTime, Utc};
-use data::capabilities::{MultilineBatchKind, multiline_concat_lines};
+use data::capabilities::{
+    LabeledResponseContext, MultilineBatchKind, multiline_concat_lines,
+};
 use data::config::buffer::{ScrollPosition, UsernameFormat};
 use data::dashboard::{self, BufferAction};
 use data::environment::{RELEASE_WEBSITE, WIKI_WEBSITE};
@@ -944,19 +946,20 @@ impl Dashboard {
                                         .map(proto::Message::from)
                                         .map(message::Encoded::from)
                                 {
-                                    if multiline {
+                                    let labeled_response_context = if multiline
+                                    {
                                         clients.send_multiline_batch(
                                             buffer,
                                             vec![encoded],
                                             TokenPriority::User,
-                                        );
+                                        )
                                     } else {
                                         clients.send(
                                             buffer,
                                             encoded,
                                             TokenPriority::User,
-                                        );
-                                    }
+                                        )
+                                    };
 
                                     return (
                                         Task::batch(
@@ -966,6 +969,7 @@ impl Dashboard {
                                                     self.history
                                                         .record_input_message(
                                                             message,
+                                                            labeled_response_context.clone(),
                                                             buffer.server(),
                                                             casemapping,
                                                             config,
@@ -3152,9 +3156,15 @@ impl Dashboard {
         &mut self,
         server: &Server,
         message: data::Message,
+        labeled_response_context: Option<LabeledResponseContext>,
         buffer_config: &config::Buffer,
     ) -> Task<Message> {
-        let tasks = self.history.record_message(server, message, buffer_config);
+        let tasks = self.history.record_message(
+            server,
+            message,
+            labeled_response_context,
+            buffer_config,
+        );
 
         Task::batch(
             tasks
@@ -3202,12 +3212,14 @@ impl Dashboard {
         server: &Server,
         casemapping: isupport::CaseMap,
         message: data::Message,
+        labeled_response_context: Option<LabeledResponseContext>,
         buffer_config: &config::Buffer,
     ) -> Task<Message> {
         let tasks = self.history.block_and_record_message(
             server,
             casemapping,
             message,
+            labeled_response_context,
             buffer_config,
         );
 
@@ -3951,6 +3963,7 @@ impl Dashboard {
                                 query,
                                 &transfer.filename,
                             ),
+                            None,
                             buffer_config,
                         ));
                     }
@@ -3962,6 +3975,7 @@ impl Dashboard {
                                 query,
                                 &transfer.filename,
                             ),
+                            None,
                             buffer_config,
                         ));
                     }


### PR DESCRIPTION
Utilize labeled-response, when available, to match local copies of sent message(s) with received echo(es).