### PR TITLE
Store Bot Mode

### DIFF
--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -276,6 +276,16 @@ impl Target {
             | Target::Highlights { .. } => None,
         }
     }
+
+    pub fn channel(&self) -> Option<&target::Channel> {
+        match self {
+            Target::Channel { channel, .. } => Some(channel),
+            Target::Query { .. }
+            | Target::Server { .. }
+            | Target::Logs { .. }
+            | Target::Highlights { .. } => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
@@ -402,8 +412,19 @@ impl Message {
         let is_echo = encoded
             .user(casemapping)
             .is_some_and(|user| user.nickname() == our_nick);
-        let (content, _) = content(
+        let (target, rerouted_from) = target(
             &encoded,
+            &our_nick,
+            reroute_rules,
+            &resolve_attributes,
+            server,
+            chantypes,
+            statusmsg,
+            casemapping,
+        )?;
+        let (content, _) = content(
+            encoded,
+            &target,
             &our_nick,
             config,
             &resolve_attributes,
@@ -413,16 +434,6 @@ impl Message {
             statusmsg,
             casemapping,
             prefix,
-        )?;
-        let (target, rerouted_from) = target(
-            encoded,
-            &our_nick,
-            reroute_rules,
-            &resolve_attributes,
-            server,
-            chantypes,
-            statusmsg,
-            casemapping,
         )?;
         let received_at = Posix::now();
         let hash = Hash::new(&server_time, &content);
@@ -467,8 +478,19 @@ impl Message {
         let is_echo = encoded
             .user(casemapping)
             .is_some_and(|user| user.nickname() == our_nick);
-        let (content, highlight) = content(
+        let (target, rerouted_from) = target(
             &encoded,
+            &our_nick,
+            reroute_rules,
+            &resolve_attributes,
+            server,
+            chantypes,
+            statusmsg,
+            casemapping,
+        )?;
+        let (content, highlight) = content(
+            encoded,
+            &target,
             &our_nick,
             config,
             &resolve_attributes,
@@ -478,16 +500,6 @@ impl Message {
             statusmsg,
             casemapping,
             prefix,
-        )?;
-        let (target, rerouted_from) = target(
-            encoded,
-            &our_nick,
-            reroute_rules,
-            &resolve_attributes,
-            server,
-            chantypes,
-            statusmsg,
-            casemapping,
         )?;
         let received_at = Posix::now();
         let hash = Hash::new(&server_time, &content);
@@ -2166,7 +2178,7 @@ impl From<formatting::Fragment> for Fragment {
 }
 
 fn target(
-    message: Encoded,
+    message: &Encoded,
     our_nick: &Nick,
     reroute_rules: &RerouteRules,
     resolve_attributes: &dyn Fn(&User, &target::Channel) -> Option<User>,
@@ -2179,11 +2191,11 @@ fn target(
 
     let user = message.user(casemapping);
 
-    match message.0.command {
+    match &message.command {
         // Channel
         Command::MODE(target, ..) => {
             if let Ok(channel) = target::Channel::parse(
-                &target,
+                target,
                 chantypes,
                 statusmsg,
                 casemapping,
@@ -2210,7 +2222,7 @@ fn target(
         }
         Command::TOPIC(channel, _) => {
             let channel = target::Channel::parse(
-                &channel,
+                channel,
                 chantypes,
                 statusmsg,
                 casemapping,
@@ -2231,7 +2243,7 @@ fn target(
         }
         Command::KICK(channel, victim, _) => {
             let channel = target::Channel::parse(
-                &channel,
+                channel,
                 chantypes,
                 statusmsg,
                 casemapping,
@@ -2255,7 +2267,7 @@ fn target(
         }
         Command::PART(channel, _) => {
             let channel = target::Channel::parse(
-                &channel,
+                channel,
                 chantypes,
                 statusmsg,
                 casemapping,
@@ -2286,7 +2298,7 @@ fn target(
         )),
         Command::JOIN(channel, _) => {
             let channel = target::Channel::parse(
-                &channel,
+                channel,
                 chantypes,
                 statusmsg,
                 casemapping,
@@ -2306,7 +2318,7 @@ fn target(
             ))
         }
         Command::NICK(new_nick) => {
-            let new_nick = Nick::from_string(new_nick, casemapping);
+            let new_nick = Nick::from_str(new_nick, casemapping);
 
             Some((
                 Target::Server {
@@ -2400,8 +2412,7 @@ fn target(
                 None,
             ))
         }
-        Command::PRIVMSG(ref target, ref text)
-        | Command::NOTICE(ref target, ref text) => {
+        Command::PRIVMSG(target, text) | Command::NOTICE(target, text) => {
             let is_notice = matches!(message.0.command, Command::NOTICE(_, _));
             let is_privmsg =
                 matches!(message.0.command, Command::PRIVMSG(_, _));
@@ -2445,14 +2456,14 @@ fn target(
             // CTCP Handling.
             let (target, rerouted_from) = if ctcp::is_query(text) && !is_action
             {
-                let user = user?;
+                let user = user.as_ref()?;
                 let target = User::from(Nick::from_str(target, casemapping));
 
                 // We want to show both requests, and responses in query with the client.
                 let user = if user.nickname() == *our_nick {
                     target
                 } else {
-                    user
+                    user.clone()
                 };
 
                 (
@@ -2470,11 +2481,12 @@ fn target(
                         statusmsg,
                         casemapping,
                     ),
-                    user,
+                    &user,
                 ) {
                     (target::Target::Channel(channel), Some(user)) => {
                         let source = source(
-                            resolve_attributes(&user, &channel).unwrap_or(user),
+                            resolve_attributes(user, &channel)
+                                .unwrap_or(user.clone()),
                         );
                         (Target::Channel { channel, source }, None)
                     }
@@ -2496,7 +2508,7 @@ fn target(
 
                         let target = Target::Query {
                             query,
-                            source: source(user),
+                            source: source(user.clone()),
                         };
 
                         if is_privmsg
@@ -2534,9 +2546,18 @@ fn target(
                 message.channel_context(chantypes, statusmsg, casemapping);
 
             Some(if let Some(channel_context) = channel_context {
+                // Resolve attributes in the context channel
+                let source =
+                    user.as_ref().map_or(Source::Server(None), |user| {
+                        source(
+                            resolve_attributes(user, &channel_context)
+                                .unwrap_or(user.clone()),
+                        )
+                    });
+
                 let channel_context = Target::Channel {
                     channel: channel_context,
-                    source: target.source().clone(),
+                    source,
                 };
 
                 if rerouted_from.is_some() {
@@ -2544,6 +2565,23 @@ fn target(
                 } else {
                     (channel_context, Some(target))
                 }
+            } else if rerouted_from.is_some()
+                && let Target::Channel { channel, source } = target
+            {
+                // Resolve attributes in the target channel
+                let source = match source {
+                    Source::User(user) => Source::User(
+                        resolve_attributes(&user, &channel).unwrap_or(user),
+                    ),
+                    Source::Action(Some(user)) => Source::Action(Some(
+                        resolve_attributes(&user, &channel).unwrap_or(user),
+                    )),
+                    Source::Action(None)
+                    | Source::Server(_)
+                    | Source::Internal(_) => source,
+                };
+
+                (Target::Channel { channel, source }, rerouted_from)
             } else {
                 (target, rerouted_from)
             })
@@ -2632,7 +2670,7 @@ fn target(
             }
         }
         Command::INVITE(invitee, channel) => {
-            let invitee = User::from(Nick::from_string(invitee, casemapping));
+            let invitee = User::from(Nick::from_str(invitee, casemapping));
 
             if invitee.nickname() == *our_nick {
                 if let Some(user) = user {
@@ -2654,7 +2692,7 @@ fn target(
             }
 
             let channel = target::Channel::parse(
-                &channel,
+                channel,
                 chantypes,
                 statusmsg,
                 casemapping,
@@ -2726,7 +2764,8 @@ fn target(
 pub type Id = Arc<str>;
 
 fn content<'a>(
-    message: &Encoded,
+    message: Encoded,
+    message_target: &Target,
     our_nick: &Nick,
     config: &Config,
     resolve_attributes: &dyn Fn(&User, &target::Channel) -> Option<User>,
@@ -2994,7 +3033,8 @@ fn content<'a>(
 
             let user = message.user(casemapping);
 
-            let channel_users = target.as_channel().and_then(channel_users);
+            let channel_users =
+                message_target.channel().and_then(channel_users);
 
             // Check if a synthetic action message
 
@@ -3866,7 +3906,7 @@ pub mod tests {
             let encoded = proto::parse::message(irc_message).unwrap();
 
             let actual = message::target(
-                message::Encoded(encoded),
+                &message::Encoded(encoded),
                 &our_nick,
                 &reroute_rules,
                 &|_: &User, _: &target::Channel| None,

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -116,8 +116,9 @@ impl Serialize for User {
             .hostname()
             .map(|hostname| format!("@{hostname}"))
             .unwrap_or_default();
+        let is_bot = if self.is_bot() { ":" } else { "" };
 
-        format!("{access_levels} {nickname}{username}{hostname}")
+        format!("{access_levels}{is_bot} {nickname}{username}{hostname}")
             .serialize(serializer)
     }
 }
@@ -129,11 +130,12 @@ impl<'de> Deserialize<'de> for User {
     {
         let value = String::deserialize(deserializer)?;
 
-        if let Some((access_levels, names)) = value.split_once(' ') {
-            let access_levels = access_levels
+        if let Some((access_levels_and_is_bot, names)) = value.split_once(' ') {
+            let access_levels = access_levels_and_is_bot
                 .chars()
                 .filter_map(|c| AccessLevel::try_from(c).ok())
                 .collect::<BTreeSet<_>>();
+            let is_bot = access_levels_and_is_bot.ends_with(':');
 
             let (nickname, username, hostname) =
                 parse_user_names(names, isupport::CaseMap::default());
@@ -145,7 +147,7 @@ impl<'de> Deserialize<'de> for User {
                 accountname: None,
                 access_levels,
                 away: false,
-                bot: false,
+                bot: is_bot,
             })
         } else {
             // Older format for user string, with no space; attempt to parse

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -410,16 +410,15 @@ impl<'a> ChannelQueryLayout<'a> {
             dimmed_background_tuple,
         );
 
-        let (user_display, show_nickname_tooltip) =
-            user_in_channel.unwrap_or(user).display_with_truncated(
+        let (user_display, show_nickname_tooltip) = user
+            .display_with_truncated(
                 with_access_levels,
                 show_bot_icon,
                 truncate,
                 truncation_character,
             );
 
-        let is_bot =
-            user_in_channel.map_or_else(|| user.is_bot(), User::is_bot);
+        let is_bot = user.is_bot();
         let show_bot_icon = is_bot && self.config.buffer.nickname.show_bot_icon;
         let brackets = &self.config.buffer.nickname.brackets;
 


### PR DESCRIPTION
Serialize a user's bot mode so it can be stored with a message, providing historical context for bot messages independent of current bot status.

Fixes regression where displayed access levels would be the user's current access level(s), rather than their access level(s) at the time of sending the message.