### PR TITLE
Bot Mode on JOIN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Fixed:
 - Backlog separator text colour now follows `buffer.backlog_rule`
 - Distinguish between reacts in chathistory vs active history
 - Channel matching on single line only
+- Do not hide consecutive nicknames if the user's displayed access levels or bot mode changes
 
 Changed:
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1777,7 +1777,7 @@ impl Client {
                 } else if let Some(channel) =
                     self.chanmap.get_mut(&target_channel)
                 {
-                    let user = if self
+                    let mut user = if self
                         .capabilities
                         .acknowledged(Capability::ExtendedJoin)
                     {
@@ -1789,6 +1789,10 @@ impl Client {
                     } else {
                         user
                     };
+
+                    if message.tags.contains_key("bot") {
+                        user.update_bot(true);
+                    }
 
                     channel.users.insert(user);
                 }

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -412,6 +412,33 @@ impl User {
         })
     }
 
+    pub fn has_matching_display(
+        &self,
+        other: &User,
+        with_access_levels: AccessLevelFormat,
+        show_bot_icon: bool,
+    ) -> bool {
+        if self != other {
+            return false;
+        }
+
+        match with_access_levels {
+            AccessLevelFormat::All => {
+                if self.access_levels != other.access_levels {
+                    return false;
+                }
+            }
+            AccessLevelFormat::Highest => {
+                if self.highest_access_level() != other.highest_access_level() {
+                    return false;
+                }
+            }
+            AccessLevelFormat::None => (),
+        }
+
+        !show_bot_icon || self.is_bot() == other.is_bot()
+    }
+
     pub fn parse(
         value: &str,
         casemapping: isupport::CaseMap,

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -227,15 +227,24 @@ fn is_consecutive_user_message(
     message: &data::Message,
     prev_message: Option<&data::Message>,
     duration: Option<chrono::TimeDelta>,
+    config: &Config,
 ) -> bool {
     matches!(message.target.source(), message::Source::User(_))
         && prev_message.is_some_and(|prev_message| {
-            matches!(
-                (message.target.source(), prev_message.target.source()),
-                (message::Source::User(user), message::Source::User(prev_user)) if user == prev_user
-            ) && duration.is_none_or(|duration| {
+            if duration.is_none_or(|duration| {
                 message.server_time - prev_message.server_time < duration
-            })
+            }) && let message::Source::User(user) = message.target.source()
+                && let message::Source::User(prev_user) =
+                    prev_message.target.source()
+            {
+                user.has_matching_display(
+                    prev_user,
+                    config.buffer.nickname.show_access_levels,
+                    config.buffer.nickname.show_bot_icon,
+                )
+            } else {
+                false
+            }
         })
 }
 
@@ -372,6 +381,7 @@ pub fn view<'a>(
                             message,
                             *prev_message,
                             duration,
+                            config,
                         )
                     } else {
                         false
@@ -386,6 +396,7 @@ pub fn view<'a>(
                             message,
                             *prev_message,
                             duration,
+                            config
                         )
                         // don't hide if prev message has visible preview (when show_after_previews is enabled)
                         && !(config


### PR DESCRIPTION
Sets a user as a bot on join when their JOIN message has the bot tag.

Tangentially-related fix: don't hide consecutive nicknames when the displayed format for the user changes (i.e. if the access level or bot mode changes and that change would be visible).