### PR TITLE
localhost http is treated as a secure transport when using `servers.<name>.filehost.override_url`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Fixed:
 Changed:
 
 - On-join topic messages disabled by default (`buffer.server_messages.topic`), instead the topic banner is enabled by default (`buffer.channel.topic_banner`)
+- For filehosts, localhost is now treated as a secure transport when using `servers.<name>.filehost.override_url`
 
 Thanks:
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -4665,8 +4665,7 @@ impl Map {
             server
                 .parent()
                 .as_ref()
-                .map(|p| self.get_filehost_is_override(p))
-                .unwrap_or(false)
+                .is_some_and(|p| self.get_filehost_is_override(p))
         } else {
             false
         }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -4648,6 +4648,30 @@ impl Map {
         self.client(server).is_none_or(|c| c.config.use_tls)
     }
 
+    pub fn get_filehost_is_override(&self, server: &Server) -> bool {
+        let Some(client) = self.client(server) else {
+            return false;
+        };
+
+        if !client.config.filehost.enabled {
+            return false;
+        }
+
+        if client.config.filehost.override_url.is_some() {
+            return true;
+        }
+
+        if server.is_bouncer_network() {
+            server
+                .parent()
+                .as_ref()
+                .map(|p| self.get_filehost_is_override(p))
+                .unwrap_or(false)
+        } else {
+            false
+        }
+    }
+
     pub fn get_features_ref(&self, server: &Server) -> &Features {
         self.client(server)
             .map_or(&features::DEFAULT, |client| &client.features)

--- a/data/src/fileupload.rs
+++ b/data/src/fileupload.rs
@@ -78,6 +78,7 @@ pub async fn upload(
     path: &Path,
     auth: Option<Auth>,
     irc_uses_tls: bool,
+    is_override_url: bool,
     client: Arc<Client>,
     proxy_config: Option<&proxy::Proxy>,
 ) -> Result<String, Error> {
@@ -93,12 +94,20 @@ pub async fn upload(
     }
 
     // Spec: clients MUST refuse unencrypted transports when IRC uses TLS.
-    if irc_uses_tls && base.scheme() != "https" {
+    if irc_uses_tls
+        && base.scheme() != "https"
+        // Exception: override_url pointing to localhost.
+        && !(is_override_url && is_localhost(&base))
+    {
         return Err(Error::InsecureTransport);
     }
 
     // Spec: SASL EXTERNAL is not valid without TLS
-    if matches!(auth, Some(Auth::External { .. })) && base.scheme() != "https" {
+    if matches!(auth, Some(Auth::External { .. }))
+        && base.scheme() != "https"
+        // same exception follows as above
+        && !(is_override_url && is_localhost(&base))
+    {
         return Err(Error::InsecureTransport);
     }
 
@@ -172,6 +181,15 @@ pub async fn upload(
     log::info!("file uploaded successfully: {file_url}");
 
     Ok(file_url.to_string())
+}
+
+fn is_localhost(url: &Url) -> bool {
+    match url.host() {
+        Some(url::Host::Domain(d)) => d == "localhost",
+        Some(url::Host::Ipv4(addr)) => addr.is_loopback(),
+        Some(url::Host::Ipv6(addr)) => addr.is_loopback(),
+        None => false,
+    }
 }
 
 fn content_disposition(file_name: &str) -> String {

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -764,6 +764,8 @@ enabled = true
 
 Override the filehost URL advertised by the server via ISUPPORT. The filehost must be compatible with the `soju.im/filehost` spec.
 
+When connecting over TLS, plain `http://` URLs are rejected unless the host is a loopback address.
+
 ```toml
 # Type: string
 # Values: any string

--- a/src/filehost.rs
+++ b/src/filehost.rs
@@ -35,6 +35,7 @@ pub struct PendingUpload {
     pub server: data::Server,
     pub target: Option<Target>,
     pub upload_url: String,
+    pub is_override_url: bool,
     pub has_credentials: bool,
     pub file_paths: Vec<PathBuf>,
     pub upload_ids: Vec<u32>,
@@ -210,6 +211,7 @@ fn start_tasks(
         server,
         target,
         upload_url,
+        is_override_url,
         has_credentials: _,
         file_paths,
         upload_ids,
@@ -235,6 +237,7 @@ fn start_tasks(
                         &file_path,
                         auth,
                         irc_uses_tls,
+                        is_override_url,
                         http_client,
                         proxy_config.as_ref(),
                     );

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -2640,6 +2640,7 @@ impl Dashboard {
                 let pending = filehost::PendingUpload {
                     window,
                     pane_id: id,
+                    is_override_url: clients.get_filehost_is_override(&server),
                     has_credentials: clients
                         .get_filehost_auth(&server)
                         .is_some(),


### PR DESCRIPTION
fixes #1875