### PR TITLE
fixup! Cycle through title instead of the underlying command

### DIFF
--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -258,7 +258,7 @@ impl Entry {
             Entry::Command(command) => replace_word_with_text(
                 input,
                 cursor_position,
-                &format!("/{command} "),
+                &format!("/{} ", command.to_lowercase()),
                 None,
             ),
             Entry::Word {


### PR DESCRIPTION
The original code forced the command to be lowercase,
but that got lost when moving to the string.

As far as I know commands are not case sensitive, so
it shouldn't really matter, but worth pointing out.
