### PR TITLE
No Show for `chathistory` Echo

### DIFF
--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -479,7 +479,7 @@ impl History {
         } = self
             && (matches!(message.direction, message::Direction::Sent)
                 || (((message.triggers_unread() && !message.blocked)
-                    || message.is_echo)
+                    || (message.is_echo && !message.deduplicate))
                     && Some(message.server_time) > *max_triggers_unread))
         {
             *show_in_sidebar = true;


### PR DESCRIPTION
Don't show queries in the sidebar when receiving echoes via chathistory.  Prevents a case where queries could reopen on launch without any new messages.