### PR TITLE
Dynamic default ports for irc, ircs, ws and wss

### DIFF
--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -29,6 +29,8 @@ pub use self::reroute::{Reroute, RerouteRule, RerouteTarget};
 
 const DEFAULT_PORT: u16 = 6667;
 const DEFAULT_TLS_PORT: u16 = 6697;
+const DEFAULT_WS_PORT: u16 = 80;
+const DEFAULT_WSS_PORT: u16 = 443;
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(default)]
@@ -57,7 +59,7 @@ pub struct Server {
     /// The server to connect to.
     pub server: String,
     /// The port to connect on.
-    pub port: u16,
+    pub port: Option<u16>,
     /// The password to connect to the server.
     pub password: Option<String>,
     /// The file with the password to connect to the server.
@@ -147,17 +149,20 @@ impl Server {
         nickname: String,
         channels: Vec<String>,
         use_tls: bool,
+        use_websocket: bool,
     ) -> Self {
         Self {
             nickname,
             server,
-            port: port.unwrap_or(if use_tls {
-                DEFAULT_TLS_PORT
-            } else {
-                DEFAULT_PORT
-            }),
+            port: Some(port.unwrap_or(match (use_tls, use_websocket) {
+                (true, true) => DEFAULT_WSS_PORT,
+                (true, false) => DEFAULT_TLS_PORT,
+                (false, true) => DEFAULT_WS_PORT,
+                _ => DEFAULT_PORT,
+            })),
             channels,
             use_tls,
+            use_websocket,
             dangerously_accept_invalid_certs: false,
             ..Default::default()
         }
@@ -186,7 +191,14 @@ impl Server {
 
         connection::Config {
             server: &self.server,
-            port: self.port,
+            port: self.port.unwrap_or(
+                match (self.use_tls, self.use_websocket) {
+                    (true, true) => DEFAULT_WSS_PORT,
+                    (true, false) => DEFAULT_TLS_PORT,
+                    (false, true) => DEFAULT_WS_PORT,
+                    _ => DEFAULT_PORT,
+                },
+            ),
             security,
             proxy: proxy.map(From::from),
             websocket: self.use_websocket.then_some(connection::WebSocket {
@@ -228,7 +240,7 @@ impl Default for Server {
             username: Option::default(),
             realname: Option::default(),
             server: String::default(),
-            port: DEFAULT_TLS_PORT,
+            port: None,
             password: Option::default(),
             password_file: Option::default(),
             password_file_first_line_only: true,

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -27,6 +27,8 @@ pub mod reroute;
 pub use self::filters::{FancyRegex, Filters, Ignore};
 pub use self::reroute::{Reroute, RerouteRule, RerouteTarget};
 
+pub(crate) const DEFAULT_UNSET_PORT: u16 = 0;
+
 const DEFAULT_PORT: u16 = 6667;
 const DEFAULT_TLS_PORT: u16 = 6697;
 const DEFAULT_WS_PORT: u16 = 80;
@@ -59,7 +61,8 @@ pub struct Server {
     /// The server to connect to.
     pub server: String,
     /// The port to connect on.
-    pub port: Option<u16>,
+    #[serde(deserialize_with = "deserialize_port")]
+    pub port: u16,
     /// The password to connect to the server.
     pub password: Option<String>,
     /// The file with the password to connect to the server.
@@ -154,12 +157,7 @@ impl Server {
         Self {
             nickname,
             server,
-            port: Some(port.unwrap_or(match (use_tls, use_websocket) {
-                (true, true) => DEFAULT_WSS_PORT,
-                (true, false) => DEFAULT_TLS_PORT,
-                (false, true) => DEFAULT_WS_PORT,
-                _ => DEFAULT_PORT,
-            })),
+            port: port.unwrap_or(default_port(use_tls, use_websocket)),
             channels,
             use_tls,
             use_websocket,
@@ -191,14 +189,7 @@ impl Server {
 
         connection::Config {
             server: &self.server,
-            port: self.port.unwrap_or(
-                match (self.use_tls, self.use_websocket) {
-                    (true, true) => DEFAULT_WSS_PORT,
-                    (true, false) => DEFAULT_TLS_PORT,
-                    (false, true) => DEFAULT_WS_PORT,
-                    _ => DEFAULT_PORT,
-                },
-            ),
+            port: self.port,
             security,
             proxy: proxy.map(From::from),
             websocket: self.use_websocket.then_some(connection::WebSocket {
@@ -240,7 +231,7 @@ impl Default for Server {
             username: Option::default(),
             realname: Option::default(),
             server: String::default(),
-            port: None,
+            port: DEFAULT_UNSET_PORT,
             password: Option::default(),
             password_file: Option::default(),
             password_file_first_line_only: true,
@@ -548,6 +539,22 @@ pub struct OptionalTyping {
     pub show: Option<bool>,
 }
 
+fn deserialize_port<'de, D>(deserializer: D) -> Result<u16, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let port = Option::<u16>::deserialize(deserializer)?;
+
+    match port {
+        None => Ok(DEFAULT_UNSET_PORT),
+        Some(DEFAULT_UNSET_PORT) => Err(serde::de::Error::invalid_value(
+            serde::de::Unexpected::Unsigned(DEFAULT_UNSET_PORT.into()),
+            &"port must be between 1 and 65535",
+        )),
+        Some(port) => Ok(port),
+    }
+}
+
 fn deserialize_anti_flood<'de, D>(deserializer: D) -> Result<Duration, D::Error>
 where
     D: Deserializer<'de>,
@@ -591,6 +598,15 @@ where
     let seconds: u64 = Deserialize::deserialize(deserializer)?;
 
     Ok(Duration::from_secs(seconds))
+}
+
+pub fn default_port(use_tls: bool, use_websocket: bool) -> u16 {
+    match (use_tls, use_websocket) {
+        (true, true) => DEFAULT_WSS_PORT,
+        (true, false) => DEFAULT_TLS_PORT,
+        (false, true) => DEFAULT_WS_PORT,
+        (false, false) => DEFAULT_PORT,
+    }
 }
 
 pub async fn read_from_command(

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -156,7 +156,7 @@ impl Server {
             nickname,
             server,
             port: match port {
-                None => default_port(use_tls, use_websocket),
+                None => Some(default_port(use_tls, use_websocket)),
                 port => port,
             },
             channels,
@@ -192,7 +192,7 @@ impl Server {
             server: &self.server,
             port: match self.port {
                 Some(port) => port,
-                None => default_port(self.use_tls, self.use_websocket).unwrap(),
+                None => default_port(self.use_tls, self.use_websocket),
             }
             .get(),
             security,
@@ -589,13 +589,14 @@ where
     Ok(Duration::from_secs(seconds))
 }
 
-pub fn default_port(use_tls: bool, use_websocket: bool) -> Option<NonZeroU16> {
+pub fn default_port(use_tls: bool, use_websocket: bool) -> NonZeroU16 {
     NonZeroU16::new(match (use_tls, use_websocket) {
         (true, true) => DEFAULT_WSS_PORT,
         (true, false) => DEFAULT_TLS_PORT,
         (false, true) => DEFAULT_WS_PORT,
         (false, false) => DEFAULT_PORT,
     })
+    .expect("default ports are non-zero")
 }
 
 pub async fn read_from_command(

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::num::NonZeroU16;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -26,8 +27,6 @@ pub mod reroute;
 
 pub use self::filters::{FancyRegex, Filters, Ignore};
 pub use self::reroute::{Reroute, RerouteRule, RerouteTarget};
-
-pub(crate) const DEFAULT_UNSET_PORT: u16 = 0;
 
 const DEFAULT_PORT: u16 = 6667;
 const DEFAULT_TLS_PORT: u16 = 6697;
@@ -61,8 +60,7 @@ pub struct Server {
     /// The server to connect to.
     pub server: String,
     /// The port to connect on.
-    #[serde(deserialize_with = "deserialize_port")]
-    pub port: u16,
+    pub port: Option<NonZeroU16>,
     /// The password to connect to the server.
     pub password: Option<String>,
     /// The file with the password to connect to the server.
@@ -148,7 +146,7 @@ pub struct Server {
 impl Server {
     pub fn new(
         server: String,
-        port: Option<u16>,
+        port: Option<NonZeroU16>,
         nickname: String,
         channels: Vec<String>,
         use_tls: bool,
@@ -157,7 +155,10 @@ impl Server {
         Self {
             nickname,
             server,
-            port: port.unwrap_or(default_port(use_tls, use_websocket)),
+            port: match port {
+                None => default_port(use_tls, use_websocket),
+                port => port,
+            },
             channels,
             use_tls,
             use_websocket,
@@ -189,7 +190,11 @@ impl Server {
 
         connection::Config {
             server: &self.server,
-            port: self.port,
+            port: match self.port {
+                Some(port) => port,
+                None => default_port(self.use_tls, self.use_websocket).unwrap(),
+            }
+            .get(),
             security,
             proxy: proxy.map(From::from),
             websocket: self.use_websocket.then_some(connection::WebSocket {
@@ -231,7 +236,7 @@ impl Default for Server {
             username: Option::default(),
             realname: Option::default(),
             server: String::default(),
-            port: DEFAULT_UNSET_PORT,
+            port: None,
             password: Option::default(),
             password_file: Option::default(),
             password_file_first_line_only: true,
@@ -539,22 +544,6 @@ pub struct OptionalTyping {
     pub show: Option<bool>,
 }
 
-fn deserialize_port<'de, D>(deserializer: D) -> Result<u16, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let port = Option::<u16>::deserialize(deserializer)?;
-
-    match port {
-        None => Ok(DEFAULT_UNSET_PORT),
-        Some(DEFAULT_UNSET_PORT) => Err(serde::de::Error::invalid_value(
-            serde::de::Unexpected::Unsigned(DEFAULT_UNSET_PORT.into()),
-            &"port must be between 1 and 65535",
-        )),
-        Some(port) => Ok(port),
-    }
-}
-
 fn deserialize_anti_flood<'de, D>(deserializer: D) -> Result<Duration, D::Error>
 where
     D: Deserializer<'de>,
@@ -600,13 +589,13 @@ where
     Ok(Duration::from_secs(seconds))
 }
 
-pub fn default_port(use_tls: bool, use_websocket: bool) -> u16 {
-    match (use_tls, use_websocket) {
+pub fn default_port(use_tls: bool, use_websocket: bool) -> Option<NonZeroU16> {
+    NonZeroU16::new(match (use_tls, use_websocket) {
         (true, true) => DEFAULT_WSS_PORT,
         (true, false) => DEFAULT_TLS_PORT,
         (false, true) => DEFAULT_WS_PORT,
         (false, false) => DEFAULT_PORT,
-    }
+    })
 }
 
 pub async fn read_from_command(

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -43,7 +43,7 @@ const URL_PATH_RESERVED: &str = r#":?@!&'()*+,;=\[\]"#;
 
 static URL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     RegexBuilder::new(concatcp!(
-        r#"(?i)(((https?|ircs?):\/\/|www\.)[\p{Letter}\p{Number}\-@:%._+~#=]{1,256}\.[\p{Letter}\p{Number}]{1,63}\b"#,
+        r#"(?i)(((https?|ircs?|wss?):\/\/|www\.)[\p{Letter}\p{Number}\-@:%._+~#=]{1,256}\.[\p{Letter}\p{Number}]{1,63}\b"#,
         r#"(?:"#,
         r#"["#, URL_PATH_UNRESERVED, URL_PATH_RESERVED, r#"%\/#]"#,
         r#"*)|halloy:\/\/[^ ]*)"#

--- a/data/src/server.rs
+++ b/data/src/server.rs
@@ -163,7 +163,7 @@ impl ConfigMap {
         for (i, (server, mut config)) in iter.into_iter().enumerate() {
             if config.port.is_none() {
                 config.port =
-                    default_port(config.use_tls, config.use_websocket);
+                    Some(default_port(config.use_tls, config.use_websocket));
             }
             if let Some(pass_file) = &config.password_file {
                 if config.password.is_some()

--- a/data/src/server.rs
+++ b/data/src/server.rs
@@ -10,7 +10,9 @@ use tokio::fs;
 
 use crate::bouncer::BouncerNetwork;
 use crate::config::buffer::typing::Typing;
-use crate::config::server::{filehost, read_from_command};
+use crate::config::server::{
+    DEFAULT_UNSET_PORT, default_port, filehost, read_from_command,
+};
 use crate::config::sidebar::{OrderBy, OrderChannelsBy};
 use crate::config::{self, Error, sidebar};
 
@@ -161,6 +163,10 @@ impl ConfigMap {
     ) -> Result<Self, Error> {
         let mut map = IndexMap::new();
         for (i, (server, mut config)) in iter.into_iter().enumerate() {
+            if config.port == DEFAULT_UNSET_PORT {
+                config.port =
+                    default_port(config.use_tls, config.use_websocket);
+            }
             if let Some(pass_file) = &config.password_file {
                 if config.password.is_some()
                     || config.password_command.is_some()

--- a/data/src/server.rs
+++ b/data/src/server.rs
@@ -10,9 +10,7 @@ use tokio::fs;
 
 use crate::bouncer::BouncerNetwork;
 use crate::config::buffer::typing::Typing;
-use crate::config::server::{
-    DEFAULT_UNSET_PORT, default_port, filehost, read_from_command,
-};
+use crate::config::server::{default_port, filehost, read_from_command};
 use crate::config::sidebar::{OrderBy, OrderChannelsBy};
 use crate::config::{self, Error, sidebar};
 
@@ -163,7 +161,7 @@ impl ConfigMap {
     ) -> Result<Self, Error> {
         let mut map = IndexMap::new();
         for (i, (server, mut config)) in iter.into_iter().enumerate() {
-            if config.port == DEFAULT_UNSET_PORT {
+            if config.port.is_none() {
                 config.port =
                     default_port(config.use_tls, config.use_websocket);
             }

--- a/data/src/stream.rs
+++ b/data/src/stream.rs
@@ -424,6 +424,10 @@ async fn _run(
                             if config.server != updated_config.server
                                 || config.port != updated_config.port
                                 || config.use_tls != updated_config.use_tls
+                                || config.use_websocket
+                                    != updated_config.use_websocket
+                                || config.websocket_path
+                                    != updated_config.websocket_path
                                 || config.dangerously_accept_invalid_certs
                                     != updated_config
                                         .dangerously_accept_invalid_certs

--- a/data/src/url.rs
+++ b/data/src/url.rs
@@ -62,7 +62,17 @@ impl FromStr for Url {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let url = s.parse::<url::Url>().map_err(|_| ())?;
 
-        if ["irc", "ircs", "halloy"].contains(&url.scheme()) {
+        if [
+            "irc",
+            "irc+insecure",
+            "ircs",
+            "halloy",
+            "ws",
+            "ws+insecure",
+            "wss",
+        ]
+        .contains(&url.scheme())
+        {
             Ok(parse(url.clone()).unwrap_or(Url::Unknown(url.to_string())))
         } else {
             Err(())
@@ -72,7 +82,7 @@ impl FromStr for Url {
 
 fn parse(url: url::Url) -> Result<Url, Error> {
     match url.scheme().to_lowercase().as_str() {
-        "irc" | "irc+insecure" | "ircs" => {
+        "irc" | "irc+insecure" | "ircs" | "ws" | "ws+insecure" | "wss" => {
             let config = parse_server_config(&url).ok_or(Error::ParseServer)?;
             let server = generate_server_name(config.server.as_str());
             let url = url.into();
@@ -123,10 +133,15 @@ fn parse_server_config(url: &url::Url) -> Option<config::Server> {
     };
     let port = url.port();
     let use_tls = match url.scheme().to_lowercase().as_str() {
-        "irc" | "irc+insecure" => Some(false),
-        "ircs" => Some(true),
-        _ => None,
-    }?;
+        "irc" | "irc+insecure" | "ws" | "ws+insecure" => false,
+        "ircs" | "wss" => true,
+        _ => return None,
+    };
+    let use_websocket = match url.scheme().to_lowercase().as_str() {
+        "irc" | "irc+insecure" | "ircs" => false,
+        "ws" | "ws+insecure" | "wss" => true,
+        _ => return None,
+    };
     let channels = {
         let default_chantype =
             isupport::DEFAULT_CHANTYPES.first().copied().unwrap_or('#');
@@ -172,7 +187,12 @@ fn parse_server_config(url: &url::Url) -> Option<config::Server> {
     };
 
     Some(config::Server::new(
-        server, port, nickname, channels, use_tls,
+        server,
+        port,
+        nickname,
+        channels,
+        use_tls,
+        use_websocket,
     ))
 }
 
@@ -240,9 +260,10 @@ mod tests {
         input: &str,
         expected_server_name: &str,
         expected_host: &str,
-        expected_port: u16,
+        expected_port: Option<u16>,
         expected_channels: &[&str],
         expected_use_tls: bool,
+        expected_use_websocket: bool,
     ) {
         let url = Url::from_str(input).unwrap();
 
@@ -254,6 +275,7 @@ mod tests {
         assert_eq!(config.server, expected_host);
         assert_eq!(config.port, expected_port);
         assert_eq!(config.use_tls, expected_use_tls);
+        assert_eq!(config.use_websocket, expected_use_websocket);
         assert_eq!(
             config.channels,
             expected_channels
@@ -269,8 +291,9 @@ mod tests {
             "irc://irc.libera.chat",
             "libera",
             "irc.libera.chat",
-            6667,
+            Some(6667),
             &[],
+            false,
             false,
         );
     }
@@ -281,9 +304,10 @@ mod tests {
             "ircs://irc.libera.chat:7000/#halloy,#rust",
             "libera",
             "irc.libera.chat",
-            7000,
+            Some(7000),
             &["#halloy", "#rust"],
             true,
+            false,
         );
     }
 
@@ -293,8 +317,9 @@ mod tests {
             "irc://127.0.0.1:6669/channel,%26local,%2Bops,!safe",
             "127.0.0.1",
             "127.0.0.1",
-            6669,
+            Some(6669),
             &["#channel", "&local", "#+ops", "#!safe"],
+            false,
             false,
         );
     }
@@ -305,9 +330,10 @@ mod tests {
             "ircs://[2001:db8::1]",
             "2001:db8::1",
             "2001:db8::1",
-            6697,
+            Some(6697),
             &[],
             true,
+            false,
         );
     }
 
@@ -317,7 +343,7 @@ mod tests {
         let config = parse_server_config(&url).unwrap();
 
         assert_eq!(config.server, "2001:db8::1");
-        assert_eq!(config.port, 6667);
+        assert_eq!(config.port, Some(6667));
         assert_eq!(config.channels, vec!["#channel"]);
         assert!(!config.use_tls);
     }
@@ -347,8 +373,9 @@ mod tests {
             "irc://irc.example.org/%23ops%5Btest%5D%7Bdev%7D%5Efoo,%23foo%25bar",
             "example",
             "irc.example.org",
-            6667,
+            Some(6667),
             &["#ops[test]{dev}^foo", "#foo%bar"],
+            false,
             false,
         );
     }
@@ -390,5 +417,31 @@ mod tests {
         // CJK characters have no ASCII-confusable prototypes
         let u = url::Url::parse("https://日本語.jp/").unwrap();
         assert_eq!(display(&u), "https://日本語.jp/");
+    }
+
+    #[test]
+    fn parses_wss_with_default_ports() {
+        assert_server_connect(
+            "wss://irc.libera.chat",
+            "libera",
+            "irc.libera.chat",
+            Some(443),
+            &[],
+            true,
+            true,
+        );
+    }
+
+    #[test]
+    fn parses_websocket_with_default_insecure_port() {
+        assert_server_connect(
+            "ws+insecure://irc.libera.chat",
+            "libera",
+            "irc.libera.chat",
+            Some(80),
+            &[],
+            false,
+            true,
+        );
     }
 }

--- a/data/src/url.rs
+++ b/data/src/url.rs
@@ -192,7 +192,7 @@ fn parse_server_config(url: &url::Url) -> Option<config::Server> {
         server,
         match port {
             Some(port) => NonZeroU16::new(port),
-            None => default_port(use_tls, use_websocket),
+            None => Some(default_port(use_tls, use_websocket)),
         },
         nickname,
         channels,

--- a/data/src/url.rs
+++ b/data/src/url.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::num::NonZeroU16;
 use std::str::FromStr;
 
 use fancy_regex::Regex;
@@ -8,6 +9,7 @@ use unicode_security::confusable_detection::skeleton;
 use unicode_security::{RestrictionLevel, RestrictionLevelDetection};
 
 use crate::appearance::theme;
+use crate::config::server::default_port;
 use crate::server::ServerName;
 use crate::{config, isupport};
 
@@ -188,7 +190,10 @@ fn parse_server_config(url: &url::Url) -> Option<config::Server> {
 
     Some(config::Server::new(
         server,
-        port,
+        match port {
+            Some(port) => NonZeroU16::new(port),
+            None => default_port(use_tls, use_websocket),
+        },
         nickname,
         channels,
         use_tls,
@@ -260,7 +265,7 @@ mod tests {
         input: &str,
         expected_server_name: &str,
         expected_host: &str,
-        expected_port: u16,
+        expected_port: Option<NonZeroU16>,
         expected_channels: &[&str],
         expected_use_tls: bool,
         expected_use_websocket: bool,
@@ -291,7 +296,7 @@ mod tests {
             "irc://irc.libera.chat",
             "libera",
             "irc.libera.chat",
-            6667,
+            NonZeroU16::new(6667),
             &[],
             false,
             false,
@@ -304,7 +309,7 @@ mod tests {
             "ircs://irc.libera.chat:7000/#halloy,#rust",
             "libera",
             "irc.libera.chat",
-            7000,
+            NonZeroU16::new(7000),
             &["#halloy", "#rust"],
             true,
             false,
@@ -317,7 +322,7 @@ mod tests {
             "irc://127.0.0.1:6669/channel,%26local,%2Bops,!safe",
             "127.0.0.1",
             "127.0.0.1",
-            6669,
+            NonZeroU16::new(6669),
             &["#channel", "&local", "#+ops", "#!safe"],
             false,
             false,
@@ -330,7 +335,7 @@ mod tests {
             "ircs://[2001:db8::1]",
             "2001:db8::1",
             "2001:db8::1",
-            6697,
+            NonZeroU16::new(6697),
             &[],
             true,
             false,
@@ -343,7 +348,7 @@ mod tests {
         let config = parse_server_config(&url).unwrap();
 
         assert_eq!(config.server, "2001:db8::1");
-        assert_eq!(config.port, 6667);
+        assert_eq!(config.port, NonZeroU16::new(6667));
         assert_eq!(config.channels, vec!["#channel"]);
         assert!(!config.use_tls);
     }
@@ -373,7 +378,7 @@ mod tests {
             "irc://irc.example.org/%23ops%5Btest%5D%7Bdev%7D%5Efoo,%23foo%25bar",
             "example",
             "irc.example.org",
-            6667,
+            NonZeroU16::new(6667),
             &["#ops[test]{dev}^foo", "#foo%bar"],
             false,
             false,
@@ -425,7 +430,7 @@ mod tests {
             "wss://irc.libera.chat",
             "libera",
             "irc.libera.chat",
-            443,
+            NonZeroU16::new(443),
             &[],
             true,
             true,
@@ -438,7 +443,7 @@ mod tests {
             "ws+insecure://irc.libera.chat",
             "libera",
             "irc.libera.chat",
-            80,
+            NonZeroU16::new(80),
             &[],
             false,
             true,

--- a/data/src/url.rs
+++ b/data/src/url.rs
@@ -260,7 +260,7 @@ mod tests {
         input: &str,
         expected_server_name: &str,
         expected_host: &str,
-        expected_port: Option<u16>,
+        expected_port: u16,
         expected_channels: &[&str],
         expected_use_tls: bool,
         expected_use_websocket: bool,
@@ -291,7 +291,7 @@ mod tests {
             "irc://irc.libera.chat",
             "libera",
             "irc.libera.chat",
-            Some(6667),
+            6667,
             &[],
             false,
             false,
@@ -304,7 +304,7 @@ mod tests {
             "ircs://irc.libera.chat:7000/#halloy,#rust",
             "libera",
             "irc.libera.chat",
-            Some(7000),
+            7000,
             &["#halloy", "#rust"],
             true,
             false,
@@ -317,7 +317,7 @@ mod tests {
             "irc://127.0.0.1:6669/channel,%26local,%2Bops,!safe",
             "127.0.0.1",
             "127.0.0.1",
-            Some(6669),
+            6669,
             &["#channel", "&local", "#+ops", "#!safe"],
             false,
             false,
@@ -330,7 +330,7 @@ mod tests {
             "ircs://[2001:db8::1]",
             "2001:db8::1",
             "2001:db8::1",
-            Some(6697),
+            6697,
             &[],
             true,
             false,
@@ -343,7 +343,7 @@ mod tests {
         let config = parse_server_config(&url).unwrap();
 
         assert_eq!(config.server, "2001:db8::1");
-        assert_eq!(config.port, Some(6667));
+        assert_eq!(config.port, 6667);
         assert_eq!(config.channels, vec!["#channel"]);
         assert!(!config.use_tls);
     }
@@ -373,7 +373,7 @@ mod tests {
             "irc://irc.example.org/%23ops%5Btest%5D%7Bdev%7D%5Efoo,%23foo%25bar",
             "example",
             "irc.example.org",
-            Some(6667),
+            6667,
             &["#ops[test]{dev}^foo", "#foo%bar"],
             false,
             false,
@@ -425,7 +425,7 @@ mod tests {
             "wss://irc.libera.chat",
             "libera",
             "irc.libera.chat",
-            Some(443),
+            443,
             &[],
             true,
             true,
@@ -438,7 +438,7 @@ mod tests {
             "ws+insecure://irc.libera.chat",
             "libera",
             "irc.libera.chat",
-            Some(80),
+            80,
             &[],
             false,
             true,

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -145,7 +145,7 @@ The port to connect on. If you want to use a plain text port like 6667 you MUST 
 
 ```toml
 # Type: integer
-# Values: any number between 1-65535
+# Values: any non-negative integer
 # Default: 6697
 
 [servers.<name>]

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -145,12 +145,25 @@ The port to connect on. If you want to use a plain text port like 6667 you MUST 
 
 ```toml
 # Type: integer
-# Values: any non-negative integer
+# Values: any number between 1-65535
 # Default: 6697
 
 [servers.<name>]
 port = 6697
 ```
+
+::: tip
+If you leave `port` unset, default ports will be chosen based on `use_tls` and
+`use_websocket` values:
+
+| `use_tls` | `use_websocket` | `port` |
+| --------- | --------------- | ------ |
+| `"true"`  | `"false"`       | `6697` |
+| `"false"` | `"false"`       | `6667` |
+| `"true"`  | `"true"`        | `443`  |
+| `"false"` | `"true"`        | `80`   |
+
+:::
 
 ## `password`
 
@@ -476,7 +489,7 @@ who_poll_enabled = true
 
 ## `who_poll_interval`
 
-WHO poll interval (in seconds) for servers without away-notify.  Specifically, the time between individual WHO requests. Will be increased automatically if the server sends a rate-limiting message.  When the server does not support SAFERATE (and [anti-flood protections](#anti_flood) are enabled) then `who_poll_interval` will be increased to more than twice [`anti_flood`](#anti_flood) if it is not already.
+WHO poll interval (in seconds) for servers without away-notify. Specifically, the time between individual WHO requests. Will be increased automatically if the server sends a rate-limiting message. When the server does not support SAFERATE (and [anti-flood protections](#anti_flood) are enabled) then `who_poll_interval` will be increased to more than twice [`anti_flood`](#anti_flood) if it is not already.
 
 ```toml
 # Type: integer
@@ -580,7 +593,7 @@ A list of users to ignore. Users may be identified in any of these four ways:
 
 [servers.<name>.filters]
 ignore = [
-"ignored_user", 
+"ignored_user",
 { regex = '''(?i)ignored_users-.*''' },
 { user = "user_in_channel", channel = "#channel_with_user" },
 { regex = '''(?i)users_in_channel-.*''', channel = "#channel_with_users" }
@@ -652,7 +665,7 @@ disconnect_on_failure = false
 
 ## `sasl.plain`
 
-Plain SASL auth using a username and password.  See the [guide by Libera.Chat](https://libera.chat/guides/sasl) for more information.
+Plain SASL auth using a username and password. See the [guide by Libera.Chat](https://libera.chat/guides/sasl) for more information.
 
 ### `username`
 
@@ -815,7 +828,7 @@ override_url = "https://example.org/upload"
 
 ### `credentials`
 
-Specify what credentials to use for filehost.  By default the SASL credentials used for the server will be used, if they have been specified.  
+Specify what credentials to use for filehost. By default the SASL credentials used for the server will be used, if they have been specified.
 
 ```toml
 # Type: string or SASL
@@ -968,8 +981,8 @@ Set values for metadata keys (`"display-name"`, `"avatar"`, `"pronouns"`, `"home
 metadata = { pronouns = "they/them" }
 ```
 
-
 [^1]: Windows path strings should usually be specified as literal strings (e.g. `'C:\Users\Default\'`), otherwise directory separators will need to be escaped (e.g. `"C:\\Users\\Default\\"`).
+
 [^2]: Relative paths are prefixed with the config directory (i.e. if you have your config.toml in `/home/me/.config/halloy/config.toml`, path `.passwd/libera` will be converted to `/home/me/.config/halloy/.passwd/libera`).
 
 ### `icon`


### PR DESCRIPTION
Added dynamic default ports, when no port is set in a server config, the default port will be chosen based on the value of `use_tls` and `use_websocket`.

Default port values:

- `irc+secure`: `6697` (default)
- `irc+insecure`: `6667`
- `ws+secure`: `443`
- `ws+insecure`: `80`

I also updated the URL regex to parse `ws://` & `wss://` links. I almost added these to the url schema handlers of the various OSes, but realized these aren't IRC specific, so I left them out for now.