### PR TITLE
Tooltip to indicate if query user is offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Added:
 - IRCv3 bot mode support, with bot icon in buffers and nicklists
 - Customize the character used to indicate a nickname was truncated with `display.truncation_character`
 - Support for IRCv3 `draft/message-redaction`
+- Tooltip to indicate if query user is offline
 
 Fixed:
 

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -532,22 +532,61 @@ fn query_title<'a>(
         .buffer
         .nickname
         .offline
-        .is_offline(!shared_channels.is_empty() && current_user.is_none());
+        .is_offline(shared_channels.is_empty() || current_user.is_none());
 
-    let nickname = text(resolved_query.as_str())
-        .style(move |_| {
-            theme::text::nickname(
-                theme,
-                &config.buffer.nickname.color,
-                Some(resolved_query.as_str()),
-                is_user_away,
-                is_user_offline,
+    let nickname: Element<'a, Message> = if is_user_offline
+        && matches!(config.tooltips, data::config::Tooltips::All)
+    {
+        iced::widget::tooltip(
+            row![
+                text(resolved_query.as_str())
+                    .style(move |_| {
+                        theme::text::nickname(
+                            theme,
+                            &config.buffer.nickname.color,
+                            Some(resolved_query.as_str()),
+                            is_user_away,
+                            is_user_offline,
+                        )
+                    })
+                    .font_maybe(
+                        theme::font_style::nickname(theme, is_user_offline)
+                            .map(font::get),
+                    )
+                    .shaping(text::Shaping::Advanced)
+            ],
+            container(
+                text("offline".to_string())
+                    .style(theme::text::secondary)
+                    .line_height(font::line_height())
+                    .font_maybe(
+                        theme::font_style::secondary(theme).map(font::get),
+                    ),
             )
-        })
-        .font_maybe(
-            theme::font_style::nickname(theme, is_user_offline).map(font::get),
+            .style(theme::container::tooltip)
+            .padding(8),
+            crate::widget::tooltip::Position::Bottom,
         )
-        .shaping(text::Shaping::Advanced);
+        .delay(iced::time::Duration::ZERO)
+        .into()
+    } else {
+        text(resolved_query.as_str())
+            .style(move |_| {
+                theme::text::nickname(
+                    theme,
+                    &config.buffer.nickname.color,
+                    Some(resolved_query.as_str()),
+                    is_user_away,
+                    is_user_offline,
+                )
+            })
+            .font_maybe(
+                theme::font_style::nickname(theme, is_user_offline)
+                    .map(font::get),
+            )
+            .shaping(text::Shaping::Advanced)
+            .into()
+    };
 
     row![
         nickname,


### PR DESCRIPTION
Fixed user's "offline" status.

Added a tooltip to show `offline` for scenarios where the colour chosen for `buffer-nickname-offline` is not super obvious (especially when nothing to contrast to).

<img width="325" height="169" alt="image" src="https://github.com/user-attachments/assets/9a19af5d-94ff-4a6e-9f34-5e85d640f1bf" />