### PR TITLE
ircv3 websockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Added:
 - Support for IRCv3 metadata `display-name`, `avatar`, `pronouns`, `homepage`, `color`, `status` keys
 - Theme colors for horizontal rule text and buffer backlog/date separators
 - Support for `draft/chathistory-end` message tag
+- Support for IRCv3 WebSockets
 
 Fixed:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3752,6 +3752,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
+ "tokio-tungstenite",
  "tokio-util",
  "xz2",
 ]
@@ -7818,6 +7819,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9119,6 +9132,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
 name = "typed-index-collections"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9319,6 +9349,12 @@ dependencies = [
  "unicode-vo",
  "xmlwriter",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8-width"

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -101,6 +101,10 @@ pub struct Server {
     /// Whether or not to use TLS.
     /// Clients will automatically panic if this is enabled without TLS support.
     pub use_tls: bool,
+    /// Whether or not to connect using IRCv3 WebSocket transport.
+    pub use_websocket: bool,
+    /// The WebSocket request path.
+    pub websocket_path: String,
     /// On `true`, all certificate validations are skipped. Defaults to `false`.
     pub dangerously_accept_invalid_certs: bool,
     /// The path to the root TLS certificate for this server in PEM format.
@@ -182,6 +186,9 @@ impl Server {
             port: self.port,
             security,
             proxy: proxy.map(From::from),
+            websocket: self.use_websocket.then_some(connection::WebSocket {
+                path: &self.websocket_path,
+            }),
         }
     }
 
@@ -235,6 +242,8 @@ impl Default for Server {
             ghost_sequence: vec!["REGAIN".into()],
             umodes: Option::default(),
             use_tls: true,
+            use_websocket: false,
+            websocket_path: "/".into(),
             dangerously_accept_invalid_certs: Default::default(),
             root_cert_path: Option::default(),
             sasl: Option::default(),

--- a/data/src/file_transfer/task.rs
+++ b/data/src/file_transfer/task.rs
@@ -286,6 +286,7 @@ async fn receive(
                 port: port.get(),
                 security: connection::Security::Unsecured,
                 proxy: proxy.map(From::from),
+                websocket: None,
             },
             BytesCodec::new(),
         )
@@ -418,6 +419,7 @@ async fn send(
                 port: port.get(),
                 security: connection::Security::Unsecured,
                 proxy: proxy.map(From::from),
+                websocket: None,
             },
             BytesCodec::new(),
         )

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -370,6 +370,32 @@ Whether or not to use TLS. Clients will automatically panic if this is enabled w
 use_tls = true
 ```
 
+## `use_websocket`
+
+Whether or not to connect using IRCv3 WebSocket transport. When enabled, Halloy connects to `ws://` if [`use_tls`](#use_tls) is `false`, and `wss://` if [`use_tls`](#use_tls) is `true`.
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: false
+
+[servers.<name>]
+use_websocket = false
+```
+
+## `websocket_path`
+
+The WebSocket request path. For soju HTTPS listeners or reverse proxies, this is usually `"/socket"`.
+
+```toml
+# Type: string
+# Values: any path
+# Default: "/"
+
+[servers.<name>]
+websocket_path = "/"
+```
+
 ## `dangerously_accept_invalid_certs`
 
 When `true`, all certificate validations are skipped.

--- a/docs/guides/connect-with-soju.md
+++ b/docs/guides/connect-with-soju.md
@@ -14,6 +14,24 @@ message-store db
 Both the `fs` and `memory` `message-store` drivers are incompatible with the proper functioning of some IRCv3 features (e.g. IRCv3 `chathistory` with the `memory` driver or IRCv3 `reactions` with the `fs` driver).
 :::
 
+## Connect over WebSocket
+
+It's also possible to connect over WebSocket using the IRCv3 WebSocket extension. For a soju that exposes WebSocket at `/socket`, configure Halloy like this:
+
+```toml
+[servers.<name>]
+nickname = "<your-nickname>"
+server = "<your-bouncer-url>"
+port = 443
+use_tls = true
+use_websocket = true
+websocket_path = "/socket"
+
+[servers.<name>.sasl.plain]
+username = "<your-username>"
+password = "<your-password>"
+```
+
 ## Automatic network detection using the `bouncer-networks` extension
 
 To connect using the `bouncer-networks` extension, you can use the following configuration template. This will ensure you are automatically connected to all your networks.

--- a/irc/Cargo.toml
+++ b/irc/Cargo.toml
@@ -31,6 +31,9 @@ tokio-rustls = { version = "0.26.0", default-features = false, features = [
     "tls12",
     "ring",
 ] }
+tokio-tungstenite = { version = "0.28.0", default-features = false, features = [
+    "handshake",
+] }
 tokio-util = { version = "0.7", features = ["codec"] }
 rustls-native-certs = "0.8.1"
 xz2 = { version = "0.1.7", features = ["static"] }

--- a/irc/src/connection.rs
+++ b/irc/src/connection.rs
@@ -13,9 +13,11 @@ use tokio_util::codec;
 use tokio_util::codec::Framed;
 
 pub use self::proxy::Proxy;
+use self::websocket::WebSocketConnection;
 
 mod proxy;
 mod tls;
+mod websocket;
 
 pub fn prepare() {
     static INIT: Once = Once::new();
@@ -35,6 +37,7 @@ pub enum IrcStream {
 pub enum Connection<Codec> {
     Tls(Framed<TlsStream<IrcStream>, Codec>),
     Unsecured(Framed<IrcStream, Codec>),
+    WebSocket(WebSocketConnection<Codec>),
 }
 
 #[derive(Debug, Clone)]
@@ -54,6 +57,12 @@ pub struct Config<'a> {
     pub port: u16,
     pub security: Security<'a>,
     pub proxy: Option<Proxy>,
+    pub websocket: Option<WebSocket<'a>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WebSocket<'a> {
+    pub path: &'a str,
 }
 
 impl<Codec> Connection<Codec> {
@@ -64,6 +73,20 @@ impl<Codec> Connection<Codec> {
             ),
             Some(proxy) => proxy.connect(config.server, config.port).await?,
         };
+
+        if let Some(websocket) = config.websocket {
+            return Ok(Self::WebSocket(
+                WebSocketConnection::connect(
+                    stream,
+                    config.server,
+                    config.port,
+                    config.security,
+                    websocket.path,
+                    codec,
+                )
+                .await?,
+            ));
+        }
 
         if let Security::Secured {
             accept_invalid_certs,
@@ -119,6 +142,9 @@ impl<Codec> Connection<Codec> {
             Connection::Unsecured(framed) => {
                 framed.into_inner().shutdown().await?;
             }
+            Connection::WebSocket(websocket) => {
+                websocket.shutdown().await?;
+            }
         }
         Ok(())
     }
@@ -132,6 +158,8 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error("proxy error: {0}")]
     Proxy(#[from] proxy::Error),
+    #[error("websocket error: {0}")]
+    WebSocket(#[from] websocket::Error),
 }
 
 macro_rules! delegate {
@@ -139,13 +167,15 @@ macro_rules! delegate {
         match $e {
             $crate::connection::Connection::Tls(framed) => framed.$($t)*,
             $crate::connection::Connection::Unsecured(framed) => framed.$($t)*,
+            $crate::connection::Connection::WebSocket(websocket) => websocket.$($t)*,
         }
     };
 }
 
 impl<Codec> Stream for Connection<Codec>
 where
-    Codec: codec::Decoder,
+    Codec: codec::Decoder + Unpin,
+    Codec::Error: From<std::io::Error>,
 {
     type Item = Result<Codec::Item, Codec::Error>;
 
@@ -159,7 +189,8 @@ where
 
 impl<Item, Codec> Sink<Item> for Connection<Codec>
 where
-    Codec: codec::Encoder<Item>,
+    Codec: codec::Encoder<Item> + Unpin,
+    Codec::Error: From<std::io::Error>,
 {
     type Error = Codec::Error;
 

--- a/irc/src/connection/websocket.rs
+++ b/irc/src/connection/websocket.rs
@@ -16,7 +16,7 @@ use super::{IrcStream, Security, tls};
 
 const BINARY_SUBPROTOCOL: &str = "binary.ircv3.net";
 const TEXT_SUBPROTOCOL: &str = "text.ircv3.net";
-const SUBPROTOCOLS: [&str; 2] = [BINARY_SUBPROTOCOL, TEXT_SUBPROTOCOL];
+const REQUESTED_SUBPROTOCOLS: &str = "binary.ircv3.net, text.ircv3.net";
 const MAX_IRC_WEBSOCKET_MESSAGE_SIZE: usize = 8192;
 
 pub struct WebSocketConnection<Codec> {
@@ -69,8 +69,7 @@ impl<Codec> WebSocketConnection<Codec> {
             websocket_uri(scheme, server, port, path).into_client_request()?;
         request.headers_mut().insert(
             http::header::SEC_WEBSOCKET_PROTOCOL,
-            http::HeaderValue::from_str(&requested_subprotocols())
-                .expect("subprotocols should be valid header value"),
+            http::HeaderValue::from_static(REQUESTED_SUBPROTOCOLS),
         );
 
         let config = WebSocketConfig::default()
@@ -220,10 +219,6 @@ fn websocket_uri(scheme: &str, server: &str, port: u16, path: &str) -> String {
     };
 
     format!("{scheme}://{host}:{port}{path}")
-}
-
-fn requested_subprotocols() -> String {
-    SUBPROTOCOLS.join(", ")
 }
 
 fn mode_from_response(

--- a/irc/src/connection/websocket.rs
+++ b/irc/src/connection/websocket.rs
@@ -1,0 +1,261 @@
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use bytes::BytesMut;
+use futures::{Sink, SinkExt, Stream, StreamExt};
+use tokio_rustls::client::TlsStream;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
+use tokio_tungstenite::tungstenite::{self, Message, Utf8Bytes, http};
+use tokio_tungstenite::{WebSocketStream, client_async_with_config};
+use tokio_util::codec::{Decoder, Encoder};
+use tokio_util::either::Either;
+
+use super::{IrcStream, Security, tls};
+
+const BINARY_SUBPROTOCOL: &str = "binary.ircv3.net";
+const TEXT_SUBPROTOCOL: &str = "text.ircv3.net";
+const SUBPROTOCOLS: [&str; 2] = [BINARY_SUBPROTOCOL, TEXT_SUBPROTOCOL];
+const MAX_IRC_WEBSOCKET_MESSAGE_SIZE: usize = 8192;
+
+pub struct WebSocketConnection<Codec> {
+    stream: WebSocketStream<WebSocketTransport>,
+    codec: Codec,
+    read: BytesMut,
+    mode: Mode,
+}
+
+type WebSocketTransport = Either<IrcStream, TlsStream<IrcStream>>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Mode {
+    Binary,
+    Text,
+}
+
+impl<Codec> WebSocketConnection<Codec> {
+    pub async fn connect(
+        stream: IrcStream,
+        server: &str,
+        port: u16,
+        security: Security<'_>,
+        path: &str,
+        codec: Codec,
+    ) -> Result<Self, Error> {
+        let (scheme, transport) = match security {
+            Security::Unsecured => ("ws", Either::Left(stream)),
+            Security::Secured {
+                accept_invalid_certs,
+                root_cert_path,
+                client_cert_path,
+                client_key_path,
+            } => {
+                let stream = tls::connect(
+                    stream,
+                    server,
+                    accept_invalid_certs,
+                    root_cert_path,
+                    client_cert_path,
+                    client_key_path,
+                )
+                .await?;
+
+                ("wss", Either::Right(stream))
+            }
+        };
+
+        let mut request =
+            websocket_uri(scheme, server, port, path).into_client_request()?;
+        request.headers_mut().insert(
+            http::header::SEC_WEBSOCKET_PROTOCOL,
+            http::HeaderValue::from_str(&requested_subprotocols())
+                .expect("subprotocols should be valid header value"),
+        );
+
+        let config = WebSocketConfig::default()
+            .max_message_size(Some(MAX_IRC_WEBSOCKET_MESSAGE_SIZE))
+            .max_frame_size(Some(MAX_IRC_WEBSOCKET_MESSAGE_SIZE));
+
+        let (stream, response) =
+            client_async_with_config(request, transport, Some(config)).await?;
+
+        Ok(Self {
+            stream,
+            codec,
+            read: BytesMut::new(),
+            mode: mode_from_response(&response)?,
+        })
+    }
+
+    pub async fn shutdown(mut self) -> Result<(), Error> {
+        self.stream.close(None).await?;
+        Ok(())
+    }
+
+    // websocket frames don't include CRLF, so we re-add it for our decoder
+    fn push_crlf_line(&mut self, bytes: &[u8]) {
+        self.read.extend_from_slice(bytes);
+        if !self.read.ends_with(b"\r\n") {
+            self.read.extend_from_slice(b"\r\n");
+        }
+    }
+}
+
+impl<Codec> Stream for WebSocketConnection<Codec>
+where
+    Codec: Decoder + Unpin,
+    Codec::Error: From<io::Error>,
+{
+    type Item = Result<Codec::Item, Codec::Error>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        loop {
+            if let Some(item) = this.codec.decode(&mut this.read)? {
+                return Poll::Ready(Some(Ok(item)));
+            }
+
+            match this.stream.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(Message::Text(text)))) => {
+                    this.push_crlf_line(text.as_ref());
+                }
+                Poll::Ready(Some(Ok(Message::Binary(bytes)))) => {
+                    this.push_crlf_line(&bytes);
+                }
+                Poll::Ready(Some(Ok(Message::Close(_)))) => {
+                    return Poll::Ready(None);
+                }
+                Poll::Ready(Some(Ok(_))) => {}
+                Poll::Ready(Some(Err(error))) => {
+                    return Poll::Ready(Some(Err(websocket_error(error))));
+                }
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}
+
+impl<Item, Codec> Sink<Item> for WebSocketConnection<Codec>
+where
+    Codec: Encoder<Item> + Unpin,
+    Codec::Error: From<io::Error>,
+{
+    type Error = Codec::Error;
+
+    fn poll_ready(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        self.get_mut()
+            .stream
+            .poll_ready_unpin(cx)
+            .map_err(websocket_error)
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: Item) -> Result<(), Self::Error> {
+        let this = self.get_mut();
+        let mut bytes = BytesMut::new();
+
+        this.codec.encode(item, &mut bytes)?;
+        // websocket frames are already message boundaries, so we strip CRLF
+        if bytes.ends_with(b"\r\n") {
+            bytes.truncate(bytes.len() - 2);
+        }
+
+        let bytes = bytes.freeze();
+        let message = match this.mode {
+            Mode::Binary => Message::Binary(bytes),
+            Mode::Text => {
+                let text = Utf8Bytes::try_from(bytes).map_err(|error| {
+                    io::Error::new(io::ErrorKind::InvalidData, error)
+                })?;
+                Message::Text(text)
+            }
+        };
+
+        this.stream
+            .start_send_unpin(message)
+            .map_err(websocket_error)
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        self.get_mut()
+            .stream
+            .poll_flush_unpin(cx)
+            .map_err(websocket_error)
+    }
+
+    fn poll_close(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        self.get_mut()
+            .stream
+            .poll_close_unpin(cx)
+            .map_err(websocket_error)
+    }
+}
+
+fn websocket_uri(scheme: &str, server: &str, port: u16, path: &str) -> String {
+    let host = if server.contains(':') && !server.starts_with('[') {
+        format!("[{server}]")
+    } else {
+        server.to_string()
+    };
+    let path = if path.is_empty() {
+        "/".to_string()
+    } else if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{path}")
+    };
+
+    format!("{scheme}://{host}:{port}{path}")
+}
+
+fn requested_subprotocols() -> String {
+    SUBPROTOCOLS.join(", ")
+}
+
+fn mode_from_response(
+    response: &http::Response<Option<Vec<u8>>>,
+) -> Result<Mode, Error> {
+    let protocol = response
+        .headers()
+        .get(http::header::SEC_WEBSOCKET_PROTOCOL)
+        .and_then(|value| value.to_str().ok());
+
+    match protocol {
+        Some(TEXT_SUBPROTOCOL) => Ok(Mode::Text),
+        Some(BINARY_SUBPROTOCOL) | None => Ok(Mode::Binary),
+        Some(protocol) => Err(Error::UnsupportedSubprotocol(protocol.into())),
+    }
+}
+
+fn websocket_error<E>(error: tungstenite::Error) -> E
+where
+    E: From<io::Error>,
+{
+    io::Error::new(io::ErrorKind::ConnectionAborted, error).into()
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("tls error: {0}")]
+    Tls(#[from] tls::Error),
+    #[error("websocket error: {0}")]
+    WebSocket(#[from] tungstenite::Error),
+    #[error("unsupported websocket subprotocol: {0}")]
+    UnsupportedSubprotocol(String),
+    #[error("io error: {0}")]
+    Io(#[from] io::Error),
+}


### PR DESCRIPTION
Fixes https://github.com/squidowl/halloy/issues/1393.

To test it, add `listen wss://0.0.0.0:8443` to your `soju.conf`, and then add the following to config.

```
[servers.*]
...
port = 8443
use_websocket = true
```