### PR TITLE
data: allow scheme://host URLs with no TLD (localhost, IPs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Changed:
 
 Thanks:
 
-- Contributions: @bb010g, @furudean, @englut, @luca020400, @4e554c4c, @stephenfin
+- Contributions: @bb010g, @furudean, @englut, @luca020400, @4e554c4c, @stephenfin, @achille
 - Bug reports: @bb010g, daniiooo, @e00E, belthesar, @Fingel, @death916, @furudean
 - Feature requests: @WinnerWind, Shyny, @classabbyamp, @4e554c4c, @furudean, @englut, @esden
 

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -43,8 +43,11 @@ const URL_PATH_RESERVED: &str = r#":?@!&'()*+,;=\[\]"#;
 
 static URL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     RegexBuilder::new(concatcp!(
-        r#"(?i)(((https?|ircs?|wss?):\/\/|www\.)[\p{Letter}\p{Number}\-@:%._+~#=]{1,256}\.[\p{Letter}\p{Number}]{1,63}\b"#,
-        r#"(?:"#,
+        r#"(?i)("#,
+        r#"(?:https?|ircs?|wss?):\/\/"#,
+        r#"[\p{Letter}\p{Number}\-@:%._+~#=]{1,256}"#,
+        r#"(?:\.[\p{Letter}\p{Number}]{1,63})?"#,
+        r#"\b(?:"#,
         r#"["#, URL_PATH_UNRESERVED, URL_PATH_RESERVED, r#"%\/#]"#,
         r#"*)|halloy:\/\/[^ ]*)"#
     ))
@@ -2016,15 +2019,9 @@ fn parse_fragments_inner<'a>(
             if let Fragment::Text(text) = &fragment {
                 return Either::Left(
                     parse_regex_fragments(&URL_REGEX, text, |url| {
-                        let url = if url.starts_with("www") {
-                            format!("https://{url}")
-                        } else {
-                            url.to_string()
-                        };
-
-                        Url::parse(&url)
+                        Url::parse(url)
                             .ok()
-                            .map(|canonical| Fragment::Url(canonical, url))
+                            .map(|canonical| Fragment::Url(canonical, url.to_string()))
                     })
                     .into_iter(),
                 );
@@ -4414,6 +4411,32 @@ pub mod tests {
                 "https://en.wiktionary.org/wiki/百聞は一見に如かず",
                 vec![Fragment::Url(
                     "https://en.wiktionary.org/wiki/百聞は一見に如かず".parse().unwrap(), "https://en.wiktionary.org/wiki/百聞は一見に如かず".to_string()
+                )],
+            ),
+            (
+                "open http://localhost/foo in a browser",
+                vec![
+                    Fragment::Text("open ".into()),
+                    Fragment::Url("http://localhost/foo".parse().unwrap(), "http://localhost/foo".to_string()),
+                    Fragment::Text(" in a browser".into()),
+                ],
+            ),
+            (
+                "http://localhost:8080/api",
+                vec![Fragment::Url(
+                    "http://localhost:8080/api".parse().unwrap(), "http://localhost:8080/api".to_string(),
+                )],
+            ),
+            (
+                "https://localhost/secure",
+                vec![Fragment::Url(
+                    "https://localhost/secure".parse().unwrap(), "https://localhost/secure".to_string(),
+                )],
+            ),
+            (
+                "ws://localhost:9000/socket",
+                vec![Fragment::Url(
+                    "ws://localhost:9000/socket".parse().unwrap(), "ws://localhost:9000/socket".to_string(),
                 )],
             ),
         ];

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -48,7 +48,10 @@ static URL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
         r#"[\p{Letter}\p{Number}\-@:%._+~#=]{1,256}"#,
         r#"(?:\.[\p{Letter}\p{Number}]{1,63})?"#,
         r#"\b(?:"#,
-        r#"["#, URL_PATH_UNRESERVED, URL_PATH_RESERVED, r#"%\/#]"#,
+        r#"["#,
+        URL_PATH_UNRESERVED,
+        URL_PATH_RESERVED,
+        r#"%\/#]"#,
         r#"*)|halloy:\/\/[^ ]*)"#
     ))
     .delegate_size_limit(15728640) // 1.5x default size_limit
@@ -2019,9 +2022,9 @@ fn parse_fragments_inner<'a>(
             if let Fragment::Text(text) = &fragment {
                 return Either::Left(
                     parse_regex_fragments(&URL_REGEX, text, |url| {
-                        Url::parse(url)
-                            .ok()
-                            .map(|canonical| Fragment::Url(canonical, url.to_string()))
+                        Url::parse(url).ok().map(|canonical| {
+                            Fragment::Url(canonical, url.to_string())
+                        })
                     })
                     .into_iter(),
                 );
@@ -4437,6 +4440,12 @@ pub mod tests {
                 "ws://localhost:9000/socket",
                 vec![Fragment::Url(
                     "ws://localhost:9000/socket".parse().unwrap(), "ws://localhost:9000/socket".to_string(),
+                )],
+            ),
+            (
+                "http://127.0.0.1:8080/api",
+                vec![Fragment::Url(
+                    "http://127.0.0.1:8080/api".parse().unwrap(), "http://127.0.0.1:8080/api".to_string(),
                 )],
             ),
         ];


### PR DESCRIPTION
URLs without a public TLD — `http://localhost/`, `http://intranet/`, IPs without dots, etc. — used to be left as plain text because the regex required a `.<tld>` suffix on every host. This PR makes the TLD optional in the `scheme://host` form, so common local-development URLs linkify.

- Also drops the bare `www.X` shortcut from the regex (and the matching `https://` auto-prefix in the caller) and inferring `https://` is a guess.
 
- Added 4 `fragments_parsing` test cases for `http://localhost/foo`, `http://localhost:8080/api`, `https://localhost/secure`, and `ws://localhost:9000/socket`.