### PR TITLE
docs: Add tip on how to find the highlights window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Changed:
 
 Thanks:
 
-- Contributions: @bb010g, @furudean, @englut, @luca020400, @4e554c4c
+- Contributions: @bb010g, @furudean, @englut, @luca020400, @4e554c4c, @stephenfin
 - Bug reports: @bb010g, daniiooo, @e00E, belthesar, @Fingel, @death916
 - Feature requests: @WinnerWind, Shyny, @classabbyamp, @4e554c4c, @furudean, @englut, @esden
 

--- a/docs/configuration/highlights.md
+++ b/docs/configuration/highlights.md
@@ -2,6 +2,12 @@
 
 Application wide highlights.
 
+::: tip
+The Highlights Window gathers all highlights in one location.
+It can be accessed using <kbd>⌘</kbd> + <kbd>i</kbd> (MacOS) / <kbd>ctrl</kbd> + <kbd>i</kbd> (other) by default.
+See [Keybord](/configuration/conditions.md) for information on how to configure these shortcuts.
+:::
+
 ## `match`
 
 Highlight based on matches

--- a/docs/configuration/highlights.md
+++ b/docs/configuration/highlights.md
@@ -4,8 +4,8 @@ Application wide highlights.
 
 ::: tip
 The Highlights Window gathers all highlights in one location.
-It can be accessed using <kbd>⌘</kbd> + <kbd>i</kbd> (MacOS) / <kbd>ctrl</kbd> + <kbd>i</kbd> (other) by default.
-See [Keybord](/configuration/conditions.md) for information on how to configure these shortcuts.
+It can be accessed via the user menu in the sidebar or the shortcut <kbd>⌘</kbd> + <kbd>i</kbd> (MacOS) / <kbd>ctrl</kbd> + <kbd>i</kbd> (other) by default.
+See [Keyboard](/configuration/keyboard.md) for information on how to configure shortcuts.
 :::
 
 ## `match`


### PR DESCRIPTION
Currently the only reference to this window is the keyboard guide. Add a small note in the highlights configuration doc.

Related: #1987
