### PR TITLE
Fix link matching for both end of line delimiters & punctuations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Fixed:
 - Do not hide consecutive nicknames if the user's displayed access levels or bot mode changes
 - Issue where unread indicator could appear in sidebar for an open pane that does not have unread messages
 - Issue where backlog divider in highlights or logs pane would not update when marking the pane as read
+- Fix link matching for both end of line delimiters & punctuations
 
 Changed:
 

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -2099,8 +2099,11 @@ fn filter_trailing_delimiter<'a>(
 
     if let Some(trimmed_end) = trim_at {
         let is_end_of_text = end >= text.len()
-            || text[end..].starts_with(|c: char| c.is_whitespace());
-
+            || text[end..].starts_with(|c: char| c.is_whitespace())
+            || matches!(
+                EXCLUDED_TRAILING_CHARS_REGEX.find_iter(&text[end..]).next(),
+                Some(Ok(_))
+            );
         if trimmed_end > 0 && trimmed_end < matching.len() && is_end_of_text {
             (&matching[..trimmed_end], Some(&matching[trimmed_end..]))
         } else {
@@ -3995,6 +3998,15 @@ pub mod tests {
                     Fragment::Text("testing new line ".into()),
                     Fragment::Channel("#match".into()),
                     Fragment::Text("\ning.".into()),
+                ],
+            ),
+            (
+                "\"a #test\",",
+                vec![
+                    Fragment::Text("\"a ".into()),
+                    Fragment::Channel("#test".into()),
+                    Fragment::Text("\"".into()),
+                    Fragment::Text(",".into()),
                 ],
             ),
             (


### PR DESCRIPTION
Fixes bug with link matching logic where doubling up on end of line delimiter + punctuation would only exclude the punctuation from the match.

e.g. `"a #test",` matched to `#test"`.

With fix in place, this matches to `#test`.