### PR TITLE
chathistory Loop Fix

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -42,7 +42,7 @@ use crate::{
 pub mod on_connect;
 
 const HIGHLIGHT_BLACKOUT_INTERVAL: Duration = Duration::from_secs(5);
-const CLIENT_CHATHISTORY_LIMIT: u16 = 500;
+const CLIENT_CHATHISTORY_LIMIT: u16 = 1000;
 const CHATHISTORY_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
 const MODE_REQUEST_DELAY: Duration = Duration::from_millis(600);
 const MODE_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
@@ -3830,6 +3830,7 @@ impl Client {
                         continue_chathistory_between(
                             target,
                             events,
+                            None,
                             message_reference,
                             self.chathistory_limit(),
                         )
@@ -3867,6 +3868,7 @@ impl Client {
                         continue_chathistory_between(
                             target,
                             events,
+                            Some(start_message_reference),
                             end_message_reference,
                             self.chathistory_limit(),
                         )
@@ -3890,6 +3892,7 @@ impl Client {
                     if *autorequest && size >= *limit {
                         continue_chathistory_targets(
                             events,
+                            start_message_reference,
                             end_message_reference,
                             self.chathistory_limit(),
                         )
@@ -4511,6 +4514,7 @@ fn is_reaction(message: &message::Encoded) -> bool {
 fn continue_chathistory_between(
     target: &Target,
     events: &[Event],
+    previous_start_message_reference: Option<&MessageReference>,
     end_message_reference: &MessageReference,
     limit: u16,
 ) -> Option<ChatHistorySubcommand> {
@@ -4525,9 +4529,27 @@ fn continue_chathistory_between(
                 MessageReference::MessageId(_) => {
                     message.message_id().map(MessageReference::MessageId)
                 }
-                MessageReference::Timestamp(_) => Some(
-                    MessageReference::Timestamp(message.server_time_or_now()),
-                ),
+                MessageReference::Timestamp(_) => {
+                    let server_time = message.server_time();
+
+                    let previous_server_time = if let Some(
+                        MessageReference::Timestamp(previous_start_timestamp),
+                    ) =
+                        previous_start_message_reference
+                    {
+                        Some(previous_start_timestamp)
+                    } else {
+                        None
+                    };
+
+                    if server_time != previous_server_time.copied() {
+                        server_time.map(|timestamp| {
+                            MessageReference::Timestamp(timestamp)
+                        })
+                    } else {
+                        None
+                    }
+                }
                 MessageReference::None => None,
             },
             Event::Broadcast(_)
@@ -4558,13 +4580,28 @@ fn continue_chathistory_between(
 
 fn continue_chathistory_targets(
     events: &[Event],
+    previous_start_message_reference: &MessageReference,
     end_message_reference: &MessageReference,
     limit: u16,
 ) -> Option<ChatHistorySubcommand> {
     let start_message_reference =
         events.last().and_then(|first_event| match first_event {
             Event::ChatHistoryTargetReceived(_, server_time) => {
-                Some(MessageReference::Timestamp(*server_time))
+                let previous_server_time = if let MessageReference::Timestamp(
+                    previous_start_timestamp,
+                ) =
+                    previous_start_message_reference
+                {
+                    Some(previous_start_timestamp)
+                } else {
+                    None
+                };
+
+                if Some(server_time) != previous_server_time {
+                    Some(MessageReference::Timestamp(*server_time))
+                } else {
+                    None
+                }
             }
             Event::Single { .. }
             | Event::PrivOrNotice { .. }

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -34,6 +34,8 @@ const MAX_MESSAGES: usize = 10_000;
 const TRUNC_COUNT: usize = 500;
 /// Duration to wait after receiving last message before flushing
 const FLUSH_AFTER_LAST_RECEIVED: Duration = Duration::from_secs(5);
+/// # new messages to trigger flush even if FLUSH_AFTER_LAST_RECEIVED has not passed
+const FLUSH_COUNT: usize = 1000;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Kind {
@@ -406,6 +408,7 @@ pub enum History {
         chathistory_references: Option<MessageReferences>,
         last_seen: HashMap<Nick, DateTime<Utc>>,
         cleared: bool,
+        last_flushed_at: usize,
     },
 }
 
@@ -724,10 +727,10 @@ impl History {
                 ..
             } => {
                 if let Some(last_received) = *last_updated_at
-                    && now.is_none_or(|now| {
+                    && (now.is_none_or(|now| {
                         now.duration_since(last_received)
                             >= FLUSH_AFTER_LAST_RECEIVED
-                    })
+                    }) || pending_messages.len() > FLUSH_COUNT)
                 {
                     let kind = kind.clone();
                     let pending_messages = std::mem::take(pending_messages);
@@ -763,13 +766,15 @@ impl History {
                 last_updated_at,
                 read_marker,
                 chathistory_references,
+                last_flushed_at,
                 ..
             } => {
                 if let Some(last_received) = *last_updated_at
-                    && now.is_none_or(|now| {
+                    && (now.is_none_or(|now| {
                         now.duration_since(last_received)
                             >= FLUSH_AFTER_LAST_RECEIVED
-                    })
+                    }) || messages.len().saturating_sub(*last_flushed_at)
+                        > FLUSH_COUNT)
                     && !messages.is_empty()
                 {
                     let kind = kind.clone();

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -1361,6 +1361,8 @@ impl Data {
                         );
                     }
 
+                    let last_flushed_at = messages.len();
+
                     entry.insert(History::Full {
                         kind,
                         messages,
@@ -1370,6 +1372,7 @@ impl Data {
                         chathistory_references,
                         last_seen,
                         cleared: false,
+                        last_flushed_at,
                     });
                 }
                 _ => {
@@ -1378,6 +1381,7 @@ impl Data {
                         .max(metadata::latest_can_reference(&messages));
 
                     let last_seen = history::get_last_seen(&messages);
+                    let last_flushed_at = messages.len();
 
                     entry.insert(History::Full {
                         kind,
@@ -1388,6 +1392,7 @@ impl Data {
                         chathistory_references,
                         last_seen,
                         cleared: false,
+                        last_flushed_at,
                     });
                 }
             },
@@ -1397,6 +1402,7 @@ impl Data {
                     .max(metadata::latest_can_reference(&messages));
 
                 let last_seen = history::get_last_seen(&messages);
+                let last_flushed_at = messages.len();
 
                 entry.insert(History::Full {
                     kind,
@@ -1407,6 +1413,7 @@ impl Data {
                     chathistory_references,
                     last_seen,
                     cleared: false,
+                    last_flushed_at,
                 });
             }
         }

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -1055,7 +1055,7 @@ pub const DEFAULT_PREFIX: &[PrefixMap] = &[
 pub const DEFAULT_STATUSMSG: &[char] =
     proto::DEFAULT_CHANNEL_MEMBERSHIP_PREFIXES;
 
-const FUZZ_SECONDS: chrono::Duration = chrono::Duration::seconds(5);
+const FUZZ_SECONDS: chrono::Duration = chrono::Duration::seconds(1);
 
 pub fn fuzz_start_message_reference(
     message_reference: MessageReference,


### PR DESCRIPTION
Fixes a scenario where chathistory requests could get in a loop, using unnecessary bandwidth and memory.