### PR TITLE
buffer: add readline-like ^u and ^w to emacs bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Added:
 - Settings to reroute direct PRIVMSG and/or NOTICE messages to another buffer (`servers.<name>.reroute.query` and `servers.<name>.reroute.notice`)
 - `channel-context` support
 - Expanded `tooltips` setting to allow hiding auto-complete tooltips
+- emacs bindings for <kbd>ctrl</kbd> + <kbd>u</kbd> and <kbd>ctrl</kbd> + <kbd>w</kbd>
 
 Changed:
 

--- a/docs/configuration/buffer.md
+++ b/docs/configuration/buffer.md
@@ -1184,12 +1184,14 @@ key_bindings = "emacs"
 
 Emacs variant has the following binds:
 
-> `ctrl+a`: Move to the beginning of the line  
-  `ctrl+e`: Move to the end of the line  
-  `ctrl+b`: Move backward one character  
-  `ctrl+f`: Move forward one character  
+> `ctrl+a`: Move the cursor to the beginning of the line  
+  `ctrl+e`: Move the cursor to the end of the line  
+  `ctrl+b`: Move the cursor backward one character  
+  `ctrl+f`: Move the cursor forward one character  
   `ctrl+d`: Delete the character under the cursor  
-  `ctrl+k`: Kill rest of line from cursor  
+  `ctrl+k`: Delete from the cursor to the end of the line  
+  `ctrl+u`: Delete from the cursor to the beginning of the line  
+  `ctrl+w`: Delete to the beginning of the word under the cursor  
   `alt+b`: Move the cursor backward one word  
   `alt+f`: Move the cursor forward one word  
 

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -230,6 +230,18 @@ fn emacs_key_binding(
         {
             Some(text_editor::Binding::Custom(Message::DeleteToEnd(true)))
         }
+        iced::keyboard::Key::Character("u")
+            if key_press.modifiers.control() =>
+        {
+            Some(text_editor::Binding::Custom(Message::DeleteToStart(true)))
+        }
+        iced::keyboard::Key::Character("w")
+            if key_press.modifiers.control() =>
+        {
+            Some(text_editor::Binding::Custom(Message::DeleteWordBackward(
+                true,
+            )))
+        }
         _ => None,
     }
 }


### PR DESCRIPTION
would you consider adding ^u for backward kill line and ^w for backward kill word to the emacs bindings, like this?

i know these are technically not bindings provided by emacs itself, but they're used in the default 'emacs-style' configuration of readline, editline, and zle (and thus most shells, repls, sql clients, etc). i'm very used to them because of that

(if it's too problematic to call these 'emacs', maybe a new set of bindings called 'readline' that's just a super-set of it?)