### PR TITLE
Prevent joining configured channels on bouncer-networks

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -332,9 +332,7 @@ impl Client {
     ) -> Vec<Event> {
         if self.registration_step == RegistrationStep::Complete {
             // TODO: allow from_modal when modal matching to bouncer networks is added.
-            if !self.capabilities.acknowledged(Capability::BouncerNetworks)
-                || !self.is_primary()
-            {
+            if !self.capabilities.acknowledged(Capability::BouncerNetworks) {
                 self.join(
                     &config
                         .channels
@@ -3106,7 +3104,6 @@ impl Client {
 
                 // Send JOIN on non bouncer networks
                 if !self.capabilities.acknowledged(Capability::BouncerNetworks)
-                    || !self.is_primary()
                 {
                     for message in group_joins(
                         &channels,


### PR DESCRIPTION
This should keep things close to how we had it before and prevent any soju networks from attempting joining channels.