### PR TITLE
Display focused buffer name in window title after closing previously last pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Fixed:
 - Emoji pickers not finding newer emoji like 🙂‍↕️
 - Selection expansion will take precedence over input history navigation (i.e. shift + ↑ will expand the selection to include the top line of input, rather than navigate to the previous input history entry)
 - Preview inclusion conditions would require both channel and user/server_message be specified, when one or the other should be sufficient
+- Window title displays buffer name after closing previously last pane
 
 Changed:
 

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -4815,6 +4815,7 @@ impl Dashboard {
             self.focus_history
                 .front()
                 .and_then(|pane| self.panes.get(w, *pane))
+                .filter(|pane| !matches!(pane.buffer, Buffer::Empty))
                 .map(|pane| pane.buffer.to_string())
         } else {
             self.panes.iter().find_map(|(win, _, pane)| {

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -3846,7 +3846,9 @@ impl Dashboard {
         window: window::Id,
         pane: pane_grid::Pane,
     ) -> Task<Message> {
-        if (self.focus != Focus { window, pane }) {
+        if (self.focus != Focus { window, pane })
+            || self.focus_history.is_empty()
+        {
             self.focus = Focus { window, pane };
 
             self.last_changed = Some(Instant::now());


### PR DESCRIPTION
When you close the last pane, we see `Halloy` in the window title. But when we open a new buffer into the pane the window title stays `Halloy` instead of displaying `<buffer name> - Halloy`.

Also, discovered that when creating a new split pane, the title displays as `Empty - Halloy`.

Addressed both scenarios.

Fixes #2017 

Thanks to @luca020400 for tag teaming this!