### PR TITLE
Iteratively decode open graph entries

### DIFF
--- a/data/src/preview.rs
+++ b/data/src/preview.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::io;
 use std::sync::{Arc, LazyLock, OnceLock};
@@ -375,7 +376,16 @@ fn exceeds_image_size(
 }
 
 fn decode_html_string(s: &str) -> String {
-    html_escape::decode_html_entities(s).to_string()
+    let mut current = s.to_string();
+
+    for _ in 0..4 {
+        match html_escape::decode_html_entities(&current) {
+            Cow::Borrowed(_) => break,
+            Cow::Owned(next) => current = next,
+        }
+    }
+
+    current
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
We'll break as soon the original input is returned
or we reach N=4 attempts at stabilzing the input.

As seen in the wild:
`doesn&amp;#39;t` -> `doesn&#39;t` -> `doesn't`

Fixes #1847
