### PR TITLE
Truncation Tweaks Re: Bot Icon

### DIFF
--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -1434,12 +1434,11 @@ impl Data {
                                 buffer_config
                                     .nickname
                                     .brackets
-                                    .format(
-                                        user.display(
-                                            with_access_levels,
-                                            truncate,
-                                        ),
-                                    )
+                                    .format(user.display(
+                                        with_access_levels,
+                                        buffer_config.nickname.show_bot_icon,
+                                        truncate,
+                                    ))
                                     .chars()
                                     .count(),
                             )
@@ -1464,12 +1463,11 @@ impl Data {
                                 buffer_config
                                     .nickname
                                     .brackets
-                                    .format(
-                                        user.display(
-                                            with_access_levels,
-                                            truncate,
-                                        ),
-                                    )
+                                    .format(user.display(
+                                        with_access_levels,
+                                        buffer_config.nickname.show_bot_icon,
+                                        truncate,
+                                    ))
                                     .chars()
                                     .count(),
                             )

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -206,14 +206,17 @@ impl User {
     pub fn display(
         &self,
         with_access_levels: AccessLevelFormat,
+        show_bot_icon: bool,
         truncate: Option<u16>,
     ) -> String {
-        self.display_with_truncated(with_access_levels, truncate).0
+        self.display_with_truncated(with_access_levels, show_bot_icon, truncate)
+            .0
     }
 
     pub fn display_with_truncated(
         &self,
         with_access_levels: AccessLevelFormat,
+        show_bot_icon: bool,
         truncate: Option<u16>,
     ) -> (String, bool) {
         let mut nickname = match with_access_levels {
@@ -235,14 +238,18 @@ impl User {
             AccessLevelFormat::None => self.nickname().to_string(),
         };
 
+        let show_bot_icon = self.is_bot() && show_bot_icon;
+
         let mut show_tooltip = false;
 
         if let Some(len) = truncate
-            && UnicodeSegmentation::graphemes(nickname.as_str(), true).count()
+            && (UnicodeSegmentation::graphemes(nickname.as_str(), true).count()
+                + if show_bot_icon { 1 } else { 0 })
                 > len as usize
         {
             nickname = UnicodeSegmentation::graphemes(nickname.as_str(), true)
-                .take(len.saturating_sub(1) as usize)
+                .take(len.saturating_sub(if show_bot_icon { 2 } else { 1 })
+                    as usize)
                 .collect::<String>();
             nickname.push('…');
 

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -244,11 +244,11 @@ impl User {
 
         if let Some(len) = truncate
             && (UnicodeSegmentation::graphemes(nickname.as_str(), true).count()
-                + if show_bot_icon { 1 } else { 0 })
+                + if show_bot_icon { 2 } else { 0 })
                 > len as usize
         {
             nickname = UnicodeSegmentation::graphemes(nickname.as_str(), true)
-                .take(len.saturating_sub(if show_bot_icon { 2 } else { 1 })
+                .take(len.saturating_sub(if show_bot_icon { 3 } else { 1 })
                     as usize)
                 .collect::<String>();
             nickname.push('…');

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -583,31 +583,54 @@ mod nick_list {
         let width = match nicklist_config.width {
             Some(width) => width,
             None => {
-                let max_nick_length = users
-                    .into_iter()
-                    .flatten()
-                    .map(|user| {
-                        user.display(
-                            nicklist_config.show_access_levels,
-                            truncate,
+                let (max_nick_length, max_bot_nick_length) =
+                    users.into_iter().flatten().fold(
+                        (0, None),
+                        |(max_nick_length, max_bot_nick_length), user| {
+                            let nick_length = user
+                                .display(
+                                    nicklist_config.show_access_levels,
+                                    nicklist_config.show_bot_icon,
+                                    truncate,
+                                )
+                                .chars()
+                                .count();
+
+                            if user.is_bot() {
+                                (
+                                    max_nick_length,
+                                    max_bot_nick_length.max(Some(nick_length)),
+                                )
+                            } else {
+                                (
+                                    max_nick_length.max(nick_length),
+                                    max_bot_nick_length,
+                                )
+                            }
+                        },
+                    );
+
+                (if let Some(max_bot_nick_length) = max_bot_nick_length {
+                    if nicklist_config.show_bot_icon {
+                        // reserve space for any eventual bot icon
+                        font::width_from_chars(max_nick_length, &config.font)
+                            .max(
+                                font::width_from_chars(
+                                    max_bot_nick_length,
+                                    &config.font,
+                                ) + theme::ICON_SIZE
+                                    + theme::ICON_SPACE,
+                            )
+                    } else {
+                        font::width_from_chars(
+                            max_nick_length.max(max_bot_nick_length),
+                            &config.font,
                         )
-                        .chars()
-                        .count()
-                    })
-                    .max()
-                    .unwrap_or_default();
-
-                font::width_from_chars(max_nick_length, &config.font) + 1.0
+                    }
+                } else {
+                    font::width_from_chars(max_nick_length, &config.font)
+                } + 1.0)
             }
-        };
-
-        let bot_nick_max_chars = if nicklist_config.show_bot_icon {
-            let char_width = font::width_from_chars(1, &config.font);
-            let available = width - theme::ICON_SIZE - theme::ICON_SPACE;
-            let px_max = (available / char_width).floor() as u16;
-            Some(truncate.map_or(px_max, |t| t.min(px_max)))
-        } else {
-            None
         };
 
         let content = column(users.into_iter().flatten().map(|user| {
@@ -616,11 +639,8 @@ mod nick_list {
             let (nick_display, show_nick_tooltip) = user
                 .display_with_truncated(
                     nicklist_config.show_access_levels,
-                    if show_bot_icon {
-                        bot_nick_max_chars
-                    } else {
-                        truncate
-                    },
+                    nicklist_config.show_bot_icon,
+                    truncate,
                 );
 
             let nick = selectable_text(nick_display)
@@ -645,9 +665,7 @@ mod nick_list {
                         Length::Shrink
                     }
                     (true, config::buffer::channel::Alignment::Right) => {
-                        Length::Fixed(
-                            width - theme::ICON_SIZE - theme::ICON_SPACE,
-                        )
+                        Length::Fixed(width)
                     }
                     (false, _) => Length::Fixed(width),
                 });

--- a/src/buffer/highlights.rs
+++ b/src/buffer/highlights.rs
@@ -99,6 +99,7 @@ pub fn view<'a>(
 
                     let with_access_levels =
                         config.buffer.nickname.show_access_levels;
+                    let show_bot_icon = config.buffer.nickname.show_bot_icon;
                     let truncate = config.buffer.nickname.truncate;
 
                     let current_user =
@@ -110,7 +111,11 @@ pub fn view<'a>(
                         };
 
                     let (user_display, show_nickname_tooltip) = user
-                        .display_with_truncated(with_access_levels, truncate);
+                        .display_with_truncated(
+                            with_access_levels,
+                            show_bot_icon,
+                            truncate,
+                        );
 
                     let nick_text =
                         config.buffer.nickname.brackets.format(user_display);

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -581,6 +581,7 @@ pub fn view<'a>(
                 container(
                     text(user.display(
                         config.buffer.text_input.nickname.show_access_levels,
+                        config.buffer.nickname.show_bot_icon,
                         None,
                     ))
                     .style(move |_| our_user_style)

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -371,6 +371,7 @@ impl<'a> ChannelQueryLayout<'a> {
             .map(|dimmed| (dimmed, self.theme.styles().buffer.background));
 
         let with_access_levels = self.config.buffer.nickname.show_access_levels;
+        let show_bot_icon = self.config.buffer.nickname.show_bot_icon;
         let truncate = self.config.buffer.nickname.truncate;
         let user_in_channel = self
             .target
@@ -408,8 +409,12 @@ impl<'a> ChannelQueryLayout<'a> {
             dimmed_background_tuple,
         );
 
-        let (user_display, show_nickname_tooltip) =
-            user.display_with_truncated(with_access_levels, truncate);
+        let (user_display, show_nickname_tooltip) = user
+            .display_with_truncated(
+                with_access_levels,
+                show_bot_icon,
+                truncate,
+            );
 
         let is_bot =
             user_in_channel.map_or_else(|| user.is_bot(), User::is_bot);

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -409,8 +409,8 @@ impl<'a> ChannelQueryLayout<'a> {
             dimmed_background_tuple,
         );
 
-        let (user_display, show_nickname_tooltip) = user
-            .display_with_truncated(
+        let (user_display, show_nickname_tooltip) =
+            user_in_channel.unwrap_or(user).display_with_truncated(
                 with_access_levels,
                 show_bot_icon,
                 truncate,

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -311,24 +311,25 @@ pub fn view<'a>(
     let status = state.status;
 
     let right_aligned_width = max_nick_chars.map(|max_nick_chars| {
-        let max_nick_width =
-            if let Some(max_bot_nick_chars) = max_bot_nick_chars {
-                if config.buffer.nickname.show_bot_icon {
-                    // reserve space for any eventual bot icon
-                    font::width_from_chars(max_nick_chars, &config.font).max(
-                        font::width_from_chars(max_nick_chars, &config.font)
-                            + theme::ICON_SIZE
-                            + theme::ICON_SPACE,
-                    )
-                } else {
-                    font::width_from_chars(
-                        max_nick_chars.max(max_bot_nick_chars),
-                        &config.font,
-                    )
-                }
+        let max_nick_width = if let Some(max_bot_nick_chars) =
+            max_bot_nick_chars
+        {
+            if config.buffer.nickname.show_bot_icon {
+                // reserve space for any eventual bot icon
+                font::width_from_chars(max_nick_chars, &config.font).max(
+                    font::width_from_chars(max_bot_nick_chars, &config.font)
+                        + theme::ICON_SIZE
+                        + theme::ICON_SPACE,
+                )
             } else {
-                font::width_from_chars(max_nick_chars, &config.font)
-            } + 1.0;
+                font::width_from_chars(
+                    max_nick_chars.max(max_bot_nick_chars),
+                    &config.font,
+                )
+            }
+        } else {
+            font::width_from_chars(max_nick_chars, &config.font)
+        } + 1.0;
         let message_marker_width =
             font::width_of_message_marker(&config.font) + 1.0;
         let mut range_end_timestamp_width = range_end_timestamp_chars.map_or(
@@ -1999,31 +2000,35 @@ fn preview_row<'a>(
             );
 
             let with_access_levels = config.buffer.nickname.show_access_levels;
+            let show_bot_icon = config.buffer.nickname.show_bot_icon;
             let truncate = config.buffer.nickname.truncate;
 
-            let nick = if let message::Source::User(user) =
-                message.target.source()
-            {
-                let mut nick = selectable_text(
-                    " ".repeat(
-                        config
-                            .buffer
-                            .nickname
-                            .brackets
-                            .format(user.display(with_access_levels, truncate))
-                            .chars()
-                            .count(),
-                    ),
-                );
+            let nick =
+                if let message::Source::User(user) = message.target.source() {
+                    let mut nick = selectable_text(
+                        " ".repeat(
+                            config
+                                .buffer
+                                .nickname
+                                .brackets
+                                .format(user.display(
+                                    with_access_levels,
+                                    show_bot_icon,
+                                    truncate,
+                                ))
+                                .chars()
+                                .count(),
+                        ),
+                    );
 
-                if let Some(width) = right_aligned_width {
-                    nick = nick.width(width);
-                }
+                    if let Some(width) = right_aligned_width {
+                        nick = nick.width(width);
+                    }
 
-                Some(nick)
-            } else {
-                None
-            };
+                    Some(nick)
+                } else {
+                    None
+                };
 
             let timestamp_nickname_row =
                 row![timestamp_gap, space, prefixes, nick];

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -187,6 +187,7 @@ pub fn view<'a>(
                         let (user_display, show_nickname_tooltip) = user
                             .display_with_truncated(
                                 with_access_levels,
+                                config.buffer.nickname.show_bot_icon,
                                 truncate,
                             );
 


### PR DESCRIPTION
Treats bot icon as one character for the purposes of truncation (to match the treatment of access levels), and makes buffer and nick list handling of truncation more consistent.