### PR TITLE
Minor History Changes

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -27,7 +27,7 @@ use crate::features::{self, Features, VersionRequest};
 use crate::history::ReadMarker;
 use crate::isupport::{
     ChatHistoryState, ChatHistorySubcommand, MessageReference, WhoToken,
-    WhoXPollParameters, find_target_limit,
+    WhoXPollParameters, find_target_limit, format_optional_message_reference,
 };
 use crate::rate_limit::{BackoffInterval, TokenBucket, TokenPriority};
 use crate::target::{self, Target};
@@ -130,7 +130,6 @@ pub enum Message {
         Result<(), Error>,
     ),
     RequestNewerChatHistory(Server, Target, DateTime<Utc>, bool),
-    RequestChatHistoryTargets(Server, Option<DateTime<Utc>>, DateTime<Utc>),
 }
 
 #[derive(Debug)]
@@ -3673,14 +3672,18 @@ impl Client {
                     limit,
                 ) => {
                     let command_message_reference =
-                        isupport::fuzz_start_message_reference(
-                            message_reference,
-                        );
+                        message_reference.map(|message_reference| {
+                            isupport::fuzz_start_message_reference(
+                                message_reference,
+                            )
+                        });
 
                     log::debug!(
                         "[{}] requesting {limit} latest messages in {target} since {}",
                         self.server,
-                        command_message_reference,
+                        format_optional_message_reference(
+                            &command_message_reference
+                        ),
                     );
 
                     self.send(
@@ -3689,7 +3692,9 @@ impl Client {
                             "CHATHISTORY",
                             "LATEST",
                             target.to_string(),
-                            command_message_reference.to_string(),
+                            format_optional_message_reference(
+                                &command_message_reference
+                            ),
                             limit.to_string(),
                         )
                         .into(),
@@ -3759,29 +3764,15 @@ impl Client {
                     );
                 }
                 ChatHistorySubcommand::Targets(
-                    start_message_reference,
-                    end_message_reference,
+                    start_timestamp,
+                    end_timestamp,
                     limit,
                 ) => {
                     let command_start_message_reference =
-                        match start_message_reference {
-                            isupport::MessageReference::Timestamp(_) => {
-                                start_message_reference
-                            }
-                            _ => isupport::MessageReference::Timestamp(
-                                DateTime::UNIX_EPOCH,
-                            ),
-                        };
+                        isupport::MessageReference::Timestamp(start_timestamp);
 
                     let command_end_message_reference =
-                        match end_message_reference {
-                            isupport::MessageReference::Timestamp(_) => {
-                                end_message_reference
-                            }
-                            _ => isupport::MessageReference::Timestamp(
-                                chrono::offset::Utc::now(),
-                            ),
-                        };
+                        isupport::MessageReference::Timestamp(end_timestamp);
 
                     let (
                         command_start_message_reference,
@@ -3841,11 +3832,7 @@ impl Client {
         } {
             if let Some(target) = target
                 && let ChatHistorySubcommand::Before(_, _, limit)
-                | ChatHistorySubcommand::Latest(
-                    _,
-                    MessageReference::None,
-                    limit,
-                ) = subcommand
+                | ChatHistorySubcommand::Latest(_, None, limit) = subcommand
             {
                 self.chathistory_exhausted
                     .insert(target.clone(), chathistory_end || size < *limit);
@@ -3862,12 +3849,13 @@ impl Client {
                         self.server,
                         size,
                         target,
-                        message_reference,
+                        format_optional_message_reference(message_reference),
                     );
 
-                    if matches!(message_reference, MessageReference::None) {
-                        None
-                    } else if *autorequest && size >= *limit && !chathistory_end
+                    if let Some(message_reference) = message_reference
+                        && *autorequest
+                        && size >= *limit
+                        && !chathistory_end
                     {
                         continue_chathistory_between(
                             target,
@@ -3919,23 +3907,23 @@ impl Client {
                     }
                 }
                 ChatHistorySubcommand::Targets(
-                    start_message_reference,
-                    end_message_reference,
+                    start_timestamp,
+                    end_timestamp,
                     limit,
                 ) => {
                     log::debug!(
                         "[{}] received {} targets between {} and {}",
                         self.server,
                         size,
-                        start_message_reference,
-                        end_message_reference,
+                        MessageReference::Timestamp(*start_timestamp),
+                        MessageReference::Timestamp(*end_timestamp),
                     );
 
                     if *autorequest && size >= *limit && !chathistory_end {
                         continue_chathistory_targets(
                             events,
-                            start_message_reference,
-                            end_message_reference,
+                            start_timestamp,
+                            end_timestamp,
                             self.chathistory_limit(),
                         )
                     } else {
@@ -3969,19 +3957,15 @@ impl Client {
                 .ok()
                 .flatten();
 
-            let start_message_reference = timestamp
-                .map_or(MessageReference::None, |timestamp| {
-                    MessageReference::Timestamp(timestamp)
-                });
+            let start_timestamp = timestamp.unwrap_or(DateTime::UNIX_EPOCH);
 
-            let end_message_reference =
-                MessageReference::Timestamp(server_time);
+            let end_timestamp = server_time;
 
             Message::ChatHistoryRequest(
                 server,
                 ChatHistorySubcommand::Targets(
-                    start_message_reference,
-                    end_message_reference,
+                    start_timestamp,
+                    end_timestamp,
                     limit,
                 ),
             )
@@ -4601,7 +4585,6 @@ fn continue_chathistory_between(
                         None
                     }
                 }
-                MessageReference::None => None,
             },
             Event::Broadcast(_)
             | Event::FileTransferRequest(_)
@@ -4631,21 +4614,17 @@ fn continue_chathistory_between(
 
 fn continue_chathistory_targets(
     events: &[Event],
-    previous_start_message_reference: &MessageReference,
-    end_message_reference: &MessageReference,
+    previous_start_timestamp: &DateTime<Utc>,
+    end_timestamp: &DateTime<Utc>,
     limit: u16,
 ) -> Option<ChatHistorySubcommand> {
-    let start_message_reference =
+    let start_timestamp =
         events.last().and_then(|first_event| match first_event {
             Event::ChatHistoryTargetReceived(_, server_time) => {
-                if let MessageReference::Timestamp(previous_start_server_time) =
-                    previous_start_message_reference
-                    && server_time > previous_start_server_time
-                    && let MessageReference::Timestamp(end_server_time) =
-                        end_message_reference
-                    && server_time < end_server_time
+                if server_time > previous_start_timestamp
+                    && server_time < end_timestamp
                 {
-                    Some(MessageReference::Timestamp(*server_time))
+                    Some(*server_time)
                 } else {
                     None
                 }
@@ -4671,12 +4650,8 @@ fn continue_chathistory_targets(
             | Event::Disconnect(_) => None,
         });
 
-    start_message_reference.map(|start_message_reference| {
-        ChatHistorySubcommand::Targets(
-            start_message_reference,
-            end_message_reference.clone(),
-            limit,
-        )
+    start_timestamp.map(|start_timestamp| {
+        ChatHistorySubcommand::Targets(start_timestamp, *end_timestamp, limit)
     })
 }
 
@@ -6024,9 +5999,9 @@ mod tests {
         client.chathistory_requests.insert(
             target.clone(),
             ChatHistoryRequest {
-                subcommand: ChatHistorySubcommand::Before(
+                subcommand: ChatHistorySubcommand::Latest(
                     target.clone(),
-                    MessageReference::None,
+                    None,
                     limit,
                 ),
                 requested_at: Instant::now(),

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -4547,7 +4547,7 @@ fn continue_chathistory_between(
                 MessageReference::MessageId(_) => {
                     message.message_id().map(MessageReference::MessageId)
                 }
-                MessageReference::Timestamp(_) => {
+                MessageReference::Timestamp(end_server_time) => {
                     let server_time = message.server_time();
 
                     let previous_server_time = if let Some(
@@ -4560,10 +4560,15 @@ fn continue_chathistory_between(
                         None
                     };
 
-                    if server_time != previous_server_time.copied() {
-                        server_time.map(|timestamp| {
-                            MessageReference::Timestamp(timestamp)
-                        })
+                    if let Some(server_time) = server_time
+                        && previous_server_time.is_none_or(
+                            |previous_server_time| {
+                                server_time < *previous_server_time
+                            },
+                        )
+                        && server_time > *end_server_time
+                    {
+                        Some(MessageReference::Timestamp(server_time))
                     } else {
                         None
                     }
@@ -4605,17 +4610,13 @@ fn continue_chathistory_targets(
     let start_message_reference =
         events.last().and_then(|first_event| match first_event {
             Event::ChatHistoryTargetReceived(_, server_time) => {
-                let previous_server_time = if let MessageReference::Timestamp(
-                    previous_start_timestamp,
-                ) =
+                if let MessageReference::Timestamp(previous_start_server_time) =
                     previous_start_message_reference
+                    && server_time > previous_start_server_time
+                    && let MessageReference::Timestamp(end_server_time) =
+                        end_message_reference
+                    && server_time < end_server_time
                 {
-                    Some(previous_start_timestamp)
-                } else {
-                    None
-                };
-
-                if Some(server_time) != previous_server_time {
                     Some(MessageReference::Timestamp(*server_time))
                 } else {
                     None

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -201,6 +201,8 @@ pub struct Client {
     capabilities: Capabilities,
     features: Features,
     sasl_succeeded: bool,
+    pending_chathistory_requests:
+        HashMap<Target, (ChatHistorySubcommand, TokenPriority)>,
     chathistory_requests: HashMap<Target, ChatHistoryRequest>,
     chathistory_exhausted: HashMap<Target, bool>,
     chathistory_targets_request: Option<ChatHistoryRequest>,
@@ -264,6 +266,7 @@ impl Client {
             capabilities: Capabilities::default(),
             features: Features::default(),
             sasl_succeeded: false,
+            pending_chathistory_requests: HashMap::new(),
             chathistory_requests: HashMap::new(),
             chathistory_exhausted: HashMap::new(),
             chathistory_targets_request: None,
@@ -2375,17 +2378,24 @@ impl Client {
             Command::Numeric(RPL_ENDOFNAMES, args) => {
                 let target = ok!(args.get(1));
 
-                let target_channel = context!(target::Channel::parse(
+                let target = context!(target::Channel::parse(
                     target,
                     self.chantypes(),
                     self.statusmsg(),
                     self.casemapping(),
                 ));
 
-                if let Some(channel) = self.chanmap.get_mut(&target_channel)
+                if let Some(channel) = self.chanmap.get_mut(&target)
                     && !channel.names_init
                 {
                     channel.names_init = true;
+
+                    if let Some((subcommand, priority)) = self
+                        .pending_chathistory_requests
+                        .remove(&Target::Channel(target))
+                    {
+                        self.send_chathistory_request(subcommand, priority);
+                    }
 
                     return Ok(vec![]);
                 }
@@ -3608,23 +3618,41 @@ impl Client {
         subcommand: ChatHistorySubcommand,
         priority: TokenPriority,
     ) {
-        use std::collections::hash_map;
-
         if self.capabilities.acknowledged(Capability::Chathistory) {
             if let Some(target) = subcommand.target() {
-                if let hash_map::Entry::Vacant(entry) =
-                    self.chathistory_requests.entry(Target::parse(
-                        target,
-                        self.chantypes(),
-                        self.statusmsg(),
-                        self.casemapping(),
-                    ))
-                {
-                    entry.insert(ChatHistoryRequest {
-                        subcommand: subcommand.clone(),
-                        requested_at: Instant::now(),
-                        autorequest: !matches!(priority, TokenPriority::User),
-                    });
+                if self.pending_chathistory_requests.contains_key(target) {
+                    return;
+                } else if !self.chathistory_requests.contains_key(target) {
+                    let autorequest = !matches!(priority, TokenPriority::User);
+
+                    // If the chathistory request is an automatic request due to
+                    // joining a channel, then we want to wait for the initial,
+                    // implicit NAMES reply to complete before requesting
+                    // chathistory so that we have as much channel state as
+                    // possible when parsing messages.
+                    if autorequest
+                        && let Some(channel) = target
+                            .as_channel()
+                            .and_then(|channel| self.chanmap.get_mut(channel))
+                        && !channel.names_init
+                    {
+                        self.pending_chathistory_requests
+                            .insert(target.clone(), (subcommand, priority));
+
+                        return;
+                    }
+
+                    self.chathistory_requests.insert(
+                        target.clone(),
+                        ChatHistoryRequest {
+                            subcommand: subcommand.clone(),
+                            requested_at: Instant::now(),
+                            autorequest: !matches!(
+                                priority,
+                                TokenPriority::User
+                            ),
+                        },
+                    );
                 } else {
                     return;
                 }

--- a/data/src/command.rs
+++ b/data/src/command.rs
@@ -13,7 +13,9 @@ use crate::capabilities::{Capabilities, Capability};
 use crate::config::buffer::text_input::AutoFormat;
 use crate::features::Features;
 use crate::history::reroute::RerouteRules;
-use crate::isupport::{self, find_target_limit};
+use crate::isupport::{
+    self, find_target_limit, format_optional_message_reference,
+};
 use crate::message::{self, formatting};
 use crate::user::{ChannelUsers, NickRef};
 use crate::{Config, Message, Server, Target, Url, User, ctcp, target};
@@ -1215,14 +1217,10 @@ fn parse_command(
                                 None,
                             ] = params
                             {
-                                let Some(message_reference) =
+                                let message_reference =
                                     validated_message_reference(
                                         &message_reference,
-                                        false,
-                                    )
-                                else {
-                                    return Err(Error::InvalidChathistoryMessageReference);
-                                };
+                                    )?;
 
                                 if let Ok(limit) = limit.parse::<u16>()
                                     && limit > 0
@@ -1270,14 +1268,10 @@ fn parse_command(
                                 None,
                             ] = params
                             {
-                                let Some(message_reference) =
-                                    validated_message_reference(
+                                let optional_message_reference =
+                                    validated_optional_message_reference(
                                         &message_reference,
-                                        true,
-                                    )
-                                else {
-                                    return Err(Error::InvalidChathistoryMessageReference);
-                                };
+                                    )?;
 
                                 if let Ok(limit) = limit.parse::<u16>()
                                     && limit > 0
@@ -1300,7 +1294,9 @@ fn parse_command(
                                         subcommand,
                                         vec![
                                             target,
-                                            message_reference.to_string(),
+                                            format_optional_message_reference(
+                                                &optional_message_reference,
+                                            ),
                                             limit,
                                         ],
                                     ),
@@ -1325,23 +1321,15 @@ fn parse_command(
                                 Some(limit),
                             ] = params
                             {
-                                let Some(first_message_reference) =
+                                let first_message_reference =
                                     validated_message_reference(
                                         &first_message_reference,
-                                        false,
-                                    )
-                                else {
-                                    return Err(Error::InvalidChathistoryMessageReference);
-                                };
+                                    )?;
 
-                                let Some(second_message_reference) =
+                                let second_message_reference =
                                     validated_message_reference(
                                         &second_message_reference,
-                                        false,
-                                    )
-                                else {
-                                    return Err(Error::InvalidChathistoryMessageReference);
-                                };
+                                    )?;
 
                                 if let Ok(limit) = limit.parse::<u16>()
                                     && limit > 0
@@ -1889,18 +1877,30 @@ fn validated_timestamp(timestamp: &str) -> Option<DateTime<Utc>> {
 
 fn validated_message_reference(
     message_reference: &str,
-    allow_none: bool,
-) -> Option<isupport::MessageReference> {
+) -> Result<isupport::MessageReference, Error> {
     if let Some(date_time) = validated_timestamp(message_reference) {
-        return Some(isupport::MessageReference::Timestamp(date_time));
+        return Ok(isupport::MessageReference::Timestamp(date_time));
     }
 
     if let Some(message_id) = message_reference.strip_prefix("msgid=") {
-        return Some(isupport::MessageReference::MessageId(message_id.into()));
+        return Ok(isupport::MessageReference::MessageId(message_id.into()));
     }
 
-    (allow_none && message_reference == "*")
-        .then_some(isupport::MessageReference::None)
+    Err(Error::InvalidChathistoryMessageReference)
+}
+
+fn validated_optional_message_reference(
+    message_reference: &str,
+) -> Result<Option<isupport::MessageReference>, Error> {
+    if let Ok(message_reference) =
+        validated_message_reference(message_reference)
+    {
+        Ok(Some(message_reference))
+    } else if message_reference == "*" {
+        Ok(None)
+    } else {
+        Err(Error::InvalidChathistoryOptionalMessageReference)
+    }
 }
 
 fn validated_mode_string(
@@ -2120,6 +2120,8 @@ pub enum Error {
     },
     #[error("invalid timestamp or message id")]
     InvalidChathistoryMessageReference,
+    #[error("invalid timestamp or message id, and is not \"*\"")]
+    InvalidChathistoryOptionalMessageReference,
     #[error("invalid timestamp")]
     InvalidChathistoryTimestamp,
     #[error("too large (maximum limit: {maximum_limit})")]

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -1482,10 +1482,24 @@ pub fn insert_message(
 
     if let Some(index) = replace_at {
         if messages[index].server_time == message.server_time {
-            messages[index] = Message {
-                id: message.id.or(messages[index].id.clone()),
-                ..message
-            };
+            if message.deduplicate
+                && has_matching_content(&messages[index], &message, false)
+            {
+                // Perform a minimal update if this is a message from
+                // chathistory (or ZNC playback) and has the same raw content,
+                // since the newly received message will have been parsed
+                // without historical state.
+                if messages[index].id.is_none() {
+                    messages[index].id = message.id;
+                }
+                messages[index].direction = message::Direction::Received;
+                messages[index].received_at = message.received_at;
+            } else {
+                messages[index] = Message {
+                    id: message.id.or(messages[index].id.clone()),
+                    ..message
+                };
+            }
         } else {
             if message_is_unlabeled_echo {
                 read_marker = Some(ReadMarker::from(&message));

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -1076,7 +1076,7 @@ impl History {
                 },
             )
         {
-            Some(message_references.message_reference(message_reference_types))
+            message_references.message_reference(message_reference_types)
         // Else, if a reference at server_time is allowed, exists, and timestamp
         // references are supported, then return a timestamp reference at
         // server_time.

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -1482,14 +1482,10 @@ pub fn insert_message(
 
     if let Some(index) = replace_at {
         if messages[index].server_time == message.server_time {
-            if has_matching_content(&messages[index], &message, false) {
-                if let Some(id) = message.id {
-                    messages[index].id = Some(id);
-                }
-                messages[index].received_at = message.received_at;
-            } else {
-                messages[index] = message;
-            }
+            messages[index] = Message {
+                id: message.id.or(messages[index].id.clone()),
+                ..message
+            };
         } else {
             if message_is_unlabeled_echo {
                 read_marker = Some(ReadMarker::from(&message));

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -912,13 +912,11 @@ pub enum ChatHistorySubcommand {
 }
 
 impl ChatHistorySubcommand {
-    pub fn target(&self) -> Option<&str> {
+    pub fn target(&self) -> Option<&Target> {
         match self {
             ChatHistorySubcommand::Latest(target, _, _)
             | ChatHistorySubcommand::Before(target, _, _)
-            | ChatHistorySubcommand::Between(target, _, _, _) => {
-                Some(target.as_str())
-            }
+            | ChatHistorySubcommand::Between(target, _, _, _) => Some(target),
             ChatHistorySubcommand::Targets(_, _, _) => None,
         }
     }

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -905,10 +905,10 @@ impl fmt::Display for ModeKind {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum ChatHistorySubcommand {
-    Latest(Target, MessageReference, u16),
+    Latest(Target, Option<MessageReference>, u16),
     Before(Target, MessageReference, u16),
     Between(Target, MessageReference, MessageReference, u16),
-    Targets(MessageReference, MessageReference, u16),
+    Targets(DateTime<Utc>, DateTime<Utc>, u16),
 }
 
 impl ChatHistorySubcommand {
@@ -946,8 +946,16 @@ pub struct CommandTargetLimit {
 pub enum MessageReference {
     Timestamp(DateTime<Utc>),
     MessageId(message::Id),
-    None,
 }
+
+// impl fmt::Display for Option<MessageReference> {
+//     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+//         match self {
+//             Some(message_reference) => write!(f, "{message_reference}"),
+//             None => write!(f, "*"),
+//         }
+//     }
+// }
 
 impl fmt::Display for MessageReference {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -958,7 +966,6 @@ impl fmt::Display for MessageReference {
                 server_time.to_rfc3339_opts(SecondsFormat::Millis, true)
             ),
             MessageReference::MessageId(id) => write!(f, "msgid={id}"),
-            MessageReference::None => write!(f, "*"),
         }
     }
 }
@@ -970,8 +977,16 @@ impl PartialEq<Message> for MessageReference {
                 other.server_time == *server_time
             }
             MessageReference::MessageId(id) => other.id.as_deref() == Some(id),
-            MessageReference::None => false,
         }
+    }
+}
+
+pub fn format_optional_message_reference(
+    optional_message_reference: &Option<MessageReference>,
+) -> String {
+    match optional_message_reference {
+        Some(message_reference) => message_reference.to_string(),
+        None => "*".to_string(),
     }
 }
 

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -3957,25 +3957,25 @@ impl MessageReferences {
     pub fn message_reference(
         &self,
         message_reference_types: &[isupport::MessageReferenceType],
-    ) -> isupport::MessageReference {
+    ) -> Option<isupport::MessageReference> {
         for message_reference_type in message_reference_types {
             match message_reference_type {
                 isupport::MessageReferenceType::MessageId => {
                     if let Some(id) = &self.id {
-                        return isupport::MessageReference::MessageId(
+                        return Some(isupport::MessageReference::MessageId(
                             id.clone(),
-                        );
+                        ));
                     }
                 }
                 isupport::MessageReferenceType::Timestamp => {
-                    return isupport::MessageReference::Timestamp(
+                    return Some(isupport::MessageReference::Timestamp(
                         self.timestamp,
-                    );
+                    ));
                 }
             }
         }
 
-        isupport::MessageReference::None
+        None
     }
 }
 

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -2968,6 +2968,7 @@ fn show_while_typing(error: &input::Error) -> bool {
             | command::Error::InvalidChannelName { .. }
             | command::Error::InvalidServerUrl
             | command::Error::InvalidChathistoryMessageReference
+            | command::Error::InvalidChathistoryOptionalMessageReference
             | command::Error::InvalidChathistoryTimestamp
             | command::Error::ChathistoryLimitTooLarge { .. }
             | command::Error::ExecDisabled

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1742,16 +1742,14 @@ impl Dashboard {
                             &server,
                         );
 
-                    let message_reference = self
-                        .history
-                        .last_can_reference_before_or_at(
+                    let message_reference =
+                        self.history.last_can_reference_before_or_at(
                             server.clone(),
                             target.clone(),
                             server_time,
                             allow_at,
                             &message_reference_types,
-                        )
-                        .unwrap_or(MessageReference::None);
+                        );
 
                     let limit = clients.get_server_chathistory_limit(&server);
 
@@ -1760,31 +1758,6 @@ impl Dashboard {
                         ChatHistorySubcommand::Latest(
                             target,
                             message_reference,
-                            limit,
-                        ),
-                        TokenPriority::High,
-                    );
-                }
-                client::Message::RequestChatHistoryTargets(
-                    server,
-                    timestamp,
-                    server_time,
-                ) => {
-                    let start_message_reference = timestamp
-                        .map_or(MessageReference::None, |timestamp| {
-                            MessageReference::Timestamp(timestamp)
-                        });
-
-                    let end_message_reference =
-                        MessageReference::Timestamp(server_time);
-
-                    let limit = clients.get_server_chathistory_limit(&server);
-
-                    clients.send_chathistory_request(
-                        &server,
-                        ChatHistorySubcommand::Targets(
-                            start_message_reference,
-                            end_message_reference,
                             limit,
                         ),
                         TokenPriority::High,
@@ -3483,7 +3456,7 @@ impl Dashboard {
         server: &Server,
         target: Target,
         message_reference_types: &[isupport::MessageReferenceType],
-    ) -> MessageReference {
+    ) -> Option<MessageReference> {
         if let Some(first_can_reference) = self
             .history
             .first_can_reference(server.clone(), target.clone())
@@ -3492,19 +3465,21 @@ impl Dashboard {
                 match message_reference_type {
                     isupport::MessageReferenceType::MessageId => {
                         if let Some(id) = &first_can_reference.id {
-                            return MessageReference::MessageId(id.clone());
+                            return Some(MessageReference::MessageId(
+                                id.clone(),
+                            ));
                         }
                     }
                     isupport::MessageReferenceType::Timestamp => {
-                        return MessageReference::Timestamp(
+                        return Some(MessageReference::Timestamp(
                             first_can_reference.server_time,
-                        );
+                        ));
                     }
                 }
             }
         }
 
-        MessageReference::None
+        None
     }
 
     pub fn request_older_chathistory(
@@ -3535,14 +3510,14 @@ impl Dashboard {
             );
 
             let subcommand =
-                if matches!(first_can_reference, MessageReference::None) {
-                    ChatHistorySubcommand::Latest(
+                if let Some(first_can_reference) = first_can_reference {
+                    ChatHistorySubcommand::Before(
                         target,
                         first_can_reference,
                         clients.get_server_chathistory_limit(server),
                     )
                 } else {
-                    ChatHistorySubcommand::Before(
+                    ChatHistorySubcommand::Latest(
                         target,
                         first_can_reference,
                         clients.get_server_chathistory_limit(server),


### PR DESCRIPTION
Two minor changes to history handling:
- Make the loop prevention merged in #1937 more defensive (updates should prevent looping even if the server/bouncer is malfunctioning)
- Make the update method for deduplicated messages and echo messages consistent; both types of message updates can be handled the same, and the criteria used to distinguish the two could fail