### PR TITLE
Add `font.stretch` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Unreleased
 
+Added:
+
+- Configuration options for font stretch (`font.stretch`)
+
+Thanks:
+
+- Contributions: @bb010g
+
 # 2026.6 (2026-04-21)
 
 Added:

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -224,6 +224,8 @@ impl Default for Scrollbar {
 #[serde(default)]
 pub struct Font {
     pub family: Option<String>,
+    #[serde(deserialize_with = "deserialize_font_stretch_from_string")]
+    pub stretch: font::Stretch,
     #[serde(deserialize_with = "deserialize_u8_positive_integer_maybe")]
     pub size: Option<u8>,
     #[serde(deserialize_with = "deserialize_f32_positive_float_maybe")]
@@ -241,12 +243,47 @@ impl Default for Font {
     fn default() -> Self {
         Self {
             family: None,
+            stretch: font::Stretch::Normal,
             size: None,
             line_height: None,
             weight: font::Weight::Normal,
             bold_weight: None,
             only_emojis_size: None,
         }
+    }
+}
+
+fn deserialize_font_stretch_from_string<'de, D>(
+    deserializer: D,
+) -> Result<font::Stretch, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let string = String::deserialize(deserializer)?;
+
+    match string.as_ref() {
+        "ultra-condensed" => Ok(font::Stretch::UltraCondensed),
+        "extra-condensed" => Ok(font::Stretch::ExtraCondensed),
+        "condensed" => Ok(font::Stretch::Condensed),
+        "semi-condensed" => Ok(font::Stretch::SemiCondensed),
+        "normal" => Ok(font::Stretch::Normal),
+        "semi-expanded" => Ok(font::Stretch::SemiExpanded),
+        "expanded" => Ok(font::Stretch::Expanded),
+        "extra-expanded" => Ok(font::Stretch::ExtraExpanded),
+        "ultra-expanded" => Ok(font::Stretch::UltraExpanded),
+        _ => Err(serde::de::Error::invalid_value(
+            serde::de::Unexpected::Str(&string),
+            &"one of \
+              \"ultra-condensed\", \
+              \"extra-condensed\", \
+              \"condensed\", \
+              \"semi-condensed\", \
+              \"normal\", \
+              \"semi-expanded\", \
+              \"expanded\", \
+              \"extra-expanded\", or \
+              \"ultra-expanded\"",
+        )),
     }
 }
 

--- a/docs/configuration/font.md
+++ b/docs/configuration/font.md
@@ -7,7 +7,7 @@ Changes to font settings require an application restart to take effect.
 :::
 
 ::: info
-If Halloy is unable to load the specified font & weight, an fallback font may be used.  If the font looks wrong, double-check the family name and that the font family has the specified weight.
+If Halloy is unable to load the specified font, stretch, & weight, an fallback font may be used.  If the font looks wrong, double-check the family name and that the font family has the specified stretch & weight.
 :::
 
 ## `family`
@@ -27,6 +27,19 @@ Variable-weight fonts are not currently supported.
 
 [font]
 family = "Comic Mono"
+```
+
+## `stretch`
+
+Font stretch.
+
+```toml
+# Type: string
+# Values: "ultra-condensed", "extra-condensed", "condensed", "semi-condensed", "normal", "semi-expanded", "expanded", "extra-expanded", and "ultra-expanded"
+# Default: "normal"
+
+[font]
+stretch = "semi-condensed"
 ```
 
 ## `size`

--- a/src/font.rs
+++ b/src/font.rs
@@ -35,6 +35,7 @@ impl Font {
     fn set(
         &self,
         name: String,
+        stretch: font::Stretch,
         weight: font::Weight,
         bold_weight: font::Weight,
     ) {
@@ -46,6 +47,7 @@ impl Font {
         };
 
         let _ = self.inner.set(iced::Font {
+            stretch,
             weight,
             style,
             ..iced::Font::with_family(name.as_str())
@@ -67,6 +69,8 @@ pub fn set(config: Option<&Config>) {
     let family = config
         .and_then(|config| config.font.family.clone())
         .unwrap_or_else(|| String::from("Iosevka Term"));
+    let stretch =
+        config.map_or(font::Stretch::Normal, |config| config.font.stretch);
     let weight =
         config.map_or(font::Weight::Normal, |config| config.font.weight);
     let bold_weight = config
@@ -83,10 +87,10 @@ pub fn set(config: Option<&Config>) {
             | font::Weight::Black => font::Weight::Black,
         });
 
-    MONO.set(family.clone(), weight, bold_weight);
-    MONO_BOLD.set(family.clone(), weight, bold_weight);
-    MONO_ITALICS.set(family.clone(), weight, bold_weight);
-    MONO_BOLD_ITALICS.set(family, weight, bold_weight);
+    MONO.set(family.clone(), stretch, weight, bold_weight);
+    MONO_BOLD.set(family.clone(), stretch, weight, bold_weight);
+    MONO_ITALICS.set(family.clone(), stretch, weight, bold_weight);
+    MONO_BOLD_ITALICS.set(family, stretch, weight, bold_weight);
 
     let lh = config
         .and_then(|c| c.font.line_height)


### PR DESCRIPTION
I have an Iosevka Aile Semi-condensed font that I couldn't use without this.