### PR TITLE
Misc. Minor Improvements/Fixes

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -2768,6 +2768,24 @@ impl Client {
                     self.resolved_host = Some(hostname.to_string());
                 }
             }
+            Command::SETNAME(_realname) => {
+                // Real names are not currently stored anywhere, but
+                // SETNAME provides an opportunity to update resolved_user
+                // and resolved_host.
+                let user = ok!(message.user(self.casemapping()));
+
+                let ourself = user.nickname() == self.nickname();
+
+                if ourself {
+                    if let Some(username) = user.username() {
+                        self.resolved_user = Some(username.to_string());
+                    }
+
+                    if let Some(hostname) = user.hostname() {
+                        self.resolved_host = Some(hostname.to_string());
+                    }
+                }
+            }
             Command::Numeric(RPL_MONONLINE, args) => {
                 let casemapping =
                     isupport::get_casemapping_or_default(&self.isupport);

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1891,7 +1891,7 @@ impl Client {
                     if let Some(client_channel) =
                         self.chanmap.get_mut(&target_channel)
                     {
-                        client_channel.update_user_away(
+                        client_channel.update_user_status(
                             ok!(args.get(5)),
                             ok!(args.get(6)),
                             casemapping,
@@ -1999,7 +1999,7 @@ impl Client {
                             {
                                 if token == WhoXPollParameters::Default.token()
                                 {
-                                    client_channel.update_user_away(
+                                    client_channel.update_user_status(
                                         ok!(args.get(3)),
                                         ok!(args.get(4)),
                                         casemapping,
@@ -2013,7 +2013,7 @@ impl Client {
                                 {
                                     let user = ok!(args.get(3));
 
-                                    client_channel.update_user_away(
+                                    client_channel.update_user_status(
                                         user,
                                         ok!(args.get(4)),
                                         casemapping,
@@ -5370,7 +5370,7 @@ pub struct Channel {
 }
 
 impl Channel {
-    pub fn update_user_away(
+    pub fn update_user_status(
         &mut self,
         user: &str,
         flags: &str,
@@ -5379,20 +5379,18 @@ impl Channel {
     ) {
         let user = User::from(Nick::from_str(user, casemapping));
 
-        if let Some(away_flag) = flags.chars().next() {
+        let away = flags.chars().next().and_then(|away_flag| {
             // H = Here, G = gone (away)
-            let away = match away_flag {
-                'G' => true,
-                'H' => false,
-                _ => return,
-            };
+            match away_flag {
+                'G' => Some(true),
+                'H' => Some(false),
+                _ => None,
+            }
+        });
 
-            self.users.update_user(
-                &user,
-                Some(away),
-                bot_mode_char.map(|bot_char| flags.contains(bot_char)),
-            );
-        }
+        let bot = bot_mode_char.map(|bot_char| flags.contains(bot_char));
+
+        self.users.update_user(&user, away, bot);
     }
 
     pub fn update_user_accountname(

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -3263,6 +3263,8 @@ impl Client {
 
                     self.metadata_sub_requests.remove(key);
                 }
+
+                return Ok(vec![]);
             }
             _ => {}
         }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -129,7 +129,7 @@ pub enum Message {
         DateTime<Utc>,
         Result<(), Error>,
     ),
-    RequestNewerChatHistory(Server, Target, DateTime<Utc>),
+    RequestNewerChatHistory(Server, Target, DateTime<Utc>, bool),
     RequestChatHistoryTargets(Server, Option<DateTime<Utc>>, DateTime<Utc>),
 }
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -389,7 +389,7 @@ impl Client {
                 }
             }
 
-            if !config.metadata.is_empty()
+            if (!config.metadata.is_empty() || !self.config.metadata.is_empty())
                 && config.metadata != self.config.metadata
             {
                 if self.capabilities.acknowledged(Capability::ReadMarker) {

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -392,7 +392,7 @@ impl Client {
             if (!config.metadata.is_empty() || !self.config.metadata.is_empty())
                 && config.metadata != self.config.metadata
             {
-                if self.capabilities.acknowledged(Capability::ReadMarker) {
+                if self.capabilities.acknowledged(Capability::Metadata) {
                     self.send(
                         None,
                         command!(
@@ -3161,7 +3161,7 @@ impl Client {
                 }
 
                 if !self.config.metadata.is_empty() {
-                    if self.capabilities.acknowledged(Capability::ReadMarker) {
+                    if self.capabilities.acknowledged(Capability::Metadata) {
                         for (key, value) in
                             self.config.metadata.clone().into_iter()
                         {

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -3244,7 +3244,7 @@ impl Client {
                         context.as_ref().and_then(|context| context.first())
                     && self.metadata_sub_requests.take(key).is_some()
                 {
-                    log::warn!(
+                    log::info!(
                         "[{}] Metadata {key} not supported by the server",
                         self.server
                     );

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -962,24 +962,38 @@ impl History {
         }
     }
 
-    pub fn last_can_reference_before(
+    pub fn last_can_reference_before_or_at(
         &self,
         server_time: DateTime<Utc>,
-    ) -> Option<MessageReferences> {
-        let can_reference = |message: &Message| {
+        allow_at: bool,
+        message_reference_types: &[isupport::MessageReferenceType],
+    ) -> Option<isupport::MessageReference> {
+        let can_reference_before = |message: &Message| {
             message.can_reference()
                 && !message.is_rerouted()
                 && message.server_time < server_time
         };
 
-        let (message, chathistory_references) = match self {
+        let mut at_message = None;
+
+        let can_reference_at = |message: &Message| {
+            message.can_reference()
+                && !message.is_rerouted()
+                && message.server_time == server_time
+        };
+
+        let (before_message, chathistory_references) = match self {
             History::Partial {
                 pending_messages,
                 chathistory_references,
                 ..
             } => (
                 pending_messages.iter().rev().find_map(|(message, _)| {
-                    can_reference(message).then_some(message)
+                    if at_message.is_none() && can_reference_at(message) {
+                        at_message = Some(message);
+                    }
+
+                    can_reference_before(message).then_some(message)
                 }),
                 chathistory_references,
             ),
@@ -988,22 +1002,49 @@ impl History {
                 chathistory_references,
                 ..
             } => (
-                messages.iter().rev().find(|message| can_reference(message)),
+                messages.iter().rev().find(|message| {
+                    if at_message.is_none() && can_reference_at(message) {
+                        at_message = Some(message);
+                    }
+
+                    can_reference_before(message)
+                }),
                 chathistory_references,
             ),
         };
 
-        message.map(Message::references).max(
-            if chathistory_references.as_ref().is_some_and(
-                |chathistory_references| {
-                    chathistory_references.timestamp < server_time
+        // If a reference before server_time exists, then return that reference.
+        if let Some(message_references) =
+            before_message.map(Message::references).max(
+                if chathistory_references.as_ref().is_some_and(
+                    |chathistory_references| {
+                        chathistory_references.timestamp < server_time
+                    },
+                ) {
+                    chathistory_references.clone()
+                } else {
+                    None
                 },
-            ) {
-                chathistory_references.clone()
-            } else {
-                None
-            },
-        )
+            )
+        {
+            Some(message_references.message_reference(message_reference_types))
+        // Else, if a reference at server_time is allowed, exists, and timestamp
+        // references are supported, then return a timestamp reference at
+        // server_time.
+        } else if allow_at
+            && message_reference_types
+                .contains(&isupport::MessageReferenceType::Timestamp)
+            && (at_message.is_some()
+                || chathistory_references.as_ref().is_some_and(
+                    |chathistory_references| {
+                        chathistory_references.timestamp == server_time
+                    },
+                ))
+        {
+            Some(isupport::MessageReference::Timestamp(server_time))
+        } else {
+            None
+        }
     }
 
     pub fn update_chathistory_references(

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -614,14 +614,21 @@ impl Manager {
         self.data.first_can_reference(server, target)
     }
 
-    pub fn last_can_reference_before(
+    pub fn last_can_reference_before_or_at(
         &self,
         server: Server,
         target: Target,
         server_time: DateTime<Utc>,
-    ) -> Option<MessageReferences> {
-        self.data
-            .last_can_reference_before(server, target, server_time)
+        allow_at: bool,
+        message_reference_types: &[isupport::MessageReferenceType],
+    ) -> Option<isupport::MessageReference> {
+        self.data.last_can_reference_before_or_at(
+            server,
+            target,
+            server_time,
+            allow_at,
+            message_reference_types,
+        )
     }
 
     pub fn mark_as_read(&mut self, kind: &history::Kind) -> Option<ReadMarker> {
@@ -1736,17 +1743,23 @@ impl Data {
             .and_then(|history| history.first_can_reference())
     }
 
-    fn last_can_reference_before(
+    fn last_can_reference_before_or_at(
         &self,
         server: Server,
         target: Target,
         server_time: DateTime<Utc>,
-    ) -> Option<MessageReferences> {
+        allow_at: bool,
+        message_reference_types: &[isupport::MessageReferenceType],
+    ) -> Option<isupport::MessageReference> {
         let kind = history::Kind::from_target(server, target);
 
-        self.map
-            .get(&kind)
-            .and_then(|history| history.last_can_reference_before(server_time))
+        self.map.get(&kind).and_then(|history| {
+            history.last_can_reference_before_or_at(
+                server_time,
+                allow_at,
+                message_reference_types,
+            )
+        })
     }
 
     fn mark_as_read(&mut self, kind: &history::Kind) -> Option<ReadMarker> {

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -970,7 +970,7 @@ impl PartialEq<Message> for MessageReference {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum MessageReferenceType {
     Timestamp,
     MessageId,

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::config::buffer::{AccessLevelFormat, UsernameFormat};
+use crate::target::Query;
 use crate::{isupport, mode};
 
 #[derive(Debug, Clone)]
@@ -527,6 +528,15 @@ impl From<NickRef<'_>> for Nick {
         Nick {
             raw: nickref.raw.to_string(),
             normalized: nickref.normalized.to_string(),
+        }
+    }
+}
+
+impl From<&Query> for Nick {
+    fn from(query: &Query) -> Self {
+        Nick {
+            raw: query.as_str().to_string(),
+            normalized: query.as_normalized_str().to_string(),
         }
     }
 }

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -933,8 +933,9 @@ impl State {
                     );
 
                     self.on_completion(buffer, history, actions, true)
-                // IRCv3 draft/multiline forbids all blank lines, so we will
-                // take that as an IRC norm and require the same
+                // IRCv3 draft/multiline forbids messages consisting
+                // entirely of blank lines, so we will take that as an
+                // IRC norm and require the same
                 } else if !self.input_content.text().trim().is_empty() {
                     // If there is an error in the input then display the error
                     // for the current line (if it has an error) or the first

--- a/src/main.rs
+++ b/src/main.rs
@@ -1669,11 +1669,12 @@ fn handle_client_events(
             Event::JoinedChannel(channel, server_time) => {
                 commands.push(
                     dashboard
-                        .load_metadata(
+                        .load_metadata_and_request_newer_chathistory(
                             clients,
                             server.clone(),
                             Target::Channel(channel),
                             server_time,
+                            false,
                         )
                         .map(Message::Dashboard),
                 );
@@ -1694,11 +1695,12 @@ fn handle_client_events(
             Event::ChatHistoryTargetReceived(target, server_time) => {
                 commands.push(
                     dashboard
-                        .load_metadata(
+                        .load_metadata_and_request_newer_chathistory(
                             clients,
                             server.clone(),
                             target,
                             server_time,
+                            true,
                         )
                         .map(Message::Dashboard),
                 );

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1709,6 +1709,7 @@ impl Dashboard {
                     server,
                     target,
                     server_time,
+                    allow_at,
                 ) => {
                     let message_reference_types = clients
                         .get_server_chathistory_message_reference_types(
@@ -1717,15 +1718,14 @@ impl Dashboard {
 
                     let message_reference = self
                         .history
-                        .last_can_reference_before(
+                        .last_can_reference_before_or_at(
                             server.clone(),
                             target.clone(),
                             server_time,
+                            allow_at,
+                            &message_reference_types,
                         )
-                        .map_or(MessageReference::None, |message_references| {
-                            message_references
-                                .message_reference(&message_reference_types)
-                        });
+                        .unwrap_or(MessageReference::None);
 
                     let limit = clients.get_server_chathistory_limit(&server);
 
@@ -3535,12 +3535,13 @@ impl Dashboard {
         mark_as_read(kind, &mut self.history, clients, TokenPriority::High);
     }
 
-    pub fn load_metadata(
+    pub fn load_metadata_and_request_newer_chathistory(
         &mut self,
         clients: &data::client::Map,
         server: Server,
         target: Target,
         server_time: DateTime<Utc>,
+        allow_at: bool,
     ) -> Task<Message> {
         let command = self
             .history
@@ -3553,6 +3554,7 @@ impl Dashboard {
                     server,
                     target,
                     server_time,
+                    allow_at,
                 ),
             )))
         } else {

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -514,10 +514,7 @@ fn query_title<'a>(
     theme: &'a Theme,
 ) -> Element<'a, Message> {
     let resolved_query = clients.resolve_query(server, query).unwrap_or(query);
-    let user = User::from(data::user::Nick::from_str(
-        resolved_query.as_str(),
-        clients.get_server_casemapping_or_default(server),
-    ));
+    let user = User::from(data::user::Nick::from(resolved_query));
     let shared_channels = clients.get_user_channels(server, user.nickname());
     let current_user = shared_channels.iter().find_map(|channel| {
         clients.resolve_user_attributes(server, channel, &user)
@@ -539,7 +536,7 @@ fn query_title<'a>(
             theme::text::nickname(
                 theme,
                 &config.buffer.nickname.color,
-                Some(resolved_query.as_str()),
+                Some(user.seed()),
                 is_user_away,
                 is_user_offline,
             )

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -525,11 +525,11 @@ fn query_title<'a>(
         .nickname
         .away
         .is_away(current_user.is_some_and(User::is_away));
-    let is_user_offline = config
-        .buffer
-        .nickname
-        .offline
-        .is_offline(!shared_channels.is_empty() && current_user.is_none());
+    // It's generally not possible to tell whether another user is offline or
+    // just not in the any shared channels.  Unless/until user offline status is
+    // monitored (via IRCv3 MONITOR or otherwise), do not display users as
+    // offline in query titles as it may be misleading.
+    let is_user_offline = config.buffer.nickname.offline.is_offline(false);
 
     let nickname = text(resolved_query.as_str())
         .style(move |_| {


### PR DESCRIPTION
A few miscellaneous imrpovements/fixes:
- Use SETNAME for setting resolved user/host (prepares the way for `draft/whoami` support)
- Hide metadata subscription confirmation from the server buffer
- Fix not clearing metadata when removing all metadata settings for a server
- Fix edge case where bot status could fail to be updated when it should be updated
- Use same color seed for query pane titles as is used for buffer/nicklist
- Reduce the number of excess chathistory messages requested from queries returned by a chathistory TARGETS request