### PR TITLE
Disable Wrapping in User Displays

### DIFF
--- a/src/widget/selectable_text.rs
+++ b/src/widget/selectable_text.rs
@@ -118,6 +118,11 @@ where
         self
     }
 
+    pub fn wrapping(mut self, wrapping: Wrapping) -> Self {
+        self.format.wrapping = wrapping;
+        self
+    }
+
     pub fn class(mut self, class: impl Into<Theme::Class<'a>>) -> Self {
         self.class = class.into();
         self

--- a/src/widget/user_display.rs
+++ b/src/widget/user_display.rs
@@ -6,6 +6,7 @@ use data::user::AccessLevel;
 use data::{Config, User, metadata};
 use iced::Color;
 use iced::alignment::Vertical;
+use iced::widget::text::Wrapping;
 use iced::widget::{container, row};
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -332,6 +333,7 @@ impl UserDisplayData {
                         .font_maybe(f)
                         .size_maybe(size)
                         .line_height(line_height)
+                        .wrapping(Wrapping::None)
                         .into()
                 } else {
                     widget::text(content)
@@ -339,6 +341,7 @@ impl UserDisplayData {
                         .font_maybe(f)
                         .size_maybe(size)
                         .line_height(line_height)
+                        .wrapping(Wrapping::None)
                         .into()
                 }
             };


### PR DESCRIPTION
Prevents wrapping in the nickname column inside buffer history due to text width measurement precision issues.