### PR TITLE
Sort highlight words in reverse len order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Fixed:
 - Issue where backlog divider in highlights or logs pane would not update when marking the pane as read
 - `VERSION` and `JOIN` commands on connect are skipped if server is primary soju server
 - `tor` enabled builds
+- Issue where a shorter highlight word would match instead of a longer one sharing the same prefix
 
 Changed:
 

--- a/data/src/config/highlights.rs
+++ b/data/src/config/highlights.rs
@@ -99,8 +99,11 @@ impl<'de> Deserialize<'de> for Match {
                 case_insensitive,
                 sound,
             } => {
-                let words =
-                    words.iter().map(|s| fancy_regex::escape(s)).join("|");
+                let words = words
+                    .iter()
+                    .sorted_by_key(|s| std::cmp::Reverse(s.len()))
+                    .map(|s| fancy_regex::escape(s))
+                    .join("|");
 
                 let flags = if case_insensitive { "(?i)" } else { "" };
 


### PR DESCRIPTION
If you have 2 words with the same prefix it's
important to "match" the longest one first.

Yes I admit having one such entry.
