### PR TITLE
Pane Title Tweaks

### DIFF
--- a/src/appearance/theme/text.rs
+++ b/src/appearance/theme/text.rs
@@ -1,5 +1,7 @@
 use data::appearance::theme::nickname_color;
 use data::config::buffer;
+use data::message;
+use data::message::source::server::{Kind, StandardReply};
 use iced::widget::text::{Catalog, Style, StyleFn};
 
 use super::Theme;
@@ -149,4 +151,43 @@ pub fn nickname(
         calculate_alpha_color(nickname_color(nickname.color, kind, seed));
 
     Style { color: Some(color) }
+}
+
+pub fn server(
+    theme: &Theme,
+    server: Option<&message::source::Server>,
+) -> Style {
+    let styles = theme.styles().buffer.server_messages;
+    let color = server
+        .and_then(|server| match server.kind() {
+            Kind::Join => styles.join.color,
+            Kind::Part => styles.part.color,
+            Kind::Quit => styles.quit.color,
+            Kind::ReplyTopic => styles.reply_topic.color,
+            Kind::ChangeHost => styles.change_host.color,
+            Kind::ChangeMode => styles.change_mode.color,
+            Kind::ChangeNick => styles.change_nick.color,
+            Kind::ChangeTopic => styles.change_topic.color,
+            Kind::MonitoredOnline => styles.monitored_online.color,
+            Kind::MonitoredOffline => styles.monitored_offline.color,
+            Kind::StandardReply(StandardReply::Fail) => styles
+                .standard_reply_fail
+                .color
+                .or(Some(theme.styles().text.error.color)),
+            Kind::StandardReply(StandardReply::Warn) => styles
+                .standard_reply_warn
+                .color
+                .or(theme.styles().text.warning.color)
+                .or(Some(theme.styles().text.error.color)),
+            Kind::StandardReply(StandardReply::Note) => {
+                styles.standard_reply_note.color
+            }
+            Kind::WAllOps => styles.wallops.color,
+            Kind::Kick => styles.kick.color,
+            Kind::Away => styles.away.color,
+            Kind::Invite => styles.invite.color,
+        })
+        .or(Some(styles.default.color));
+
+    Style { color }
 }

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -1,7 +1,7 @@
 use data::user::{ChannelUsers, User};
 use data::{Config, file_transfer, history, preview};
 use iced::widget::{button, center, column, container, pane_grid, row, text};
-use iced::{Length, Size, Task};
+use iced::{Length, Size, Task, padding};
 
 use super::sidebar;
 use crate::buffer::{self, Buffer};
@@ -561,9 +561,9 @@ fn query_title<'a>(
                                     is_user_offline,
                                 )
                             })
-                            .line_height(1.0),
-                        text(" ")
+                            .line_height(1.0)
                     ]
+                    .padding(padding::horizontal(4))
                     .align_y(iced::Alignment::Center),
                     container(
                         text(format!("Authenticated as {accountname}"))
@@ -582,14 +582,13 @@ fn query_title<'a>(
                 .into()
             }
         ),
-        text(format!("@ {server}"))
+        text(format!(" @ {server}"))
             .style(theme::text::buffer_title_bar)
             .font_maybe(
                 theme::font_style::buffer_title_bar(theme).map(font::get)
             )
             .shaping(text::Shaping::Advanced),
     ]
-    .spacing(4)
     .width(Length::Shrink)
     .align_y(iced::Alignment::Center)
     .into()

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -100,7 +100,12 @@ impl Pane {
                 ]
                 .into()
             }
-            Buffer::Server(state) => text(state.server.to_string()).into(),
+            Buffer::Server(state) => text(state.server.to_string())
+                .style(|theme| theme::text::server(theme, None))
+                .font_maybe(
+                    theme::font_style::server(theme, None).map(font::get),
+                )
+                .into(),
             Buffer::Query(state) => query_title(
                 &state.server,
                 &state.target,

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -81,21 +81,24 @@ impl Pane {
                 };
 
                 let server = &state.server;
-                if let Some(mode) =
-                    clients.get_channel_mode(&state.server, &state.target)
-                {
-                    let users = clients
-                        .get_channel_users(&state.server, &state.target)
-                        .map(ChannelUsers::len)
-                        .unwrap_or_default();
+                row![
+                    text(display_channel).style(theme::text::url).font_maybe(
+                        theme::font_style::url(theme).map(font::get),
+                    ),
+                    if let Some(mode) =
+                        clients.get_channel_mode(&state.server, &state.target)
+                    {
+                        let users = clients
+                            .get_channel_users(&state.server, &state.target)
+                            .map(ChannelUsers::len)
+                            .unwrap_or_default();
 
-                    text(format!(
-                        "{display_channel} ({mode}) @ {server} - {users} users"
-                    ))
-                    .into()
-                } else {
-                    text(format!("{display_channel} @ {server}")).into()
-                }
+                        text(format!(" ({mode}) @ {server} - {users} users"))
+                    } else {
+                        text(format!(" @ {server}"))
+                    }
+                ]
+                .into()
             }
             Buffer::Server(state) => text(state.server.to_string()).into(),
             Buffer::Query(state) => query_title(


### PR DESCRIPTION
Adds coloring to channel and server pane titles to help differentiate panes, and in the case of channels highlight the channel title over the channel properties.