### PR TITLE
Security Update

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,4 +27,6 @@ jobs:
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ignore: RUSTSEC-2023-0071 # rsa: Marvin Attack - no fix available, transitive via arti-client (which is unaffected https://gitlab.torproject.org/tpo/core/arti/-/issues/1141)
+          ignore: RUSTSEC-2023-0071,RUSTSEC-2026-0097
+          # RUSTSEC-2023-0071 rsa: Marvin Attack - no fix available, transitive via arti-client (which is unaffected https://gitlab.torproject.org/tpo/core/arti/-/issues/1141)
+          # RUSTSEC-2026-0097 rand: unsound when certain conditions are met - no fix available, transitive via arti-client

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6407,9 +6407,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
Two updates to address security audit:
- Updates `rustls-webpki` for [RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099.html)
- Excludes `rand` while no fix is yet available for [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html) (the unsound version of `rand` is only included via [Arti](https://gitlab.torproject.org/tpo/core/arti))