### PR TITLE
synthetic emoji shortcodes where missing + search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Fixed:
 - `VERSION` and `JOIN` commands on connect are skipped if server is primary soju server
 - `tor` enabled builds
 - Issue where a shorter highlight word would match instead of a longer one sharing the same prefix
+- Emoji pickers not finding newer emoji like 🙂‍↕️
 
 Changed:
 

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -3115,7 +3115,7 @@ enum Emojis {
     Idle,
     Selecting {
         highlighted: Option<usize>,
-        filtered: Vec<&'static str>,
+        filtered: Vec<String>,
     },
     Selected {
         emoji: &'static str,
@@ -3176,11 +3176,11 @@ impl Emojis {
 
     fn select_at(&mut self, index: usize, config: &Config) -> Option<String> {
         if let Self::Selecting { filtered, .. } = self
-            && let Some(shortcode) = filtered.get(index).copied()
+            && index < filtered.len()
         {
+            let shortcode = filtered.swap_remove(index);
             *self = Self::Idle;
-
-            return pick_emoji(shortcode, config.buffer.emojis.skin_tone)
+            return pick_emoji(&shortcode, config.buffer.emojis.skin_tone)
                 .map(ToString::to_string);
         }
 
@@ -3493,7 +3493,7 @@ impl Paths {
 }
 
 fn pick_emoji(shortcode: &str, skin_tone: SkinTone) -> Option<&'static str> {
-    emojis::get_by_shortcode(shortcode).map(|emoji| {
+    emoji::get_by_shortcode(shortcode).map(|emoji| {
         if let Some(emoji_with_skin_tone) =
             emoji.with_skin_tone(skin_tone.into())
         {

--- a/src/emoji.rs
+++ b/src/emoji.rs
@@ -4,7 +4,7 @@ use strsim::jaro_winkler;
 
 struct SearchMatch {
     emoji: &'static emojis::Emoji,
-    shortcode: &'static str,
+    shortcode: String,
     similarity: f64,
 }
 
@@ -23,29 +23,67 @@ pub fn matching_emojis(query: &str) -> Vec<&'static emojis::Emoji> {
         .collect()
 }
 
-pub fn matching_shortcodes(query: &str) -> Vec<&'static str> {
+pub fn matching_shortcodes(query: &str) -> Vec<String> {
     search_matches(query)
         .into_iter()
         .map(|matched| matched.shortcode)
         .collect()
 }
 
-fn search_matches(query: &str) -> Vec<SearchMatch> {
-    let mut filtered = emojis::iter()
-        .flat_map(|emoji| {
-            emoji.shortcodes().filter_map(move |shortcode| {
-                if shortcode.contains(query) {
-                    Some(SearchMatch {
-                        emoji,
-                        shortcode,
-                        similarity: jaro_winkler(query, shortcode),
-                    })
-                } else {
-                    None
-                }
-            })
+pub fn get_by_shortcode(shortcode: &str) -> Option<&'static emojis::Emoji> {
+    emojis::get_by_shortcode(shortcode).or_else(|| {
+        emojis::iter().find(|e| {
+            e.shortcodes().next().is_none()
+                && synthetic_shortcode(e) == shortcode
         })
-        .collect::<Vec<_>>();
+    })
+}
+
+/// Newer emoji have no shortcodes in the upstream crate. They get a
+/// synthetic shortcode derived from their Unicode name.
+fn synthetic_shortcode(emoji: &emojis::Emoji) -> String {
+    emoji.name().to_lowercase().replace(' ', "_")
+}
+
+fn shortcodes_for(emoji: &emojis::Emoji) -> Vec<String> {
+    let real: Vec<_> = emoji.shortcodes().map(str::to_string).collect();
+    if real.is_empty() {
+        vec![synthetic_shortcode(emoji)]
+    } else {
+        real
+    }
+}
+
+fn search_matches(query: &str) -> Vec<SearchMatch> {
+    let mut filtered = Vec::new();
+
+    for emoji in emojis::iter() {
+        let shortcodes = shortcodes_for(emoji);
+
+        let mut any_matched = false;
+        for shortcode in &shortcodes {
+            if shortcode.contains(query) {
+                filtered.push(SearchMatch {
+                    similarity: jaro_winkler(query, shortcode),
+                    shortcode: shortcode.clone(),
+                    emoji,
+                });
+                any_matched = true;
+            }
+        }
+
+        // Fall back to name search when no shortcode matched, using the first shortcode
+        if !any_matched {
+            let name = emoji.name();
+            if name.to_lowercase().contains(query) {
+                filtered.push(SearchMatch {
+                    similarity: jaro_winkler(query, name),
+                    shortcode: shortcodes[0].clone(),
+                    emoji,
+                });
+            }
+        }
+    }
 
     filtered.sort_by(|a, b| b.similarity.total_cmp(&a.similarity));
     filtered


### PR DESCRIPTION
newer emoji like 🙂‍↕️ (github mangles the rendering - that is a real emoji) do not have assigned emoji shortcodes like `:head_shaking_vertically:`. after doing some research, it turns out the upstream emojis crate does not cover these cases as their data source have not been updated in many years

while fixing this, i also noticed that you cant search using spaces in the reaction picker

this patch:

- generates a synthetic shortcode from the Unicode name (`Head Shaking Vertically` -> `head_shaking_vertically`) for emoji where they're missing
- Adds a name-based fallback search path for the reaction picker