### PR TITLE
Allow bouncer network configuration

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1355,7 +1355,23 @@ impl Client {
                 }
 
                 let network = BouncerNetwork::parse(netid, network)?;
-                let network_config = self.config.bouncer_config();
+                let mut network_config = self.config.bouncer_config();
+
+                if let Some(bouncer_config) = self.config.bouncer.as_ref() {
+                    let applied_config =
+                        bouncer_config.apply(&network, &network_config);
+
+                    if applied_config != network_config {
+                        log::info!(
+                            "[{}] Applying bouncer config for network {}",
+                            self.server,
+                            network.name,
+                        );
+                    }
+
+                    network_config = applied_config;
+                }
+
                 return Ok(vec![Event::BouncerNetwork(
                     Server {
                         network: Some(network.into()),

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1355,24 +1355,8 @@ impl Client {
                 }
 
                 let network = BouncerNetwork::parse(netid, network)?;
-                let mut network_config = self.config.bouncer_config();
-
-                if let Some(bouncer_config) =
-                    self.config.bouncer_networks.as_ref()
-                {
-                    let new_config =
-                        bouncer_config.overlay(&network, &network_config);
-
-                    if new_config != network_config {
-                        log::info!(
-                            "[{}] Applying bouncer config for network {}",
-                            self.server,
-                            network.name,
-                        );
-
-                        network_config = new_config;
-                    }
-                }
+                let network_config =
+                    self.config.bouncer_network_config(&network);
 
                 return Ok(vec![Event::BouncerNetwork(
                     Server {

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1357,19 +1357,21 @@ impl Client {
                 let network = BouncerNetwork::parse(netid, network)?;
                 let mut network_config = self.config.bouncer_config();
 
-                if let Some(bouncer_config) = self.config.bouncer.as_ref() {
-                    let applied_config =
-                        bouncer_config.apply(&network, &network_config);
+                if let Some(bouncer_config) =
+                    self.config.bouncer_networks.as_ref()
+                {
+                    let new_config =
+                        bouncer_config.overlay(&network, &network_config);
 
-                    if applied_config != network_config {
+                    if new_config != network_config {
                         log::info!(
                             "[{}] Applying bouncer config for network {}",
                             self.server,
                             network.name,
                         );
-                    }
 
-                    network_config = applied_config;
+                        network_config = new_config;
+                    }
                 }
 
                 return Ok(vec![Event::BouncerNetwork(

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -11,6 +11,7 @@ use tokio::process::Command;
 use self::bouncer::BouncerConfig;
 use self::filehost::Filehost;
 use self::icon::Icon;
+use crate::bouncer::BouncerNetwork;
 use crate::config::inclusivities::{
     Inclusivities, is_target_channel_included, is_target_query_included,
 };
@@ -211,7 +212,7 @@ impl Server {
         }
     }
 
-    pub fn bouncer_config(&self) -> Self {
+    fn bouncer_config(&self) -> Self {
         Self {
             // nickserv info not relevant to the bounced network
             nick_password_file: Option::default(),
@@ -226,6 +227,18 @@ impl Server {
             ghost_sequence: Server::default().ghost_sequence,
 
             ..self.clone()
+        }
+    }
+
+    pub fn bouncer_network_config(
+        &self,
+        bouncer_network: &BouncerNetwork,
+    ) -> Self {
+        match self.bouncer_networks.as_ref() {
+            Some(bouncer_config) => {
+                bouncer_config.overlay(bouncer_network, &self.bouncer_config())
+            }
+            None => self.bouncer_config(),
         }
     }
 }

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -147,7 +147,7 @@ pub struct Server {
     pub filehost: Filehost,
     pub metadata: HashMap<metadata::Key, String>,
     pub icon: Icon,
-    pub bouncer: Option<BouncerConfig>,
+    pub bouncer_networks: Option<BouncerConfig>,
 }
 
 impl Server {
@@ -281,7 +281,7 @@ impl Default for Server {
             filehost: Filehost::default(),
             metadata: HashMap::default(),
             icon: Icon::default(),
-            bouncer: None,
+            bouncer_networks: None,
         }
     }
 }

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -212,7 +212,7 @@ impl Server {
         }
     }
 
-    fn bouncer_config(&self) -> Self {
+    fn default_bouncer_config(&self) -> Self {
         Self {
             // nickserv info not relevant to the bounced network
             nick_password_file: Option::default(),
@@ -233,13 +233,14 @@ impl Server {
     pub fn bouncer_network_config(
         &self,
         bouncer_network: &BouncerNetwork,
-    ) -> Self {
-        match self.bouncer_networks.as_ref() {
-            Some(bouncer_config) => {
-                bouncer_config.overlay(bouncer_network, &self.bouncer_config())
-            }
-            None => self.bouncer_config(),
+    ) -> Server {
+        let mut config = self.default_bouncer_config();
+
+        if let Some(bouncer_config) = self.bouncer_networks.as_ref() {
+            bouncer_config.overlay(bouncer_network, &mut config);
         }
+
+        config
     }
 }
 

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Deserializer};
 use tokio::fs;
 use tokio::process::Command;
 
+use self::bouncer::BouncerConfig;
 use self::filehost::Filehost;
 use self::icon::Icon;
 use crate::config::inclusivities::{
@@ -21,6 +22,7 @@ use crate::serde::{
 };
 use crate::{config, isupport, metadata, target};
 
+pub mod bouncer;
 pub mod filehost;
 pub mod filters;
 pub mod icon;
@@ -145,6 +147,7 @@ pub struct Server {
     pub filehost: Filehost,
     pub metadata: HashMap<metadata::Key, String>,
     pub icon: Icon,
+    pub bouncer: Option<BouncerConfig>,
 }
 
 impl Server {
@@ -278,6 +281,7 @@ impl Default for Server {
             filehost: Filehost::default(),
             metadata: HashMap::default(),
             icon: Icon::default(),
+            bouncer: None,
         }
     }
 }

--- a/data/src/config/server/bouncer.rs
+++ b/data/src/config/server/bouncer.rs
@@ -16,10 +16,8 @@ impl BouncerConfig {
     pub fn overlay(
         &self,
         bouncer_network: &BouncerNetwork,
-        server: &Server,
-    ) -> Server {
-        let mut server = server.clone();
-
+        server: &mut Server,
+    ) {
         if let Some(bouncer_network_config) =
             self.networks.get(&bouncer_network.name)
         {
@@ -37,8 +35,6 @@ impl BouncerConfig {
                 server.order_channels_by = Some(order_channels_by);
             }
         }
-
-        server
     }
 }
 

--- a/data/src/config/server/bouncer.rs
+++ b/data/src/config/server/bouncer.rs
@@ -7,20 +7,19 @@ use crate::config::server::icon::Icon;
 use crate::config::sidebar::OrderChannelsBy;
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
-#[serde(default)]
+#[serde(default, transparent)]
 pub struct BouncerConfig {
     pub networks: IndexMap<String, NetworkConfig>,
 }
 
 impl BouncerConfig {
-    pub fn apply(
+    pub fn overlay(
         &self,
         bouncer_network: &BouncerNetwork,
         server: &Server,
     ) -> Server {
         let mut server = server.clone();
 
-        #[allow(clippy::collapsible_if)]
         if let Some(bouncer_network_config) =
             self.networks.get(&bouncer_network.name)
         {
@@ -28,10 +27,8 @@ impl BouncerConfig {
                 server.icon = icon.clone();
             }
 
-            if let Some(channels_to_order) =
-                &bouncer_network_config.channels_to_order
-            {
-                server.channels = channels_to_order.clone();
+            if let Some(channels) = &bouncer_network_config.channels {
+                server.channels = channels.clone();
             }
 
             if let Some(order_channels_by) =
@@ -49,6 +46,6 @@ impl BouncerConfig {
 #[serde(default)]
 pub struct NetworkConfig {
     pub icon: Option<Icon>,
-    pub channels_to_order: Option<Vec<String>>,
+    pub channels: Option<Vec<String>>,
     pub order_channels_by: Option<OrderChannelsBy>,
 }

--- a/data/src/config/server/bouncer.rs
+++ b/data/src/config/server/bouncer.rs
@@ -1,0 +1,39 @@
+use indexmap::IndexMap;
+use serde::Deserialize;
+
+use crate::bouncer::BouncerNetwork;
+use crate::config::Server;
+use crate::config::server::icon::Icon;
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
+#[serde(default)]
+pub struct BouncerConfig {
+    pub networks: IndexMap<String, NetworkConfig>,
+}
+
+impl BouncerConfig {
+    pub fn apply(
+        &self,
+        bouncer_network: &BouncerNetwork,
+        server: &Server,
+    ) -> Server {
+        let mut server = server.clone();
+
+        #[allow(clippy::collapsible_if)]
+        if let Some(bouncer_network_config) =
+            self.networks.get(&bouncer_network.name)
+        {
+            if let Some(icon) = &bouncer_network_config.icon {
+                server.icon = icon.clone();
+            }
+        }
+
+        server
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
+#[serde(default)]
+pub struct NetworkConfig {
+    pub icon: Option<Icon>,
+}

--- a/data/src/config/server/bouncer.rs
+++ b/data/src/config/server/bouncer.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 use crate::bouncer::BouncerNetwork;
 use crate::config::Server;
 use crate::config::server::icon::Icon;
+use crate::config::sidebar::OrderChannelsBy;
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
 #[serde(default)]
@@ -26,6 +27,18 @@ impl BouncerConfig {
             if let Some(icon) = &bouncer_network_config.icon {
                 server.icon = icon.clone();
             }
+
+            if let Some(channels_to_order) =
+                &bouncer_network_config.channels_to_order
+            {
+                server.channels = channels_to_order.clone();
+            }
+
+            if let Some(order_channels_by) =
+                bouncer_network_config.order_channels_by
+            {
+                server.order_channels_by = Some(order_channels_by);
+            }
         }
 
         server
@@ -36,4 +49,6 @@ impl BouncerConfig {
 #[serde(default)]
 pub struct NetworkConfig {
     pub icon: Option<Icon>,
+    pub channels_to_order: Option<Vec<String>>,
+    pub order_channels_by: Option<OrderChannelsBy>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -949,14 +949,19 @@ impl Halloy {
                     for bouncer_network in
                         self.servers.get_bouncer_networks(&server)
                     {
-                        bouncer_network_events.push((
-                            bouncer_network.clone(),
-                            self.clients.update_config(
-                                bouncer_network,
-                                updated_config.bouncer_config().into(),
-                                false,
-                            ),
-                        ));
+                        if let Some(network) = bouncer_network.network.as_ref()
+                        {
+                            bouncer_network_events.push((
+                                bouncer_network.clone(),
+                                self.clients.update_config(
+                                    bouncer_network,
+                                    updated_config
+                                        .bouncer_network_config(network)
+                                        .into(),
+                                    false,
+                                ),
+                            ));
+                        }
                     }
 
                     if let Screen::Dashboard(dashboard) = &mut self.screen {
@@ -1541,11 +1546,14 @@ impl Halloy {
                             .collect::<Vec<_>>();
 
                         for bouncer_network in bouncer_networks {
-                            if let Some(bouncer_network) =
-                                self.servers.get_mut(&bouncer_network)
+                            if let Some(network) =
+                                bouncer_network.network.as_ref()
+                                && let Some(existing) =
+                                    self.servers.get_mut(&bouncer_network)
                             {
-                                *bouncer_network =
-                                    config.bouncer_config().into();
+                                *existing = config
+                                    .bouncer_network_config(network)
+                                    .into();
                             }
                         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1931,6 +1931,12 @@ fn handle_client_events(
                 dashboard.set_reroute_rules(servers, clients);
 
                 dashboard.update_filters(servers, clients, &config.buffer);
+
+                commands.push(
+                    dashboard
+                        .request_override_server_icons(servers)
+                        .map(Message::Dashboard),
+                );
             }
             Event::AddToSidebar(query) => {
                 dashboard.add_to_sidebar(server.clone(), query);


### PR DESCRIPTION
Allow to override config for bouncer networks

For example
[servers.soju.bouncer_networks."Libera.Chat"]
icon.override_url = "https://libera.chat/static/img/libera-color.svg"

Will override the icon for the specified network
