### PR TITLE
Fix `tor` enabled builds

### DIFF
--- a/data/src/config/proxy.rs
+++ b/data/src/config/proxy.rs
@@ -108,7 +108,9 @@ pub fn build_client(
             reqwest::Client::builder().proxy(proxy)
         }
         #[cfg(feature = "tor")]
-        Some(Proxy::Tor) => Err(BuildError::Tor),
+        Some(Proxy::Tor) => {
+            return Err(BuildError::Tor);
+        }
     };
 
     if let Some(identity) = identity {


### PR DESCRIPTION
Builds with `--all-features` or the flag to enable just `tor` are failing in the current release.

<img width="1311" height="651" alt="image" src="https://github.com/user-attachments/assets/8d46afaa-bbb9-4a8a-8898-f408830376ee" />

Looks like there was a change that ignored the `tor` arm of the match. I've made some changes to get the build going again.

Distros (like [archlinux](https://gitlab.archlinux.org/archlinux/packaging/packages/halloy/-/commit/1008cb85650902e23c920242a7570546fc90043d)) that build with `--all-features` are likely failing due to this bug. 