### PR TITLE
Display Redacted Messages as Redactions

### DIFF
--- a/data/src/config/buffer/redaction.rs
+++ b/data/src/config/buffer/redaction.rs
@@ -11,11 +11,16 @@ pub struct Redaction {
 pub enum Display {
     #[default]
     None,
+    Redacted,
     Dimmed,
 }
 
 impl Display {
-    pub fn is_dimmed(self) -> bool {
-        matches!(self, Self::Dimmed)
+    pub fn is_visible(self) -> bool {
+        matches!(self, Self::Redacted | Self::Dimmed)
+    }
+
+    pub fn is_redacted(self) -> bool {
+        matches!(self, Self::Redacted)
     }
 }

--- a/data/src/config/buffer/redaction.rs
+++ b/data/src/config/buffer/redaction.rs
@@ -9,8 +9,8 @@ pub struct Redaction {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum Display {
-    #[default]
     None,
+    #[default]
     Redacted,
     Dimmed,
 }

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -635,14 +635,14 @@ impl History {
 
     // Find the first message in the condensation, then return all messages in
     // the condensation
-    fn get_condensed_messages(
+    fn get_expansion_messages(
         &mut self,
         server_time: DateTime<Utc>,
         hash: message::Hash,
         config: &config::buffer::Condensation,
     ) -> Vec<&mut Message> {
         match self {
-            History::Partial { .. } => vec![],
+            History::Partial { .. } => (),
             History::Full { messages, .. } => {
                 if messages.is_empty() {
                     return vec![];
@@ -673,31 +673,35 @@ impl History {
                         (message.hash == hash)
                             .then_some(start_index + slice_index)
                     })
-                    && let Some(first_index) = messages[..=index]
+                {
+                    if messages[index].redaction.is_some() {
+                        return vec![&mut messages[index]];
+                    } else if let Some(first_index) = messages[..=index]
                         .iter()
                         .rev()
                         .position(|message| message.condensed.is_some())
                         .map(|position| index - position)
-                {
-                    messages[first_index..]
-                        .iter_mut()
-                        .filter(|message| !message.blocked)
-                        .scan(true, |is_first_message, message| {
-                            if *is_first_message {
-                                *is_first_message = false;
-                                Some(message)
-                            } else {
-                                (message.can_condense(config)
-                                    && message.condensed.is_none())
-                                .then_some(message)
-                            }
-                        })
-                        .collect()
-                } else {
-                    vec![]
+                    {
+                        return messages[first_index..]
+                            .iter_mut()
+                            .filter(|message| !message.blocked)
+                            .scan(true, |is_first_message, message| {
+                                if *is_first_message {
+                                    *is_first_message = false;
+                                    Some(message)
+                                } else {
+                                    (message.can_condense(config)
+                                        && message.condensed.is_none())
+                                    .then_some(message)
+                                }
+                            })
+                            .collect();
+                    }
                 }
             }
         }
+
+        vec![]
     }
 
     // If now is None then history will be flushed regardless of time

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -553,26 +553,24 @@ impl Manager {
         self.data.remove_message(kind, server_time, hash, resend)
     }
 
-    pub fn expand_condensed_message(
+    pub fn expand_message(
         &mut self,
         kind: history::Kind,
         server_time: DateTime<Utc>,
         hash: message::Hash,
         config: &config::buffer::Condensation,
     ) {
-        self.data
-            .expand_condensed_message(kind, server_time, hash, config);
+        self.data.expand_message(kind, server_time, hash, config);
     }
 
-    pub fn contract_condensed_message(
+    pub fn contract_message(
         &mut self,
         kind: history::Kind,
         server_time: DateTime<Utc>,
         hash: message::Hash,
         config: &config::buffer::Condensation,
     ) {
-        self.data
-            .contract_condensed_message(kind, server_time, hash, config);
+        self.data.contract_message(kind, server_time, hash, config);
     }
 
     pub fn update_chathistory_references<T: Into<history::Kind>>(
@@ -1051,7 +1049,7 @@ impl Manager {
                 message.blocked = false;
 
                 if message.redaction.is_some()
-                    && !buffer_config.redaction.display.is_dimmed()
+                    && !buffer_config.redaction.display.is_visible()
                 {
                     message.blocked = true;
                 } else {
@@ -1703,7 +1701,7 @@ impl Data {
         })
     }
 
-    fn expand_condensed_message(
+    fn expand_message(
         &mut self,
         kind: history::Kind,
         server_time: DateTime<Utc>,
@@ -1712,7 +1710,7 @@ impl Data {
     ) {
         if let Some(history) = self.map.get_mut(&kind) {
             history
-                .get_condensed_messages(server_time, hash, config)
+                .get_expansion_messages(server_time, hash, config)
                 .iter_mut()
                 .for_each(|message| {
                     message.expanded = true;
@@ -1720,7 +1718,7 @@ impl Data {
         }
     }
 
-    fn contract_condensed_message(
+    fn contract_message(
         &mut self,
         kind: history::Kind,
         server_time: DateTime<Utc>,
@@ -1729,7 +1727,7 @@ impl Data {
     ) {
         if let Some(history) = self.map.get_mut(&kind) {
             history
-                .get_condensed_messages(server_time, hash, config)
+                .get_expansion_messages(server_time, hash, config)
                 .iter_mut()
                 .for_each(|message| {
                     message.expanded = false;

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -308,7 +308,7 @@ pub struct Message {
     pub is_echo: bool, // Only relevant if direction == Direction::Received
     pub blocked: bool,
     pub condensed: Option<Arc<Message>>,
-    pub expanded: bool, // Only relevant if can_condense
+    pub expanded: bool, // Only relevant if can_condense or redaction.is_some()
     pub command: Option<command::Irc>, // Only relevant if direction == Direction::Sent
     pub reactions: Vec<Reaction>,
     pub rerouted_from: Option<Target>,
@@ -3767,8 +3767,8 @@ pub enum Link {
     Url(String),
     User(Server, User),
     GoToMessage(Server, target::Channel, Hash),
-    ExpandCondensedMessage(DateTime<Utc>, Hash),
-    ContractCondensedMessage(DateTime<Utc>, Hash),
+    ExpandMessage(DateTime<Utc>, Hash),
+    ContractMessage(DateTime<Utc>, Hash),
 }
 
 impl Link {

--- a/docs/configuration/buffer.md
+++ b/docs/configuration/buffer.md
@@ -1572,11 +1572,11 @@ Customize how redacted messages behave in buffers
 
 ### `display`
 
-How to display redacted messages in the buffer.
+How to display redacted messages in the buffer.  If displayed as `"dimmed"` then the message will be displayed dimmed and the redaction reason viewable via tooltip.  If displayed as `"redacted"` then the message will be replaced with the redaction reason, and the redcated message can be revealed by clicking on the message. 
 
 ```toml
 # Type: string
-# Values: "none", "dimmed"
+# Values: "none", "dimmed", "redacted"
 # Default: "none"
 
 [buffer.redaction]

--- a/src/appearance/theme/selectable_text.rs
+++ b/src/appearance/theme/selectable_text.rs
@@ -230,8 +230,8 @@ impl selectable_rich_text::Link for message::Link {
             data::message::Link::User(..)
             | data::message::Link::Channel(..)
             | data::message::Link::GoToMessage(..)
-            | data::message::Link::ExpandCondensedMessage(..)
-            | data::message::Link::ContractCondensedMessage(..) => false,
+            | data::message::Link::ExpandMessage(..)
+            | data::message::Link::ContractMessage(..) => false,
         }
     }
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -76,8 +76,8 @@ pub enum Event {
     MarkAsRead(history::Kind),
     OpenUrl(String),
     ImagePreview(PathBuf, url::Url),
-    ExpandCondensedMessage(DateTime<Utc>, message::Hash),
-    ContractCondensedMessage(DateTime<Utc>, message::Hash),
+    ExpandMessage(DateTime<Utc>, message::Hash),
+    ContractMessage(DateTime<Utc>, message::Hash),
     InputSent {
         history_task: Task<history::manager::Message>,
         open_buffers: Vec<(Target, BufferAction)>,
@@ -295,14 +295,12 @@ impl Buffer {
                     channel::Event::ImagePreview(path, url) => {
                         Event::ImagePreview(path, url)
                     }
-                    channel::Event::ExpandCondensedMessage(
-                        server_time,
-                        hash,
-                    ) => Event::ExpandCondensedMessage(server_time, hash),
-                    channel::Event::ContractCondensedMessage(
-                        server_time,
-                        hash,
-                    ) => Event::ContractCondensedMessage(server_time, hash),
+                    channel::Event::ExpandMessage(server_time, hash) => {
+                        Event::ExpandMessage(server_time, hash)
+                    }
+                    channel::Event::ContractMessage(server_time, hash) => {
+                        Event::ContractMessage(server_time, hash)
+                    }
                     channel::Event::InputSent {
                         history_task,
                         open_buffers,
@@ -361,14 +359,12 @@ impl Buffer {
                     server::Event::ImagePreview(path, url) => {
                         Event::ImagePreview(path, url)
                     }
-                    server::Event::ExpandCondensedMessage(
-                        server_time,
-                        hash,
-                    ) => Event::ExpandCondensedMessage(server_time, hash),
-                    server::Event::ContractCondensedMessage(
-                        server_time,
-                        hash,
-                    ) => Event::ContractCondensedMessage(server_time, hash),
+                    server::Event::ExpandMessage(server_time, hash) => {
+                        Event::ExpandMessage(server_time, hash)
+                    }
+                    server::Event::ContractMessage(server_time, hash) => {
+                        Event::ContractMessage(server_time, hash)
+                    }
                     server::Event::InputSent {
                         history_task,
                         open_buffers,
@@ -432,13 +428,12 @@ impl Buffer {
                     query::Event::ImagePreview(path, url) => {
                         Event::ImagePreview(path, url)
                     }
-                    query::Event::ExpandCondensedMessage(server_time, hash) => {
-                        Event::ExpandCondensedMessage(server_time, hash)
+                    query::Event::ExpandMessage(server_time, hash) => {
+                        Event::ExpandMessage(server_time, hash)
                     }
-                    query::Event::ContractCondensedMessage(
-                        server_time,
-                        hash,
-                    ) => Event::ContractCondensedMessage(server_time, hash),
+                    query::Event::ContractMessage(server_time, hash) => {
+                        Event::ContractMessage(server_time, hash)
+                    }
                     query::Event::InputSent {
                         history_task,
                         open_buffers,
@@ -517,13 +512,12 @@ impl Buffer {
                     logs::Event::ImagePreview(path, url) => {
                         Event::ImagePreview(path, url)
                     }
-                    logs::Event::ExpandCondensedMessage(server_time, hash) => {
-                        Event::ExpandCondensedMessage(server_time, hash)
+                    logs::Event::ExpandMessage(server_time, hash) => {
+                        Event::ExpandMessage(server_time, hash)
                     }
-                    logs::Event::ContractCondensedMessage(
-                        server_time,
-                        hash,
-                    ) => Event::ContractCondensedMessage(server_time, hash),
+                    logs::Event::ContractMessage(server_time, hash) => {
+                        Event::ContractMessage(server_time, hash)
+                    }
                 });
 
                 (command.map(Message::Logs), event)
@@ -554,14 +548,12 @@ impl Buffer {
                     highlights::Event::ImagePreview(path, url) => {
                         Event::ImagePreview(path, url)
                     }
-                    highlights::Event::ExpandCondensedMessage(
-                        server_time,
-                        hash,
-                    ) => Event::ExpandCondensedMessage(server_time, hash),
-                    highlights::Event::ContractCondensedMessage(
-                        server_time,
-                        hash,
-                    ) => Event::ContractCondensedMessage(server_time, hash),
+                    highlights::Event::ExpandMessage(server_time, hash) => {
+                        Event::ExpandMessage(server_time, hash)
+                    }
+                    highlights::Event::ContractMessage(server_time, hash) => {
+                        Event::ContractMessage(server_time, hash)
+                    }
                 });
 
                 (command.map(Message::Highlights), event)

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -43,8 +43,8 @@ pub enum Event {
     MarkAsRead(history::Kind),
     OpenUrl(String),
     ImagePreview(PathBuf, url::Url),
-    ExpandCondensedMessage(DateTime<Utc>, message::Hash),
-    ContractCondensedMessage(DateTime<Utc>, message::Hash),
+    ExpandMessage(DateTime<Utc>, message::Hash),
+    ContractMessage(DateTime<Utc>, message::Hash),
     InputSent {
         history_task: Task<history::manager::Message>,
         open_buffers: Vec<(Target, BufferAction)>,
@@ -317,15 +317,11 @@ impl Channel {
                     scroll_view::Event::ImagePreview(path, url) => {
                         Some(Event::ImagePreview(path, url))
                     }
-                    scroll_view::Event::ExpandCondensedMessage(
-                        server_time,
-                        hash,
-                    ) => Some(Event::ExpandCondensedMessage(server_time, hash)),
-                    scroll_view::Event::ContractCondensedMessage(
-                        server_time,
-                        hash,
-                    ) => {
-                        Some(Event::ContractCondensedMessage(server_time, hash))
+                    scroll_view::Event::ExpandMessage(server_time, hash) => {
+                        Some(Event::ExpandMessage(server_time, hash))
+                    }
+                    scroll_view::Event::ContractMessage(server_time, hash) => {
+                        Some(Event::ContractMessage(server_time, hash))
                     }
                 });
 

--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -36,8 +36,8 @@ pub fn update(message: Message) -> Option<Event> {
             )))
         }
         Message::Link(message::Link::GoToMessage(..))
-        | Message::Link(message::Link::ExpandCondensedMessage(..))
-        | Message::Link(message::Link::ContractCondensedMessage(..)) => None,
+        | Message::Link(message::Link::ExpandMessage(..))
+        | Message::Link(message::Link::ContractMessage(..)) => None,
     }
 }
 

--- a/src/buffer/highlights.rs
+++ b/src/buffer/highlights.rs
@@ -27,8 +27,8 @@ pub enum Event {
     History(Task<history::manager::Message>),
     OpenUrl(String),
     ImagePreview(PathBuf, url::Url),
-    ExpandCondensedMessage(DateTime<Utc>, message::Hash),
-    ContractCondensedMessage(DateTime<Utc>, message::Hash),
+    ExpandMessage(DateTime<Utc>, message::Hash),
+    ContractMessage(DateTime<Utc>, message::Hash),
 }
 
 pub fn view<'a>(
@@ -359,15 +359,11 @@ impl Highlights {
                     scroll_view::Event::ImagePreview(path, url) => {
                         Some(Event::ImagePreview(path, url))
                     }
-                    scroll_view::Event::ExpandCondensedMessage(
-                        server_time,
-                        hash,
-                    ) => Some(Event::ExpandCondensedMessage(server_time, hash)),
-                    scroll_view::Event::ContractCondensedMessage(
-                        server_time,
-                        hash,
-                    ) => {
-                        Some(Event::ContractCondensedMessage(server_time, hash))
+                    scroll_view::Event::ExpandMessage(server_time, hash) => {
+                        Some(Event::ExpandMessage(server_time, hash))
+                    }
+                    scroll_view::Event::ContractMessage(server_time, hash) => {
+                        Some(Event::ContractMessage(server_time, hash))
                     }
                 });
 

--- a/src/buffer/logs.rs
+++ b/src/buffer/logs.rs
@@ -20,8 +20,8 @@ pub enum Event {
     MarkAsRead,
     OpenUrl(String),
     ImagePreview(PathBuf, url::Url),
-    ExpandCondensedMessage(DateTime<Utc>, message::Hash),
-    ContractCondensedMessage(DateTime<Utc>, message::Hash),
+    ExpandMessage(DateTime<Utc>, message::Hash),
+    ContractMessage(DateTime<Utc>, message::Hash),
 }
 
 pub fn view<'a>(
@@ -162,15 +162,11 @@ impl Logs {
                     scroll_view::Event::ImagePreview(path, url) => {
                         Some(Event::ImagePreview(path, url))
                     }
-                    scroll_view::Event::ExpandCondensedMessage(
-                        server_time,
-                        hash,
-                    ) => Some(Event::ExpandCondensedMessage(server_time, hash)),
-                    scroll_view::Event::ContractCondensedMessage(
-                        server_time,
-                        hash,
-                    ) => {
-                        Some(Event::ContractCondensedMessage(server_time, hash))
+                    scroll_view::Event::ExpandMessage(server_time, hash) => {
+                        Some(Event::ExpandMessage(server_time, hash))
+                    }
+                    scroll_view::Event::ContractMessage(server_time, hash) => {
+                        Some(Event::ContractMessage(server_time, hash))
                     }
                 });
 

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -584,7 +584,7 @@ impl<'a> ChannelQueryLayout<'a> {
             }
         });
 
-        let redaction_tooltip = if let Some(redaction) =
+        let redaction_message = if let Some(redaction) =
             message.redaction.as_ref()
         {
             match &redaction.reason {
@@ -598,57 +598,96 @@ impl<'a> ChannelQueryLayout<'a> {
             None
         };
 
-        let message_content = tooltip(
-            message_content::with_context(
-                &message.content,
-                self.server,
-                self.chantypes,
-                self.casemapping,
-                self.theme,
-                Message::Link,
-                None,
-                message_style,
-                theme::font_style::primary,
-                color_transformation,
-                move |link| match link {
-                    message::Link::User(_, _) => {
-                        if rerouted_private && !is_ourself {
-                            vec![context_menu::Entry::Whois]
-                        } else {
-                            context_menu::Entry::user_list(
-                                formatter.target.is_channel(),
-                                user_in_channel,
-                                formatter.target.our_user(),
-                                formatter.config.file_transfer.enabled,
+        let (message_content, after_content) =
+            if self.config.buffer.redaction.display.is_redacted()
+                && !message.expanded
+                && let Some(redaction_message) = redaction_message
+            {
+                (
+                    button(
+                        selectable_text(redaction_message)
+                            .font_maybe(
+                                theme::font_style::primary(self.theme)
+                                    .map(font::get),
                             )
-                        }
-                    }
-                    message::Link::Url(_) => {
-                        formatter.url_entries(message, link)
-                    }
-                    _ => vec![],
-                },
-                move |link, entry, length| {
-                    entry
-                        .view(
-                            formatter.link_context(message, link),
-                            length,
-                            formatter.config,
-                            formatter.theme,
-                        )
-                        .map(Message::ContextMenu)
-                },
-                self.config,
-            ),
-            redaction_tooltip,
-            tooltip::Position::Top,
-            self.theme,
-        );
+                            .style(message_style),
+                    )
+                    .style(theme::button::bare)
+                    .padding(0)
+                    .on_press(Message::Link(message::Link::ExpandMessage(
+                        message.server_time,
+                        message.hash,
+                    )))
+                    .into(),
+                    vec![],
+                )
+            } else {
+                let link = (self.config.buffer.redaction.display.is_redacted()
+                    && message.expanded
+                    && redaction_message.is_some())
+                .then_some(message::Link::ContractMessage(
+                    message.server_time,
+                    message.hash,
+                ));
 
-        let after_content =
-            self.reaction_row(message).into_iter().chain(not_sent_row);
+                (
+                    tooltip(
+                        message_content::with_context(
+                            &message.content,
+                            self.server,
+                            self.chantypes,
+                            self.casemapping,
+                            self.theme,
+                            Message::Link,
+                            link,
+                            message_style,
+                            theme::font_style::primary,
+                            color_transformation,
+                            move |link| match link {
+                                message::Link::User(_, _) => {
+                                    if rerouted_private && !is_ourself {
+                                        vec![context_menu::Entry::Whois]
+                                    } else {
+                                        context_menu::Entry::user_list(
+                                            formatter.target.is_channel(),
+                                            user_in_channel,
+                                            formatter.target.our_user(),
+                                            formatter
+                                                .config
+                                                .file_transfer
+                                                .enabled,
+                                        )
+                                    }
+                                }
+                                message::Link::Url(_) => {
+                                    formatter.url_entries(message, link)
+                                }
+                                _ => vec![],
+                            },
+                            move |link, entry, length| {
+                                entry
+                                    .view(
+                                        formatter.link_context(message, link),
+                                        length,
+                                        formatter.config,
+                                        formatter.theme,
+                                    )
+                                    .map(Message::ContextMenu)
+                            },
+                            self.config,
+                        ),
+                        redaction_message,
+                        tooltip::Position::Top,
+                        self.theme,
+                    ),
+                    self.reaction_row(message)
+                        .into_iter()
+                        .chain(not_sent_row)
+                        .collect(),
+                )
+            };
 
-        (nick_element, message_content, after_content.collect())
+        (nick_element, message_content, after_content)
     }
 
     fn format_server_message(
@@ -682,12 +721,10 @@ impl<'a> ChannelQueryLayout<'a> {
             theme::font_style::server(message_theme, server)
         };
 
-        let link = message.expanded.then_some(
-            message::Link::ContractCondensedMessage(
-                message.server_time,
-                message.hash,
-            ),
-        );
+        let link = message.expanded.then_some(message::Link::ContractMessage(
+            message.server_time,
+            message.hash,
+        ));
 
         let marker_style = move |message_theme: &Theme| {
             if message.expanded || message.condensed.is_some() {
@@ -794,10 +831,8 @@ impl<'a> ChannelQueryLayout<'a> {
             theme::font_style::server(message_theme, None)
         };
 
-        let link = message::Link::ExpandCondensedMessage(
-            message.server_time,
-            message.hash,
-        );
+        let link =
+            message::Link::ExpandMessage(message.server_time, message.hash);
         let moved_link = link.clone();
 
         let range_end_timestamp = if let message::Source::Internal(

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -128,7 +128,15 @@ impl<'a> ChannelQueryLayout<'a> {
         }
 
         // A message can only be redacted once.
-        message.redaction.is_none()
+        if message.redaction.is_none() {
+            return false;
+        }
+
+        // Message MUST be PRIVMSG, NOTICE, or TAGMSG
+        match message.target.source() {
+            message::Source::User(_) | message::Source::Action(_) => true,
+            message::Source::Server(_) | message::Source::Internal(_) => false,
+        }
     }
 
     fn condensation_marker(

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -128,7 +128,7 @@ impl<'a> ChannelQueryLayout<'a> {
         }
 
         // A message can only be redacted once.
-        if message.redaction.is_none() {
+        if message.redaction.is_some() {
             return false;
         }
 

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -38,8 +38,8 @@ pub enum Event {
     MarkAsRead(history::Kind),
     OpenUrl(String),
     ImagePreview(PathBuf, url::Url),
-    ExpandCondensedMessage(DateTime<Utc>, message::Hash),
-    ContractCondensedMessage(DateTime<Utc>, message::Hash),
+    ExpandMessage(DateTime<Utc>, message::Hash),
+    ContractMessage(DateTime<Utc>, message::Hash),
     InputSent {
         history_task: Task<history::manager::Message>,
         open_buffers: Vec<(Target, BufferAction)>,
@@ -266,15 +266,11 @@ impl Query {
                     scroll_view::Event::ImagePreview(path, url) => {
                         Some(Event::ImagePreview(path, url))
                     }
-                    scroll_view::Event::ExpandCondensedMessage(
-                        server_time,
-                        hash,
-                    ) => Some(Event::ExpandCondensedMessage(server_time, hash)),
-                    scroll_view::Event::ContractCondensedMessage(
-                        server_time,
-                        hash,
-                    ) => {
-                        Some(Event::ContractCondensedMessage(server_time, hash))
+                    scroll_view::Event::ExpandMessage(server_time, hash) => {
+                        Some(Event::ExpandMessage(server_time, hash))
+                    }
+                    scroll_view::Event::ContractMessage(server_time, hash) => {
+                        Some(Event::ContractMessage(server_time, hash))
                     }
                 });
 

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -88,8 +88,8 @@ pub enum Event {
     MarkAsRead,
     OpenUrl(String),
     ImagePreview(PathBuf, url::Url),
-    ExpandCondensedMessage(DateTime<Utc>, message::Hash),
-    ContractCondensedMessage(DateTime<Utc>, message::Hash),
+    ExpandMessage(DateTime<Utc>, message::Hash),
+    ContractMessage(DateTime<Utc>, message::Hash),
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1044,22 +1044,19 @@ impl State {
                     );
                 }
             }
-            Message::Link(message::Link::ExpandCondensedMessage(
-                server_time,
-                hash,
-            )) => {
+            Message::Link(message::Link::ExpandMessage(server_time, hash)) => {
                 return (
                     Task::none(),
-                    Some(Event::ExpandCondensedMessage(server_time, hash)),
+                    Some(Event::ExpandMessage(server_time, hash)),
                 );
             }
-            Message::Link(message::Link::ContractCondensedMessage(
+            Message::Link(message::Link::ContractMessage(
                 server_time,
                 hash,
             )) => {
                 return (
                     Task::none(),
-                    Some(Event::ContractCondensedMessage(server_time, hash)),
+                    Some(Event::ContractMessage(server_time, hash)),
                 );
             }
             Message::RequestOlderChatHistory => {

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -55,8 +55,8 @@ pub enum Event {
     MarkAsRead(history::Kind),
     OpenUrl(String),
     ImagePreview(PathBuf, url::Url),
-    ExpandCondensedMessage(DateTime<Utc>, message::Hash),
-    ContractCondensedMessage(DateTime<Utc>, message::Hash),
+    ExpandMessage(DateTime<Utc>, message::Hash),
+    ContractMessage(DateTime<Utc>, message::Hash),
     InputSent {
         history_task: Task<history::manager::Message>,
         open_buffers: Vec<(Target, BufferAction)>,
@@ -397,15 +397,11 @@ impl Server {
                     scroll_view::Event::ImagePreview(path, url) => {
                         Some(Event::ImagePreview(path, url))
                     }
-                    scroll_view::Event::ExpandCondensedMessage(
-                        server_time,
-                        hash,
-                    ) => Some(Event::ExpandCondensedMessage(server_time, hash)),
-                    scroll_view::Event::ContractCondensedMessage(
-                        server_time,
-                        hash,
-                    ) => {
-                        Some(Event::ContractCondensedMessage(server_time, hash))
+                    scroll_view::Event::ExpandMessage(server_time, hash) => {
+                        Some(Event::ExpandMessage(server_time, hash))
+                    }
+                    scroll_view::Event::ContractMessage(server_time, hash) => {
+                        Some(Event::ContractMessage(server_time, hash))
                     }
                 });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1824,7 +1824,7 @@ fn handle_client_events(
                     dashboard.redact_message(
                         server,
                         redaction,
-                        config.buffer.redaction.display.is_dimmed(),
+                        config.buffer.redaction.display.is_visible(),
                     );
                 }
             }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -2538,11 +2538,11 @@ impl Dashboard {
             buffer::Event::ImagePreview(path, url) => {
                 return (Task::none(), Some(Event::ImagePreview(path, url)));
             }
-            buffer::Event::ExpandCondensedMessage(server_time, hash) => {
+            buffer::Event::ExpandMessage(server_time, hash) => {
                 if let Some(kind) =
                     pane.buffer.data().and_then(history::Kind::from_buffer)
                 {
-                    self.history.expand_condensed_message(
+                    self.history.expand_message(
                         kind,
                         server_time,
                         hash,
@@ -2550,11 +2550,11 @@ impl Dashboard {
                     );
                 }
             }
-            buffer::Event::ContractCondensedMessage(server_time, hash) => {
+            buffer::Event::ContractMessage(server_time, hash) => {
                 if let Some(kind) =
                     pane.buffer.data().and_then(history::Kind::from_buffer)
                 {
-                    self.history.contract_condensed_message(
+                    self.history.contract_message(
                         kind,
                         server_time,
                         hash,

--- a/src/widget/message_content.rs
+++ b/src/widget/message_content.rs
@@ -1,14 +1,14 @@
 use data::appearance::theme::{FontStyle, nickname_color};
 use data::{Config, Server, isupport, message, target};
-use iced::widget::span;
 use iced::widget::text::Span;
+use iced::widget::{button, span};
 use iced::{Color, Length, border};
 use unicode_segmentation::UnicodeSegmentation;
 
 use super::{Element, Renderer, selectable_rich_text, selectable_text};
 use crate::{Theme, font, theme};
 
-pub fn message_content<'a, M: 'a>(
+pub fn message_content<'a, M: 'a + std::clone::Clone>(
     content: &'a message::Content,
     server: &'a Server,
     chantypes: &[char],
@@ -37,7 +37,7 @@ pub fn message_content<'a, M: 'a>(
     )
 }
 
-pub fn with_context<'a, T: Copy + 'a, M: 'a>(
+pub fn with_context<'a, T: Copy + 'a, M: 'a + std::clone::Clone>(
     content: &'a message::Content,
     server: &'a Server,
     chantypes: &[char],
@@ -69,7 +69,7 @@ pub fn with_context<'a, T: Copy + 'a, M: 'a>(
 }
 
 #[allow(clippy::type_complexity)]
-fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
+fn message_content_impl<'a, T: Copy + 'a, M: 'a + std::clone::Clone>(
     content: &'a message::Content,
     server: &'a Server,
     chantypes: &[char],
@@ -88,7 +88,8 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
 ) -> Element<'a, M> {
     match content {
         data::message::Content::Plain(text) => {
-            if let Some(only_emojis_size) = config.font.only_emojis_size
+            let selectable_text = if let Some(only_emojis_size) =
+                config.font.only_emojis_size
                 && UnicodeSegmentation::graphemes(text.as_str(), true)
                     .all(|grapheme| emojis::get(grapheme).is_some())
             {
@@ -96,12 +97,20 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a>(
                     .font_maybe(font_style(theme).map(font::get))
                     .size(f32::from(only_emojis_size))
                     .style(style)
-                    .into()
             } else {
                 selectable_text(text)
                     .font_maybe(font_style(theme).map(font::get))
                     .style(style)
+            };
+
+            if let Some(default_link) = default_link {
+                button(selectable_text)
+                    .style(theme::button::bare)
+                    .padding(0)
+                    .on_press(on_link(default_link))
                     .into()
+            } else {
+                selectable_text.into()
             }
         }
         data::message::Content::Fragments(fragments) => {


### PR DESCRIPTION
Adds `"redacted"` variant to `buffer.redaction.display` which displays redacted messages as their redaction reason (and redactor), with the original, redacted message visible by clicking on the redaction reason.