### PR TITLE
Mark-as-Read On-Message Tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Added:
 - The default font is not bundled if default feature `iosevka-font` is disabled.
 - Customize the character used to indicate a nickname was truncated with `display.truncation_character`
 - Support for `draft/chathistory-end` message tag
+- Setting to mark new messages as read for any open buffer when the buffer is scrolled to the bottom and Halloy is focused (`buffer.mark_as_read.on_message`)
 
 Fixed:
 
@@ -36,12 +37,13 @@ Changed:
 
 - On-join topic messages disabled by default (`buffer.server_messages.topic`), instead the topic banner is enabled by default (`buffer.channel.topic_banner`)
 - For filehosts, localhost is now treated as a secure transport when using `servers.<name>.filehost.override_url`
+- `buffer.mark_as_read.on_message = true` is now equivalent to `buffer.mark_as_read.on_message = "open"` (previously equivalent to `buffer.mark_as_read.on_message = "focused"`)
 
 Thanks:
 
 - Contributions: @bb010g, @furudean, @englut, @luca020400, @4e554c4c
 - Bug reports: @bb010g, daniiooo, @e00E, belthesar, @Fingel, @death916
-- Feature requests: @WinnerWind, Shyny, @classabbyamp, @4e554c4c
+- Feature requests: @WinnerWind, Shyny, @classabbyamp, @4e554c4c, @furudean, @englut
 
 # 2026.6 (2026-04-21)
 

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -145,7 +145,7 @@ pub struct MarkAsRead {
     pub on_buffer_close: OnBufferClose,
     pub on_scroll_to_bottom: bool,
     pub on_message_sent: bool,
-    pub on_message: bool,
+    pub on_message: OnMessage,
 }
 
 impl Default for MarkAsRead {
@@ -155,7 +155,7 @@ impl Default for MarkAsRead {
             on_buffer_close: OnBufferClose::default(),
             on_scroll_to_bottom: true,
             on_message_sent: true,
-            on_message: true,
+            on_message: OnMessage::default(),
         }
     }
 }
@@ -188,6 +188,51 @@ impl OnBufferClose {
 #[serde(rename_all = "kebab-case")]
 pub enum OnBufferCloseCondition {
     ScrolledToBottom,
+}
+
+#[derive(Debug, Default, Clone)]
+pub enum OnMessage {
+    #[default]
+    Focused,
+    Open,
+    None,
+}
+
+impl<'de> Deserialize<'de> for OnMessage {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "kebab-case")]
+        pub enum Enum {
+            Focused,
+            Open,
+            None,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum OnMessageCondition {
+            Enum(Enum),
+            Bool(bool),
+        }
+
+        match OnMessageCondition::deserialize(deserializer)? {
+            OnMessageCondition::Enum(on_message) => Ok(match on_message {
+                Enum::Focused => Self::Focused,
+                Enum::Open => Self::Open,
+                Enum::None => Self::None,
+            }),
+            OnMessageCondition::Bool(boolean) => {
+                if boolean {
+                    Ok(Self::Open)
+                } else {
+                    Ok(Self::None)
+                }
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]

--- a/docs/configuration/buffer.md
+++ b/docs/configuration/buffer.md
@@ -735,15 +735,15 @@ on_message_sent = true
 
 ### `on_message`
 
-Marks as read when a new message arrives in the focused buffer and you are at the bottom.
+Marks as read when Halloy is focused and a new message arrives in a buffer that is scrolled to the bottom.  If `"focused"` then only the currently focused buffer will have new messages marked as read, while `"open"` will mark messages as read for any open buffer.
 
 ```toml
 # Type: boolean
-# Values: true, false
-# Default: true
+# Values: "focused", "open", "none"
+# Default: "focused"
 
 [buffer.mark_as_read]
-on_message = true
+on_message = "open"
 ```
 
 ## `close`

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -717,7 +717,7 @@ pub fn view<'a>(
         space::vertical().height(h)
     });
 
-    let show_backlog_divier = if old.is_empty() {
+    let show_backlog_divider = if old.is_empty() {
         // If all newer messages in viewport, only show backlog divider at the top
         // if we don't have any older messages at all (we're scrolled all the way up)
         !has_more_older_messages
@@ -730,7 +730,7 @@ pub fn view<'a>(
         }
     };
 
-    let divider = if show_backlog_divier {
+    let divider = if show_backlog_divider {
         match &config.buffer.backlog_separator.text {
             data::buffer::BacklogText::Hidden => row![
                 container(rule::horizontal(1).style(theme::rule::backlog))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1939,6 +1939,8 @@ fn handle_single_event(
         return;
     };
 
+    handle_on_message_display_mark_as_read(server, &message, dashboard, config);
+
     commands.push(
         dashboard
             .block_and_record_message(
@@ -1974,6 +1976,8 @@ fn handle_with_target_event(
     ) else {
         return;
     };
+
+    handle_on_message_display_mark_as_read(server, &message, dashboard, config);
 
     commands.push(
         dashboard
@@ -2032,16 +2036,15 @@ fn handle_priv_or_notice(
         );
     }
 
+    let should_display_mark_as_read =
+        handle_on_message_display_mark_as_read(server, &msg, dashboard, config);
+
+    let should_mark_as_read =
+        should_display_mark_as_read && msg.triggers_unread();
+
     let window = kind
         .as_ref()
         .and_then(|kind| dashboard.find_window_with_history(kind));
-
-    let should_mark_as_read = config.buffer.mark_as_read.on_message
-        && !msg.blocked
-        && msg.triggers_unread()
-        && kind.as_ref().is_some_and(|kind| {
-            dashboard.is_focused_and_at_bottom(kind, window)
-        });
 
     if let Some(highlight) = highlight {
         handle_highlight(
@@ -2097,13 +2100,6 @@ fn handle_priv_or_notice(
         if let Some(req) = request_attention {
             commands.push(req);
         }
-    }
-
-    if should_mark_as_read && let Some(kind) = kind.as_ref() {
-        dashboard.update_display_read_marker(
-            kind.clone(),
-            history::ReadMarker::from(&msg),
-        );
     }
 
     commands.push(
@@ -2566,4 +2562,31 @@ fn handle_isupport_param(
         }
         _ => (),
     }
+}
+
+fn handle_on_message_display_mark_as_read(
+    server: &Server,
+    message: &data::Message,
+    dashboard: &mut screen::Dashboard,
+    config: &Config,
+) -> bool {
+    let kind = history::Kind::from_server_message(server, message);
+
+    let window = kind
+        .as_ref()
+        .and_then(|kind| dashboard.find_window_with_history(kind));
+
+    let should_display_mark_as_read = config.buffer.mark_as_read.on_message
+        && kind.as_ref().is_some_and(|kind| {
+            dashboard.is_focused_and_at_bottom(kind, window)
+        });
+
+    if should_display_mark_as_read && let Some(kind) = kind.as_ref() {
+        dashboard.update_display_read_marker(
+            kind.clone(),
+            history::ReadMarker::from(message),
+        );
+    }
+
+    should_display_mark_as_read
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ use std::{env, mem};
 use appearance::{Theme, theme};
 use data::capabilities::LabeledResponseContext;
 use data::client::{self, Destination};
+use data::config::buffer::OnMessage;
 use data::config::{self, Config};
 use data::history::filter::FilterChain;
 use data::history::manager::{EchoEvent, ReactionToEcho, ReplyToEcho};
@@ -1604,6 +1605,7 @@ fn handle_client_events(
                     &mut commands,
                     clients,
                     config,
+                    main_window,
                 );
             }
             Event::PrivOrNotice {
@@ -1644,6 +1646,7 @@ fn handle_client_events(
                     &mut commands,
                     clients,
                     config,
+                    main_window,
                 );
             }
             Event::Broadcast(broadcast) => {
@@ -1926,6 +1929,7 @@ fn handle_single_event(
     commands: &mut Vec<Task<Message>>,
     clients: &data::client::Map,
     config: &Config,
+    main_window: &Window,
 ) {
     let Some(message) = create_message(
         server,
@@ -1939,7 +1943,13 @@ fn handle_single_event(
         return;
     };
 
-    handle_on_message_display_mark_as_read(server, &message, dashboard, config);
+    handle_on_message_display_mark_as_read(
+        server,
+        &message,
+        dashboard,
+        config,
+        main_window,
+    );
 
     commands.push(
         dashboard
@@ -1964,6 +1974,7 @@ fn handle_with_target_event(
     commands: &mut Vec<Task<Message>>,
     clients: &data::client::Map,
     config: &Config,
+    main_window: &Window,
 ) {
     let Some(message) = create_message(
         server,
@@ -1977,7 +1988,13 @@ fn handle_with_target_event(
         return;
     };
 
-    handle_on_message_display_mark_as_read(server, &message, dashboard, config);
+    handle_on_message_display_mark_as_read(
+        server,
+        &message,
+        dashboard,
+        config,
+        main_window,
+    );
 
     commands.push(
         dashboard
@@ -2036,8 +2053,13 @@ fn handle_priv_or_notice(
         );
     }
 
-    let should_display_mark_as_read =
-        handle_on_message_display_mark_as_read(server, &msg, dashboard, config);
+    let should_display_mark_as_read = handle_on_message_display_mark_as_read(
+        server,
+        &msg,
+        dashboard,
+        config,
+        main_window,
+    );
 
     let should_mark_as_read =
         should_display_mark_as_read && msg.triggers_unread();
@@ -2569,21 +2591,26 @@ fn handle_on_message_display_mark_as_read(
     message: &data::Message,
     dashboard: &mut screen::Dashboard,
     config: &Config,
+    main_window: &Window,
 ) -> bool {
-    let kind = history::Kind::from_server_message(server, message);
+    if !main_window.focused {
+        return false;
+    }
 
-    let window = kind
-        .as_ref()
-        .and_then(|kind| dashboard.find_window_with_history(kind));
+    let Some(kind) = history::Kind::from_server_message(server, message) else {
+        return false;
+    };
 
-    let should_display_mark_as_read = config.buffer.mark_as_read.on_message
-        && kind.as_ref().is_some_and(|kind| {
-            dashboard.is_focused_and_at_bottom(kind, window)
-        });
+    let should_display_mark_as_read =
+        match config.buffer.mark_as_read.on_message {
+            OnMessage::Focused => dashboard.is_focused_and_at_bottom(&kind),
+            OnMessage::Open => dashboard.is_open_and_at_bottom(&kind),
+            OnMessage::None => false,
+        };
 
-    if should_display_mark_as_read && let Some(kind) = kind.as_ref() {
+    if should_display_mark_as_read {
         dashboard.update_display_read_marker(
-            kind.clone(),
+            kind,
             history::ReadMarker::from(message),
         );
     }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -3359,26 +3359,66 @@ impl Dashboard {
             .redact_message(server, redaction, display_redacted);
     }
 
-    pub fn is_focused_and_at_bottom(
-        &self,
-        kind: &history::Kind,
-        kind_window: Option<window::Id>,
-    ) -> bool {
+    pub fn is_focused_and_at_bottom(&self, kind: &history::Kind) -> bool {
+        let Some((kind_window, kind_pane)) =
+            self.panes.iter().find_map(|(window, _, state)| {
+                state
+                    .buffer
+                    .data()
+                    .and_then(history::Kind::from_buffer)
+                    .is_some_and(|pane_kind| pane_kind == *kind)
+                    .then_some((window, state))
+            })
+        else {
+            return false;
+        };
+
+        if kind_pane
+            .buffer
+            .is_scrolled_to_bottom()
+            .is_none_or(|is_scrolled_to_bottom| !is_scrolled_to_bottom)
+        {
+            return false;
+        }
+
         self.get_focused()
             .is_some_and(|(focused_window, _, focused_pane)| {
-                let is_focused_window = kind_window == Some(focused_window);
+                let is_focused_window = kind_window == focused_window;
 
                 let focused_kind = focused_pane
                     .buffer
                     .data()
                     .and_then(history::Kind::from_buffer);
-                let is_same_buffer = focused_kind.as_ref() == Some(kind);
+                let is_focused_pane = focused_kind.as_ref() == Some(kind);
 
-                let is_at_bottom =
-                    focused_pane.buffer.is_scrolled_to_bottom() == Some(true);
-
-                is_focused_window && is_same_buffer && is_at_bottom
+                is_focused_window && is_focused_pane
             })
+    }
+
+    pub fn is_open_and_at_bottom(&self, kind: &history::Kind) -> bool {
+        let Some((kind_window, kind_pane)) =
+            self.panes.iter().find_map(|(window, _, state)| {
+                state
+                    .buffer
+                    .data()
+                    .and_then(history::Kind::from_buffer)
+                    .is_some_and(|pane_kind| pane_kind == *kind)
+                    .then_some((window, state))
+            })
+        else {
+            return false;
+        };
+
+        if kind_pane
+            .buffer
+            .is_scrolled_to_bottom()
+            .is_none_or(|is_scrolled_to_bottom| !is_scrolled_to_bottom)
+        {
+            return false;
+        }
+
+        self.get_focused()
+            .is_some_and(|(focused_window, _, _)| kind_window == focused_window)
     }
 
     pub fn block_and_record_message(


### PR DESCRIPTION
Changes re: `buffer.mark_as_read.on_message`:
- Display marked as read for messages that don't trigger unread (i.e. prevent non-`PRIVMSG`/`NOTICE` messages from appearing after the backlog divider, or showing the backlog divider if it is set to hide).
- Expands the setting as an enum with `"focused"`, `"open"`, and `"none"` values;  corresponding to only for the focused pane, for all open panes, and for no panes
- Fixes bug/regression where setting would apply even when Halloy was not focused