### PR TITLE
Order Reactions by Time of First React

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -150,6 +150,8 @@ pub enum Event {
         message: message::Encoded,
         our_nick: Nick,
         notification_enabled: bool,
+        deduplicate: bool,
+        labeled_response_context: Option<LabeledResponseContext>,
     },
     Redaction(message::Encoded, Nick),
     WithTarget {
@@ -1148,7 +1150,9 @@ impl Client {
                 return Ok(vec![Event::Reaction {
                     message,
                     our_nick: self.nickname().to_owned(),
-                    notification_enabled: true,
+                    deduplicate: false,
+                    notification_enabled: self.notification_blackout.allowed(),
+                    labeled_response_context: context.and_then(Into::into),
                 }]);
             }
             _ if matches!(message.command, Command::REDACT(_, _, _)) => {
@@ -3343,6 +3347,8 @@ impl Client {
                         message,
                         our_nick: self.nickname().to_owned(),
                         notification_enabled: false,
+                        deduplicate: true,
+                        labeled_response_context: None,
                     }]
                 }
                 Command::REDACT(_, _, _) => {
@@ -3477,6 +3483,8 @@ impl Client {
                     message,
                     our_nick: self.nickname().to_owned(),
                     notification_enabled: false,
+                    deduplicate: true,
+                    labeled_response_context: None,
                 }]
             }
             Command::REDACT(_, _, _) => {

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -16,6 +16,7 @@ pub use self::manager::{
 pub use self::metadata::{Metadata, ReadMarker};
 use crate::capabilities::LabeledResponseContext;
 use crate::message::{self, Direction, MessageReferences, Source};
+use crate::reaction::Reaction;
 use crate::redaction::Redaction;
 use crate::target::{self, Target};
 use crate::user::Nick;
@@ -282,39 +283,42 @@ pub async fn append(
 
     // pending reactions should only exist for unloaded history entries
     for (id, pending) in pending_reactions.into_iter() {
-        if let Some(message) =
-            find_reply_target_mut(&mut all_messages, &id, &pending.server_time)
+        if let Some(server_time) = pending.server_time()
+            && let Some(message) =
+                find_reply_target_mut(&mut all_messages, &id, &server_time)
         {
             if message.is_echo
                 && message.direction == Direction::Received
                 && let Ok(target) = Target::try_from(message.target.clone())
             {
                 let message_text = message.text();
-                for (reaction, notification_enabled) in
-                    pending.clone().reactions.into_iter()
-                {
-                    if notification_enabled {
+                for pending_reaction in pending.reactions.iter() {
+                    if pending_reaction.notification_enabled {
                         let reaction_to_echo = ReactionToEcho {
                             reaction: reaction::Context {
-                                inner: reaction,
+                                inner: pending_reaction.reaction.clone(),
                                 target: target.clone(),
                                 in_reply_to: id.clone(),
-                                server_time: pending.server_time,
+                                is_echo: pending_reaction.is_echo,
+                                deduplicate: pending_reaction.deduplicate,
                             },
                             message_text: message_text.clone(),
                         };
+
                         echo_events.push(EchoEvent::Reaction(reaction_to_echo));
                     }
                 }
             }
 
-            message.reactions.append(
-                &mut pending
-                    .reactions
-                    .iter()
-                    .map(|(reaction, _)| reaction.clone())
-                    .collect(),
-            );
+            for pending_reaction in pending.reactions.into_iter() {
+                insert_reaction(
+                    &mut message.reactions,
+                    pending_reaction.reaction,
+                    pending_reaction.is_echo,
+                    pending_reaction.deduplicate,
+                    pending_reaction.labeled_response_context,
+                );
+            }
         }
     }
 
@@ -1209,6 +1213,7 @@ impl History {
         &mut self,
         reaction: reaction::Context,
         notification_enabled: bool,
+        labeled_response_context: Option<LabeledResponseContext>,
     ) -> Option<ReactionToEcho> {
         match self {
             History::Partial {
@@ -1246,15 +1251,15 @@ impl History {
                 } else {
                     let pending = pending_reactions
                         .entry(reaction.in_reply_to)
-                        .or_insert(reaction::Pending::new(
-                            reaction.server_time,
-                        ));
+                        .or_insert(reaction::Pending::default());
 
-                    pending.server_time =
-                        (pending.server_time).min(reaction.server_time);
-                    pending
-                        .reactions
-                        .push((reaction.inner, notification_enabled));
+                    pending.reactions.push(reaction::PendingReaction {
+                        reaction: reaction.inner,
+                        is_echo: reaction.is_echo,
+                        deduplicate: reaction.deduplicate,
+                        labeled_response_context,
+                        notification_enabled,
+                    });
                 }
 
                 *last_updated_at = Some(Instant::now());
@@ -1267,7 +1272,7 @@ impl History {
                 let message = find_reply_target_mut(
                     messages,
                     &reaction.in_reply_to,
-                    &reaction.server_time,
+                    &reaction.inner.server_time,
                 )?;
                 message.reactions.push(reaction.inner.clone());
 
@@ -1570,6 +1575,44 @@ fn has_matching_content(
         }
     } else {
         false
+    }
+}
+
+pub fn insert_reaction(
+    reactions: &mut Vec<Reaction>,
+    reaction: Reaction,
+    is_echo: bool,
+    deduplicate: bool,
+    labeled_response_context: Option<LabeledResponseContext>,
+) {
+    if reactions.is_empty() {
+        reactions.push(reaction);
+
+        return;
+    }
+
+    if let Some(labeled_response_context) = &labeled_response_context {
+        if let Some(index) = reactions.iter().position(|reaction| {
+            reaction
+                .id
+                .as_ref()
+                .is_some_and(|id| *id == labeled_response_context.label_as_id)
+        }) {
+            reactions.remove(index);
+        }
+
+        reactions.push(reaction);
+    } else if let Some(index) = reactions.iter().position(|stored| {
+        (stored.id.is_some() && stored.id == reaction.id)
+            || (deduplicate
+                && (stored.server_time == reaction.server_time || is_echo)
+                && stored.sender == reaction.sender
+                && stored.text == reaction.text
+                && stored.unreact == reaction.unreact)
+    }) {
+        reactions[index] = reaction;
+    } else {
+        reactions.push(reaction);
     }
 }
 

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -43,7 +43,7 @@ impl Resource {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReactionToEcho {
     pub reaction: reaction::Context,
     pub message_text: String,
@@ -478,9 +478,14 @@ impl Manager {
         server: &Server,
         reaction: reaction::Context,
         notification_enabled: bool,
+        labeled_response_context: Option<LabeledResponseContext>,
     ) -> Option<impl Future<Output = Message> + use<>> {
-        self.data
-            .add_reaction(server.clone(), reaction, notification_enabled)
+        self.data.add_reaction(
+            server.clone(),
+            reaction,
+            notification_enabled,
+            labeled_response_context,
+        )
     }
 
     pub fn redact_message(
@@ -1356,17 +1361,25 @@ impl Data {
                     let mut last_seen = last_seen.clone();
 
                     for (id, pending) in std::mem::take(pending_reactions) {
-                        if let Some(message) = history::find_reply_target_mut(
-                            &mut messages,
-                            &id,
-                            &pending.server_time,
-                        ) {
-                            message.reactions.extend(
-                                pending
-                                    .reactions
-                                    .into_iter()
-                                    .map(|(reaction, _)| reaction),
-                            );
+                        if let Some(server_time) = pending.server_time()
+                            && let Some(message) =
+                                history::find_reply_target_mut(
+                                    &mut messages,
+                                    &id,
+                                    &server_time,
+                                )
+                        {
+                            for pending_reaction in
+                                pending.reactions.into_iter()
+                            {
+                                history::insert_reaction(
+                                    &mut message.reactions,
+                                    pending_reaction.reaction,
+                                    pending_reaction.is_echo,
+                                    pending_reaction.deduplicate,
+                                    pending_reaction.labeled_response_context,
+                                );
+                            }
                         }
                     }
 
@@ -1892,14 +1905,17 @@ impl Data {
         server: Server,
         reaction: reaction::Context,
         notification_enabled: bool,
+        labeled_response_context: Option<LabeledResponseContext>,
     ) -> Option<impl Future<Output = Message> + use<>> {
         let kind =
             history::Kind::from_target(server.clone(), reaction.target.clone());
         match self.map.entry(kind.clone()) {
             hash_map::Entry::Occupied(mut entry) => {
-                let reactions = entry
-                    .get_mut()
-                    .add_reaction(reaction, notification_enabled);
+                let reactions = entry.get_mut().add_reaction(
+                    reaction,
+                    notification_enabled,
+                    labeled_response_context,
+                );
 
                 if notification_enabled {
                     reactions.map(|reaction| {
@@ -1916,9 +1932,11 @@ impl Data {
                 }
             }
             hash_map::Entry::Vacant(entry) => {
-                entry
-                    .insert(History::partial(kind.clone()))
-                    .add_reaction(reaction, notification_enabled);
+                entry.insert(History::partial(kind.clone())).add_reaction(
+                    reaction,
+                    notification_enabled,
+                    labeled_response_context,
+                );
 
                 Some(
                     async move {

--- a/data/src/notification.rs
+++ b/data/src/notification.rs
@@ -2,7 +2,7 @@ use crate::target::Channel;
 use crate::user::Nick;
 use crate::{User, isupport, reaction};
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Notification {
     Connected,
     Disconnected,

--- a/data/src/reaction.rs
+++ b/data/src/reaction.rs
@@ -3,30 +3,38 @@ use irc::proto::Command;
 use serde::{Deserialize, Serialize};
 use unicode_segmentation::UnicodeSegmentation;
 
+use crate::capabilities::LabeledResponseContext;
 use crate::isupport;
 use crate::message::{Encoded, Id};
+use crate::serde::{deserialize_date_time_utc_or_epoch, fail_as_none};
 use crate::target::Target;
 use crate::user::Nick;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Reaction {
     pub sender: Nick,
     pub text: String,
     pub unreact: bool,
+    #[serde(default, deserialize_with = "fail_as_none")]
+    pub id: Option<Id>,
+    #[serde(default, deserialize_with = "deserialize_date_time_utc_or_epoch")]
+    pub server_time: DateTime<Utc>,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Context {
     pub inner: Reaction,
     pub target: Target,
     pub in_reply_to: Id,
-    pub server_time: DateTime<Utc>,
+    pub is_echo: bool,
+    pub deduplicate: bool,
 }
 
 impl Reaction {
     pub fn received(
         message: Encoded,
         our_nick: Nick,
+        deduplicate: bool,
         chantypes: &[char],
         statusmsg: &[char],
         casemapping: isupport::CaseMap,
@@ -50,6 +58,7 @@ impl Reaction {
             return None;
         }
         let in_reply_to = message.in_reply_to()?;
+        let id = message.message_id();
         let server_time = message.server_time_or_now();
 
         let (Command::PRIVMSG(target, _) | Command::TAGMSG(target)) =
@@ -65,30 +74,50 @@ impl Reaction {
                 Target::parse(&target, chantypes, statusmsg, casemapping)
             };
 
+        let sender = Nick::from(user);
+
+        let is_echo = sender == our_nick;
+
         Some(Context {
             inner: Reaction {
-                sender: Nick::from(user),
+                sender,
                 text,
                 unreact,
+                id,
+                server_time,
             },
             in_reply_to,
             target,
-            server_time,
+            is_echo,
+            deduplicate,
         })
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Pending {
-    pub reactions: Vec<(Reaction, bool)>,
-    pub server_time: DateTime<Utc>,
+    pub reactions: Vec<PendingReaction>,
 }
 
 impl Pending {
-    pub fn new(server_time: DateTime<Utc>) -> Self {
-        Self {
-            reactions: vec![],
-            server_time,
-        }
+    pub fn server_time(&self) -> Option<DateTime<Utc>> {
+        self.reactions
+            .iter()
+            .fold(None, |server_time, pending_reaction| {
+                Some(if let Some(server_time) = server_time {
+                    server_time.min(pending_reaction.reaction.server_time)
+                } else {
+                    pending_reaction.reaction.server_time
+                })
+            })
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct PendingReaction {
+    pub reaction: Reaction,
+    pub is_echo: bool,
+    pub deduplicate: bool,
+    pub labeled_response_context: Option<LabeledResponseContext>,
+    pub notification_enabled: bool,
 }

--- a/data/src/serde.rs
+++ b/data/src/serde.rs
@@ -1,6 +1,7 @@
 use std::path::{self, PathBuf};
 
 use chrono::format::StrftimeItems;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Deserializer};
 
 use crate::Config;
@@ -234,6 +235,22 @@ where
 {
     let s = String::deserialize(deserializer)?;
     Ok((!s.is_empty()).then_some(s))
+}
+
+pub fn deserialize_date_time_utc_or_epoch<'de, D>(
+    deserializer: D,
+) -> Result<DateTime<Utc>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let date_time: Result<DateTime<Utc>, D::Error> =
+        Deserialize::deserialize(deserializer);
+
+    if let Ok(date_time) = date_time {
+        Ok(date_time)
+    } else {
+        Ok(DateTime::UNIX_EPOCH)
+    }
 }
 
 #[cfg(test)]

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -1421,7 +1421,8 @@ fn send_reaction(
     };
 
     let encoded = message::Encoded::try_from(command).ok()?;
-    clients.send(buffer, encoded, TokenPriority::User);
+    let labeled_response_context =
+        clients.send(buffer, encoded, TokenPriority::User);
 
     if !clients.get_server_supports_echoes(server) {
         let nick = clients.nickname(server)?;
@@ -1432,12 +1433,17 @@ fn send_reaction(
                     sender: nick.to_owned(),
                     text: text.into_owned(),
                     unreact,
+                    id: labeled_response_context
+                        .map(|context| context.label_as_id),
+                    server_time: Utc::now(),
                 },
                 target,
                 in_reply_to: msgid,
-                server_time: Utc::now(),
+                is_echo: false,
+                deduplicate: false,
             },
             false,
+            None,
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1814,10 +1814,13 @@ fn handle_client_events(
                 message,
                 our_nick,
                 notification_enabled,
+                deduplicate,
+                labeled_response_context,
             } => {
                 if let Some(reaction) = Reaction::received(
                     message,
                     our_nick,
+                    deduplicate,
                     clients.get_server_chantypes_or_default(server),
                     clients.get_server_statusmsg_or_default(server),
                     clients.get_server_casemapping_or_default(server),
@@ -1829,6 +1832,7 @@ fn handle_client_events(
                                 server,
                                 reaction,
                                 notification_enabled,
+                                labeled_response_context,
                             )
                             .map(Message::Dashboard),
                     );
@@ -2402,7 +2406,7 @@ fn handle_reaction_to_echo(
             &config.notifications,
             &Notification::Reaction {
                 casemapping,
-                reaction: reaction_to_echo.reaction.clone(),
+                reaction: reaction_to_echo.reaction,
                 message_text: reaction_to_echo.message_text,
             },
             server,

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -3339,11 +3339,13 @@ impl Dashboard {
         server: &Server,
         reaction: reaction::Context,
         notification_enabled: bool,
+        labeled_response_context: Option<LabeledResponseContext>,
     ) -> Task<Message> {
         let future = self.history.record_reaction(
             server,
             reaction,
             notification_enabled,
+            labeled_response_context,
         );
         if let Some(f) = future {
             Task::perform(f, Message::History)

--- a/src/widget/reaction_row.rs
+++ b/src/widget/reaction_row.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
+use chrono::{DateTime, Utc};
 use data::isupport::CaseMap;
 use data::user::{ChannelUsers, Nick, NickRef, User};
 use data::{Config, metadata};
@@ -44,153 +45,159 @@ where
 {
     let emoji_size = (font_size - 1.0).max(10.0);
     let count_size = (font_size - 1.0).max(10.0);
-    let m = visible_reactions(message);
+    let visible = visible_reactions(message);
+    let any_visible = !visible.is_empty();
 
-    let mut row = Row::from_iter(m.iter().map(|(reaction_text, nicks)| {
-        // we reacted to this message already
-        let selected =
-            our_nick.is_some_and(|nick| nicks.contains(&nick.as_str()));
-        let on_press = if selected {
-            on_unreact.as_ref().map(|f| f(reaction_text))
-        } else {
-            on_react.as_ref().map(|f| f(reaction_text))
-        };
-        let react_count = nicks.len();
-        let emoji =
-            text(truncate_text(reaction_text, max_reaction_display as usize))
-                .shaping(iced::widget::text::Shaping::Advanced)
-                .size(emoji_size)
-                .style(theme::text::primary);
-        let mut button_content = row![emoji];
-        if react_count >= 2 {
-            button_content = button_content.push(Space::new().width(4)).push(
-                text(react_count.to_string())
-                    .size(count_size)
-                    .style(theme::text::primary),
-            );
-        }
-        let button_content: Element<'a, M> =
-            button_content.align_y(alignment::Vertical::Center).into();
-
-        let content: Element<'a, M> = button(button_content)
-            .padding([2, 6])
-            .on_press_maybe(on_press)
-            .style(move |theme, status| {
-                theme::button::secondary(theme, status, selected)
-            })
-            .into();
-
-        let display_max = if nicks.len() == REACTION_TOOLTIP_MAX_NAMES + 1 {
-            REACTION_TOOLTIP_MAX_NAMES + 1
-        } else {
-            REACTION_TOOLTIP_MAX_NAMES
-        };
-        let hidden_count = nicks.len().saturating_sub(display_max);
-        let displayed: Vec<_> = nicks.iter().take(display_max).collect();
-        let total = displayed.len() + usize::from(hidden_count > 0);
-        let mut tooltip_nicks: Vec<Element<'a, M>> = vec![];
-        for (i, nick) in displayed.iter().enumerate() {
-            let resolved = users.and_then(|u| {
-                u.iter().find(|u| u.nickname().as_str() == **nick)
-            });
-            let fallback;
-            let user: &User = if let Some(user) = resolved {
-                user
+    let mut row = Row::from_iter(visible.into_iter().flat_map(|reactions| {
+        reactions.into_iter().map(|(reaction_text, nicks)| {
+            // we reacted to this message already
+            let selected =
+                our_nick.is_some_and(|nick| nicks.contains(&nick.as_str()));
+            let on_press = if selected {
+                on_unreact.as_ref().map(|f| f(reaction_text))
             } else {
-                fallback = User::from(Nick::from_string(
-                    nick.to_string(),
-                    casemapping,
-                ));
-                &fallback
+                on_react.as_ref().map(|f| f(reaction_text))
             };
-            let nick_element = UserDisplay::new(
-                user,
-                config.buffer.nickname.show_access_levels,
-                config.buffer.nickname.show_bot_icon,
-                registry,
-                &config.display.nickname,
-                None,
-                config.display.truncation_character,
-                None,
-                false,
-            )
-            .into_element(
-                user, false, false, None, None, false, false, theme, config,
-            );
-
-            // trailing separator attached to nicks so it never starts a new line alone
-            let position = i + 1;
-            let trailing = if position + 1 == total && hidden_count == 0 {
-                Some(" and")
-            } else if position < displayed.len() {
-                Some(",")
-            } else {
-                None
-            };
-
-            tooltip_nicks.push(match trailing {
-                Some(t) => {
-                    row![nick_element, text(t).style(theme::text::secondary),]
-                        .into()
-                }
-                None => nick_element,
-            });
-
-            // space between items (wrappable, so lines start on the next nick)
-            if position < total {
-                tooltip_nicks
-                    .push(text(" ").style(theme::text::secondary).into());
+            let react_count = nicks.len();
+            let emoji = text(truncate_text(
+                reaction_text,
+                max_reaction_display as usize,
+            ))
+            .shaping(iced::widget::text::Shaping::Advanced)
+            .size(emoji_size)
+            .style(theme::text::primary);
+            let mut button_content = row![emoji];
+            if react_count >= 2 {
+                button_content =
+                    button_content.push(Space::new().width(4)).push(
+                        text(react_count.to_string())
+                            .size(count_size)
+                            .style(theme::text::primary),
+                    );
             }
-        }
-        if hidden_count > 0 {
-            tooltip_nicks.push(
-                text(format!("and {hidden_count} others…"))
-                    .shaping(iced::widget::text::Shaping::Advanced)
-                    .style(theme::text::secondary)
+            let button_content: Element<'a, M> =
+                button_content.align_y(alignment::Vertical::Center).into();
+
+            let content: Element<'a, M> = button(button_content)
+                .padding([2, 6])
+                .on_press_maybe(on_press)
+                .style(move |theme, status| {
+                    theme::button::secondary(theme, status, selected)
+                })
+                .into();
+
+            let display_max = if nicks.len() == REACTION_TOOLTIP_MAX_NAMES + 1 {
+                REACTION_TOOLTIP_MAX_NAMES + 1
+            } else {
+                REACTION_TOOLTIP_MAX_NAMES
+            };
+            let hidden_count = nicks.len().saturating_sub(display_max);
+            let displayed: Vec<_> =
+                nicks.into_iter().take(display_max).collect();
+            let total = displayed.len() + usize::from(hidden_count > 0);
+            let mut tooltip_nicks: Vec<Element<'a, M>> = vec![];
+            for (i, nick) in displayed.iter().enumerate() {
+                let resolved = users.and_then(|u| {
+                    u.iter().find(|u| u.nickname().as_str() == *nick)
+                });
+                let fallback;
+                let user: &User = if let Some(user) = resolved {
+                    user
+                } else {
+                    fallback = User::from(Nick::from_string(
+                        nick.to_string(),
+                        casemapping,
+                    ));
+                    &fallback
+                };
+                let nick_element = UserDisplay::new(
+                    user,
+                    config.buffer.nickname.show_access_levels,
+                    config.buffer.nickname.show_bot_icon,
+                    registry,
+                    &config.display.nickname,
+                    None,
+                    config.display.truncation_character,
+                    None,
+                    false,
+                )
+                .into_element(
+                    user, false, false, None, None, false, false, theme, config,
+                );
+
+                // trailing separator attached to nicks so it never starts a new line alone
+                let position = i + 1;
+                let trailing = if position + 1 == total && hidden_count == 0 {
+                    Some(" and")
+                } else if position < displayed.len() {
+                    Some(",")
+                } else {
+                    None
+                };
+
+                tooltip_nicks.push(match trailing {
+                    Some(t) => row![
+                        nick_element,
+                        text(t).style(theme::text::secondary),
+                    ]
                     .into(),
-            );
-        }
-        let tooltip_content = Row::from_iter(tooltip_nicks)
-            .align_y(alignment::Vertical::Center)
-            .wrap();
+                    None => nick_element,
+                });
 
-        let tooltip_emoji_size = if let Some(only_emojis_size) =
-            only_emojis_size
-            && UnicodeSegmentation::graphemes(*reaction_text, true)
-                .all(|grapheme| emojis::get(grapheme).is_some())
-        {
-            only_emojis_size
-        } else {
-            font_size
-        };
+                // space between items (wrappable, so lines start on the next nick)
+                if position < total {
+                    tooltip_nicks
+                        .push(text(" ").style(theme::text::secondary).into());
+                }
+            }
+            if hidden_count > 0 {
+                tooltip_nicks.push(
+                    text(format!("and {hidden_count} others…"))
+                        .shaping(iced::widget::text::Shaping::Advanced)
+                        .style(theme::text::secondary)
+                        .into(),
+                );
+            }
+            let tooltip_content = Row::from_iter(tooltip_nicks)
+                .align_y(alignment::Vertical::Center)
+                .wrap();
 
-        let tooltip_content = row![
-            text(*reaction_text)
-                .shaping(iced::widget::text::Shaping::Advanced)
-                .size(tooltip_emoji_size)
-                .line_height(LineHeight::Relative(1.0))
-                .style(theme::text::primary),
-            tooltip_content,
-        ]
-        .spacing(8.0)
-        .align_y(alignment::Vertical::Center);
+            let tooltip_emoji_size = if let Some(only_emojis_size) =
+                only_emojis_size
+                && UnicodeSegmentation::graphemes(reaction_text, true)
+                    .all(|grapheme| emojis::get(grapheme).is_some())
+            {
+                only_emojis_size
+            } else {
+                font_size
+            };
 
-        iced::widget::tooltip(
-            content,
-            container(tooltip_content)
-                .style(theme::container::tooltip)
-                .padding(8)
-                .max_width(300),
-            Position::Bottom,
-        )
-        .into()
+            let tooltip_content = row![
+                text(reaction_text)
+                    .shaping(iced::widget::text::Shaping::Advanced)
+                    .size(tooltip_emoji_size)
+                    .line_height(LineHeight::Relative(1.0))
+                    .style(theme::text::primary),
+                tooltip_content,
+            ]
+            .spacing(8.0)
+            .align_y(alignment::Vertical::Center);
+
+            iced::widget::tooltip(
+                content,
+                container(tooltip_content)
+                    .style(theme::container::tooltip)
+                    .padding(8)
+                    .max_width(300),
+                Position::Bottom,
+            )
+            .into()
+        })
     }))
     .padding(padding::all(0).top(2))
     .spacing(2.0);
 
-    if !m.is_empty()
-        && let Some(on_open_picker) = on_open_picker
-    {
+    if any_visible && let Some(on_open_picker) = on_open_picker {
         let open_picker = tooltip(
             button(
                 icon::plus()
@@ -215,41 +222,66 @@ where
     container(row).into()
 }
 
-fn visible_reactions<'a>(
-    message: &'a data::Message,
-) -> BTreeMap<&'a str, BTreeSet<&'a str>> {
-    // We need a deterministic order so that the UI elements don't move around.
-    let mut reactions = BTreeMap::<&'a str, BTreeMap<&'a str, i16>>::new();
+// We need a deterministic order so that the UI elements don't move around.
+fn visible_reactions(
+    message: &data::Message,
+) -> Vec<BTreeMap<&str, Vec<&str>>> {
+    // First sort by reaction, then sender, then time.
+    let mut sorted_reactions =
+        BTreeMap::<&str, BTreeMap<&Nick, BTreeMap<DateTime<Utc>, bool>>>::new();
 
     for reaction in &message.reactions {
-        let reactions_for_sender = reactions
+        let reactions_for_sender = sorted_reactions
             .entry(&reaction.text)
             .or_default()
-            .entry(reaction.sender.as_str())
+            .entry(&reaction.sender)
             .or_default();
 
-        if reaction.unreact {
-            *reactions_for_sender -= 1;
-        } else {
-            *reactions_for_sender += 1;
+        reactions_for_sender.insert(reaction.server_time, reaction.unreact);
+    }
+
+    let mut reactions =
+        BTreeMap::<DateTime<Utc>, BTreeMap<&str, Vec<&str>>>::new();
+
+    for (reaction, senders) in sorted_reactions {
+        let reaction_senders: BTreeMap<DateTime<Utc>, &str> = senders
+            .into_iter()
+            .filter_map(|(sender, server_times)| {
+                // Find the earliest react time for each sender that doesn't have a subsequent unreact
+                let mut sender_count = 0;
+                let mut sender_server_time = None;
+
+                for (server_time, unreact) in server_times {
+                    if unreact {
+                        sender_count -= 1;
+                        if sender_count == 0 {
+                            sender_server_time = None;
+                        }
+                    } else {
+                        sender_count += 1;
+                        if sender_count == 1 {
+                            sender_server_time = Some(server_time);
+                        }
+                    }
+                }
+
+                sender_server_time.map(|sender_server_time| {
+                    (sender_server_time, sender.as_str())
+                })
+            })
+            .collect();
+
+        if let Some(reaction_server_time) =
+            reaction_senders.keys().min().copied()
+        {
+            let reactions_at_server_time =
+                reactions.entry(reaction_server_time).or_default();
+            reactions_at_server_time
+                .insert(reaction, reaction_senders.into_values().collect());
         }
     }
 
-    reactions
-        .into_iter()
-        .map(|(text, senders)| {
-            (
-                text,
-                senders
-                    .into_iter()
-                    .filter_map(|(sender, count)| {
-                        (count >= 1).then_some(sender)
-                    })
-                    .collect::<BTreeSet<&str>>(),
-            )
-        })
-        .filter(|(_, senders)| !senders.is_empty())
-        .collect()
+    reactions.into_values().collect()
 }
 
 pub fn truncate_text<'a>(text: &'a str, max_chars: usize) -> Cow<'a, str> {


### PR DESCRIPTION
Order reactions in the reaction row based on the earliest time they were first reacted (with the time being reset if the reaction is unreacted to zero).  And, lists the senders of a reaction by time of react.

Also adds deduplication to reactions received via chathistory or ZNC playback.