### PR TITLE
Settings for Hiding URLs in Messages with Visible Previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Added:
 - Customize the character used to indicate a nickname was truncated with `display.truncation_character`
 - Support for `draft/chathistory-end` message tag
 - Setting to mark new messages as read for any open buffer when the buffer is scrolled to the bottom and Halloy is focused (`buffer.mark_as_read.on_message`)
+- Setting to hide the text of messages that contain only a single URL, when the URL's preview is visible (`preview.hide_url`)
 
 Fixed:
 

--- a/data/src/config/preview.rs
+++ b/data/src/config/preview.rs
@@ -14,8 +14,8 @@ use crate::{Server, isupport};
 pub struct Preview {
     pub enabled: Enabled,
     pub exclude: Exclude,
-    #[serde(default = "default_max_per_message")]
     pub max_per_message: usize,
+    pub hide_url: HideUrlCondition,
     pub request: Request,
     pub card: Card,
     pub image: Image,
@@ -26,7 +26,8 @@ impl Default for Preview {
         Self {
             enabled: Enabled::default(),
             exclude: Exclude::default(),
-            max_per_message: default_max_per_message(),
+            max_per_message: 1,
+            hide_url: HideUrlCondition::default(),
             request: Request::default(),
             card: Card::default(),
             image: Image::default(),
@@ -34,8 +35,12 @@ impl Default for Preview {
     }
 }
 
-fn default_max_per_message() -> usize {
-    1
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum HideUrlCondition {
+    #[default]
+    ContainsOnlyUrl,
+    Never,
 }
 
 impl Preview {

--- a/data/src/config/preview.rs
+++ b/data/src/config/preview.rs
@@ -15,7 +15,6 @@ pub struct Preview {
     pub enabled: Enabled,
     pub exclude: Exclude,
     pub max_per_message: usize,
-    pub hide_url: HideUrlCondition,
     pub request: Request,
     pub card: Card,
     pub image: Image,
@@ -27,20 +26,11 @@ impl Default for Preview {
             enabled: Enabled::default(),
             exclude: Exclude::default(),
             max_per_message: 1,
-            hide_url: HideUrlCondition::default(),
             request: Request::default(),
             card: Card::default(),
             image: Image::default(),
         }
     }
-}
-
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum HideUrlCondition {
-    #[default]
-    ContainsOnlyUrl,
-    Never,
 }
 
 impl Preview {
@@ -55,6 +45,19 @@ impl Preview {
             Enabled::Regex(regexes) => regexes
                 .iter()
                 .any(|regex| regex.is_match(url).unwrap_or(false)),
+        }
+    }
+
+    pub fn hide_url_when(
+        &self,
+        preview: &crate::Preview,
+        hide_url_condition: HideUrlCondition,
+    ) -> bool {
+        match preview {
+            crate::Preview::Card(_) => self.card.hide_url == hide_url_condition,
+            crate::Preview::Image(_) => {
+                self.image.hide_url == hide_url_condition
+            }
         }
     }
 }
@@ -221,11 +224,20 @@ impl Default for ImageCache {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum HideUrlCondition {
+    #[default]
+    ContainsOnlyUrl,
+    Never,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct Card {
     pub exclude: Option<Inclusivities>,
     pub include: Option<Inclusivities>,
+    pub hide_url: HideUrlCondition,
     pub show_image: bool,
     pub round_image_corners: bool,
     /// Maximum width of the card in pixels
@@ -241,6 +253,7 @@ impl Default for Card {
         Self {
             exclude: None,
             include: None,
+            hide_url: HideUrlCondition::Never,
             show_image: true,
             round_image_corners: true,
             max_width: 400.0,
@@ -291,6 +304,7 @@ pub struct Image {
     pub action: ImageAction,
     pub exclude: Option<Inclusivities>,
     pub include: Option<Inclusivities>,
+    pub hide_url: HideUrlCondition,
     pub round_corners: bool,
     /// Maximum width of the image in pixels
     pub max_width: f32,
@@ -304,6 +318,7 @@ impl Default for Image {
             action: ImageAction::default(),
             exclude: None,
             include: None,
+            hide_url: HideUrlCondition::default(),
             round_corners: true,
             max_width: 550.0,
             max_height: 350.0,

--- a/data/src/config/preview.rs
+++ b/data/src/config/preview.rs
@@ -48,16 +48,10 @@ impl Preview {
         }
     }
 
-    pub fn hide_url_when(
-        &self,
-        preview: &crate::Preview,
-        hide_url_condition: HideUrlCondition,
-    ) -> bool {
+    pub fn hide_url_when(&self, preview: &crate::Preview) -> HideUrlCondition {
         match preview {
-            crate::Preview::Card(_) => self.card.hide_url == hide_url_condition,
-            crate::Preview::Image(_) => {
-                self.image.hide_url == hide_url_condition
-            }
+            crate::Preview::Card(_) => self.card.hide_url,
+            crate::Preview::Image(_) => self.image.hide_url,
         }
     }
 }
@@ -229,6 +223,7 @@ impl Default for ImageCache {
 pub enum HideUrlCondition {
     #[default]
     ContainsOnlyUrl,
+    Trailing,
     Never,
 }
 

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -401,6 +401,14 @@ impl Message {
         }
     }
 
+    pub fn redaction_expanded(
+        &self,
+        config: &config::buffer::Redaction,
+    ) -> Option<bool> {
+        (self.redaction.is_some() && config.display.is_redacted())
+            .then_some(self.expanded)
+    }
+
     pub fn references(&self) -> MessageReferences {
         MessageReferences {
             timestamp: self.server_time,

--- a/docs/configuration/preview.md
+++ b/docs/configuration/preview.md
@@ -73,19 +73,6 @@ Maximum number of previews to show for a single message.
 max_per_message = 1
 ```
 
-## `hide_url`
-
-When set to `"contains-only-url"` then for messages that consist of only a URL, the text of message will be hidden when the preview is visible.
-
-```toml
-# Type: string
-# Values: "contains-only-url" or "never"
-# Default: "contains-only-url"
-
-[preview]
-hide_url = "never"
-```
-
 ## `card`
 
 Specific card preview settings.
@@ -94,6 +81,19 @@ Specific card preview settings.
 [preview.card]
 exclude = "*" # hide card previews in all channels
 include = { channels = ["#halloy"] } # show card previews in #halloy
+```
+
+### `hide_url`
+
+When set to `"contains-only-url"`, messages that consist of only a URL will have the text of message hidden when the card preview is visible.
+
+```toml
+# Type: string
+# Values: "contains-only-url" or "never"
+# Default: "never"
+
+[preview.card]
+hide_url = "contains-only-url"
 ```
 
 ### `show_image`
@@ -213,6 +213,19 @@ Action when clicking on a image. `open-url` will open the image in the browser, 
 
 [preview.image]
 action = "preview"
+```
+
+### `hide_url`
+
+When set to `"contains-only-url"`, messages that consist of only a URL will have the text of message hidden when the image preview is visible.
+
+```toml
+# Type: string
+# Values: "contains-only-url" or "never"
+# Default: "contains-only-url"
+
+[preview.image]
+hide_url = "never"
 ```
 
 ### `round_corners`

--- a/docs/configuration/preview.md
+++ b/docs/configuration/preview.md
@@ -85,11 +85,17 @@ include = { channels = ["#halloy"] } # show card previews in #halloy
 
 ### `hide_url`
 
-When set to `"contains-only-url"`, messages that consist of only a URL will have the text of message hidden when the card preview is visible.
+Hides URL(s) in messages when their card preview is visible and the specified condition is met.
+
+| Condition             | Description                                                                       |
+| --------------------- | --------------------------------------------------------------------------------- |
+| `"trailing"`          | URL is hidden when it is at the end of a message and its card preview is visible. |
+| `"contains-only-url"` | URL is hidden when it is the entire message.                                      |
+| `"never"`             | URLs are never hidden.                                                            |
 
 ```toml
 # Type: string
-# Values: "contains-only-url" or "never"
+# Values: "trailing", "contains-only-url", or "never"
 # Default: "never"
 
 [preview.card]
@@ -217,15 +223,21 @@ action = "preview"
 
 ### `hide_url`
 
-When set to `"contains-only-url"`, messages that consist of only a URL will have the text of message hidden when the image preview is visible.
+Hides URL(s) in messages when their image preview is visible and the specified condition is met.
+
+| Condition             | Description                                                                        |
+| --------------------- | ---------------------------------------------------------------------------------- |
+| `"trailing"`          | URL is hidden when it is at the end of a message and its image preview is visible. |
+| `"contains-only-url"` | URL is hidden when it is the entire message.                                       |
+| `"never"`             | URLs are never hidden.                                                             |
 
 ```toml
 # Type: string
-# Values: "contains-only-url" or "never"
+# Values: "trailing", "contains-only-url", or "never"
 # Default: "contains-only-url"
 
 [preview.image]
-hide_url = "never"
+hide_url = "trailing"
 ```
 
 ### `round_corners`

--- a/docs/configuration/preview.md
+++ b/docs/configuration/preview.md
@@ -73,6 +73,19 @@ Maximum number of previews to show for a single message.
 max_per_message = 1
 ```
 
+## `hide_url`
+
+When set to `"contains-only-url"` then for messages that consist of only a URL, the text of message will be hidden when the preview is visible.
+
+```toml
+# Type: string
+# Values: "contains-only-url" or "never"
+# Default: "contains-only-url"
+
+[preview]
+hide_url = "never"
+```
+
 ## `card`
 
 Specific card preview settings.

--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -136,8 +136,9 @@ pub fn view<'a>(
                         context_menu::has_user_metadata(user, registry, config),
                     )
                 }
-                message::Link::Url(_) =>
-                    context_menu::Entry::url_list(None, false, false, false),
+                message::Link::Url(_) => context_menu::Entry::url_list(
+                    false, None, None, false, false, false
+                ),
                 _ => vec![],
             },
             move |link, entry, length| {
@@ -159,11 +160,13 @@ pub fn view<'a>(
                 } else {
                     link.url().map(|url| Context::Url {
                         url,
-                        message: None,
+                        server_time: None,
+                        hash: None,
                         msgid: None,
                         selected_reactions: vec![],
                         to_nick: None,
                         reply_preview: None,
+                        redaction: None,
                     })
                 };
 

--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -113,6 +113,7 @@ pub fn view<'a>(
     let content = column![
         message_content::with_context(
             content,
+            &[],
             server,
             registry,
             chantypes,

--- a/src/buffer/channel_discovery.rs
+++ b/src/buffer/channel_discovery.rs
@@ -276,7 +276,7 @@ fn channel_list_view<'a>(
                             move |link| match link {
                                 message::Link::Url(_) => {
                                     context_menu::Entry::url_list(
-                                        None, false, false, false,
+                                        false, None, None, false, false, false,
                                     )
                                 }
                                 _ => vec![],
@@ -286,11 +286,13 @@ fn channel_list_view<'a>(
                                     .view(
                                         link.url().map(|url| Context::Url {
                                             url,
-                                            message: None,
+                                            server_time: None,
+                                            hash: None,
                                             msgid: None,
                                             selected_reactions: vec![],
                                             to_nick: None,
                                             reply_preview: None,
+                                            redaction: None,
                                         }),
                                         length,
                                         config,

--- a/src/buffer/channel_discovery.rs
+++ b/src/buffer/channel_discovery.rs
@@ -263,6 +263,7 @@ fn channel_list_view<'a>(
                     } else {
                         Some(message_content::with_context(
                             topic_content,
+                            &[],
                             server,
                             metadata::EMPTY,
                             clients.get_server_chantypes_or_default(server),

--- a/src/buffer/context_menu.rs
+++ b/src/buffer/context_menu.rs
@@ -3,6 +3,7 @@ use std::string::ToString;
 
 use chrono::{DateTime, Utc};
 use data::dashboard::BufferAction;
+use data::redaction::Redaction;
 use data::user::Nick;
 use data::{
     Config, Server, User, config, ctcp, isupport, message, metadata, preview,
@@ -30,19 +31,24 @@ pub enum Context<'a> {
     },
     Url {
         url: &'a str,
-        message: Option<message::Hash>,
+        server_time: Option<&'a DateTime<Utc>>,
+        hash: Option<&'a message::Hash>,
         msgid: Option<&'a message::Id>,
         selected_reactions: Vec<&'a str>,
         to_nick: Option<String>,
         reply_preview: Option<String>,
+        redaction: Option<&'a Redaction>,
     },
     Timestamp(&'a DateTime<Utc>),
     NotSentMessage(&'a DateTime<Utc>, &'a message::Hash),
     Message {
+        server_time: &'a DateTime<Utc>,
+        hash: &'a message::Hash,
         msgid: Option<&'a message::Id>,
         selected_reactions: &'a [String],
         content: &'a message::Content,
         source: &'a message::Source,
+        redaction: Option<&'a Redaction>,
     },
 }
 
@@ -72,9 +78,12 @@ pub enum Entry {
     ResendMessage,
     // message context
     CopyMessage,
+    CopyRedaction,
     Reply,
     AddReaction,
     Redact,
+    HideWithRedaction,
+    ShowRedactedMessage,
 }
 
 #[derive(Debug, Clone)]
@@ -97,34 +106,69 @@ impl Entry {
     }
 
     pub fn message_list(
+        has_redaction: bool,
+        redaction_expanded: Option<bool>,
         can_send_reactions: bool,
         can_redact: bool,
         can_send_replies: bool,
     ) -> Vec<Self> {
         let mut entries = vec![];
+
+        if let Some(redaction_expanded) = redaction_expanded {
+            entries.push(if redaction_expanded {
+                Entry::HideWithRedaction
+            } else {
+                Entry::ShowRedactedMessage
+            });
+
+            entries.push(Entry::HorizontalRule);
+        }
+
+        entries.push(Entry::CopyMessage);
+        if has_redaction {
+            entries.push(Entry::CopyRedaction);
+        }
+
+        if can_send_replies || can_send_reactions || can_redact {
+            entries.push(Entry::HorizontalRule);
+        }
+
         if can_send_replies {
             entries.push(Entry::Reply);
         }
+
         if can_send_reactions {
             entries.push(Entry::AddReaction);
         }
-        if can_send_replies || can_send_reactions {
-            entries.push(Entry::HorizontalRule);
-        }
-        entries.push(Entry::CopyMessage);
+
         if can_redact {
             entries.push(Entry::Redact);
         }
+
         entries
     }
 
     pub fn url_list(
+        has_redaction: bool,
+        redaction_expanded: Option<bool>,
         preview_hidden: Option<bool>,
         can_send_reactions: bool,
         can_redact: bool,
         can_send_replies: bool,
     ) -> Vec<Self> {
-        let mut entries = vec![Entry::CopyUrl, Entry::OpenUrl];
+        let mut entries = vec![];
+
+        if let Some(redaction_expanded) = redaction_expanded {
+            entries.push(if redaction_expanded {
+                Entry::HideWithRedaction
+            } else {
+                Entry::ShowRedactedMessage
+            });
+            entries.push(Entry::HorizontalRule);
+        }
+
+        entries.push(Entry::CopyUrl);
+        entries.push(Entry::OpenUrl);
 
         if let Some(preview_hidden) = preview_hidden {
             entries.push(Entry::HorizontalRule);
@@ -133,6 +177,12 @@ impl Entry {
             } else {
                 Entry::HidePreview
             });
+        }
+
+        entries.push(Entry::HorizontalRule);
+        entries.push(Entry::CopyMessage);
+        if has_redaction {
+            entries.push(Entry::CopyRedaction);
         }
 
         if can_send_replies || can_send_reactions || can_redact {
@@ -458,10 +508,9 @@ impl Entry {
                     config,
                 )
             }
-            (Entry::HidePreview, Context::Url { url, message, .. }) => {
-                let message = message.map(|message| {
-                    Message::HidePreview(message, url.to_string())
-                });
+            (Entry::HidePreview, Context::Url { url, hash, .. }) => {
+                let message = hash
+                    .map(|hash| Message::HidePreview(*hash, url.to_string()));
 
                 menu_button(
                     "Hide Preview".to_string(),
@@ -471,10 +520,9 @@ impl Entry {
                     config,
                 )
             }
-            (Entry::ShowPreview, Context::Url { url, message, .. }) => {
-                let message = message.map(|message| {
-                    Message::ShowPreview(message, url.to_string())
-                });
+            (Entry::ShowPreview, Context::Url { url, hash, .. }) => {
+                let message = hash
+                    .map(|hash| Message::ShowPreview(*hash, url.to_string()));
 
                 menu_button(
                     "Show Preview".to_string(),
@@ -529,12 +577,29 @@ impl Entry {
             (Entry::CopyMessage, Context::Message { content, .. }) => {
                 menu_button(
                     "Copy message".to_string(),
-                    Some(Message::CopyMessage(content.text().into_owned())),
+                    Some(Message::CopyText(content.text().into_owned())),
                     length,
                     theme,
                     config,
                 )
             }
+            (
+                Entry::CopyRedaction,
+                Context::Message {
+                    redaction: Some(redaction),
+                    ..
+                }
+                | Context::Url {
+                    redaction: Some(redaction),
+                    ..
+                },
+            ) => menu_button(
+                "Copy redaction".to_string(),
+                Some(Message::CopyText(redaction.message())),
+                length,
+                theme,
+                config,
+            ),
             (
                 Entry::Reply,
                 Context::Message {
@@ -644,6 +709,40 @@ impl Entry {
                 theme,
                 config,
             ),
+            (
+                Entry::HideWithRedaction,
+                Context::Message {
+                    server_time, hash, ..
+                }
+                | Context::Url {
+                    server_time: Some(server_time),
+                    hash: Some(hash),
+                    ..
+                },
+            ) => menu_button(
+                "Hide with redaction".to_string(),
+                Some(Message::ContractMessage(*server_time, *hash)),
+                length,
+                theme,
+                config,
+            ),
+            (
+                Entry::ShowRedactedMessage,
+                Context::Message {
+                    server_time, hash, ..
+                }
+                | Context::Url {
+                    server_time: Some(server_time),
+                    hash: Some(hash),
+                    ..
+                },
+            ) => menu_button(
+                "Show redacted message".to_string(),
+                Some(Message::ExpandMessage(*server_time, *hash)),
+                length,
+                theme,
+                config,
+            ),
             _ => row![].into(),
         })
     }
@@ -659,8 +758,7 @@ pub enum Message {
     InsertNickname(Nick),
     CtcpRequest(ctcp::Command, Server, Nick, Option<String>),
     CopyUrl(String),
-    #[allow(clippy::enum_variant_names)]
-    CopyMessage(String),
+    CopyText(String),
     OpenUrl(String),
     HidePreview(message::Hash, String),
     ShowPreview(message::Hash, String),
@@ -678,6 +776,10 @@ pub enum Message {
     },
     LoadUserAvatar(Server, url::Url),
     Link(message::Link),
+    #[allow(clippy::enum_variant_names)]
+    ExpandMessage(DateTime<Utc>, message::Hash),
+    #[allow(clippy::enum_variant_names)]
+    ContractMessage(DateTime<Utc>, message::Hash),
 }
 
 #[derive(Debug, Clone)]
@@ -690,8 +792,7 @@ pub enum Event {
     InsertNickname(Nick),
     CtcpRequest(ctcp::Command, Server, Nick, Option<String>),
     CopyUrl(String),
-    #[allow(clippy::enum_variant_names)]
-    CopyMessage(String),
+    CopyText(String),
     OpenUrl(String),
     HidePreview(message::Hash, String),
     ShowPreview(message::Hash, String),
@@ -706,6 +807,8 @@ pub enum Event {
         reply_preview: String,
     },
     LoadUserAvatar(Server, url::Url),
+    ExpandMessage(DateTime<Utc>, message::Hash),
+    ContractMessage(DateTime<Utc>, message::Hash),
 }
 
 pub fn update(message: Message) -> Option<Event> {
@@ -724,7 +827,7 @@ pub fn update(message: Message) -> Option<Event> {
             Some(Event::CtcpRequest(command, server, nick, params))
         }
         Message::CopyUrl(url) => Some(Event::CopyUrl(url)),
-        Message::CopyMessage(text) => Some(Event::CopyMessage(text)),
+        Message::CopyText(text) => Some(Event::CopyText(text)),
         Message::OpenUrl(url) => Some(Event::OpenUrl(url)),
         Message::HidePreview(message, url) => {
             Some(Event::HidePreview(message, url))
@@ -735,11 +838,11 @@ pub fn update(message: Message) -> Option<Event> {
         Message::CopyTimestamp(date_time) => {
             Some(Event::CopyTimestamp(date_time))
         }
-        Message::DeleteMessage(sesrver_time, hash) => {
-            Some(Event::DeleteMessage(sesrver_time, hash))
+        Message::DeleteMessage(server_time, hash) => {
+            Some(Event::DeleteMessage(server_time, hash))
         }
-        Message::ResendMessage(sesrver_time, hash) => {
-            Some(Event::ResendMessage(sesrver_time, hash))
+        Message::ResendMessage(server_time, hash) => {
+            Some(Event::ResendMessage(server_time, hash))
         }
         Message::OpenReactionModal(msgid, selected_reactions) => {
             Some(Event::OpenReactionModal(msgid, selected_reactions))
@@ -759,18 +862,28 @@ pub fn update(message: Message) -> Option<Event> {
         }
         Message::Link(message::Link::Url(url)) => Some(Event::OpenUrl(url)),
         Message::Link(_) => None,
+        Message::ExpandMessage(server_time, hash) => {
+            Some(Event::ExpandMessage(server_time, hash))
+        }
+        Message::ContractMessage(server_time, hash) => {
+            Some(Event::ContractMessage(server_time, hash))
+        }
     }
 }
 
 pub fn message<'a, M>(
     content: impl Into<Element<'a, M>>,
     source: &'a message::Source,
+    server_time: &'a DateTime<Utc>,
+    hash: &'a message::Hash,
     msgid: Option<&'a message::Id>,
     selected_reactions: Vec<String>,
     can_send_replies: bool,
     can_send_reactions: bool,
     can_redact: bool,
     message_content: &'a message::Content,
+    redaction: Option<&'a Redaction>,
+    redaction_expanded: Option<bool>,
     config: &'a Config,
     theme: &'a Theme,
 ) -> Element<'a, M>
@@ -782,6 +895,8 @@ where
     }
 
     let entries = Entry::message_list(
+        redaction.is_some(),
+        redaction_expanded,
         can_send_reactions && msgid.is_some(),
         can_redact && msgid.is_some(),
         can_send_replies && msgid.is_some(),
@@ -798,9 +913,12 @@ where
             entry
                 .view(
                     Some(Context::Message {
+                        server_time,
+                        hash,
                         msgid,
                         selected_reactions: &selected_reactions,
                         content: message_content,
+                        redaction,
                         source,
                     }),
                     length,
@@ -816,11 +934,11 @@ where
 pub fn preview<'a, M>(
     content: impl Into<Element<'a, M>>,
     url: &'a str,
-    preview_hidden: Option<bool>,
     can_send_replies: bool,
     can_send_reactions: bool,
     can_redact: bool,
-    message_hash: message::Hash,
+    server_time: &'a DateTime<Utc>,
+    hash: &'a message::Hash,
     msgid: Option<&'a message::Id>,
     user: Option<&'a User>,
     message_content: &'a message::Content,
@@ -832,7 +950,9 @@ where
     M: From<Message> + 'a,
 {
     let entries = Entry::url_list(
-        preview_hidden,
+        false, // Previews are hidden if the message is redacted
+        None,  // Previews are hidden if the message is redacted
+        Some(false),
         can_send_reactions && msgid.is_some(),
         can_redact && msgid.is_some(),
         can_send_replies && msgid.is_some(),
@@ -850,12 +970,14 @@ where
                 .view(
                     Some(Context::Url {
                         url,
-                        message: Some(message_hash),
+                        server_time: Some(server_time),
+                        hash: Some(hash),
                         msgid,
                         selected_reactions: selected_reactions.clone(),
                         to_nick: user.map(|user| user.nickname().to_string()),
                         reply_preview: (can_send_replies && msgid.is_some())
                             .then_some(message_content.preview_text()),
+                        redaction: None, // Previews are hidden if the message is redacted
                     }),
                     length,
                     config,

--- a/src/buffer/context_menu.rs
+++ b/src/buffer/context_menu.rs
@@ -813,6 +813,60 @@ where
     .into()
 }
 
+pub fn preview<'a, M>(
+    content: impl Into<Element<'a, M>>,
+    url: &'a str,
+    preview_hidden: Option<bool>,
+    can_send_replies: bool,
+    can_send_reactions: bool,
+    can_redact: bool,
+    message_hash: message::Hash,
+    msgid: Option<&'a message::Id>,
+    user: Option<&'a User>,
+    message_content: &'a message::Content,
+    selected_reactions: Vec<&'a str>,
+    config: &'a Config,
+    theme: &'a Theme,
+) -> Element<'a, M>
+where
+    M: From<Message> + 'a,
+{
+    let entries = Entry::url_list(
+        preview_hidden,
+        can_send_reactions && msgid.is_some(),
+        can_redact && msgid.is_some(),
+        can_send_replies && msgid.is_some(),
+    );
+
+    context_menu(
+        context_menu::MouseButton::Right,
+        context_menu::Anchor::Cursor,
+        context_menu::ToggleBehavior::KeepOpen,
+        None,
+        content,
+        entries,
+        move |entry, length| {
+            entry
+                .view(
+                    Some(Context::Url {
+                        url,
+                        message: Some(message_hash),
+                        msgid,
+                        selected_reactions: selected_reactions.clone(),
+                        to_nick: user.map(|user| user.nickname().to_string()),
+                        reply_preview: (can_send_replies && msgid.is_some())
+                            .then_some(message_content.preview_text()),
+                    }),
+                    length,
+                    config,
+                    theme,
+                )
+                .map(M::from)
+        },
+    )
+    .into()
+}
+
 pub fn user<'a>(
     content: impl Into<Element<'a, Message>>,
     server: &'a Server,

--- a/src/buffer/highlights.rs
+++ b/src/buffer/highlights.rs
@@ -191,7 +191,7 @@ pub fn view<'a>(
                             }
                             message::Link::Url(_) => {
                                 context_menu::Entry::url_list(
-                                    None, false, false, false,
+                                    false, None, None, false, false, false,
                                 )
                             }
                             _ => vec![],
@@ -214,11 +214,13 @@ pub fn view<'a>(
                             } else {
                                 link.url().map(|url| Context::Url {
                                     url,
-                                    message: None,
+                                    server_time: None,
+                                    hash: None,
                                     msgid: None,
                                     selected_reactions: vec![],
                                     to_nick: None,
                                     reply_preview: None,
+                                    redaction: None,
                                 })
                             };
 

--- a/src/buffer/highlights.rs
+++ b/src/buffer/highlights.rs
@@ -165,6 +165,7 @@ pub fn view<'a>(
 
                     let text = message_content::with_context(
                         &message.content,
+                        &[],
                         server,
                         registry,
                         chantypes,
@@ -280,6 +281,7 @@ pub fn view<'a>(
 
                     let text = message_content(
                         &message.content,
+                        &[],
                         server,
                         clients.get_registry(server),
                         chantypes,

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use chrono::{DateTime, TimeDelta, Utc};
 use data::buffer::RightAlignmentWidths;
@@ -9,20 +9,26 @@ use data::preview::{self, Previews};
 use data::redaction::Redaction;
 use data::server::Server;
 use data::user::{ChannelUsers, NickRef};
-use data::{Config, User, message, metadata, target};
+use data::{Config, Preview, User, message, metadata, target};
 use iced::widget::text::Wrapping;
-use iced::widget::{Space, button, column, container, row, text};
-use iced::{Color, Length, alignment};
+use iced::widget::{
+    Space, button, center, column, container, mouse_area, right, row, space,
+    stack, text,
+};
+use iced::{Color, ContentFit, Length, alignment, mouse, padding};
 
-use super::context_menu::{self, Context};
-use super::scroll_view::LayoutMessage;
-use crate::buffer::scroll_view::Message;
+use crate::buffer::context_menu::{self, Context};
+use crate::buffer::scroll_view::keyed::{self, keyed};
+use crate::buffer::scroll_view::{LayoutMessage, Message};
 use crate::widget::reaction_row::{has_visible_reactions, reaction_row};
 use crate::widget::user_display::UserDisplay;
 use crate::widget::{
-    Element, Marker, message_content, message_marker, selectable_text, tooltip,
+    Element, Marker, image, message_content, message_marker, notify_visibility,
+    selectable_text, tooltip,
 };
 use crate::{Theme, font, icon, theme};
+
+const HIDE_BUTTON_WIDTH: f32 = 22.0;
 
 #[derive(Clone, Copy)]
 pub enum TargetInfo<'a> {
@@ -378,13 +384,177 @@ impl<'a> ChannelQueryLayout<'a> {
         ))
     }
 
+    fn preview_row(
+        &self,
+        message: &'a data::Message,
+        preview: &'a Preview,
+        url: &'a url::Url,
+        index: usize,
+        is_hovered: bool,
+    ) -> Element<'a, Message> {
+        let content = match preview {
+            data::Preview::Card(preview::Card {
+                image,
+                title,
+                description,
+                ..
+            }) => keyed(
+                keyed::Key::Preview(message.hash, index),
+                button(
+                    container(
+                        column![
+                            text(title)
+                                .shaping(text::Shaping::Advanced)
+                                .style(theme::text::primary)
+                                .font_maybe(
+                                    theme::font_style::primary(self.theme)
+                                        .map(font::get)
+                                ),
+                            description.as_ref().map(|description| {
+                                container(
+                                    text(description)
+                                        .shaping(text::Shaping::Advanced)
+                                        .wrapping(text::Wrapping::WordOrGlyph)
+                                        .style(theme::text::secondary)
+                                        .font_maybe(
+                                            theme::font_style::secondary(
+                                                self.theme,
+                                            )
+                                            .map(font::get),
+                                        ),
+                                )
+                                .clip(false)
+                                .max_height(
+                                    self.config
+                                        .preview
+                                        .card
+                                        .description_max_height,
+                                )
+                            }),
+                            self.config.preview.card.show_image.then_some(
+                                container(image::from_data(
+                                    image,
+                                    self.config.preview.image.round_corners,
+                                    ContentFit::ScaleDown,
+                                ))
+                                .padding(padding::top(8))
+                                .max_height(
+                                    self.config.preview.card.image_max_height
+                                )
+                            ),
+                        ]
+                        .spacing(8)
+                        .max_width(self.config.preview.card.max_width),
+                    )
+                    .padding(8),
+                )
+                .style(theme::button::preview_card)
+                .on_press(Message::Link(message::Link::Url(url.to_string()))),
+            ),
+            data::Preview::Image(image) => keyed(
+                keyed::Key::Preview(message.hash, index),
+                button(
+                    container(image::from_data(
+                        image,
+                        self.config.preview.image.round_corners,
+                        ContentFit::ScaleDown,
+                    ))
+                    .max_width(self.config.preview.image.max_width)
+                    .max_height(self.config.preview.image.max_height),
+                )
+                .on_press(match self.config.preview.image.action {
+                    data::config::preview::ImageAction::OpenUrl => {
+                        Message::Link(message::Link::Url(image.url.to_string()))
+                    }
+                    data::config::preview::ImageAction::Preview => {
+                        Message::ImagePreview(image.clone())
+                    }
+                })
+                .padding(0)
+                .style(theme::button::bare),
+            ),
+        };
+
+        let formatter = *self;
+
+        let content = crate::widget::context_menu::context_menu(
+            crate::widget::context_menu::MouseButton::Right,
+            crate::widget::context_menu::Anchor::Cursor,
+            crate::widget::context_menu::ToggleBehavior::KeepOpen,
+            Some(mouse::Interaction::Pointer),
+            content,
+            context_menu::Entry::url_list(
+                formatter.preview_hidden_for_url(message, url.as_str()),
+                false,
+                false,
+                false,
+            ),
+            move |entry, length| {
+                entry
+                    .view(
+                        Some(context_menu::Context::Url {
+                            url: url.as_str(),
+                            message: Some(message.hash),
+                            msgid: None,
+                            selected_reactions: vec![],
+                            to_nick: None,
+                            reply_preview: None,
+                        }),
+                        length,
+                        formatter.config,
+                        formatter.theme,
+                    )
+                    .map(Message::ContextMenu)
+            },
+        );
+
+        let hide_button = if is_hovered {
+            container(tooltip(
+                button(center(icon::cancel()))
+                    .padding(5)
+                    .width(HIDE_BUTTON_WIDTH)
+                    .height(HIDE_BUTTON_WIDTH)
+                    .on_press(Message::HidePreview(message.hash, url.clone()))
+                    .style(|theme, status| {
+                        theme::button::secondary(theme, status, false)
+                    }),
+                self.config
+                    .tooltips
+                    .show_for_buttons()
+                    .then_some("Hide Preview"),
+                tooltip::Position::Top,
+                self.theme,
+            ))
+        } else {
+            container(
+                space::horizontal().width(Length::Fixed(HIDE_BUTTON_WIDTH)),
+            )
+        };
+
+        // Iced hack: using a stack with right-aligned hide_button ensures the button always stays visible
+        // at the edge of the content, even when the parent container is resized to a smaller width.
+        let stack = stack![
+            container(content).padding(padding::right(HIDE_BUTTON_WIDTH + 2.0)),
+            right(hide_button),
+        ];
+
+        let content = container(stack)
+            .align_y(alignment::Vertical::Top)
+            .width(Length::Fill)
+            .padding(padding::top(4).bottom(4));
+
+        mouse_area(content)
+            .on_enter(Message::PreviewHovered(message.hash, index))
+            .on_exit(Message::PreviewUnhovered(message.hash, index))
+            .into()
+    }
+
     fn format_user_message(
         &self,
         message: &'a data::Message,
         right_alignment_middle_width: Option<f32>,
         user: &'a User,
         hide_nickname: bool,
-        registry: &'a dyn metadata::Registry,
     ) -> (
         Option<Element<'a, Message>>,
         Element<'a, Message>,
@@ -424,7 +594,7 @@ impl<'a> ChannelQueryLayout<'a> {
             user,
             self.config.buffer.nickname.show_access_levels,
             self.config.buffer.nickname.show_bot_icon,
-            registry,
+            self.registry,
             &self.config.display.nickname,
             self.config.buffer.nickname.truncate,
             self.config.display.truncation_character,
@@ -950,7 +1120,11 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
         right_alignment_widths: Option<RightAlignmentWidths>,
         hide_timestamp: bool,
         hide_nickname: bool,
-        registry: &'a dyn metadata::Registry,
+        visible_for_source: Option<
+            &impl Fn(&Preview, &message::Source) -> bool,
+        >,
+        visible_url_messages: &HashMap<message::Hash, Vec<url::Url>>,
+        hovered_preview: Option<(message::Hash, usize)>,
     ) -> Option<Element<'a, Message>> {
         let mut prefixes: Option<Element<_>> = self.format_prefixes(message);
 
@@ -994,7 +1168,6 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
                 right_alignment_middle_width,
                 user,
                 hide_nickname,
-                registry,
             )),
             message::Source::Server(server_message) => {
                 Some(self.format_server_message(
@@ -1178,6 +1351,96 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
             middle,
             middle_is_some.then_some(selectable_text(" ")),
         ];
+
+        let content = if let message::Content::Fragments(fragments) =
+            &message.content
+        {
+            let urls = eligible_preview_urls(
+                fragments.iter().filter_map(message::Fragment::url),
+                &message.hidden_urls,
+                self.config.preview.max_per_message,
+            );
+
+            if !urls.is_empty() {
+                let is_message_visible =
+                    visible_url_messages.contains_key(&message.hash);
+
+                let mut column = column![].spacing(2);
+
+                if fragments.len() == 1
+                    && urls.len() == 1
+                    && let Some(url) = urls.first()
+                    && let Some(preview::State::Loaded(preview)) =
+                        self.previews.get(url)
+                    && visible_for_source.is_none_or(|visible_for_source| {
+                        visible_for_source(preview, message.target.source())
+                    })
+                {
+                    let is_hovered = hovered_preview.is_some_and(
+                        |(hovered_hash, hovered_index)| {
+                            hovered_hash == message.hash && hovered_index == 0
+                        },
+                    );
+
+                    column = column.push(
+                        self.preview_row(message, preview, url, 0, is_hovered),
+                    );
+                } else {
+                    column = column.push(content);
+
+                    for (index, url) in urls.iter().enumerate() {
+                        if is_message_visible
+                            && let Some(preview::State::Loaded(preview)) =
+                                self.previews.get(url)
+                            && visible_for_source.is_none_or(
+                                |visible_for_source| {
+                                    visible_for_source(
+                                        preview,
+                                        message.target.source(),
+                                    )
+                                },
+                            )
+                        {
+                            let is_hovered = hovered_preview.is_some_and(
+                                |(hovered_hash, hovered_index)| {
+                                    hovered_hash == message.hash
+                                        && hovered_index == index
+                                },
+                            );
+
+                            column = column.push(self.preview_row(
+                                message, preview, url, index, is_hovered,
+                            ));
+                        }
+                    }
+                }
+
+                if is_message_visible {
+                    notify_visibility(
+                        column,
+                        2000.0,
+                        notify_visibility::When::NotVisible,
+                        message.hash,
+                        Message::ExitingViewport(message.hash),
+                    )
+                } else {
+                    notify_visibility(
+                        column,
+                        1000.0,
+                        notify_visibility::When::Visible,
+                        message.hash,
+                        Message::EnteringViewport(
+                            message.hash,
+                            urls.into_iter().cloned().collect(),
+                        ),
+                    )
+                }
+            } else {
+                content
+            }
+        } else {
+            content
+        };
 
         let message_element = if self.content_on_new_line(message) {
             container(column![row, content]).into()
@@ -1375,5 +1638,16 @@ fn selected_reactions_refs<'a>(
     selected
         .into_iter()
         .filter_map(|(text, count)| (count >= 1).then_some(text))
+        .collect()
+}
+
+fn eligible_preview_urls<'a>(
+    urls: impl IntoIterator<Item = &'a url::Url>,
+    hidden_urls: &HashSet<url::Url>,
+    max_per_message: usize,
+) -> Vec<&'a url::Url> {
+    urls.into_iter()
+        .filter(|url| !hidden_urls.contains(*url))
+        .take(max_per_message)
         .collect()
 }

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -97,12 +97,18 @@ pub struct ChannelQueryLayout<'a> {
 }
 
 impl<'a> ChannelQueryLayout<'a> {
+    fn previews_enabled(&self, message: &data::Message) -> bool {
+        !self.not_sent(message) && message.redaction.is_none()
+    }
+
     fn preview_hidden_for_url(
         &self,
         message: &data::Message,
         url: &str,
     ) -> Option<bool> {
-        if !self.config.preview.is_enabled(url) {
+        if self.previews_enabled(message)
+            || !self.config.preview.is_enabled(url)
+        {
             return None;
         }
 
@@ -129,6 +135,8 @@ impl<'a> ChannelQueryLayout<'a> {
         let can_send_replies = self.can_send_replies && message.id.is_some();
         match link {
             message::Link::Url(url) => context_menu::Entry::url_list(
+                message.redaction.is_some(),
+                message.redaction_expanded(&self.config.buffer.redaction),
                 self.preview_hidden_for_url(message, url),
                 self.can_send_reactions,
                 self.can_redact_message(message),
@@ -481,11 +489,11 @@ impl<'a> ChannelQueryLayout<'a> {
         let content = context_menu::preview(
             content,
             url.as_str(),
-            Some(false),
             self.can_send_replies,
             self.can_send_reactions,
             self.can_redact_message(message),
-            message.hash,
+            &message.server_time,
+            &message.hash,
             message.id.as_ref(),
             message.user(),
             &message.content,
@@ -700,14 +708,6 @@ impl<'a> ChannelQueryLayout<'a> {
                     vec![],
                 )
             } else {
-                let link = (self.config.buffer.redaction.display.is_redacted()
-                    && message.expanded
-                    && redaction_message.is_some())
-                .then_some(message::Link::ContractMessage(
-                    message.server_time,
-                    message.hash,
-                ));
-
                 (
                     tooltip(
                         message_content::with_context(
@@ -718,7 +718,7 @@ impl<'a> ChannelQueryLayout<'a> {
                             self.casemapping,
                             self.theme,
                             Message::Link,
-                            link,
+                            None,
                             message_style,
                             theme::font_style::primary,
                             color_transformation,
@@ -1089,11 +1089,13 @@ impl<'a> ChannelQueryLayout<'a> {
 
             link.url().map(move |url| Context::Url {
                 url,
-                message: Some(message.hash),
+                server_time: Some(&message.server_time),
+                hash: Some(&message.hash),
                 msgid: message.id.as_ref(),
                 selected_reactions: selected_reaction_texts,
                 to_nick,
                 reply_preview,
+                redaction: message.redaction.as_ref(),
             })
         }
     }
@@ -1307,12 +1309,16 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
         let content = context_menu::message(
             content,
             message.target.source(),
+            &message.server_time,
+            &message.hash,
             message.id.as_ref(),
             selected_reaction_texts,
             self.can_send_replies,
             self.can_send_reactions,
             self.can_redact_message(message),
             &message.content,
+            message.redaction.as_ref(),
+            message.redaction_expanded(&self.config.buffer.redaction),
             self.config,
             self.theme,
         );
@@ -1333,8 +1339,7 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
             middle_is_some.then_some(selectable_text(" ")),
         ];
 
-        let content = if !(self.not_sent(message)
-            || message.redaction.is_some())
+        let content = if self.previews_enabled(message)
             && let message::Content::Fragments(fragments) = &message.content
         {
             let urls = eligible_preview_urls(

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -546,6 +546,7 @@ impl<'a> ChannelQueryLayout<'a> {
     fn format_user_message(
         &self,
         message: &'a data::Message,
+        hidden_fragments: &[usize],
         right_alignment_middle_width: Option<f32>,
         user: &'a User,
         hide_nickname: bool,
@@ -712,6 +713,7 @@ impl<'a> ChannelQueryLayout<'a> {
                     tooltip(
                         message_content::with_context(
                             &message.content,
+                            hidden_fragments,
                             self.server,
                             self.registry,
                             self.chantypes,
@@ -780,6 +782,7 @@ impl<'a> ChannelQueryLayout<'a> {
     fn format_server_message(
         &self,
         message: &'a data::Message,
+        hidden_fragments: &[usize],
         right_alignment_middle_width: Option<f32>,
         server: Option<&'a message::source::Server>,
     ) -> (
@@ -834,6 +837,7 @@ impl<'a> ChannelQueryLayout<'a> {
 
         let message_content = message_content::with_context(
             &message.content,
+            hidden_fragments,
             formatter.server,
             formatter.registry,
             formatter.chantypes,
@@ -982,6 +986,7 @@ impl<'a> ChannelQueryLayout<'a> {
 
         let message_content = message_content::with_context(
             &message.content,
+            &[],
             formatter.server,
             formatter.registry,
             formatter.chantypes,
@@ -1146,6 +1151,107 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
         let right_alignment_middle_width = right_alignment_widths
             .map(|right_alignment_widths| right_alignment_widths.middle);
 
+        let (
+            message_has_urls,
+            enumerated_previews,
+            hidden_fragments,
+            is_visible_url_message,
+        ) = if self.previews_enabled(message)
+            && let message::Content::Fragments(fragments) = &message.content
+        {
+            let urls = eligible_preview_urls(
+                fragments,
+                &message.hidden_urls,
+                self.config.preview.max_per_message,
+            );
+
+            if !urls.is_empty() {
+                let is_visible_url_message =
+                    visible_url_messages.contains_key(&message.hash);
+
+                let enumerated_urls = urls
+                    .into_iter()
+                    .enumerate()
+                    .map(|(url_index, (fragment_index, url))| {
+                        if let Some(preview::State::Loaded(preview)) =
+                            self.previews.get(url)
+                            && visible_for_source.is_none_or(
+                                |visible_for_source| {
+                                    visible_for_source(
+                                        preview,
+                                        message.target.source(),
+                                    )
+                                },
+                            )
+                        {
+                            (fragment_index, url_index, url, Some(preview))
+                        } else {
+                            (fragment_index, url_index, url, None)
+                        }
+                    })
+                    .collect::<Vec<_>>();
+
+                let mut hidden_fragments: Vec<usize> = vec![];
+                let mut is_trailing_fragment = true;
+
+                for (fragment_index, _, _, preview) in
+                    enumerated_urls.iter().rev()
+                {
+                    if let Some(preview) = preview {
+                        if is_trailing_fragment {
+                            let trailing_fragments: Vec<_> = fragments
+                                .iter()
+                                .enumerate()
+                                .skip(fragment_index.saturating_add(1))
+                                .collect();
+
+                            is_trailing_fragment = trailing_fragments
+                                .is_empty()
+                                || trailing_fragments.iter().all(
+                                    |(index, fragment)| {
+                                        hidden_fragments.contains(index)
+                                            || fragment
+                                                .as_str()
+                                                .trim_end()
+                                                .is_empty()
+                                    },
+                                );
+                        }
+
+                        match self.config.preview.hide_url_when(preview) {
+                            HideUrlCondition::ContainsOnlyUrl => {
+                                if fragments.len() == 1 {
+                                    hidden_fragments.push(*fragment_index);
+                                }
+                            }
+                            HideUrlCondition::Trailing => {
+                                if is_trailing_fragment {
+                                    hidden_fragments.push(*fragment_index);
+                                }
+                            }
+                            HideUrlCondition::Never => (),
+                        }
+                    }
+                }
+
+                (
+                    true,
+                    enumerated_urls
+                        .into_iter()
+                        .map(|(_, url_index, url, preview)| {
+                            (url_index, url, preview)
+                        })
+                        .collect(),
+                    hidden_fragments,
+                    is_visible_url_message,
+                )
+            } else {
+                (false, vec![], vec![], false)
+            }
+        } else {
+            (false, vec![], vec![], false)
+        };
+
         let (middle, content, after_content): (
             Option<Element<'a, Message>>,
             Element<'a, Message>,
@@ -1153,6 +1259,7 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
         ) = match message.target.source() {
             message::Source::User(user) => Some(self.format_user_message(
                 message,
+                &hidden_fragments,
                 right_alignment_middle_width,
                 user,
                 hide_nickname,
@@ -1160,6 +1267,7 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
             message::Source::Server(server_message) => {
                 Some(self.format_server_message(
                     message,
+                    &hidden_fragments,
                     right_alignment_middle_width,
                     server_message.as_ref(),
                 ))
@@ -1202,6 +1310,7 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
 
                 let message_content = message_content::with_context(
                     &message.content,
+                    &hidden_fragments,
                     formatter.server,
                     formatter.registry,
                     formatter.chantypes,
@@ -1274,6 +1383,7 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
 
                 let message = message_content(
                     &message.content,
+                    &[],
                     self.server,
                     self.registry,
                     self.chantypes,
@@ -1339,95 +1449,64 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
             middle_is_some.then_some(selectable_text(" ")),
         ];
 
-        let content = if self.previews_enabled(message)
-            && let message::Content::Fragments(fragments) = &message.content
-        {
-            let urls = eligible_preview_urls(
-                fragments.iter().filter_map(message::Fragment::url),
-                &message.hidden_urls,
-                self.config.preview.max_per_message,
-            );
+        let content = if message_has_urls {
+            let mut column = column![].spacing(2);
 
-            if !urls.is_empty() {
-                let is_message_visible =
-                    visible_url_messages.contains_key(&message.hash);
+            let show_message_content = if hidden_fragments.is_empty() {
+                true
+            } else if let message::Content::Fragments(fragments) =
+                &message.content
+            {
+                fragments.iter().enumerate().any(|(index, fragment)| {
+                    !hidden_fragments.contains(&index)
+                        && !fragment.as_str().trim_end().is_empty()
+                })
+            } else {
+                true
+            };
 
-                let mut column = column![].spacing(2);
+            if show_message_content {
+                column = column.push(content);
+            }
 
-                if fragments.len() == 1
-                    && urls.len() == 1
-                    && let Some(url) = urls.first()
-                    && let Some(preview::State::Loaded(preview)) =
-                        self.previews.get(url)
-                    && visible_for_source.is_none_or(|visible_for_source| {
-                        visible_for_source(preview, message.target.source())
-                    })
-                    && self.config.preview.hide_url_when(
-                        preview,
-                        HideUrlCondition::ContainsOnlyUrl,
-                    )
-                {
+            for (index, url, preview) in &enumerated_previews {
+                if let Some(preview) = preview {
                     let is_hovered = hovered_preview.is_some_and(
                         |(hovered_hash, hovered_index)| {
-                            hovered_hash == message.hash && hovered_index == 0
+                            hovered_hash == message.hash
+                                && hovered_index == *index
                         },
                     );
 
-                    column = column.push(
-                        self.preview_row(message, preview, url, 0, is_hovered),
-                    );
-                } else {
-                    column = column.push(content);
-
-                    for (index, url) in urls.iter().enumerate() {
-                        if is_message_visible
-                            && let Some(preview::State::Loaded(preview)) =
-                                self.previews.get(url)
-                            && visible_for_source.is_none_or(
-                                |visible_for_source| {
-                                    visible_for_source(
-                                        preview,
-                                        message.target.source(),
-                                    )
-                                },
-                            )
-                        {
-                            let is_hovered = hovered_preview.is_some_and(
-                                |(hovered_hash, hovered_index)| {
-                                    hovered_hash == message.hash
-                                        && hovered_index == index
-                                },
-                            );
-
-                            column = column.push(self.preview_row(
-                                message, preview, url, index, is_hovered,
-                            ));
-                        }
-                    }
+                    column = column.push(self.preview_row(
+                        message, preview, url, *index, is_hovered,
+                    ));
                 }
+            }
 
-                if is_message_visible {
-                    notify_visibility(
-                        column,
-                        2000.0,
-                        notify_visibility::When::NotVisible,
-                        message.hash,
-                        Message::ExitingViewport(message.hash),
-                    )
-                } else {
-                    notify_visibility(
-                        column,
-                        1000.0,
-                        notify_visibility::When::Visible,
-                        message.hash,
-                        Message::EnteringViewport(
-                            message.hash,
-                            urls.into_iter().cloned().collect(),
-                        ),
-                    )
-                }
+            if is_visible_url_message {
+                notify_visibility(
+                    column,
+                    2000.0,
+                    notify_visibility::When::NotVisible,
+                    message.hash,
+                    Message::ExitingViewport(message.hash),
+                )
             } else {
-                content
+                notify_visibility(
+                    column,
+                    1000.0,
+                    notify_visibility::When::Visible,
+                    message.hash,
+                    Message::EnteringViewport(
+                        message.hash,
+                        enumerated_previews
+                            .into_iter()
+                            .map(|(_, url, _)| url)
+                            .cloned()
+                            .collect(),
+                    ),
+                )
             }
         } else {
             content
@@ -1639,12 +1718,15 @@ fn selected_reactions_refs<'a>(
 }
 
 fn eligible_preview_urls<'a>(
-    urls: impl IntoIterator<Item = &'a url::Url>,
+    fragments: &'a [message::Fragment],
     hidden_urls: &HashSet<url::Url>,
     max_per_message: usize,
-) -> Vec<&'a url::Url> {
-    urls.into_iter()
-        .filter(|url| !hidden_urls.contains(*url))
+) -> Vec<(usize, &'a url::Url)> {
+    fragments
+        .iter()
+        .enumerate()
+        .filter_map(|(index, fragment)| fragment.url().map(|url| (index, url)))
+        .filter(|(_, url)| !hidden_urls.contains(*url))
         .take(max_per_message)
         .collect()
 }

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -16,7 +16,7 @@ use iced::widget::{
     Space, button, center, column, container, mouse_area, right, row, space,
     stack, text,
 };
-use iced::{Color, ContentFit, Length, alignment, mouse, padding};
+use iced::{Color, ContentFit, Length, alignment, padding};
 
 use crate::buffer::context_menu::{self, Context};
 use crate::buffer::scroll_view::keyed::{self, keyed};
@@ -287,17 +287,19 @@ impl<'a> ChannelQueryLayout<'a> {
         })
     }
 
+    fn not_sent(&self, message: &data::Message) -> bool {
+        self.confirm_message_delivery
+            && message.command.is_some()
+            && matches!(message.direction, message::Direction::Sent)
+            && Utc::now().signed_duration_since(message.server_time)
+                > TimeDelta::seconds(10)
+    }
+
     fn not_sent_row(
         &self,
         message: &'a data::Message,
     ) -> Option<Element<'a, Message>> {
-        let not_sent = self.confirm_message_delivery
-            && message.command.is_some()
-            && matches!(message.direction, message::Direction::Sent)
-            && Utc::now().signed_duration_since(message.server_time)
-                > TimeDelta::seconds(10);
-
-        if !not_sent {
+        if !self.not_sent(message) {
             return None;
         }
 
@@ -476,37 +478,20 @@ impl<'a> ChannelQueryLayout<'a> {
             ),
         };
 
-        let formatter = *self;
-
-        let content = crate::widget::context_menu::context_menu(
-            crate::widget::context_menu::MouseButton::Right,
-            crate::widget::context_menu::Anchor::Cursor,
-            crate::widget::context_menu::ToggleBehavior::KeepOpen,
-            Some(mouse::Interaction::Pointer),
+        let content = context_menu::preview(
             content,
-            context_menu::Entry::url_list(
-                formatter.preview_hidden_for_url(message, url.as_str()),
-                false,
-                false,
-                false,
-            ),
-            move |entry, length| {
-                entry
-                    .view(
-                        Some(context_menu::Context::Url {
-                            url: url.as_str(),
-                            message: Some(message.hash),
-                            msgid: None,
-                            selected_reactions: vec![],
-                            to_nick: None,
-                            reply_preview: None,
-                        }),
-                        length,
-                        formatter.config,
-                        formatter.theme,
-                    )
-                    .map(Message::ContextMenu)
-            },
+            url.as_str(),
+            Some(false),
+            self.can_send_replies,
+            self.can_send_reactions,
+            self.can_redact_message(message),
+            message.hash,
+            message.id.as_ref(),
+            message.user(),
+            &message.content,
+            selected_reactions_refs(message, self.our_nick),
+            self.config,
+            self.theme,
         );
 
         let hide_button = if is_hovered {
@@ -1318,6 +1303,7 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
 
         let selected_reaction_texts =
             selected_reactions(message, self.our_nick);
+
         let content = context_menu::message(
             content,
             message.target.source(),
@@ -1330,12 +1316,6 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
             self.config,
             self.theme,
         );
-
-        let content = if after_content.is_empty() {
-            content
-        } else {
-            column![content].extend(after_content).into()
-        };
 
         let middle_is_some = middle.is_some();
 
@@ -1353,8 +1333,9 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
             middle_is_some.then_some(selectable_text(" ")),
         ];
 
-        let content = if let message::Content::Fragments(fragments) =
-            &message.content
+        let content = if !(self.not_sent(message)
+            || message.redaction.is_some())
+            && let message::Content::Fragments(fragments) = &message.content
         {
             let urls = eligible_preview_urls(
                 fragments.iter().filter_map(message::Fragment::url),
@@ -1445,6 +1426,12 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
             }
         } else {
             content
+        };
+
+        let content = if after_content.is_empty() {
+            content
+        } else {
+            column![content].extend(after_content).into()
         };
 
         let message_element = if self.content_on_new_line(message) {

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -106,7 +106,7 @@ impl<'a> ChannelQueryLayout<'a> {
         message: &data::Message,
         url: &str,
     ) -> Option<bool> {
-        if self.previews_enabled(message)
+        if !self.previews_enabled(message)
             || !self.config.preview.is_enabled(url)
         {
             return None;

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -4,6 +4,7 @@ use chrono::{DateTime, TimeDelta, Utc};
 use data::buffer::RightAlignmentWidths;
 use data::config::buffer::nickname::ShownStatus;
 use data::config::buffer::{CondensationIcon, Dimmed};
+use data::config::preview::HideUrlCondition;
 use data::isupport::{CaseMap, PrefixMap};
 use data::preview::{self, Previews};
 use data::redaction::Redaction;
@@ -1367,7 +1368,10 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
 
                 let mut column = column![].spacing(2);
 
-                if fragments.len() == 1
+                if matches!(
+                    self.config.preview.hide_url,
+                    HideUrlCondition::ContainsOnlyUrl
+                ) && fragments.len() == 1
                     && urls.len() == 1
                     && let Some(url) = urls.first()
                     && let Some(preview::State::Loaded(preview)) =

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -1368,10 +1368,7 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
 
                 let mut column = column![].spacing(2);
 
-                if matches!(
-                    self.config.preview.hide_url,
-                    HideUrlCondition::ContainsOnlyUrl
-                ) && fragments.len() == 1
+                if fragments.len() == 1
                     && urls.len() == 1
                     && let Some(url) = urls.first()
                     && let Some(preview::State::Loaded(preview)) =
@@ -1379,6 +1376,10 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
                     && visible_for_source.is_none_or(|visible_for_source| {
                         visible_for_source(preview, message.target.source())
                     })
+                    && self.config.preview.hide_url_when(
+                        preview,
+                        HideUrlCondition::ContainsOnlyUrl,
+                    )
                 {
                     let is_hovered = hovered_preview.is_some_and(
                         |(hovered_hash, hovered_index)| {

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -391,6 +391,7 @@ pub fn view<'a>(
                                             } else {
                                                 0.0
                                             }
+                                            + 1.0
                                     })
                             } else {
                                 None

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -16,22 +16,19 @@ use data::server::Server;
 use data::target::{self, Target};
 use data::{Config, Image, Preview, client, history, metadata, reaction};
 use iced::widget::{
-    self, Scrollable, Space, button, center, column, container, mouse_area,
-    right, row, rule, scrollable, space, stack, text,
+    self, Scrollable, button, column, container, row, rule, scrollable, space,
+    text,
 };
-use iced::{
-    ContentFit, Length, Padding, Size, Task, alignment, mouse, padding,
-};
+use iced::{Length, Size, Task, padding};
 use tokio::time;
 
 use self::correct_viewport::correct_viewport;
 use self::keyed::keyed;
 use super::context_menu;
 use crate::widget::user_display::UserDisplay;
-use crate::widget::{Element, image, notify_visibility, on_resize, tooltip};
-use crate::{Theme, buffer, font, icon, theme};
+use crate::widget::{Element, on_resize};
+use crate::{Theme, buffer, font, theme};
 
-const HIDE_BUTTON_WIDTH: f32 = 22.0;
 const SCROLL_TO_TIMEOUT: Duration = Duration::from_millis(200);
 /// Pages of off-screen messages to keep rendered above and below the viewport
 const BUFFER_PAGES: usize = 3;
@@ -134,7 +131,11 @@ pub trait LayoutMessage<'a> {
         right_alignment_widths: Option<RightAlignmentWidths>,
         hide_timestamp: bool,
         hide_nickname: bool,
-        registry: &'a dyn metadata::Registry,
+        visible_for_source: Option<
+            &impl Fn(&Preview, &message::Source) -> bool,
+        >,
+        visible_url_messages: &HashMap<message::Hash, Vec<url::Url>>,
+        hovered_preview: Option<(message::Hash, usize)>,
     ) -> Option<Element<'a, Message>>;
 }
 
@@ -153,7 +154,11 @@ where
         right_alignment_widths: Option<RightAlignmentWidths>,
         hide_timestamp: bool,
         hide_nickname: bool,
-        _registry: &dyn metadata::Registry,
+        _visible_for_source: Option<
+            &impl Fn(&Preview, &message::Source) -> bool,
+        >,
+        _visible_url_messages: &HashMap<message::Hash, Vec<url::Url>>,
+        _hovered_preview: Option<(message::Hash, usize)>,
     ) -> Option<Element<'a, Message>> {
         self(
             message,
@@ -206,18 +211,6 @@ fn has_visible_preview(
         );
     }
     false
-}
-
-fn eligible_preview_urls<'a>(
-    urls: impl IntoIterator<Item = &'a url::Url>,
-    hidden_urls: &HashSet<url::Url>,
-    max_per_message: usize,
-) -> Vec<url::Url> {
-    urls.into_iter()
-        .filter(|url| !hidden_urls.contains(*url))
-        .take(max_per_message)
-        .cloned()
-        .collect()
 }
 
 fn is_consecutive_user_message(
@@ -481,7 +474,9 @@ pub fn view<'a>(
                             right_alignment_widths,
                             hide_timestamp,
                             hide_nickname,
-                            registry,
+                            visible_for_source.as_ref(),
+                            &state.visible_url_messages,
+                            state.hovered_preview,
                         )
                         .map(|element| (message, element)),
                 )
@@ -494,87 +489,6 @@ pub fn view<'a>(
                 let is_new_day = last_date.is_none_or(|prev| date > prev);
 
                 *last_date = Some(date);
-
-                let content = if let (
-                    message::Content::Fragments(fragments),
-                    Some(previews),
-                ) = (&message.content, previews)
-                {
-                    let urls = eligible_preview_urls(
-                        fragments.iter().filter_map(message::Fragment::url),
-                        &message.hidden_urls,
-                        config.preview.max_per_message,
-                    );
-
-                    if !urls.is_empty() {
-                        let is_message_visible = state
-                            .visible_url_messages
-                            .contains_key(&message.hash);
-
-                        let mut column = column![element].spacing(2);
-
-                        for (idx, url) in urls.iter().enumerate() {
-                            if let (
-                                true,
-                                Some(preview::State::Loaded(preview)),
-                            ) = (is_message_visible, previews.get(url))
-                            {
-                                let is_hovered =
-                                    state.hovered_preview.is_some_and(
-                                        |(a, b)| a == message.hash && b == idx,
-                                    );
-
-                                let is_visible_for_source =
-                                    if let Some(visible_for_source) =
-                                        &visible_for_source
-                                    {
-                                        visible_for_source(
-                                            preview,
-                                            message.target.source(),
-                                        )
-                                    } else {
-                                        true
-                                    };
-
-                                if is_visible_for_source {
-                                    column = column.push(preview_row(
-                                        message,
-                                        preview,
-                                        url,
-                                        idx,
-                                        right_alignment_widths,
-                                        is_hovered,
-                                        config,
-                                        registry,
-                                        theme,
-                                    ));
-                                }
-                            }
-                        }
-
-                        if is_message_visible {
-                            notify_visibility(
-                                column,
-                                2000.0,
-                                notify_visibility::When::NotVisible,
-                                message.hash,
-                                Message::ExitingViewport(message.hash),
-                            )
-                        } else {
-                            notify_visibility(
-                                column,
-                                1000.0,
-                                notify_visibility::When::Visible,
-                                message.hash,
-                                Message::EnteringViewport(message.hash, urls),
-                            )
-                        }
-                    } else {
-                        element
-                    }
-                } else {
-                    element
-                };
 
                 let content = if is_new_day
                     && config.buffer.date_separators.show
@@ -601,11 +515,11 @@ pub fn view<'a>(
                         ]
                         .padding(2)
                         .align_y(iced::Alignment::Center),
-                        content
+                        element
                     ]
                     .into()
                 } else {
-                    content
+                    element
                 };
 
                 Some(keyed(keyed::Key::message(message), content))
@@ -1592,7 +1506,7 @@ fn step_messages(height: f32, config: &Config) -> usize {
     (height / line_height).max(8.0) as usize
 }
 
-mod keyed {
+pub mod keyed {
     use data::message;
     use iced::advanced::widget::{self, Operation};
     use iced::widget::scrollable::{self, AbsoluteOffset};
@@ -1892,222 +1806,6 @@ mod keyed {
             heights: vec![],
         })
     }
-}
-
-fn preview_row<'a>(
-    message: &'a data::Message,
-    preview: &'a Preview,
-    url: &url::Url,
-    idx: usize,
-    right_alignment_widths: Option<RightAlignmentWidths>,
-    is_hovered: bool,
-    config: &'a Config,
-    registry: &'a dyn metadata::Registry,
-    theme: &'a Theme,
-) -> Element<'a, Message> {
-    let content = match preview {
-        data::Preview::Card(preview::Card {
-            image,
-            title,
-            description,
-            ..
-        }) => keyed(
-            keyed::Key::Preview(message.hash, idx),
-            button(
-                container(
-                    column![
-                        text(title)
-                            .shaping(text::Shaping::Advanced)
-                            .style(theme::text::primary)
-                            .font_maybe(
-                                theme::font_style::primary(theme)
-                                    .map(font::get)
-                            ),
-                        description.as_ref().map(|description| {
-                            container(
-                                text(description)
-                                    .shaping(text::Shaping::Advanced)
-                                    .wrapping(text::Wrapping::WordOrGlyph)
-                                    .style(theme::text::secondary)
-                                    .font_maybe(
-                                        theme::font_style::secondary(theme)
-                                            .map(font::get),
-                                    ),
-                            )
-                            .clip(false)
-                            .max_height(
-                                config.preview.card.description_max_height,
-                            )
-                        }),
-                        config.preview.card.show_image.then_some(
-                            container(image::from_data(
-                                image,
-                                config.preview.image.round_corners,
-                                ContentFit::ScaleDown,
-                            ))
-                            .padding(Padding::default().top(8))
-                            .max_height(config.preview.card.image_max_height)
-                        ),
-                    ]
-                    .spacing(8)
-                    .max_width(config.preview.card.max_width),
-                )
-                .padding(8),
-            )
-            .style(theme::button::preview_card)
-            .on_press(Message::Link(message::Link::Url(url.to_string()))),
-        ),
-        data::Preview::Image(image) => keyed(
-            keyed::Key::Preview(message.hash, idx),
-            button(
-                container(image::from_data(
-                    image,
-                    config.preview.image.round_corners,
-                    ContentFit::ScaleDown,
-                ))
-                .max_width(config.preview.image.max_width)
-                .max_height(config.preview.image.max_height),
-            )
-            .on_press(match config.preview.image.action {
-                data::config::preview::ImageAction::OpenUrl => {
-                    Message::Link(message::Link::Url(image.url.to_string()))
-                }
-                data::config::preview::ImageAction::Preview => {
-                    Message::ImagePreview(image.clone())
-                }
-            })
-            .padding(0)
-            .style(theme::button::bare),
-        ),
-    };
-
-    let url_string = url.to_string();
-    let content: Element<'a, Message> =
-        crate::widget::context_menu::context_menu(
-            crate::widget::context_menu::MouseButton::Right,
-            crate::widget::context_menu::Anchor::Cursor,
-            crate::widget::context_menu::ToggleBehavior::KeepOpen,
-            Some(mouse::Interaction::Pointer),
-            content,
-            context_menu::Entry::url_list(
-                config
-                    .preview
-                    .is_enabled(url.as_str())
-                    .then_some(message.hidden_urls.contains(url)),
-                false,
-                false,
-                false,
-            ),
-            move |entry, length| {
-                entry
-                    .view(
-                        Some(context_menu::Context::Url {
-                            url: url_string.as_str(),
-                            message: Some(message.hash),
-                            msgid: None,
-                            selected_reactions: vec![],
-                            to_nick: None,
-                            reply_preview: None,
-                        }),
-                        length,
-                        config,
-                        theme,
-                    )
-                    .map(Message::ContextMenu)
-            },
-        )
-        .into();
-
-    let aligned_content = match &config.buffer.nickname.alignment {
-        data::buffer::Alignment::Left => {
-            let mut alignment_width = 0.0;
-
-            let prefixes_width = prefixes_width(message, config);
-
-            if let Some(prefixes_width) = prefixes_width {
-                alignment_width += prefixes_width;
-            }
-
-            let timestamp_width = timestamp_width(message, config);
-
-            let space_width = font::width_from_str(" ", &config.font);
-
-            if let Some(timestamp_width) = timestamp_width {
-                alignment_width += timestamp_width + space_width;
-            }
-
-            alignment_width +=
-                if let message::Source::User(user) = message.target.source() {
-                    UserDisplay::new(
-                        user,
-                        config.buffer.nickname.show_access_levels,
-                        config.buffer.nickname.show_bot_icon,
-                        registry,
-                        &config.display.nickname,
-                        config.buffer.nickname.truncate,
-                        config.display.truncation_character,
-                        Some(&config.buffer.nickname.brackets),
-                        true,
-                    )
-                    .width(config)
-                } else {
-                    font::width_of_message_marker(&config.font)
-                } + space_width;
-
-            row![Space::new().width(alignment_width), content].into()
-        }
-        data::buffer::Alignment::Right => {
-            let right_alignment_widths =
-                right_alignment_widths.unwrap_or_default();
-
-            let space_width = font::width_from_str(" ", &config.font);
-
-            let alignment_width = right_alignment_widths.prefixes
-                + right_alignment_widths.timestamp
-                + space_width
-                + right_alignment_widths.middle
-                + space_width;
-
-            row![Space::new().width(alignment_width), content].into()
-        }
-        data::buffer::Alignment::Top => content,
-    };
-
-    let hide_button = if is_hovered {
-        container(tooltip(
-            button(center(icon::cancel()))
-                .padding(5)
-                .width(HIDE_BUTTON_WIDTH)
-                .height(HIDE_BUTTON_WIDTH)
-                .on_press(Message::HidePreview(message.hash, url.clone()))
-                .style(|theme, status| {
-                    theme::button::secondary(theme, status, false)
-                }),
-            config.tooltips.show_for_buttons().then_some("Hide Preview"),
-            tooltip::Position::Top,
-            theme,
-        ))
-    } else {
-        container(space::horizontal().width(Length::Fixed(HIDE_BUTTON_WIDTH)))
-    };
-
-    // Iced hack: using a stack with right-aligned hide_button ensures the button always stays visible
-    // at the edge of the content, even when the parent container is resized to a smaller width.
-    let stack = stack![
-        container(aligned_content)
-            .padding(Padding::default().right(HIDE_BUTTON_WIDTH + 2.0)),
-        right(hide_button),
-    ];
-
-    let content = container(stack)
-        .align_y(alignment::Vertical::Top)
-        .width(Length::Fill)
-        .padding(Padding::default().top(4).bottom(4));
-
-    mouse_area(content)
-        .on_enter(Message::PreviewHovered(message.hash, idx))
-        .on_exit(Message::PreviewUnhovered(message.hash, idx))
-        .into()
 }
 
 mod correct_viewport {

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -150,12 +150,17 @@ pub fn view<'a>(
                         Some(context_menu::message(
                             row_with_timestamp(timestamp, text_content),
                             message.target.source(),
+                            &message.server_time,
+                            &message.hash,
                             None,
                             vec![],
                             false,
                             false,
                             false,
                             &message.content,
+                            message.redaction.as_ref(),
+                            message
+                                .redaction_expanded(&config.buffer.redaction),
                             config,
                             theme,
                         ))
@@ -275,12 +280,17 @@ pub fn view<'a>(
                                 timestamp, nick, content,
                             ),
                             message.target.source(),
+                            &message.server_time,
+                            &message.hash,
                             None,
                             vec![],
                             false,
                             false,
                             false,
                             &message.content,
+                            message.redaction.as_ref(),
+                            message
+                                .redaction_expanded(&config.buffer.redaction),
                             config,
                             theme,
                         ))

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -124,6 +124,7 @@ pub fn view<'a>(
                     message::Source::Server(server) => {
                         let text_content = message_content(
                             &message.content,
+                            &[],
                             &state.server,
                             registry,
                             chantypes,
@@ -170,6 +171,7 @@ pub fn view<'a>(
                     ) => {
                         let content = message_content(
                             &message.content,
+                            &[],
                             &state.server,
                             registry,
                             chantypes,
@@ -256,6 +258,7 @@ pub fn view<'a>(
 
                         let content = message_content(
                             &message.content,
+                            &[],
                             &state.server,
                             registry,
                             chantypes,

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -2176,7 +2176,7 @@ impl Dashboard {
                         tasks.push(clipboard::write(url));
                         None
                     }
-                    buffer::context_menu::Event::CopyMessage(text) => {
+                    buffer::context_menu::Event::CopyText(text) => {
                         tasks.push(clipboard::write(text));
                         None
                     }
@@ -2450,6 +2450,44 @@ impl Dashboard {
                     }
                     buffer::context_menu::Event::Reply { .. } => {
                         tasks.push(self.focus_pane(window, id));
+
+                        None
+                    }
+                    buffer::context_menu::Event::ExpandMessage(
+                        server_time,
+                        hash,
+                    ) => {
+                        if let Some(kind) =
+                            pane.buffer.upstream().map(|buffer| {
+                                history::Kind::from_input_buffer(buffer.clone())
+                            })
+                        {
+                            self.history.expand_message(
+                                kind,
+                                server_time,
+                                hash,
+                                &config.buffer.server_messages.condense,
+                            );
+                        }
+
+                        None
+                    }
+                    buffer::context_menu::Event::ContractMessage(
+                        server_time,
+                        hash,
+                    ) => {
+                        if let Some(kind) =
+                            pane.buffer.upstream().map(|buffer| {
+                                history::Kind::from_input_buffer(buffer.clone())
+                            })
+                        {
+                            self.history.contract_message(
+                                kind,
+                                server_time,
+                                hash,
+                                &config.buffer.server_messages.condense,
+                            );
+                        }
 
                         None
                     }

--- a/src/widget/message_content.rs
+++ b/src/widget/message_content.rs
@@ -12,6 +12,7 @@ use crate::{Theme, font, theme};
 
 pub fn message_content<'a, M: 'a + std::clone::Clone>(
     content: &'a message::Content,
+    hidden_fragments: &[usize],
     server: &'a Server,
     registry: &'a dyn metadata::Registry,
     chantypes: &[char],
@@ -26,6 +27,7 @@ pub fn message_content<'a, M: 'a + std::clone::Clone>(
 ) -> Element<'a, M> {
     message_content_impl::<(), M>(
         content,
+        hidden_fragments,
         server,
         registry,
         chantypes,
@@ -43,6 +45,7 @@ pub fn message_content<'a, M: 'a + std::clone::Clone>(
 
 pub fn with_context<'a, T: Copy + 'a, M: 'a + std::clone::Clone>(
     content: &'a message::Content,
+    hidden_fragments: &[usize],
     server: &'a Server,
     registry: &'a dyn metadata::Registry,
     chantypes: &[char],
@@ -59,6 +62,7 @@ pub fn with_context<'a, T: Copy + 'a, M: 'a + std::clone::Clone>(
 ) -> Element<'a, M> {
     message_content_impl(
         content,
+        hidden_fragments,
         server,
         registry,
         chantypes,
@@ -77,6 +81,7 @@ pub fn with_context<'a, T: Copy + 'a, M: 'a + std::clone::Clone>(
 #[allow(clippy::type_complexity)]
 fn message_content_impl<'a, T: Copy + 'a, M: 'a + std::clone::Clone>(
     content: &'a message::Content,
+    hidden_fragments: &[usize],
     server: &'a Server,
     registry: &'a dyn metadata::Registry,
     chantypes: &[char],
@@ -153,7 +158,12 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a + std::clone::Clone>(
             >(
                 fragments
                     .iter()
-                    .map(|fragment| {
+                    .enumerate()
+                    .filter_map(|(index, fragment)| {
+                        if hidden_fragments.contains(&index) {
+                            return None;
+                        }
+
                         let transform_color = |color: Color| -> Color {
                             if let Some(color_transformation) =
                                 &color_transformation
@@ -331,13 +341,15 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a + std::clone::Clone>(
                                 ),
                         };
 
-                        if span.link.is_none()
-                            && let Some(default_link) = &default_link
-                        {
-                            span.link(default_link.clone())
-                        } else {
-                            span
-                        }
+                        Some(
+                            if span.link.is_none()
+                                && let Some(default_link) = &default_link
+                            {
+                                span.link(default_link.clone())
+                            } else {
+                                span
+                            },
+                        )
                     })
                     .collect::<Vec<_>>(),
             )


### PR DESCRIPTION
Adds settings for hiding URLs in messages when the URL's preview is visible and a condition is met.  Implemented conditions are:
- the message consists of only the URL
- the URL is the trailing fragment in the message (ignoring whitespace and hidden fragments)