### PR TITLE
tooltip adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Changed:
 - On-join topic messages disabled by default (`buffer.server_messages.topic`), instead the topic banner is enabled by default (`buffer.channel.topic_banner`)
 - For filehosts, localhost is now treated as a secure transport when using `servers.<name>.filehost.override_url`
 - `buffer.mark_as_read.on_message = true` is now equivalent to `buffer.mark_as_read.on_message = "open"` (previously equivalent to `buffer.mark_as_read.on_message = "focused"`)
+- Tooltips have had their spacing tightened
 
 Thanks:
 

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet, VecDeque, hash_map};
+use std::ops::RangeInclusive;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -79,7 +80,10 @@ pub struct Dashboard {
 pub enum Message {
     Pane(window::Id, pane::Message),
     Sidebar(sidebar::Message),
-    SelectedText(Vec<(f32, String)>, advanced::clipboard::Kind),
+    SelectedText(
+        Vec<(RangeInclusive<f32>, String)>,
+        advanced::clipboard::Kind,
+    ),
     History(history::manager::Message),
     DashboardSaved(Result<(), data::dashboard::Error>),
     Task(command_bar::Message),
@@ -776,20 +780,31 @@ impl Dashboard {
                 );
             }
             Message::SelectedText(contents, clipboard_kind) => {
-                let mut last_y = None;
+                let mut last_y_range: Option<RangeInclusive<f32>> = None;
                 let contents = contents.into_iter().fold(
                     String::new(),
-                    |acc, (y, content)| {
-                        if let Some(_y) = last_y {
-                            let new_line = if y == _y { "" } else { "\n" };
-                            last_y = Some(y);
+                    |acc, (y_range, content)| {
+                        let content = if let Some(last_y_range) = &last_y_range
+                        {
+                            // If the widget's y ranges do not overlap, then add
+                            // a new line before appending the selected content.
+                            let new_line = if y_range.start()
+                                < last_y_range.end()
+                                && last_y_range.start() < y_range.end()
+                            {
+                                ""
+                            } else {
+                                "\n"
+                            };
 
                             format!("{acc}{new_line}{content}")
                         } else {
-                            last_y = Some(y);
-
                             content
-                        }
+                        };
+
+                        last_y_range = Some(y_range);
+
+                        content
                     },
                 );
 

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -570,7 +570,9 @@ fn query_title<'a>(
                     container(
                         text(format!("Authenticated as {accountname}"))
                             .style(theme::text::secondary)
-                            .line_height(font::line_height())
+                            .line_height(
+                                iced::widget::text::LineHeight::Relative(1.0),
+                            )
                             .font_maybe(
                                 theme::font_style::secondary(theme)
                                     .map(font::get),

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -148,7 +148,7 @@ pub fn bot_icon<'a, M>(
     style: impl Fn(&Theme) -> selectable_text::Style + 'a,
 ) -> Element<'a, M> {
     selectable_text(String::from("\u{1F916}"))
-        .line_height(LineHeight::Relative(1.45))
+        .line_height(LineHeight::Relative(1.0))
         .font(*font::ICON)
         .style(style)
         .size(ICON_SIZE)

--- a/src/widget/reaction_row.rs
+++ b/src/widget/reaction_row.rs
@@ -107,10 +107,12 @@ where
             text(*reaction_text)
                 .shaping(iced::widget::text::Shaping::Advanced)
                 .size(tooltip_emoji_size)
+                .line_height(LineHeight::Relative(1.0))
                 .style(theme::text::primary),
             tooltip_content,
         ]
-        .spacing(6);
+        .spacing(6)
+        .align_y(alignment::Vertical::Center);
 
         iced::widget::tooltip(
             content,

--- a/src/widget/reaction_row.rs
+++ b/src/widget/reaction_row.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 
 use data::user::NickRef;
+use iced::widget::text::LineHeight;
 pub use iced::widget::tooltip::Position;
 use iced::widget::{Space, button, container, row};
 use iced::{alignment, padding};
@@ -79,6 +80,7 @@ where
                 text(*nick)
                     .shaping(iced::widget::text::Shaping::Advanced)
                     .style(theme::text::secondary)
+                    .line_height(LineHeight::Relative(1.0))
                     .into()
             }),
         );
@@ -86,7 +88,8 @@ where
             tooltip_content = tooltip_content.push(
                 text(format!("and {hidden_count} others..."))
                     .shaping(iced::widget::text::Shaping::Advanced)
-                    .style(theme::text::secondary),
+                    .style(theme::text::secondary)
+                    .line_height(LineHeight::Relative(1.0)),
             );
         }
 

--- a/src/widget/selectable_text.rs
+++ b/src/widget/selectable_text.rs
@@ -1,3 +1,5 @@
+use std::ops::RangeInclusive;
+
 use iced::advanced::renderer::Quad;
 use iced::advanced::text::{Paragraph, paragraph};
 use iced::advanced::widget::{Operation, Tree, operation, tree};
@@ -503,11 +505,11 @@ impl Interaction {
 // }
 
 pub fn selected<Message: Send + 'static>(
-    f: fn(Vec<(f32, String)>) -> Message,
+    f: fn(Vec<(RangeInclusive<f32>, String)>) -> Message,
 ) -> Task<Message> {
     struct Selected<T> {
-        contents: Vec<(f32, String)>,
-        f: fn(Vec<(f32, String)>) -> T,
+        contents: Vec<(RangeInclusive<f32>, String)>,
+        f: fn(Vec<(RangeInclusive<f32>, String)>) -> T,
     }
 
     impl<T> Operation<T> for Selected<T> {
@@ -524,7 +526,10 @@ pub fn selected<Message: Send + 'static>(
             state: &mut dyn std::any::Any,
         ) {
             if let Some(content) = state.downcast_ref::<String>() {
-                self.contents.push((bounds.y, content.clone()));
+                self.contents.push((
+                    RangeInclusive::new(bounds.y, bounds.y + bounds.height),
+                    content.clone(),
+                ));
             }
         }
 

--- a/src/widget/tooltip.rs
+++ b/src/widget/tooltip.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use iced::widget::text::LineHeight;
 pub use iced::widget::tooltip::Position;
 use iced::widget::{container, text};
 
@@ -18,7 +19,7 @@ pub fn tooltip<'a, Message: 'a>(
             container(
                 text(tooltip.into())
                     .style(theme::text::secondary)
-                    .line_height(font::line_height())
+                    .line_height(LineHeight::Relative(1.0))
                     .font_maybe(
                         theme::font_style::secondary(theme).map(font::get),
                     ),

--- a/src/widget/user_display.rs
+++ b/src/widget/user_display.rs
@@ -5,10 +5,11 @@ use data::target::{Query, TargetRef};
 use data::user::AccessLevel;
 use data::{Config, User, metadata};
 use iced::Color;
+use iced::alignment::Vertical;
 use iced::widget::{container, row};
 use unicode_segmentation::UnicodeSegmentation;
 
-use super::{Element, selectable_text};
+use super::{Element, selectable_text, text};
 use crate::widget::TextExt as _;
 use crate::{Theme, font, theme, widget};
 
@@ -101,8 +102,16 @@ impl UserDisplay {
         });
 
         let base = self.base.into_element(
-            user, color, is_away, is_offline, dimmed, size, selectable, theme,
+            user,
+            color,
+            is_away,
+            is_offline,
+            dimmed,
+            size,
+            selectable,
+            theme,
             config,
+            font::line_height(),
         );
 
         let base = if highlight {
@@ -123,19 +132,37 @@ impl UserDisplay {
                 container(container(if tooltip.bot_icon {
                     row![
                         tooltip.into_element(
-                            user, color, false, false, None, None, true, theme,
+                            user,
+                            color,
+                            false,
+                            false,
+                            None,
+                            None,
+                            true,
+                            theme,
                             config,
+                            iced::widget::text::LineHeight::Relative(1.0),
                         ),
-                        selectable_text(String::from(
-                            " has marked itself as a bot"
-                        ))
+                        text(String::from(" has marked itself as a bot"))
+                            .style(theme::text::secondary)
+                            .line_height(
+                                iced::widget::text::LineHeight::Relative(1.0),
+                            )
                     ]
                     .spacing(theme::ICON_SPACE)
                     .into()
                 } else {
                     tooltip.into_element(
-                        user, color, false, false, None, None, true, theme,
+                        user,
+                        color,
+                        false,
+                        false,
+                        None,
+                        None,
+                        true,
+                        theme,
                         config,
+                        iced::widget::text::LineHeight::Relative(1.0),
                     )
                 }))
                 .style(theme::container::tooltip)
@@ -270,6 +297,7 @@ impl UserDisplayData {
         selectable: bool,
         theme: &'a Theme,
         config: &'a Config,
+        line_height: iced::widget::text::LineHeight,
     ) -> Element<'a, M> {
         let style = theme::selectable_text::dimmed(
             theme::selectable_text::nickname(
@@ -279,7 +307,7 @@ impl UserDisplayData {
             dimmed,
         );
 
-        self.render(style, is_offline, size, selectable, theme)
+        self.render(style, is_offline, size, selectable, theme, line_height)
     }
 
     fn render<'a, M: 'a>(
@@ -289,6 +317,7 @@ impl UserDisplayData {
         size: Option<f32>,
         selectable: bool,
         theme: &'a Theme,
+        line_height: iced::widget::text::LineHeight,
     ) -> Element<'a, M> {
         let font =
             theme::font_style::nickname(theme, is_offline).map(font::get);
@@ -302,12 +331,14 @@ impl UserDisplayData {
                         .style(move |_| style)
                         .font_maybe(f)
                         .size_maybe(size)
+                        .line_height(line_height)
                         .into()
                 } else {
                     widget::text(content)
                         .color_maybe(style.color)
                         .font_maybe(f)
                         .size_maybe(size)
+                        .line_height(line_height)
                         .into()
                 }
             };
@@ -318,7 +349,7 @@ impl UserDisplayData {
             } else {
                 widget::text(String::from("\u{1F916}"))
                     .color_maybe(style.color)
-                    .line_height(iced::widget::text::LineHeight::Relative(1.45))
+                    .line_height(line_height)
                     .font(*font::ICON)
                     .size(theme::ICON_SIZE)
                     .into()
@@ -329,6 +360,7 @@ impl UserDisplayData {
                 self.right.map(|right| text_piece(right, font)),
             ]
             .spacing(theme::ICON_SPACE)
+            .align_y(Vertical::Center)
             .into()
         } else {
             text_piece(self.left, font)


### PR DESCRIPTION
- render bot mode tooltip with a color consistent to other tooltips (with `theme::text::secondary` instead of `theme::text::primary`)
- simplify bot mode vertical alignment independent of font
- all tooltips now have a text align of 1.0. this is more consistent with how tooltips are handled across different UIs


<details>
<summary>
before/afters
</summary>

<img width="1084" height="854" alt="Screenshot 2026-05-08 at 4 48 26 PM" src="https://github.com/user-attachments/assets/be43d4f4-224d-41bf-b20b-c498fa303fa1" />
<img width="1084" height="854" alt="Screenshot 2026-05-08 at 4 48 29 PM" src="https://github.com/user-attachments/assets/a09cef86-8182-42ba-bfdc-0b78e6dc1e2c" />
<img width="1084" height="854" alt="Screenshot 2026-05-08 at 4 48 42 PM" src="https://github.com/user-attachments/assets/f85317c3-857b-4825-9ef7-27c1feafa579" />
<img width="1084" height="854" alt="Screenshot 2026-05-08 at 4 48 33 PM" src="https://github.com/user-attachments/assets/0ceb7210-39ff-44ba-af83-36162e74c449" />

</details>


