### PR TITLE
Preview Inclusion Conditions Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Fixed:
 - Issue where a shorter highlight word would match instead of a longer one sharing the same prefix
 - Emoji pickers not finding newer emoji like 🙂‍↕️
 - Selection expansion will take precedence over input history navigation (i.e. shift + ↑ will expand the selection to include the top line of input, rather than navigate to the previous input history entry)
+- Preview inclusion conditions would require both channel and user/server_message be specified, when one or the other should be sufficient
 
 Changed:
 
@@ -56,7 +57,7 @@ Changed:
 Thanks:
 
 - Contributions: @bb010g, @furudean, @englut, @luca020400, @4e554c4c, @stephenfin
-- Bug reports: @bb010g, daniiooo, @e00E, belthesar, @Fingel, @death916
+- Bug reports: @bb010g, daniiooo, @e00E, belthesar, @Fingel, @death916, @furudean
 - Feature requests: @WinnerWind, Shyny, @classabbyamp, @4e554c4c, @furudean, @englut, @esden
 
 # 2026.6 (2026-04-21)

--- a/data/src/config/inclusivities.rs
+++ b/data/src/config/inclusivities.rs
@@ -318,6 +318,39 @@ impl Inclusivities {
         }
     }
 
+    pub fn has_user_or_server_message_conditions(
+        &self,
+        target_ref: TargetRef,
+        server: &Server,
+        casemapping: isupport::CaseMap,
+    ) -> bool {
+        self.users.is_some()
+            || self.server_messages.is_some()
+            || self.criteria.iter().any(|criterion| {
+                (criterion.users.is_some()
+                    || criterion.server_message.is_some())
+                    && criterion.channels.as_ref().is_none_or(
+                        |criterion_channels| {
+                            target_ref.as_channel().is_some_and(|channel| {
+                                criterion_channels.iter().any(
+                                    |criterion_channel| {
+                                        channel.as_normalized_str()
+                                            == casemapping
+                                                .normalize(criterion_channel)
+                                                .as_str()
+                                    },
+                                )
+                            })
+                        },
+                    )
+                    && criterion.server.as_ref().is_none_or(
+                        |criterion_server| {
+                            match_server(server, criterion_server)
+                        },
+                    )
+            })
+    }
+
     pub fn is_channel_inclusive(
         &self,
         channel: &Channel,

--- a/data/src/config/preview.rs
+++ b/data/src/config/preview.rs
@@ -264,11 +264,10 @@ impl Card {
         target_ref: TargetRef,
         server: &Server,
         casemapping: isupport::CaseMap,
-    ) -> bool {
-        is_target_ref_included(
+    ) -> Visibility {
+        Visibility::for_target_ref(
             self.include.as_ref(),
             self.exclude.as_ref(),
-            None,
             target_ref,
             server,
             casemapping,
@@ -335,11 +334,10 @@ impl Image {
         target_ref: TargetRef,
         server: &Server,
         casemapping: isupport::CaseMap,
-    ) -> bool {
-        is_target_ref_included(
+    ) -> Visibility {
+        Visibility::for_target_ref(
             self.include.as_ref(),
             self.exclude.as_ref(),
-            None,
             target_ref,
             server,
             casemapping,
@@ -397,6 +395,63 @@ where
             } else {
                 Ok(integer)
             }
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum Visibility {
+    All,
+    BySource,
+    None,
+}
+
+impl Visibility {
+    pub fn for_target_ref(
+        include: Option<&Inclusivities>,
+        exclude: Option<&Inclusivities>,
+        target_ref: TargetRef,
+        server: &Server,
+        casemapping: isupport::CaseMap,
+    ) -> Visibility {
+        if is_target_ref_included(
+            include,
+            Some(&Inclusivities::all()),
+            None,
+            target_ref,
+            server,
+            casemapping,
+        ) {
+            Visibility::All
+        } else if is_target_ref_included(
+            None,
+            exclude,
+            None,
+            target_ref,
+            server,
+            casemapping,
+        ) {
+            if include.is_some_and(|include| {
+                include.has_user_or_server_message_conditions(
+                    target_ref,
+                    server,
+                    casemapping,
+                )
+            }) {
+                Visibility::BySource
+            } else {
+                Visibility::None
+            }
+        } else if exclude.is_some_and(|exclude| {
+            exclude.has_user_or_server_message_conditions(
+                target_ref,
+                server,
+                casemapping,
+            )
+        }) {
+            Visibility::BySource
+        } else {
+            Visibility::None
         }
     }
 }

--- a/data/src/preview.rs
+++ b/data/src/preview.rs
@@ -18,6 +18,7 @@ use url::Url;
 
 pub use self::card::Card;
 use crate::cache::{self, Asset, CacheState, CachedAsset, FileCache};
+use crate::config::preview::Visibility;
 use crate::image::Image;
 use crate::message::Source;
 use crate::server::Server;
@@ -41,8 +42,8 @@ static META_ATTR_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 #[derive(Clone, Copy)]
 pub struct Previews<'a> {
     collection: &'a Collection,
-    cards_are_visible: bool,
-    images_are_visible: bool,
+    cards_are_visible: Visibility,
+    images_are_visible: Visibility,
 }
 
 impl<'a> Previews<'a> {
@@ -71,16 +72,28 @@ impl<'a> Previews<'a> {
     pub fn get(&self, url: &Url) -> Option<&'a State> {
         self.collection.get(url).filter(|state| match state {
             State::Loading => true,
-            State::Loaded(preview) => match preview {
-                Preview::Card(_) => self.cards_are_visible,
-                Preview::Image(_) => self.images_are_visible,
-            },
+            State::Loaded(preview) => {
+                let visibility = match preview {
+                    Preview::Card(_) => self.cards_are_visible,
+                    Preview::Image(_) => self.images_are_visible,
+                };
+
+                matches!(visibility, Visibility::All | Visibility::BySource)
+            }
             State::Error(_) => true,
         })
     }
 
     pub fn collection(&self) -> &'a Collection {
         self.collection
+    }
+
+    pub fn cards_visibility(&self) -> Visibility {
+        self.cards_are_visible
+    }
+
+    pub fn images_visibility(&self) -> Visibility {
+        self.images_are_visible
     }
 }
 
@@ -107,21 +120,31 @@ impl Preview {
         channel: Option<&target::Channel>,
         server: Option<&Server>,
         casemapping: isupport::CaseMap,
+        cards_visibility: Visibility,
+        images_visibility: Visibility,
         config: &config::Preview,
     ) -> bool {
         match self {
-            Self::Card(_) => config.card.visible_for_source(
-                source,
-                channel,
-                server,
-                casemapping,
-            ),
-            Self::Image(_) => config.image.visible_for_source(
-                source,
-                channel,
-                server,
-                casemapping,
-            ),
+            Self::Card(_) => match cards_visibility {
+                Visibility::All => true,
+                Visibility::BySource => config.card.visible_for_source(
+                    source,
+                    channel,
+                    server,
+                    casemapping,
+                ),
+                Visibility::None => false,
+            },
+            Self::Image(_) => match images_visibility {
+                Visibility::All => true,
+                Visibility::BySource => config.image.visible_for_source(
+                    source,
+                    channel,
+                    server,
+                    casemapping,
+                ),
+                Visibility::None => false,
+            },
         }
     }
 }

--- a/data/src/target.rs
+++ b/data/src/target.rs
@@ -78,6 +78,14 @@ impl PartialEq<Target> for TargetRef<'_> {
     }
 }
 
+impl<'a> TargetRef<'a> {
+    pub fn as_channel(&self) -> Option<&'a Channel> {
+        match self {
+            TargetRef::Channel(channel) => Some(channel),
+            TargetRef::Query(_) => None,
+        }
+    }
+}
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Target {
     Channel(Channel),

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -144,6 +144,8 @@ pub fn view<'a>(
                     Some(channel),
                     Some(server),
                     casemapping,
+                    previews.cards_visibility(),
+                    previews.images_visibility(),
                     &config.preview,
                 )
             }),


### PR DESCRIPTION
Fix for preview inclusion conditions requiring both channel and user/server_message be specified, when one or the other should be sufficient.