### PR TITLE
Add support for account-tag extension

### DIFF
--- a/data/src/capabilities.rs
+++ b/data/src/capabilities.rs
@@ -19,6 +19,7 @@ pub static DEFAULT: LazyLock<Capabilities> =
 #[derive(Debug, Eq, PartialEq, Hash)]
 pub enum Capability {
     AccountNotify,
+    AccountTag,
     AwayNotify,
     Batch,
     BouncerNetworks,
@@ -48,6 +49,7 @@ impl FromStr for Capability {
     fn from_str(cap: &str) -> Result<Self, Self::Err> {
         match cap {
             "account-notify" => Ok(Self::AccountNotify),
+            "account-tag" => Ok(Self::AccountTag),
             "away-notify" => Ok(Self::AwayNotify),
             "batch" => Ok(Self::Batch),
             "chghost" => Ok(Self::Chghost),
@@ -349,6 +351,12 @@ impl Capabilities {
             {
                 requested.push("extended-join");
             }
+        }
+
+        if self.pending.contains_key("account-tag")
+            && !self.acknowledged(Capability::AccountTag)
+        {
+            requested.push("account-tag");
         }
 
         if self.pending.contains_key("batch")

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -124,6 +124,7 @@ impl Encoded {
                 user.clone(),
                 casemapping,
                 self.from_bot(),
+                self.accountname(),
             )),
             _ => None,
         }
@@ -153,6 +154,10 @@ impl Encoded {
 
     pub fn from_bot(&self) -> bool {
         self.tags.contains_key("bot")
+    }
+
+    pub fn accountname(&self) -> Option<String> {
+        self.tags.get("account").map(ToString::to_string)
     }
 
     pub fn channel_context(

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -203,12 +203,13 @@ impl User {
         user: proto::User,
         casemapping: isupport::CaseMap,
         from_bot: bool,
+        accountname: Option<String>,
     ) -> Self {
         User {
             nickname: Nick::from_string(user.nickname, casemapping),
             username: user.username,
             hostname: user.hostname,
-            accountname: None,
+            accountname,
             access_levels: BTreeSet::default(),
             away: false,
             bot: from_bot,

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -136,9 +136,13 @@ impl Serialize for User {
             .hostname()
             .map(|hostname| format!("@{hostname}"))
             .unwrap_or_default();
+        let accountname = self
+            .accountname()
+            .map(ToString::to_string)
+            .unwrap_or_default();
         let is_bot = if self.is_bot() { ":" } else { "" };
 
-        format!("{access_levels}{is_bot} {nickname}{username}{hostname}")
+        format!("{access_levels}{is_bot} {nickname}{username}{hostname} {accountname}")
             .serialize(serializer)
     }
 }
@@ -150,25 +154,52 @@ impl<'de> Deserialize<'de> for User {
     {
         let value = String::deserialize(deserializer)?;
 
-        if let Some((access_levels_and_is_bot, names)) = value.split_once(' ') {
+        if let Some((access_levels_and_is_bot, names_and_accountname)) =
+            value.split_once(' ')
+        {
             let access_levels = access_levels_and_is_bot
                 .chars()
                 .filter_map(|c| AccessLevel::try_from(c).ok())
                 .collect::<BTreeSet<_>>();
             let is_bot = access_levels_and_is_bot.ends_with(':');
 
-            let (nickname, username, hostname) =
-                parse_user_names(names, isupport::CaseMap::default());
+            if let Some((names, accountname)) =
+                names_and_accountname.split_once(' ')
+            {
+                let accountname = if accountname.is_empty() {
+                    None
+                } else {
+                    Some(accountname.to_string())
+                };
 
-            Ok(User {
-                nickname,
-                username,
-                hostname,
-                accountname: None,
-                access_levels,
-                away: false,
-                bot: is_bot,
-            })
+                let (nickname, username, hostname) =
+                    parse_user_names(names, isupport::CaseMap::default());
+
+                Ok(User {
+                    nickname,
+                    username,
+                    hostname,
+                    accountname,
+                    access_levels,
+                    away: false,
+                    bot: is_bot,
+                })
+            } else {
+                let (nickname, username, hostname) = parse_user_names(
+                    names_and_accountname,
+                    isupport::CaseMap::default(),
+                );
+
+                Ok(User {
+                    nickname,
+                    username,
+                    hostname,
+                    accountname: None,
+                    access_levels,
+                    away: false,
+                    bot: is_bot,
+                })
+            }
         } else {
             // Older format for user string, with no space; attempt to parse
             // with default
@@ -840,7 +871,7 @@ mod tests {
                     away: false,
                     bot: false,
                 },
-                [Token::String("+@ dan")],
+                [Token::String("+@ dan ")],
             ),
             (
                 User {
@@ -855,7 +886,7 @@ mod tests {
                     away: false,
                     bot: false,
                 },
-                [Token::String(" dan!d@localhost")],
+                [Token::String(" dan!d@localhost ")],
             ),
             (
                 User {
@@ -872,7 +903,7 @@ mod tests {
                     away: false,
                     bot: false,
                 },
-                [Token::String("@ d@n!d@localhost")],
+                [Token::String("@ d@n!d@localhost ")],
             ),
             (
                 User {
@@ -887,7 +918,7 @@ mod tests {
                     away: false,
                     bot: false,
                 },
-                [Token::String(" foobar")],
+                [Token::String(" foobar ")],
             ),
             (
                 User {
@@ -905,7 +936,7 @@ mod tests {
                     bot: false,
                 },
                 [Token::String(
-                    " foobar!8a027a9a4a@2201:12f1:2:1162:1242:1fg:he11:abde",
+                    " foobar!8a027a9a4a@2201:12f1:2:1162:1242:1fg:he11:abde ",
                 )],
             ),
             (
@@ -924,7 +955,7 @@ mod tests {
                     away: false,
                     bot: false,
                 },
-                [Token::String("+@ foobar!~foobar@12.521.212.521")],
+                [Token::String("+@ foobar!~foobar@12.521.212.521 ")],
             ),
             (
                 User {
@@ -941,7 +972,7 @@ mod tests {
                     away: false,
                     bot: false,
                 },
-                [Token::String("@ H1N5!the.flu@in.you")],
+                [Token::String("@ H1N5!the.flu@in.you ")],
             ),
             (
                 User {
@@ -956,7 +987,7 @@ mod tests {
                     away: false,
                     bot: false,
                 },
-                [Token::String(" *status")],
+                [Token::String(" *status ")],
             ),
             (
                 User {
@@ -973,7 +1004,22 @@ mod tests {
                     away: false,
                     bot: false,
                 },
-                [Token::String("@ 714user")],
+                [Token::String("@ 714user ")],
+            ),
+            (
+                User {
+                    nickname: Nick::from_str(
+                        "alice",
+                        isupport::CaseMap::default(),
+                    ),
+                    username: None,
+                    hostname: None,
+                    accountname: Some("eve".into()),
+                    access_levels: BTreeSet::<AccessLevel>::new(),
+                    away: false,
+                    bot: false,
+                },
+                [Token::String(" alice eve")],
             ),
         ];
 

--- a/irc/proto/src/parse.rs
+++ b/irc/proto/src/parse.rs
@@ -493,6 +493,21 @@ mod test {
                     ),
                 },
             ),
+            (
+                Vec::from(b"@account=hax0r :user PRIVMSG #atheme :Now I'm logged in.\r\n"),
+                Message {
+                    tags: tags!["account" => "hax0r"],
+                    source: Some(Source::User(User {
+                        nickname: "user".into(),
+                        username: None,
+                        hostname: None,
+                    })),
+                    command: Command::PRIVMSG(
+                        "#atheme".to_string(),
+                        "Now I'm logged in.".to_string(),
+                    ),
+                },
+            ),
         ];
 
         for (test, expected) in tests {


### PR DESCRIPTION
In case a decoded message contains such information
we now store it within the User struct.

Relying on extended-join and account-notify isn't enough
as they do not work with private messages.
