### PR TITLE
User Display Tweaks

### DIFF
--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -608,11 +608,12 @@ mod nick_list {
                         nicklist_config.show_access_levels,
                         nicklist_config.show_bot_icon,
                         registry,
+                        &config.display.nicklist_nickname,
                         nicklist_config
                             .truncate
                             .or(config.buffer.nickname.truncate),
+                        config.display.truncation_character,
                         None,
-                        config,
                     ),
                 )
             })

--- a/src/buffer/highlights.rs
+++ b/src/buffer/highlights.rs
@@ -120,9 +120,10 @@ pub fn view<'a>(
                         config.buffer.nickname.show_access_levels,
                         config.buffer.nickname.show_bot_icon,
                         clients.get_registry(server),
+                        &config.display.nickname,
                         config.buffer.nickname.truncate,
+                        config.display.truncation_character,
                         Some(&config.buffer.nickname.brackets),
-                        config,
                     );
 
                     let nick_text = user_display.into_element(

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -568,9 +568,10 @@ pub fn view<'a>(
                 config.buffer.text_input.nickname.show_access_levels,
                 config.buffer.nickname.show_bot_icon,
                 registry,
+                &config.display.nickname,
                 None,
+                config.display.truncation_character,
                 None,
-                config,
             );
 
             container(user_display.into_element(

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -405,9 +405,10 @@ impl<'a> ChannelQueryLayout<'a> {
             self.config.buffer.nickname.show_access_levels,
             self.config.buffer.nickname.show_bot_icon,
             registry,
+            &self.config.display.nickname,
             self.config.buffer.nickname.truncate,
+            self.config.display.truncation_character,
             Some(&self.config.buffer.nickname.brackets),
-            self.config,
         );
 
         let nick_element: Element<_> = if hide_nickname {

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -338,9 +338,10 @@ pub fn view<'a>(
                             config.buffer.nickname.show_access_levels,
                             config.buffer.nickname.show_bot_icon,
                             registry,
+                            &config.display.nickname,
                             config.buffer.nickname.truncate,
+                            config.display.truncation_character,
                             Some(&config.buffer.nickname.brackets),
-                            config,
                         );
 
                         Some(user_display.width(config) + 1.0)
@@ -2047,9 +2048,10 @@ fn preview_row<'a>(
                         config.buffer.nickname.show_access_levels,
                         config.buffer.nickname.show_bot_icon,
                         registry,
+                        &config.display.nickname,
                         config.buffer.nickname.truncate,
+                        config.display.truncation_character,
                         Some(&config.buffer.nickname.brackets),
-                        config,
                     )
                     .width(config)
                 } else {

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -189,9 +189,10 @@ pub fn view<'a>(
                             config.buffer.nickname.show_access_levels,
                             config.buffer.nickname.show_bot_icon,
                             registry,
+                            &config.display.nickname,
                             config.buffer.nickname.truncate,
+                            config.display.truncation_character,
                             Some(&config.buffer.nickname.brackets),
-                            config,
                         );
 
                         let nick: Element<_> = if hide_nickname {

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -133,7 +133,7 @@ pub fn bot_icon<'a, M>(
     style: impl Fn(&Theme) -> selectable_text::Style + 'a,
 ) -> Element<'a, M> {
     selectable_text(String::from("\u{1F916}"))
-        .line_height(LineHeight::Relative(1.35))
+        .line_height(LineHeight::Relative(1.45))
         .font(*font::ICON)
         .style(style)
         .size(ICON_SIZE)

--- a/src/widget/user_display.rs
+++ b/src/widget/user_display.rs
@@ -22,23 +22,21 @@ impl UserDisplay {
         show_access_levels: AccessLevelFormat,
         show_bot_icon: bool,
         registry: &dyn metadata::Registry,
+        enabled: &[Metadata],
         truncate: Option<u16>,
+        truncation_character: char,
         brackets: Option<&Brackets>,
-        config: &Config,
     ) -> Self {
         let full = UserDisplayData::new(
             user,
             show_access_levels,
             show_bot_icon,
             registry,
-            config,
+            enabled,
         );
 
         if let Some(truncated) = truncate.and_then(|truncation_length| {
-            full.truncate(
-                truncation_length as usize,
-                config.display.truncation_character,
-            )
+            full.truncate(truncation_length as usize, truncation_character)
         }) {
             Self {
                 base: truncated.bracket(brackets),
@@ -119,7 +117,7 @@ impl UserDisplayData {
         show_access_levels: AccessLevelFormat,
         show_bot_icon: bool,
         registry: &dyn metadata::Registry,
-        config: &Config,
+        enabled: &[Metadata],
     ) -> Self {
         let access_levels = match show_access_levels {
             AccessLevelFormat::All => {
@@ -147,18 +145,17 @@ impl UserDisplayData {
 
         let query = Query::from(user);
 
-        let display_name =
-            if config.display.nickname.contains(&Metadata::DisplayName)
-                && let Some(display_name) =
-                    registry.display_name(TargetRef::Query(&query))
-                && !display_name.is_empty()
-            {
-                Some(display_name)
-            } else {
-                None
-            };
+        let display_name = if enabled.contains(&Metadata::DisplayName)
+            && let Some(display_name) =
+                registry.display_name(TargetRef::Query(&query))
+            && !display_name.is_empty()
+        {
+            Some(display_name)
+        } else {
+            None
+        };
 
-        let pronouns = if config.display.nickname.contains(&Metadata::Pronouns)
+        let pronouns = if enabled.contains(&Metadata::Pronouns)
             && let Some(pronouns) = registry.pronouns(&query)
             && !pronouns.is_empty()
         {

--- a/src/widget/user_display.rs
+++ b/src/widget/user_display.rs
@@ -50,9 +50,11 @@ impl UserDisplay {
                 tooltip: Some(full),
             }
         } else {
+            let tooltip = full.bot_icon.then_some(full.clone());
+
             Self {
                 base: full.bracket(brackets),
-                tooltip: None,
+                tooltip,
             }
         }
     }


### PR DESCRIPTION
Minor fixes/tweaks:
- Bot icon vertical alignment
- Show tooltip in the nicklist if the user is a bot even if the user display was not truncated
- Use nicklist_nickname setting when constructing nickname elements for the nicklist