### PR TITLE
Two-Step Flush

### DIFF
--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -419,6 +419,9 @@ pub enum History {
         pending_reactions: HashMap<message::Id, reaction::Pending>,
         pending_redactions: HashMap<message::Id, redaction::Pending>,
         show_in_sidebar: bool,
+        flushing_messages: Vec<(Message, Option<LabeledResponseContext>)>,
+        flushing_reactions: HashMap<message::Id, reaction::Pending>,
+        flushing_redactions: HashMap<message::Id, redaction::Pending>,
     },
     Full {
         kind: Kind,
@@ -447,6 +450,9 @@ impl History {
             pending_reactions: HashMap::new(),
             pending_redactions: HashMap::new(),
             show_in_sidebar: false,
+            flushing_messages: vec![],
+            flushing_reactions: HashMap::new(),
+            flushing_redactions: HashMap::new(),
         }
     }
 
@@ -772,6 +778,9 @@ impl History {
                 chathistory_references,
                 pending_reactions,
                 pending_redactions,
+                flushing_messages,
+                flushing_reactions,
+                flushing_redactions,
                 ..
             } => {
                 if let Some(last_received) = *last_updated_at
@@ -779,13 +788,19 @@ impl History {
                         now.duration_since(last_received)
                             >= FLUSH_AFTER_LAST_RECEIVED
                     }) || pending_messages.len() > FLUSH_COUNT)
+                    && flushing_messages.is_empty()
+                    && flushing_reactions.is_empty()
+                    && flushing_redactions.is_empty()
                 {
                     let kind = kind.clone();
                     let pending_messages = std::mem::take(pending_messages);
+                    *flushing_messages = pending_messages.clone();
                     let read_marker = *read_marker;
                     let chathistory_references = chathistory_references.clone();
                     let pending_reactions = std::mem::take(pending_reactions);
+                    *flushing_reactions = pending_reactions.clone();
                     let pending_redactions = std::mem::take(pending_redactions);
+                    *flushing_redactions = pending_redactions.clone();
 
                     *last_updated_at = None;
 
@@ -896,6 +911,9 @@ impl History {
                         pending_reactions: HashMap::new(),
                         pending_redactions: HashMap::new(),
                         show_in_sidebar: true,
+                        flushing_messages: vec![],
+                        flushing_reactions: HashMap::new(),
+                        flushing_redactions: HashMap::new(),
                     },
                 );
 

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -194,6 +194,9 @@ impl Manager {
                 if !matches!(kind, history::Kind::Logs) {
                     log::debug!("flushed history for {kind}",);
                 }
+
+                self.data.flushed(&kind, true);
+
                 if !events.is_empty()
                     && let Some(server) = kind.server()
                 {
@@ -202,6 +205,8 @@ impl Manager {
             }
             Message::Flushed(kind, Err(error)) => {
                 log::warn!("failed to flush history for {kind}: {error}");
+
+                self.data.flushed(&kind, false);
             }
             Message::UpdatePartial(kind, Ok(metadata)) => {
                 log::debug!("loaded metadata for {kind}");
@@ -1346,6 +1351,9 @@ impl Data {
                     last_seen,
                     pending_reactions,
                     pending_redactions,
+                    flushing_messages,
+                    flushing_reactions,
+                    flushing_redactions,
                     ..
                 } => {
                     let read_marker =
@@ -1360,7 +1368,10 @@ impl Data {
 
                     let mut last_seen = last_seen.clone();
 
-                    for (id, pending) in std::mem::take(pending_reactions) {
+                    for (id, pending) in std::mem::take(pending_reactions)
+                        .into_iter()
+                        .chain(std::mem::take(flushing_reactions))
+                    {
                         if let Some(server_time) = pending.server_time()
                             && let Some(message) =
                                 history::find_reply_target_mut(
@@ -1383,7 +1394,10 @@ impl Data {
                         }
                     }
 
-                    for (id, pending) in std::mem::take(pending_redactions) {
+                    for (id, pending) in std::mem::take(pending_redactions)
+                        .into_iter()
+                        .chain(std::mem::take(flushing_redactions))
+                    {
                         if let Some(message) = history::find_reply_target_mut(
                             &mut messages,
                             &id,
@@ -1395,6 +1409,8 @@ impl Data {
 
                     for (message, labeled_response_context) in
                         std::mem::take(pending_messages)
+                            .into_iter()
+                            .chain(std::mem::take(flushing_messages))
                     {
                         history::update_last_seen(&mut last_seen, &message);
 
@@ -1856,6 +1872,39 @@ impl Data {
                 )
             })
             .collect()
+    }
+
+    fn flushed(&mut self, kind: &history::Kind, flush_ok: bool) {
+        if let Some(History::Partial {
+            pending_messages,
+            pending_reactions,
+            pending_redactions,
+            flushing_messages,
+            flushing_reactions,
+            flushing_redactions,
+            ..
+        }) = self.map.get_mut(kind)
+        {
+            if flush_ok {
+                flushing_messages.clear();
+
+                flushing_reactions.clear();
+
+                flushing_redactions.clear();
+            } else {
+                pending_messages.extend(std::mem::take(flushing_messages));
+
+                for (id, flushing) in std::mem::take(flushing_reactions) {
+                    let pending = pending_reactions.entry(id).or_default();
+
+                    pending.reactions.extend(flushing.reactions);
+                }
+
+                for (id, flushing) in std::mem::take(flushing_redactions) {
+                    pending_redactions.entry(id).or_insert(flushing);
+                }
+            }
+        }
     }
 
     fn is_preview_hidden(

--- a/data/src/redaction.rs
+++ b/data/src/redaction.rs
@@ -68,7 +68,7 @@ impl Redaction {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Pending {
     pub redaction: Redaction,
     pub server_time: DateTime<Utc>,


### PR DESCRIPTION
Clear pending messages/reactions/redactions after flush has completed, instead of when the flush task is dispatched.  This is to prevent a potential race condition between history flush and load, where a history loaded with inopportune timing could result in lost message(s).  At this time the hope is this fixes #1263, but I currently don't have a way to easily reproduce the required conditions.