### PR TITLE
`VERSION` and `JOIN` commands on connect are skipped if server is primary soju server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Fixed:
 - Fix link matching for both end of line delimiters & punctuations
 - Matching against `users` for some include/exclude conditions
 - Handle URLs ending with paired delimiters chars
+- `VERSION` and `JOIN` commands on connect are skipped if server is primary soju server
 
 Changed:
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -332,7 +332,7 @@ impl Client {
     ) -> Vec<Event> {
         if self.registration_step == RegistrationStep::Complete {
             // TODO: allow from_modal when modal matching to bouncer networks is added.
-            if !self.server.is_bouncer_network() {
+            if !self.server.is_bouncer_network() && !self.is_primary() {
                 self.join(
                     &config
                         .channels
@@ -3072,7 +3072,7 @@ impl Client {
                     .collect::<Vec<_>>();
 
                 // Send JOIN on non bouncer networks
-                if !self.server.is_bouncer_network() {
+                if !self.server.is_bouncer_network() && !self.is_primary() {
                     for message in group_joins(
                         &channels,
                         &self.config.channel_keys,
@@ -3129,10 +3129,12 @@ impl Client {
                     ))))
                     .collect::<Vec<_>>();
 
-                if matches!(
-                    self.features.version_request,
-                    VersionRequest::Need(true)
-                ) {
+                if !self.is_primary()
+                    && matches!(
+                        self.features.version_request,
+                        VersionRequest::Need(true)
+                    )
+                {
                     self.features.version_request = VersionRequest::Sent;
 
                     self.send(


### PR DESCRIPTION
Right now we send `VERSION` to the soju primary server, but soju doesn't support `VERSION` so this leads to seeing the following in the soju server buffer:

```
VERSION Unknown command
```

I'm also seeing `JOIN`s being attempted on the primary soju server, so I expanded the conditional for connect joins to exclude the primary server as well.

```
JOIN Cannot interact with channels and users on the bouncer connection. Did you mean to use a specific network?
```

Both scenarios are cleaned up via this PR.