### PR TITLE
Add client side ping for websocket keepalive

### DIFF
--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -105,6 +105,9 @@ pub struct Server {
     pub use_websocket: bool,
     /// The WebSocket request path.
     pub websocket_path: String,
+    /// The WebSocket ping interval in seconds.
+    #[serde(deserialize_with = "deserialize_who_poll_interval")]
+    pub websocket_ping_interval: Duration,
     /// On `true`, all certificate validations are skipped. Defaults to `false`.
     pub dangerously_accept_invalid_certs: bool,
     /// The path to the root TLS certificate for this server in PEM format.
@@ -188,6 +191,7 @@ impl Server {
             proxy: proxy.map(From::from),
             websocket: self.use_websocket.then_some(connection::WebSocket {
                 path: &self.websocket_path,
+                ping_interval: self.websocket_ping_interval,
             }),
         }
     }
@@ -244,6 +248,7 @@ impl Default for Server {
             use_tls: true,
             use_websocket: false,
             websocket_path: "/".into(),
+            websocket_ping_interval: Duration::from_secs(60),
             dangerously_accept_invalid_certs: Default::default(),
             root_cert_path: Option::default(),
             sasl: Option::default(),

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -396,6 +396,19 @@ The WebSocket request path. For soju HTTPS listeners or reverse proxies, this is
 websocket_path = "/"
 ```
 
+## `websocket_ping_interval`
+
+The interval in seconds at which to send WebSocket pings when [`use_websocket`](#use_websocket) is `true`. This is in addition to regular IRC pings controlled by [`ping_time`](#ping_time).
+
+```toml
+# Type: integer
+# Values: any non-negative integer
+# Default: 60
+
+[servers.<name>]
+websocket_ping_interval = 60
+```
+
 ## `dangerously_accept_invalid_certs`
 
 When `true`, all certificate validations are skipped.

--- a/irc/src/connection.rs
+++ b/irc/src/connection.rs
@@ -2,6 +2,7 @@ use std::net::IpAddr;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Once;
+use std::time::Duration;
 
 #[cfg(feature = "tor")]
 use arti_client::DataStream as TorStream;
@@ -63,6 +64,7 @@ pub struct Config<'a> {
 #[derive(Debug, Clone)]
 pub struct WebSocket<'a> {
     pub path: &'a str,
+    pub ping_interval: Duration,
 }
 
 impl<Codec> Connection<Codec> {
@@ -82,6 +84,7 @@ impl<Codec> Connection<Codec> {
                     config.port,
                     config.security,
                     websocket.path,
+                    websocket.ping_interval,
                     codec,
                 )
                 .await?,

--- a/irc/src/connection/websocket.rs
+++ b/irc/src/connection/websocket.rs
@@ -1,9 +1,11 @@
 use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::time::Duration;
 
 use bytes::BytesMut;
 use futures::{Sink, SinkExt, Stream, StreamExt};
+use tokio::time::Interval;
 use tokio_rustls::client::TlsStream;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
@@ -24,6 +26,7 @@ pub struct WebSocketConnection<Codec> {
     codec: Codec,
     read: BytesMut,
     mode: Mode,
+    ping_interval: Interval,
 }
 
 type WebSocketTransport = Either<IrcStream, TlsStream<IrcStream>>;
@@ -41,6 +44,7 @@ impl<Codec> WebSocketConnection<Codec> {
         port: u16,
         security: Security<'_>,
         path: &str,
+        ping_interval: Duration,
         codec: Codec,
     ) -> Result<Self, Error> {
         let (scheme, transport) = match security {
@@ -84,6 +88,7 @@ impl<Codec> WebSocketConnection<Codec> {
             codec,
             read: BytesMut::new(),
             mode: mode_from_response(&response)?,
+            ping_interval: tokio::time::interval(ping_interval),
         })
     }
 
@@ -113,6 +118,16 @@ where
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
+
+        // This is a best effort attempt at sending pings at regular intervals.
+        if this.ping_interval.poll_tick(cx).is_ready()
+            && this.stream.poll_ready_unpin(cx).is_ready()
+        {
+            let _ = this
+                .stream
+                .start_send_unpin(Message::Ping(bytes::Bytes::new()));
+            let _ = this.stream.poll_flush_unpin(cx);
+        }
 
         loop {
             if let Some(item) = this.codec.decode(&mut this.read)? {


### PR DESCRIPTION
This differs from the IRC ping as we don't send
anything on the wire, just a Message::Ping.

This is "needed" on servers behind a cloudflare proxy.
