### PR TITLE
Use `UserDisplay` for quoting replies of actions

### DIFF
--- a/src/widget/reply.rs
+++ b/src/widget/reply.rs
@@ -1,3 +1,4 @@
+use data::config::buffer::AccessLevelFormat;
 use data::user::ChannelUsers;
 use data::{Config, message, metadata};
 use iced::alignment;
@@ -60,63 +61,45 @@ pub fn reply_preview_content<'a, Message: 'a + std::clone::Clone>(
         }
 
         if let Some(user) = reply.user.as_ref() {
-            if reply.is_action {
-                let metadata_color =
-                    registry.color(&data::target::Query::from(user)).map(|c| {
-                        config.display.adapt_metadata_colors.adapt(
-                            c,
-                            theme.styles().buffer.nickname.color,
-                            theme.styles().buffer.background,
-                        )
-                    });
-                let nick_color = theme::selectable_text::nickname(
-                    theme,
-                    config,
+            let user = channel_users
+                .and_then(|users| users.resolve(user))
+                .unwrap_or(user);
+            let user_display = if reply.is_action {
+                UserDisplay::new(
                     user,
-                    metadata_color,
+                    AccessLevelFormat::None,
                     false,
+                    registry,
+                    &config.display.nickname,
+                    None,
+                    config.display.truncation_character,
+                    None,
                     false,
                 )
-                .color;
-                row = row.push(
-                    text(user.nickname().to_string())
-                        .style(move |_: &Theme| iced::widget::text::Style {
-                            color: nick_color,
-                        })
-                        .size(text_size)
-                        .font_maybe(
-                            theme::font_style::action(theme).map(font::get),
-                        ),
-                );
             } else {
-                let user = channel_users
-                    .and_then(|users| users.resolve(user))
-                    .unwrap_or(user);
-                row = row.push(
-                    UserDisplay::new(
-                        user,
-                        config.buffer.nickname.show_access_levels,
-                        config.buffer.nickname.show_bot_icon,
-                        registry,
-                        &config.display.nickname,
-                        config.buffer.nickname.truncate,
-                        config.display.truncation_character,
-                        Some(&config.buffer.nickname.brackets),
-                        false,
-                    )
-                    .into_element(
-                        user,
-                        false,
-                        false,
-                        None,
-                        Some(text_size),
-                        highlight,
-                        false,
-                        theme,
-                        config,
-                    ),
-                );
-            }
+                UserDisplay::new(
+                    user,
+                    config.buffer.nickname.show_access_levels,
+                    config.buffer.nickname.show_bot_icon,
+                    registry,
+                    &config.display.nickname,
+                    config.buffer.nickname.truncate,
+                    config.display.truncation_character,
+                    Some(&config.buffer.nickname.brackets),
+                    false,
+                )
+            };
+            row = row.push(user_display.into_element(
+                user,
+                false,
+                false,
+                None,
+                Some(text_size),
+                highlight,
+                false,
+                theme,
+                config,
+            ));
         }
     }
 


### PR DESCRIPTION
Looks like when displaying the quoted reply of an action, the metadata color is being used regardless of if `display.nickname` has `color` in in the config.

### before
<img width="322" height="91" alt="Screenshot_20260524_132218" src="https://github.com/user-attachments/assets/c8ba502e-e062-4032-ae12-e741223fade7" />

### after, without color metadata enabled
<img width="298" height="77" alt="Screenshot_20260524_132229" src="https://github.com/user-attachments/assets/88e9bb61-274d-4ff3-b378-865f26f6b98c" />

### after, with color metadata enabled
<img width="285" height="98" alt="image" src="https://github.com/user-attachments/assets/b2815fe8-6f93-47a5-8a8c-95cc4bb5d6a6" />
