### PR TITLE
Reaction Tweaks

### DIFF
--- a/src/appearance/theme/button.rs
+++ b/src/appearance/theme/button.rs
@@ -144,6 +144,30 @@ pub fn picker(theme: &Theme, status: Status, is_selected: bool) -> Style {
     button(foreground, background, background_hover, status)
 }
 
+pub fn reaction(
+    theme: &Theme,
+    status: Status,
+    already_reacted: bool,
+    selection: bool,
+) -> Style {
+    let foreground = theme.styles().text.secondary.color;
+    let button_colors = theme.styles().buttons.secondary;
+
+    let background = match (selection, already_reacted) {
+        (true, _) => button_colors.background_selected,
+        (false, true) => button_colors.background_hover,
+        (false, false) => button_colors.background,
+    };
+
+    let background_hover = match (selection, already_reacted) {
+        (true, _) => button_colors.background_selected_hover,
+        (false, true) => button_colors.background_selected,
+        (false, false) => button_colors.background_hover,
+    };
+
+    button(foreground, background, background_hover, status)
+}
+
 pub fn bare(_theme: &Theme, status: Status) -> Style {
     match status {
         Status::Active | Status::Pressed | Status::Hovered => Style {

--- a/src/buffer/channel_discovery.rs
+++ b/src/buffer/channel_discovery.rs
@@ -125,7 +125,7 @@ pub fn view<'a>(
                 )
                 .on_select(Message::SelectServer)
                 .placeholder("Select server"),
-                text_input("Search..", &state.search_query)
+                text_input("Search...", &state.search_query)
                     .id(state.search_query_id.clone())
                     .style(move |theme, status| {
                         // Show the disabled text_input as active, since we only

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -368,6 +368,7 @@ impl<'a> ChannelQueryLayout<'a> {
             message,
             self.our_nick,
             self.config.font.size.map_or(theme::TEXT_SIZE, f32::from),
+            self.config.font.only_emojis_size.map(f32::from),
             self.config.buffer.channel.message.max_reaction_display,
             on_react,
             on_unreact,

--- a/src/screen/dashboard/modal/reaction.rs
+++ b/src/screen/dashboard/modal/reaction.rs
@@ -7,7 +7,7 @@ use iced::widget::{
 };
 use iced::{Length, Task};
 
-use crate::widget::{Element, Row, text};
+use crate::widget::{Element, Row, key_press, text};
 use crate::{emoji, theme, widget};
 
 const MODAL_WIDTH: f32 = 380.0;
@@ -18,14 +18,17 @@ const EMOJI_BUTTON_HEIGHT: f32 = 32.0;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct State {
     msgid: message::Id,
-    selected_reactions: HashSet<Cow<'static, str>>,
+    already_reacted: HashSet<Cow<'static, str>>,
     search_query_id: iced::widget::Id,
     search_query: String,
+    selection: Option<usize>,
 }
 
 #[derive(Debug, Clone)]
 pub enum Message {
     SearchChanged(String),
+    Tab(bool),
+    SearchSelect,
     SelectEmoji(Cow<'static, str>),
 }
 
@@ -39,15 +42,16 @@ pub enum Event {
 }
 
 impl State {
-    pub fn new(msgid: message::Id, selected_reactions: Vec<String>) -> Self {
+    pub fn new(msgid: message::Id, already_reacted: Vec<String>) -> Self {
         Self {
             msgid,
-            selected_reactions: selected_reactions
+            already_reacted: already_reacted
                 .into_iter()
                 .map(Cow::Owned)
                 .collect(),
             search_query_id: iced::widget::Id::unique(),
             search_query: String::new(),
+            selection: None,
         }
     }
 
@@ -55,10 +59,56 @@ impl State {
         match message {
             Message::SearchChanged(search_query) => {
                 self.search_query = search_query;
+
+                let filtered = self.filtered_emojis();
+
+                if filtered.is_empty() {
+                    self.selection = None;
+                } else {
+                    self.selection = Some(0);
+                }
+
                 None
             }
+            Message::Tab(shift) => {
+                let filtered = self.filtered_emojis();
+
+                if filtered.is_empty() {
+                    self.selection = None;
+                } else {
+                    self.selection =
+                        Some(if let Some(selection) = self.selection {
+                            if shift {
+                                if selection == 0 {
+                                    filtered.len() - 1
+                                } else {
+                                    selection - 1
+                                }
+                            } else {
+                                (selection + 1) % filtered.len()
+                            }
+                        } else if shift {
+                            filtered.len() - 1
+                        } else {
+                            0
+                        });
+                }
+
+                None
+            }
+            Message::SearchSelect => self.selection.and_then(|selection| {
+                self.filtered_emojis().get(selection).map(|emoji| {
+                    let unreact = self.already_reacted.contains(emoji.as_str());
+
+                    Event::Toggle {
+                        msgid: self.msgid.clone(),
+                        text: Cow::Borrowed(emoji.as_str()),
+                        unreact,
+                    }
+                })
+            }),
             Message::SelectEmoji(text) => {
-                let unreact = self.selected_reactions.contains(&text);
+                let unreact = self.already_reacted.contains(&text);
 
                 Some(Event::Toggle {
                     msgid: self.msgid.clone(),
@@ -80,13 +130,18 @@ impl State {
             }
         })
     }
+
+    fn filtered_emojis(&self) -> Vec<&'static emojis::Emoji> {
+        let query = normalized_query(&self.search_query);
+
+        emoji::matching_emojis(&query)
+    }
 }
 
 pub fn view<'a>(state: &'a State, config: &'a Config) -> Element<'a, Message> {
-    let query = normalized_query(&state.search_query);
-    let filtered = filtered_emojis(&query);
+    let filtered = state.filtered_emojis();
     let has_results = !filtered.is_empty();
-    let grid = emoji_grid(&filtered, &state.selected_reactions);
+    let grid = emoji_grid(&filtered, &state.already_reacted, state.selection);
 
     let body: Element<'a, Message> = if has_results {
         Scrollable::new(container(grid).width(Length::Fill))
@@ -108,10 +163,21 @@ pub fn view<'a>(state: &'a State, config: &'a Config) -> Element<'a, Message> {
     };
 
     let content = column![
-        text_input("Search..", &state.search_query)
-            .id(state.search_query_id.clone())
-            .on_input(Message::SearchChanged)
-            .padding(8),
+        key_press(
+            key_press(
+                text_input("Search...", &state.search_query)
+                    .id(state.search_query_id.clone())
+                    .on_input(Message::SearchChanged)
+                    .on_submit(Message::SearchSelect)
+                    .padding(8),
+                key_press::Key::Named(key_press::Named::Tab),
+                key_press::Modifiers::SHIFT,
+                Message::Tab(true),
+            ),
+            key_press::Key::Named(key_press::Named::Tab),
+            key_press::Modifiers::default(),
+            Message::Tab(false),
+        ),
         body
     ]
     .spacing(12)
@@ -127,14 +193,17 @@ pub fn view<'a>(state: &'a State, config: &'a Config) -> Element<'a, Message> {
 
 fn emoji_grid<'a>(
     emojis: &[&'static emojis::Emoji],
-    selected_reactions: &HashSet<Cow<'static, str>>,
+    already_reacted: &HashSet<Cow<'static, str>>,
+    selection: Option<usize>,
 ) -> Element<'a, Message> {
     emojis
         .iter()
-        .fold(Row::new().spacing(4), |row, emoji| {
+        .enumerate()
+        .fold(Row::new().spacing(4), |row, (index, emoji)| {
             row.push(emoji_button(
                 emoji,
-                selected_reactions.contains(emoji.as_str()),
+                already_reacted.contains(emoji.as_str()),
+                selection.is_some_and(|selection| selection == index),
             ))
         })
         .wrap()
@@ -143,7 +212,8 @@ fn emoji_grid<'a>(
 
 fn emoji_button<'a>(
     emoji: &'static emojis::Emoji,
-    selected: bool,
+    already_reacted: bool,
+    selection: bool,
 ) -> widget::Button<'a, Message> {
     button(
         container(text(emoji.as_str()).size(16))
@@ -155,13 +225,9 @@ fn emoji_button<'a>(
     .width(Length::Fixed(EMOJI_BUTTON_WIDTH))
     .height(Length::Fixed(EMOJI_BUTTON_HEIGHT))
     .style(move |theme, status| {
-        theme::button::secondary(theme, status, selected)
+        theme::button::reaction(theme, status, already_reacted, selection)
     })
     .on_press(Message::SelectEmoji(Cow::Borrowed(emoji.as_str())))
-}
-
-fn filtered_emojis(query: &str) -> Vec<&'static emojis::Emoji> {
-    emoji::matching_emojis(query)
 }
 
 fn normalized_query(query: &str) -> String {

--- a/src/widget/reaction_row.rs
+++ b/src/widget/reaction_row.rs
@@ -21,6 +21,7 @@ pub fn reaction_row<'a, M, F1, F2>(
     message: &'a data::Message,
     our_nick: Option<NickRef<'a>>,
     font_size: f32,
+    only_emojis_size: Option<f32>,
     max_reaction_display: u32,
     on_react: Option<F1>,
     on_unreact: Option<F2>,
@@ -88,6 +89,25 @@ where
                     .style(theme::text::secondary),
             );
         }
+
+        let tooltip_emoji_size = if let Some(only_emojis_size) =
+            only_emojis_size
+            && UnicodeSegmentation::graphemes(*reaction_text, true)
+                .all(|grapheme| emojis::get(grapheme).is_some())
+        {
+            only_emojis_size
+        } else {
+            font_size
+        };
+
+        let tooltip_content = row![
+            text(*reaction_text)
+                .shaping(iced::widget::text::Shaping::Advanced)
+                .size(tooltip_emoji_size)
+                .style(theme::text::primary),
+            tooltip_content,
+        ]
+        .spacing(6);
 
         iced::widget::tooltip(
             content,


### PR DESCRIPTION
Two potential tweaks to reactions:
- Allow reactions to be selected using the keyboard. E.g. entering entering `fire` in the search box and hitting enter will react with :fire:, and the selection can be moved using (`shift` +) `tab`.
- Show the reaction with size `font.size` or `font.only_emojis_size` (if it's only emojis) in the tooltip.