### PR TITLE
Minor Display Read Marker Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Fixed:
 - Distinguish between reacts in chathistory vs active history
 - Channel matching on single line only
 - Do not hide consecutive nicknames if the user's displayed access levels or bot mode changes
+- Issue where unread indicator could appear in sidebar for an open pane that does not have unread messages
+- Issue where backlog divider in highlights or logs pane would not update when marking the pane as read
 
 Changed:
 

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -465,14 +465,15 @@ impl History {
             }
             History::Full {
                 messages,
-                read_marker,
+                display_read_marker,
                 ..
             } => {
                 let latest = metadata::latest_triggers_unread(messages);
 
-                if let Some(read_marker) = read_marker {
-                    latest
-                        .is_some_and(|latest| read_marker.date_time() < latest)
+                if let Some(display_read_marker) = display_read_marker {
+                    latest.is_some_and(|latest| {
+                        display_read_marker.date_time() < latest
+                    })
                 } else {
                     latest.is_some()
                 }

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -906,8 +906,17 @@ impl History {
             History::Full {
                 messages,
                 read_marker,
+                display_read_marker,
                 ..
-            } => (read_marker, ReadMarker::latest(messages)),
+            } => {
+                let latest = ReadMarker::latest(messages);
+
+                if latest > *display_read_marker {
+                    *display_read_marker = latest;
+                }
+
+                (read_marker, latest)
+            }
         };
 
         if latest > *read_marker {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -544,6 +544,9 @@ impl Buffer {
                         message,
                     ) => Event::GoToMessage(server, channel, message),
                     highlights::Event::History(task) => Event::History(task),
+                    highlights::Event::MarkAsRead => {
+                        Event::MarkAsRead(history::Kind::Highlights)
+                    }
                     highlights::Event::OpenUrl(url) => Event::OpenUrl(url),
                     highlights::Event::ImagePreview(path, url) => {
                         Event::ImagePreview(path, url)

--- a/src/buffer/highlights.rs
+++ b/src/buffer/highlights.rs
@@ -26,6 +26,7 @@ pub enum Event {
     GoToMessage(Server, target::Channel, message::Hash),
     History(Task<history::manager::Message>),
     OpenUrl(String),
+    MarkAsRead,
     ImagePreview(PathBuf, url::Url),
     ExpandMessage(DateTime<Utc>, message::Hash),
     ContractMessage(DateTime<Utc>, message::Hash),
@@ -352,7 +353,7 @@ impl Highlights {
                     scroll_view::Event::RequestOlderChatHistory => None,
                     scroll_view::Event::PreviewChanged => None,
                     scroll_view::Event::HidePreview(..) => None,
-                    scroll_view::Event::MarkAsRead => None,
+                    scroll_view::Event::MarkAsRead => Some(Event::MarkAsRead),
                     scroll_view::Event::OpenUrl(url) => {
                         Some(Event::OpenUrl(url))
                     }


### PR DESCRIPTION
A couple minor fixes:
- Fix "mark as read" button and "mark as read" shortcuts on logs and highlights panes (by updating the display read marker when the history is open)
- Use display read marker to determine whether an open pane has unread messages