### PR TITLE
Show Server Messages in Labeled Context Buffer

### DIFF
--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -11,7 +11,7 @@ pub use self::timestamp::Timestamp;
 use crate::appearance::theme::hex_to_color;
 use crate::serde::deserialize_strftime_date;
 use crate::target::{self, Target};
-use crate::{Server, channel, config, message};
+use crate::{Server, channel, config};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -97,25 +97,6 @@ impl Upstream {
             Self::Channel(_, channel) => Some(Target::Channel(channel.clone())),
             Self::Query(_, query) => Some(Target::Query(query.clone())),
             Self::Server(_) => None,
-        }
-    }
-
-    pub fn server_message_target(
-        self,
-        source: Option<message::source::Server>,
-    ) -> message::Target {
-        match self {
-            Self::Server(_) => message::Target::Server {
-                source: message::Source::Server(source),
-            },
-            Self::Channel(_, channel) => message::Target::Channel {
-                channel,
-                source: message::Source::Server(source),
-            },
-            Self::Query(_, query) => message::Target::Query {
-                query,
-                source: message::Source::Server(source),
-            },
         }
     }
 }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -29,7 +29,6 @@ use crate::isupport::{
     ChatHistoryState, ChatHistorySubcommand, MessageReference, WhoToken,
     WhoXPollParameters, find_target_limit,
 };
-use crate::message::source;
 use crate::rate_limit::{BackoffInterval, TokenBucket, TokenPriority};
 use crate::target::{self, Target};
 use crate::time::Posix;
@@ -131,7 +130,7 @@ pub enum Event {
     WithTarget {
         message: message::Encoded,
         our_nick: Nick,
-        target: message::Target,
+        target: Option<Target>, // None → Server
         deduplicate: bool,
     },
     Broadcast(Broadcast),
@@ -534,10 +533,7 @@ impl Client {
         message: &mut message::Encoded,
     ) -> Option<LabeledResponseContext> {
         buffer.and_then(|buffer| {
-            let labeled_response_context = if self
-                .capabilities
-                .acknowledged(Capability::LabeledResponse)
-            {
+            if self.capabilities.acknowledged(Capability::LabeledResponse) {
                 let label = generate_label();
 
                 let context =
@@ -553,13 +549,12 @@ impl Client {
 
                 labeled_response_context
             } else {
+                self.reroute_responses_to = self
+                    .start_reroute(&message.command)
+                    .then(|| buffer.clone());
+
                 None
-            };
-
-            self.reroute_responses_to =
-                self.start_reroute(&message.command).then(|| buffer.clone());
-
-            labeled_response_context
+            }
         })
     }
 
@@ -1059,20 +1054,6 @@ impl Client {
                     }
                 }
             }
-            // Label context whois
-            _ if context.as_ref().is_some_and(Context::is_whois) => {
-                if let Some(source) = context
-                    .map(Context::buffer)
-                    .map(|buffer| buffer.server_message_target(None))
-                {
-                    return Ok(vec![Event::WithTarget {
-                        message,
-                        our_nick: self.nickname().to_owned(),
-                        target: source,
-                        deduplicate: false,
-                    }]);
-                }
-            }
             _ if is_reaction(&message) => {
                 return Ok(vec![Event::Reaction(
                     message,
@@ -1093,15 +1074,15 @@ impl Client {
                 | ERR_NOTONCHANNEL | ERR_CHANOPRIVSNEEDED | ERR_USERONCHANNEL,
                 _,
             ) if self.reroute_responses_to.is_some() => {
-                if let Some(source) = self
+                if let Some(target) = self
                     .reroute_responses_to
-                    .clone()
-                    .map(|buffer| buffer.server_message_target(None))
+                    .as_ref()
+                    .map(buffer::Upstream::target)
                 {
                     return Ok(vec![Event::WithTarget {
                         message,
                         our_nick: self.nickname().to_owned(),
-                        target: source,
+                        target,
                         deduplicate: false,
                     }]);
                 }
@@ -1861,15 +1842,15 @@ impl Client {
                         // User did not request, don't save to history
                         return Ok(vec![]);
                     // Reroute who responses
-                    } else if let Some(source) = self
+                    } else if let Some(target) = self
                         .reroute_responses_to
-                        .clone()
-                        .map(|buffer| buffer.server_message_target(None))
+                        .as_ref()
+                        .map(buffer::Upstream::target)
                     {
                         return Ok(vec![Event::WithTarget {
                             message,
                             our_nick: self.nickname().to_owned(),
-                            target: source,
+                            target,
                             deduplicate: false,
                         }]);
                     }
@@ -1979,15 +1960,15 @@ impl Client {
                         // User did not request, don't save to history
                         return Ok(vec![]);
                     // Reroute who responses
-                    } else if let Some(source) = self
+                    } else if let Some(target) = self
                         .reroute_responses_to
-                        .clone()
-                        .map(|buffer| buffer.server_message_target(None))
+                        .as_ref()
+                        .map(buffer::Upstream::target)
                     {
                         return Ok(vec![Event::WithTarget {
                             message,
                             our_nick: self.nickname().to_owned(),
-                            target: source,
+                            target,
                             deduplicate: false,
                         }]);
                     }
@@ -2055,15 +2036,15 @@ impl Client {
                         // User did not request, don't save to history
                         return Ok(vec![]);
                     // Reroute who responses
-                    } else if let Some(source) = self
+                    } else if let Some(target) = self
                         .reroute_responses_to
-                        .clone()
-                        .map(|buffer| buffer.server_message_target(None))
+                        .as_ref()
+                        .map(buffer::Upstream::target)
                     {
                         return Ok(vec![Event::WithTarget {
                             message,
                             our_nick: self.nickname().to_owned(),
-                            target: source,
+                            target,
                             deduplicate: false,
                         }]);
                     }
@@ -3056,11 +3037,24 @@ impl Client {
             _ => {}
         }
 
-        Ok(vec![Event::Single {
-            message,
-            our_nick: self.nickname().to_owned(),
-            deduplicate: false,
-        }])
+        if let Some(target) = context
+            .map(Context::buffer)
+            .as_ref()
+            .map(buffer::Upstream::target)
+        {
+            Ok(vec![Event::WithTarget {
+                message,
+                our_nick: self.nickname().to_owned(),
+                target,
+                deduplicate: false,
+            }])
+        } else {
+            Ok(vec![Event::Single {
+                message,
+                our_nick: self.nickname().to_owned(),
+                deduplicate: false,
+            }])
+        }
     }
 
     fn handle_chathistory(
@@ -3081,108 +3075,30 @@ impl Client {
                 _ if is_reaction(&message) => {
                     vec![Event::Reaction(message, self.nickname().to_owned())]
                 }
-                Command::NICK(new_nick) => {
-                    let new_nick = Nick::from_str(new_nick, self.casemapping());
-
-                    batch_target
-                        .as_channel()
-                        .map(|channel| {
-                            let target = message::Target::Channel {
-                                channel: channel.clone(),
-                                source: source::Source::Server(Some(
-                                    source::Server::new(
-                                        source::server::Kind::ChangeNick,
-                                        message.user(self.casemapping()).map(
-                                            |user| Nick::from(user.nickname()),
-                                        ),
-                                        Some(source::server::Change::Nick(
-                                            new_nick,
-                                        )),
-                                    ),
-                                )),
-                            };
-
-                            vec![Event::WithTarget {
-                                message,
-                                our_nick: self.nickname().to_owned(),
-                                target,
-                                deduplicate: true,
-                            }]
-                        })
-                        .unwrap_or_default()
-                }
-                Command::JOIN(_, _) => batch_target
-                    .as_channel()
-                    .map(|channel| {
-                        let target = message::Target::Channel {
-                            channel: channel.clone(),
-                            source: source::Source::Server(Some(
-                                source::Server::new(
-                                    source::server::Kind::Join,
-                                    message.user(self.casemapping()).map(
-                                        |user| Nick::from(user.nickname()),
-                                    ),
-                                    None,
-                                ),
-                            )),
-                        };
-
-                        vec![Event::WithTarget {
-                            message,
-                            our_nick: self.nickname().to_owned(),
-                            target,
-                            deduplicate: true,
-                        }]
-                    })
-                    .unwrap_or_default(),
-                Command::PART(_, _) => batch_target
-                    .as_channel()
-                    .map(|channel| {
-                        let target = message::Target::Channel {
-                            channel: channel.clone(),
-                            source: source::Source::Server(Some(
-                                source::Server::new(
-                                    source::server::Kind::Part,
-                                    message.user(self.casemapping()).map(
-                                        |user| Nick::from(user.nickname()),
-                                    ),
-                                    None,
-                                ),
-                            )),
-                        };
-
-                        vec![Event::WithTarget {
-                            message,
-                            our_nick: self.nickname().to_owned(),
-                            target,
-                            deduplicate: true,
-                        }]
-                    })
-                    .unwrap_or_default(),
-                Command::QUIT(_) => batch_target
-                    .as_channel()
-                    .map(|channel| {
-                        let target = message::Target::Channel {
-                            channel: channel.clone(),
-                            source: source::Source::Server(Some(
-                                source::Server::new(
-                                    source::server::Kind::Quit,
-                                    message.user(self.casemapping()).map(
-                                        |user| Nick::from(user.nickname()),
-                                    ),
-                                    None,
-                                ),
-                            )),
-                        };
-
-                        vec![Event::WithTarget {
-                            message,
-                            our_nick: self.nickname().to_owned(),
-                            target,
-                            deduplicate: true,
-                        }]
-                    })
-                    .unwrap_or_default(),
+                Command::NICK(_) => vec![Event::WithTarget {
+                    message,
+                    our_nick: self.nickname().to_owned(),
+                    target: Some(batch_target),
+                    deduplicate: true,
+                }],
+                Command::JOIN(_, _) => vec![Event::WithTarget {
+                    message,
+                    our_nick: self.nickname().to_owned(),
+                    target: Some(batch_target),
+                    deduplicate: true,
+                }],
+                Command::PART(_, _) => vec![Event::WithTarget {
+                    message,
+                    our_nick: self.nickname().to_owned(),
+                    target: Some(batch_target),
+                    deduplicate: true,
+                }],
+                Command::QUIT(_) => vec![Event::WithTarget {
+                    message,
+                    our_nick: self.nickname().to_owned(),
+                    target: Some(batch_target),
+                    deduplicate: true,
+                }],
                 Command::PRIVMSG(target, text)
                 | Command::NOTICE(target, text) => {
                     if ctcp::is_query(text) && !message::is_action(text) {
@@ -5026,7 +4942,6 @@ impl Map {
 pub enum Context {
     Buffer(buffer::Upstream),
     PrivOrNotice(buffer::Upstream, Option<LabeledResponseContext>),
-    Whois(buffer::Upstream),
 }
 
 impl Context {
@@ -5036,7 +4951,6 @@ impl Context {
         label: Option<&str>,
     ) -> Self {
         match &message.command {
-            Command::WHOIS(_, _) => Self::Whois(buffer),
             Command::PRIVMSG(_, _) | Command::NOTICE(_, _) => {
                 Self::PrivOrNotice(
                     buffer,
@@ -5059,15 +4973,10 @@ impl Context {
         }
     }
 
-    fn is_whois(&self) -> bool {
-        matches!(self, Self::Whois(_))
-    }
-
     fn buffer(self) -> buffer::Upstream {
         match self {
             Context::Buffer(buffer) => buffer,
             Context::PrivOrNotice(buffer, _) => buffer,
-            Context::Whois(buffer) => buffer,
         }
     }
 
@@ -5076,7 +4985,7 @@ impl Context {
             Context::PrivOrNotice(_, labeled_response_context) => {
                 labeled_response_context.as_ref()
             }
-            Context::Buffer(_) | Context::Whois(_) => None,
+            Context::Buffer(_) => None,
         }
     }
 }
@@ -5087,7 +4996,7 @@ impl From<Context> for Option<LabeledResponseContext> {
             Context::PrivOrNotice(_, labeled_response_context) => {
                 labeled_response_context
             }
-            Context::Buffer(_) | Context::Whois(_) => None,
+            Context::Buffer(_) => None,
         }
     }
 }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -101,6 +101,27 @@ pub enum Broadcast {
 }
 
 #[derive(Debug)]
+pub enum Destination {
+    Server,
+    Target(Target),
+}
+
+impl From<&buffer::Upstream> for Destination {
+    fn from(buffer: &buffer::Upstream) -> Self {
+        match buffer.target() {
+            Some(target) => Self::Target(target),
+            None => Self::Server,
+        }
+    }
+}
+
+impl From<Target> for Destination {
+    fn from(target: Target) -> Self {
+        Self::Target(target)
+    }
+}
+
+#[derive(Debug)]
 pub enum Message {
     ChatHistoryRequest(Server, ChatHistorySubcommand),
     ChatHistoryTargetsTimestampUpdated(
@@ -130,7 +151,7 @@ pub enum Event {
     WithTarget {
         message: message::Encoded,
         our_nick: Nick,
-        target: Option<Target>, // None → Server
+        target: Destination,
         deduplicate: bool,
     },
     Broadcast(Broadcast),
@@ -1074,10 +1095,8 @@ impl Client {
                 | ERR_NOTONCHANNEL | ERR_CHANOPRIVSNEEDED | ERR_USERONCHANNEL,
                 _,
             ) if self.reroute_responses_to.is_some() => {
-                if let Some(target) = self
-                    .reroute_responses_to
-                    .as_ref()
-                    .map(buffer::Upstream::target)
+                if let Some(target) =
+                    self.reroute_responses_to.as_ref().map(Destination::from)
                 {
                     return Ok(vec![Event::WithTarget {
                         message,
@@ -1845,7 +1864,7 @@ impl Client {
                     } else if let Some(target) = self
                         .reroute_responses_to
                         .as_ref()
-                        .map(buffer::Upstream::target)
+                        .map(Destination::from)
                     {
                         return Ok(vec![Event::WithTarget {
                             message,
@@ -1963,7 +1982,7 @@ impl Client {
                     } else if let Some(target) = self
                         .reroute_responses_to
                         .as_ref()
-                        .map(buffer::Upstream::target)
+                        .map(Destination::from)
                     {
                         return Ok(vec![Event::WithTarget {
                             message,
@@ -2039,7 +2058,7 @@ impl Client {
                     } else if let Some(target) = self
                         .reroute_responses_to
                         .as_ref()
-                        .map(buffer::Upstream::target)
+                        .map(Destination::from)
                     {
                         return Ok(vec![Event::WithTarget {
                             message,
@@ -3037,10 +3056,8 @@ impl Client {
             _ => {}
         }
 
-        if let Some(target) = context
-            .map(Context::buffer)
-            .as_ref()
-            .map(buffer::Upstream::target)
+        if let Some(target) =
+            context.map(Context::buffer).as_ref().map(Destination::from)
         {
             Ok(vec![Event::WithTarget {
                 message,
@@ -3078,25 +3095,25 @@ impl Client {
                 Command::NICK(_) => vec![Event::WithTarget {
                     message,
                     our_nick: self.nickname().to_owned(),
-                    target: Some(batch_target),
+                    target: batch_target.into(),
                     deduplicate: true,
                 }],
                 Command::JOIN(_, _) => vec![Event::WithTarget {
                     message,
                     our_nick: self.nickname().to_owned(),
-                    target: Some(batch_target),
+                    target: batch_target.into(),
                     deduplicate: true,
                 }],
                 Command::PART(_, _) => vec![Event::WithTarget {
                     message,
                     our_nick: self.nickname().to_owned(),
-                    target: Some(batch_target),
+                    target: batch_target.into(),
                     deduplicate: true,
                 }],
                 Command::QUIT(_) => vec![Event::WithTarget {
                     message,
                     our_nick: self.nickname().to_owned(),
-                    target: Some(batch_target),
+                    target: batch_target.into(),
                     deduplicate: true,
                 }],
                 Command::PRIVMSG(target, text)

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -20,6 +20,7 @@ pub use self::highlight::Highlight;
 pub use self::source::Source;
 pub use self::source::server::{Change, Kind, StandardReply};
 use crate::capabilities::LabeledResponseContext;
+use crate::client::Destination;
 use crate::config::buffer::{CondensationFormat, UsernameFormat};
 use crate::config::{self, Highlights};
 use crate::history::reroute::RerouteRules;
@@ -650,22 +651,26 @@ impl Message {
         }
     }
 
-    pub fn with_target(self, target: Option<target::Target>) -> Self {
+    pub fn with_target(self, target: Destination) -> Self {
         let source = self.target.source();
 
         Self {
             target: match target {
-                None => Target::Server {
+                Destination::Server => Target::Server {
                     source: source.clone(),
                 },
-                Some(target::Target::Channel(channel)) => Target::Channel {
-                    channel,
-                    source: source.clone(),
-                },
-                Some(target::Target::Query(query)) => Target::Query {
-                    query,
-                    source: source.clone(),
-                },
+                Destination::Target(target::Target::Channel(channel)) => {
+                    Target::Channel {
+                        channel,
+                        source: source.clone(),
+                    }
+                }
+                Destination::Target(target::Target::Query(query)) => {
+                    Target::Query {
+                        query,
+                        source: source.clone(),
+                    }
+                }
             },
             ..self
         }

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -650,8 +650,25 @@ impl Message {
         }
     }
 
-    pub fn with_target(self, target: Target) -> Self {
-        Self { target, ..self }
+    pub fn with_target(self, target: Option<target::Target>) -> Self {
+        let source = self.target.source();
+
+        Self {
+            target: match target {
+                None => Target::Server {
+                    source: source.clone(),
+                },
+                Some(target::Target::Channel(channel)) => Target::Channel {
+                    channel,
+                    source: source.clone(),
+                },
+                Some(target::Target::Query(query)) => Target::Query {
+                    query,
+                    source: source.clone(),
+                },
+            },
+            ..self
+        }
     }
 
     pub fn with_labeled_response_context(
@@ -2252,6 +2269,16 @@ fn target(
                 None,
             ))
         }
+        Command::QUIT(_) => Some((
+            Target::Server {
+                source: source::Source::Server(Some(source::Server::new(
+                    source::server::Kind::Quit,
+                    Some(user?.nickname().to_owned()),
+                    None,
+                ))),
+            },
+            None,
+        )),
         Command::JOIN(channel, _) => {
             let channel = target::Channel::parse(
                 &channel,
@@ -2268,6 +2295,20 @@ fn target(
                         Kind::Join,
                         Some(user?.nickname().to_owned()),
                         None,
+                    ))),
+                },
+                None,
+            ))
+        }
+        Command::NICK(new_nick) => {
+            let new_nick = Nick::from_string(new_nick, casemapping);
+
+            Some((
+                Target::Server {
+                    source: source::Source::Server(Some(source::Server::new(
+                        source::server::Kind::ChangeNick,
+                        Some(user?.nickname().to_owned()),
+                        Some(source::server::Change::Nick(new_nick)),
                     ))),
                 },
                 None,
@@ -2625,11 +2666,9 @@ fn target(
         }
         // Server
         Command::PASS(_)
-        | Command::NICK(_)
         | Command::CHGHOST(_, _)
         | Command::USER(_, _)
         | Command::OPER(_, _)
-        | Command::QUIT(_)
         | Command::SQUIT(_, _)
         | Command::NAMES(_)
         | Command::LIST(_, _)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1903,7 +1903,7 @@ fn handle_with_target_event(
     server: &Server,
     encoded: message::Encoded,
     our_nick: data::user::Nick,
-    target: message::Target,
+    target: Option<Target>,
     deduplicate: bool,
     dashboard: &mut screen::Dashboard,
     commands: &mut Vec<Task<Message>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ use std::{env, mem};
 
 use appearance::{Theme, theme};
 use data::capabilities::LabeledResponseContext;
+use data::client::{self, Destination};
 use data::config::{self, Config};
 use data::history::ReactionToEcho;
 use data::history::filter::FilterChain;
@@ -39,8 +40,7 @@ use data::target::{self, Target};
 use data::user::Nick;
 use data::version::Version;
 use data::{
-    Notification, Server, Url, User, client, environment, history, server,
-    version,
+    Notification, Server, Url, User, environment, history, server, version,
 };
 use iced::widget::{column, container};
 use iced::{Length, Subscription, Task, padding};
@@ -1903,7 +1903,7 @@ fn handle_with_target_event(
     server: &Server,
     encoded: message::Encoded,
     our_nick: data::user::Nick,
-    target: Option<Target>,
+    target: Destination,
     deduplicate: bool,
     dashboard: &mut screen::Dashboard,
     commands: &mut Vec<Task<Message>>,


### PR DESCRIPTION
Show server messages in labeled context buffer by default, when available.  In particular, to show standard replies in the buffer that the command was sent from (e.g. if attempting and failing to redact a message in a buffer, then the standard reply `FAIL` will show in that buffer).