### PR TITLE
Channel matching on single line only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Fixed:
 - `NICK` and `QUIT` messages returned by `draft/event-playback` (`chathistory`)
 - Backlog separator text colour now follows `buffer.backlog_rule`
 - Distinguish between reacts in chathistory vs active history
+- Channel matching on single line only
 
 Thanks:
 

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -55,7 +55,7 @@ static URL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 
 // Restrict characters per spec: https://modern.ircdocs.horse/#channels
 static CHANNEL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    RegexBuilder::new(r#"(?i)(?<!\w)#([^ ,\x07]+)(?!\w)"#)
+    RegexBuilder::new(r#"(?i)(?<!\w)#([^\s,\x07]+)(?!\w)"#)
         .build()
         .unwrap()
 });
@@ -3995,6 +3995,14 @@ pub mod tests {
                     Fragment::Text(" and ".into()),
                     Fragment::Channel("#channel2".into()),
                     Fragment::Text(").".into()),
+                ],
+            ),
+            (
+                "testing new line #match\ning.",
+                vec![
+                    Fragment::Text("testing new line ".into()),
+                    Fragment::Channel("#match".into()),
+                    Fragment::Text("\ning.".into()),
                 ],
             ),
             (


### PR DESCRIPTION
Thanks for spotting this @andymandias!

Multiline channel matching should not be possible now :saluting_face: 