### PR TITLE
support `draft/chathistory-end` message tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Added:
 - Setting to close queries when closing query buffer panes (`buffer.close.query`)
 - Support for IRCv3 metadata `display-name`, `avatar`, `pronouns`, `homepage`, `color`, `status` keys
 - Theme colors for horizontal rule text and buffer backlog/date separators
+- Support for `draft/chathistory-end` message tag
 
 Fixed:
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -5955,6 +5955,100 @@ mod tests {
     }
 
     #[test]
+    fn chathistory_end_tag_marks_history_exhausted() {
+        let mut client = test_client("tester");
+        let config = config::Config::default();
+        let server = proto::Source::Server("irc.test".to_string());
+        let alice = proto::Source::User(proto::User {
+            nickname: "alice".to_string(),
+            username: Some("alice".to_string()),
+            hostname: Some("example.test".to_string()),
+        });
+
+        let target = Target::parse(
+            "#test",
+            isupport::DEFAULT_CHANTYPES,
+            &[],
+            isupport::CaseMap::default(),
+        );
+
+        // limit=5 so that without draft/chathistory-end, receiving exactly 5
+        // messages would leave exhausted=false (size >= limit)
+        let limit: u16 = 5;
+
+        client.chathistory_requests.insert(
+            target.clone(),
+            ChatHistoryRequest {
+                subcommand: ChatHistorySubcommand::Before(
+                    target.clone(),
+                    MessageReference::None,
+                    limit,
+                ),
+                requested_at: Instant::now(),
+                autorequest: false,
+            },
+        );
+
+        // BATCH +1 chathistory #test (with draft/chathistory-end tag)
+        client
+            .handle(
+                message::Encoded(proto::Message {
+                    tags: BTreeMap::from([(
+                        "draft/chathistory-end".to_string(),
+                        String::new(),
+                    )]),
+                    source: Some(server.clone()),
+                    command: Command::BATCH(
+                        "+1".to_string(),
+                        vec!["chathistory".to_string(), "#test".to_string()],
+                    ),
+                }),
+                None,
+                &config,
+            )
+            .unwrap();
+
+        // Send exactly `limit` messages to test for boundary edge case
+        for _ in 0..limit {
+            client
+                .handle(
+                    message::Encoded(proto::Message {
+                        tags: BTreeMap::from([(
+                            "batch".to_string(),
+                            "1".to_string(),
+                        )]),
+                        source: Some(alice.clone()),
+                        command: Command::PRIVMSG(
+                            "#test".to_string(),
+                            "message".to_string(),
+                        ),
+                    }),
+                    None,
+                    &config,
+                )
+                .unwrap();
+        }
+
+        // BATCH -1
+        client
+            .handle(
+                message::Encoded(proto::Message {
+                    tags: BTreeMap::default(),
+                    source: Some(server.clone()),
+                    command: Command::BATCH("-1".to_string(), vec![]),
+                }),
+                None,
+                &config,
+            )
+            .unwrap();
+
+        assert!(
+            client.chathistory_exhausted(&target),
+            "draft/chathistory-end tag should mark history as exhausted"
+        );
+    }
+
+    #[test]
     fn chathistory_direct_messages_record_query_in_querymap() {
         let mut client = test_client("tester");
         let canonical = query("FooBar");

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -903,6 +903,9 @@ impl Client {
                     '+' => {
                         let mut batch = Batch::new(context);
 
+                        batch.chathistory_end =
+                            message.tags.contains_key("draft/chathistory-end");
+
                         batch.kind = match params.first().map(String::as_str) {
                             Some("chathistory") => {
                                 params.get(1).map(|target| {
@@ -1018,6 +1021,7 @@ impl Client {
                                                 Some(batch_target),
                                                 finished.size,
                                                 &finished.events,
+                                                finished.chathistory_end,
                                             );
 
                                         self.clear_chathistory_request(Some(
@@ -1039,6 +1043,7 @@ impl Client {
                                                 None,
                                                 finished.size,
                                                 &finished.events,
+                                                finished.chathistory_end,
                                             );
 
                                         self.clear_chathistory_request(None);
@@ -3785,6 +3790,7 @@ impl Client {
         target: Option<&Target>,
         size: u16,
         events: &[Event],
+        chathistory_end: bool,
     ) -> Option<ChatHistorySubcommand> {
         if let Some(ChatHistoryRequest {
             subcommand,
@@ -3804,7 +3810,11 @@ impl Client {
                 ) = subcommand
             {
                 self.chathistory_exhausted
-                    .insert(target.clone(), size < *limit);
+                    .insert(target.clone(), chathistory_end || size < *limit);
+            }
+
+            if chathistory_end {
+                return None;
             }
 
             match subcommand {
@@ -5445,6 +5455,7 @@ pub struct Batch {
     events: Vec<Event>,
     kind: Option<BatchKind>,
     size: u16,
+    chathistory_end: bool,
 }
 
 impl Batch {
@@ -5454,6 +5465,7 @@ impl Batch {
             events: vec![],
             kind: None,
             size: 0,
+            chathistory_end: false,
         }
     }
 }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -3813,10 +3813,6 @@ impl Client {
                     .insert(target.clone(), chathistory_end || size < *limit);
             }
 
-            if chathistory_end {
-                return None;
-            }
-
             match subcommand {
                 ChatHistorySubcommand::Latest(
                     target,
@@ -3833,7 +3829,8 @@ impl Client {
 
                     if matches!(message_reference, MessageReference::None) {
                         None
-                    } else if *autorequest && size >= *limit {
+                    } else if *autorequest && size >= *limit && !chathistory_end
+                    {
                         continue_chathistory_between(
                             target,
                             events,
@@ -3871,7 +3868,7 @@ impl Client {
                         end_message_reference,
                     );
 
-                    if *autorequest && size >= *limit {
+                    if *autorequest && size >= *limit && !chathistory_end {
                         continue_chathistory_between(
                             target,
                             events,
@@ -3896,7 +3893,7 @@ impl Client {
                         end_message_reference,
                     );
 
-                    if *autorequest && size >= *limit {
+                    if *autorequest && size >= *limit && !chathistory_end {
                         continue_chathistory_targets(
                             events,
                             start_message_reference,


### PR DESCRIPTION
implements https://github.com/ircv3/ircv3-specifications/pull/598

this fixes an edge case when chathistory ends on a page boundary, where it is unclear whether or not there are any more messages to query. the server can indiciate draft/chathistory-end on a batch, and then we set `exhausted = true` eagerly and preventing a spurious request

has upstream support in ergo to be released in next version. no support in soju yet