### PR TITLE
Treat RUST_LOG Parse Error as None

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -15,8 +15,7 @@ pub fn setup(
     let env_rust_log = env::var("RUST_LOG")
         .ok()
         .as_deref()
-        .map(str::parse::<log::Level>)
-        .transpose()?;
+        .and_then(|rust_log| str::parse::<log::Level>(rust_log).ok());
 
     let file_level_filter = env_rust_log
         .map_or(log::LevelFilter::from(config.file_level), |env| {


### PR DESCRIPTION
Treat `RUST_LOG` that fails to parse the same as no `RUST_LOG` provided.  Fixes #2010.