### PR TITLE
buffer: add kill_to_clipboard setting to control clipboard behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Added:
 - `channel-context` support
 - Expanded `tooltips` setting to allow hiding auto-complete tooltips
 - emacs bindings for <kbd>ctrl</kbd> + <kbd>u</kbd> and <kbd>ctrl</kbd> + <kbd>w</kbd>
+- `buffer.text_input.kill_to_clipboard` to control key bindings moving killed text to clipboard
 
 Changed:
 

--- a/data/src/config/buffer/text_input.rs
+++ b/data/src/config/buffer/text_input.rs
@@ -11,6 +11,7 @@ pub struct TextInput {
     pub autocomplete: Autocomplete,
     pub nickname: Nickname,
     pub key_bindings: KeyBindings,
+    pub kill_to_clipboard: bool,
     #[serde(deserialize_with = "deserialize_usize_positive_integer")]
     pub max_lines: usize,
     pub send_line_delay: u64,
@@ -25,6 +26,7 @@ impl Default for TextInput {
             autocomplete: Autocomplete::default(),
             nickname: Nickname::default(),
             key_bindings: KeyBindings::default(),
+            kill_to_clipboard: true,
             max_lines: 5,
             send_line_delay: 100,
             persist: true,

--- a/docs/configuration/buffer.md
+++ b/docs/configuration/buffer.md
@@ -1199,6 +1199,19 @@ Emacs variant has the following binds:
 Global [keyboard shortcuts](/configuration/keyboard) take precedence. Unset any that collide (e.g., set `command_bar = "unset"`).
 :::
 
+### `kill_to_clipboard`
+
+If enabled, certain key bindings move killed (deleted) text to the clipboard.
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: true
+
+[buffer.text_input]
+kill_to_clipboard = true
+```
+
 ### `max_lines`
 
 Maximum number of lines in a single input.  If [`multiline`](https://ircv3.net/specs/extensions/multiline) is supported by the server then it will be utilized, otherwise messages will be sent individually with [`send_line_delay`](#send_line_delay) milliseconds between them.

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -1315,7 +1315,9 @@ impl State {
                     text_editor::Motion::WordLeft,
                 ));
 
-                let task = if save_to_clipboard {
+                let task = if save_to_clipboard
+                    && config.buffer.text_input.kill_to_clipboard
+                {
                     self.input_content.selection().map_or_else(
                         Task::none,
                         |selection| {
@@ -1339,7 +1341,9 @@ impl State {
                     text_editor::Motion::WordRight,
                 ));
 
-                let task = if save_to_clipboard {
+                let task = if save_to_clipboard
+                    && config.buffer.text_input.kill_to_clipboard
+                {
                     self.input_content.selection().map_or_else(
                         Task::none,
                         |selection| {
@@ -1363,7 +1367,9 @@ impl State {
                     text_editor::Motion::End,
                 ));
 
-                let task = if save_to_clipboard {
+                let task = if save_to_clipboard
+                    && config.buffer.text_input.kill_to_clipboard
+                {
                     self.input_content.selection().map_or_else(
                         Task::none,
                         |selection| {
@@ -1386,7 +1392,9 @@ impl State {
                     text_editor::Motion::Home,
                 ));
 
-                let task = if save_to_clipboard {
+                let task = if save_to_clipboard
+                    && config.buffer.text_input.kill_to_clipboard
+                {
                     self.input_content.selection().map_or_else(
                         Task::none,
                         |selection| {


### PR DESCRIPTION
related to but independent of #1848

certain bindings like ^k simulate emacs by moving killed text to the clipboard. if you've mostly used these bindings in the terminal (which doesn't usually integrate with the clipboard by default, at least on macos), this can be very weird and disruptive

is it reasonable to have a setting to disable it, like this?