### PR TITLE
No more read & unread button

### DIFF
--- a/src/icon.rs
+++ b/src/icon.rs
@@ -101,10 +101,6 @@ pub fn share<'a>() -> Text<'a> {
     to_text('\u{E813}')
 }
 
-pub fn mark_as_read<'a>() -> Text<'a> {
-    to_text('\u{E817}')
-}
-
 pub fn config<'a>() -> Text<'a> {
     to_text('\u{F1C9}')
 }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -72,6 +72,7 @@ pub struct Dashboard {
     typing_animation: Option<buffer::typing::Animation>,
     http_client: Option<Arc<reqwest::Client>>,
     buffer_settings: dashboard::BufferSettings,
+    pending_mark_as_read: HashSet<history::Kind>,
     pub filehost: filehost::Manager,
 }
 
@@ -159,6 +160,7 @@ impl Dashboard {
             typing_animation: None,
             http_client: http_client_from_config(config).map(Arc::new),
             buffer_settings: dashboard::BufferSettings::default(),
+            pending_mark_as_read: HashSet::new(),
             filehost: filehost::Manager::new(),
         };
 
@@ -335,7 +337,15 @@ impl Dashboard {
             Message::Pane(window, message) => {
                 match message {
                     pane::Message::PaneClicked(pane) => {
-                        return (self.focus_pane(window, pane), None);
+                        return (
+                            self.focus_pane(window, pane).chain(
+                                Task::done(Message::Pane(
+                                    window,
+                                    pane::Message::MarkAsRead,
+                                ))
+                            ),
+                            None,
+                        );
                     }
                     pane::Message::PaneResized(pane_grid::ResizeEvent {
                         split,
@@ -813,6 +823,15 @@ impl Dashboard {
                 {
                     match event {
                         history::manager::Event::Loaded(kind) => {
+                            if self.pending_mark_as_read.remove(&kind) {
+                                mark_as_read(
+                                    kind.clone(),
+                                    &mut self.history,
+                                    clients,
+                                    TokenPriority::User,
+                                );
+                            }
+
                             let buffer = kind.into();
 
                             if let Some((window, pane, state)) =
@@ -2887,7 +2906,15 @@ impl Dashboard {
                     advanced::clipboard::Kind::Standard,
                 )
             }),
-            LeftClick => self.refocus_pane(),
+            LeftClick => {
+                let Focus { window, pane: _ } = self.focus;
+                self.refocus_pane().chain(
+                    Task::done(Message::Pane(
+                        window,
+                        pane::Message::MarkAsRead,
+                    ))
+                )
+            }
             UpdatePrimaryClipboard => {
                 selectable_text::selected(|selected_text| {
                     Message::SelectedText(
@@ -3026,6 +3053,10 @@ impl Dashboard {
                     Task::batch(vec![
                         self.reset_pane(window, pane),
                         self.focus_pane(window, pane),
+                        Task::done(Message::Pane(
+                            window,
+                            pane::Message::MarkAsRead,
+                        )),
                     ])
                 } else {
                     log::error!("Didn't find any panes to replace");
@@ -3038,7 +3069,13 @@ impl Dashboard {
                     if pane.buffer.data().as_ref() == Some(&buffer) {
                         self.focus = Focus { window, pane: id };
 
-                        return self.focus_pane(window, id);
+                        return Task::batch(vec![
+                            self.focus_pane(window, id),
+                            Task::done(Message::Pane(
+                                window,
+                                pane::Message::MarkAsRead,
+                            )),
+                        ]);
                     }
                 }
 
@@ -3056,7 +3093,13 @@ impl Dashboard {
                             });
                             self.last_changed = Some(Instant::now());
 
-                            return self.focus_pane(self.main_window(), *id);
+                            return Task::batch(vec![
+                                self.focus_pane(self.main_window(), *id),
+                                Task::done(Message::Pane(
+                                    self.main_window(),
+                                    pane::Message::MarkAsRead,
+                                )),
+                            ]);
                         }
                     }
                 }
@@ -3128,7 +3171,13 @@ impl Dashboard {
                 );
 
                 if let Some((pane, _)) = result {
-                    return self.focus_pane(self.main_window(), pane);
+                    return Task::batch(vec![
+                        self.focus_pane(self.main_window(), pane),
+                        Task::done(Message::Pane(
+                            self.main_window(),
+                            pane::Message::MarkAsRead,
+                        )),
+                    ]);
                 }
 
                 Task::none()
@@ -4281,8 +4330,29 @@ impl Dashboard {
             typing_animation: None,
             http_client: http_client_from_config(config).map(Arc::new),
             buffer_settings: data.buffer_settings.clone(),
+            pending_mark_as_read: HashSet::new(),
             filehost: filehost::Manager::new(),
         };
+
+        let mut pending_mark_as_read = dashboard
+            .panes
+            .iter()
+            .filter_map(|(_, _, pane)| {
+                pane.buffer
+                    .data()
+                    .and_then(history::Kind::from_buffer)
+            })
+            .collect::<HashSet<_>>();
+
+        for pane in &data.popout_panes {
+            if let data::Pane::Buffer { buffer } = pane {
+                if let Some(kind) = history::Kind::from_buffer(buffer.clone()) {
+                    pending_mark_as_read.insert(kind);
+                }
+            }
+        }
+
+        dashboard.pending_mark_as_read = pending_mark_as_read;
 
         let mut tasks = vec![sidebar_task.map(Message::Sidebar)];
 

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -3858,10 +3858,10 @@ impl Dashboard {
                 config,
             );
 
-            if config.buffer.close.query.close()
-                && let Some(history::Kind::Query(server, nick)) =
-                    state.buffer.data().and_then(history::Kind::from_buffer)
+            if let Some(history::Kind::Query(server, nick)) =
+                state.buffer.data().and_then(history::Kind::from_buffer)
             {
+                // Always close query history when closing pane to remove from sidebar
                 tasks.push(
                     self.history
                         .close(history::Kind::Query(server, nick), clients)
@@ -3896,6 +3896,9 @@ impl Dashboard {
             );
             return Task::batch(tasks);
         }
+
+        // Update history tracking to reflect closed pane
+        tasks.push(self.track(Some(clients)));
 
         Task::batch(tasks)
     }

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -251,7 +251,7 @@ impl TitleBar {
     fn view<'a>(
         &'a self,
         buffer: &Buffer,
-        history: &'a history::Manager,
+        _history: &'a history::Manager,
         title: Element<'a, Message>,
         _id: pane_grid::Pane,
         panes: usize,
@@ -267,49 +267,12 @@ impl TitleBar {
     ) -> widget::TitleBar<'a, Message> {
         let maybe_buffer_kind =
             buffer.data().and_then(history::Kind::from_buffer);
-        let can_mark_as_read = if let Some(kind) = &maybe_buffer_kind {
-            history.can_mark_as_read(kind)
-        } else {
-            false
-        };
-        let has_unread = if let Some(kind) = &maybe_buffer_kind {
-            history.has_unread(kind)
-        } else {
-            false
-        };
 
         // Pane controls.
         let controls = row![
             if maybe_buffer_kind.is_some() {
-                let mark_as_read_button = button(center(icon::mark_as_read()))
-                    .padding(5)
-                    .width(22)
-                    .height(22)
-                    .on_press_maybe(
-                        can_mark_as_read.then_some(Message::MarkAsRead),
-                    )
-                    .style(move |theme, status| {
-                        theme::button::secondary(theme, status, has_unread)
-                    });
-
-                let mark_as_read_button_with_tooltip = tooltip(
-                    mark_as_read_button,
-                    show_tooltips.then_some(if can_mark_as_read {
-                        "Mark messages as read"
-                    } else {
-                        "No unread messages"
-                    }),
-                    tooltip::Position::Bottom,
-                    theme,
-                );
-                Some(mark_as_read_button_with_tooltip)
-            } else {
-                None
-            },
-            {
-                if maybe_buffer_kind.is_some() {
-                    let can_scroll_to_bottom =
-                        !buffer.is_scrolled_to_bottom().unwrap_or_default();
+                let can_scroll_to_bottom =
+                    !buffer.is_scrolled_to_bottom().unwrap_or_default();
                     let scroll_to_bottom_button =
                         button(center(icon::scroll_to_bottom()))
                             .padding(5)
@@ -336,8 +299,7 @@ impl TitleBar {
                     Some(scroll_to_bottom_button_with_tooltip)
                 } else {
                     None
-                }
-            },
+                },
             if let Buffer::Channel(state) = &buffer {
                 if let Some(topic) =
                     clients.get_channel_topic(&state.server, &state.target)

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -813,17 +813,13 @@ fn upstream_buffer_button<'a>(
         (state.buffer.upstream() == Some(&buffer)).then_some((window_id, pane))
     });
 
-    let has_unread = if config.sidebar.unread_indicator.show_on_open_buffers
-        || open.is_none()
-    {
+    let has_unread = if open.is_none() {
         history.has_unread(&kind)
     } else {
         false
     };
 
-    let has_highlight = if config.sidebar.unread_indicator.show_on_open_buffers
-        || open.is_none()
-    {
+    let has_highlight = if open.is_none() {
         history.has_highlight(&kind)
     } else {
         false


### PR DESCRIPTION
Opened visible panes are always read, no more toggles and:
- when a buffer is open in at least one panel, the sidebar always considers it read
- unread/highlight badges are not shown for already opened buffers
- logic no longer depends on config.sidebar.unread_indicator.show_on_open_buffers for open buffers