### PR TITLE
Minor Reply Fixes/Tweaks

### DIFF
--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -13,7 +13,7 @@ use super::reroute::RerouteRules;
 use crate::capabilities::LabeledResponseContext;
 use crate::history::{self, History, MessageReferences, ReadMarker, metadata};
 use crate::message::broadcast::{self, Broadcast};
-use crate::message::{self, Limit};
+use crate::message::{self, Limit, ReplyPreview};
 use crate::redaction::Redaction;
 use crate::target::{self, Target};
 use crate::user::Nick;
@@ -605,8 +605,8 @@ impl Manager {
         kind: history::Kind,
         id: &message::Id,
         server_time: &DateTime<Utc>,
-    ) {
-        self.data.generate_reply_preview(kind, id, server_time);
+    ) -> Option<ReplyPreview> {
+        self.data.generate_reply_preview(kind, id, server_time)
     }
 
     pub fn update_chathistory_references<T: Into<history::Kind>>(
@@ -1732,14 +1732,11 @@ impl Data {
         kind: history::Kind,
         id: &message::Id,
         server_time: &DateTime<Utc>,
-    ) {
-        if let Some(message) = self
-            .map
+    ) -> Option<ReplyPreview> {
+        self.map
             .get_mut(&kind)
             .and_then(|history| history.find_reply_target_mut(id, server_time))
-        {
-            message.reply_preview = Some(message.as_reply_preview());
-        }
+            .map(|message| message.as_reply_preview())
     }
 
     fn update_chathistory_references<T: Into<history::Kind>>(

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1176,6 +1176,25 @@ impl Buffer {
             Buffer::Query(state) => state.input_view.draft_reply(),
         }
     }
+
+    pub fn set_reply_preview(&mut self, reply_preview: message::ReplyPreview) {
+        match self {
+            Buffer::Empty
+            | Buffer::FileTransfers(_)
+            | Buffer::Logs(_)
+            | Buffer::Highlights(_)
+            | Buffer::ChannelDiscovery(_) => (),
+            Buffer::Server(state) => {
+                state.input_view.set_reply_preview(reply_preview);
+            }
+            Buffer::Channel(state) => {
+                state.input_view.set_reply_preview(reply_preview);
+            }
+            Buffer::Query(state) => {
+                state.input_view.set_reply_preview(reply_preview);
+            }
+        }
+    }
 }
 
 impl fmt::Display for Buffer {

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -202,20 +202,6 @@ pub fn view<'a>(
 
     let filehost_url = clients.get_filehost(server);
 
-    let reply_preview =
-        state.input_view.draft_reply().and_then(|draft_reply| {
-            let kind = history::Kind::from_target(
-                state.server.clone(),
-                Target::Channel(state.target.clone()),
-            );
-
-            history.get_reply_preview(
-                kind,
-                &draft_reply.id,
-                &draft_reply.server_time,
-            )
-        });
-
     let text_input = show_text_input.then(move || {
         input_view::view(
             &state.input_view,
@@ -226,7 +212,6 @@ pub fn view<'a>(
             config,
             theme,
             filehost_url,
-            reply_preview,
         )
         .map(Message::InputView)
     });

--- a/src/buffer/context_menu.rs
+++ b/src/buffer/context_menu.rs
@@ -848,7 +848,9 @@ where
         message.redaction_expanded(&config.buffer.redaction),
         can_send_reactions && message.id.is_some(),
         can_redact && message.id.is_some(),
-        can_send_replies && message.id.is_some(),
+        can_send_replies
+            && message.id.is_some()
+            && message.rerouted_from.is_none(),
     );
 
     context_menu(

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -351,7 +351,6 @@ pub fn view<'a>(
     config: &'a Config,
     theme: &'a Theme,
     filehost_url: Option<&'a str>,
-    reply_preview: Option<&'a message::ReplyPreview>,
 ) -> Element<'a, Message> {
     let style = if let Some(notice) = &state.notice {
         match notice {
@@ -671,7 +670,7 @@ pub fn view<'a>(
             )
         });
 
-    let maybe_reply_bar = reply_preview.map(|reply_preview| {
+    let maybe_reply_bar = state.reply_preview.as_ref().map(|reply_preview| {
         reply_bar(reply_preview, channel_users, registry, config, theme)
     });
 
@@ -816,6 +815,7 @@ pub struct State {
     spinner_hovered: bool,
     upload_abort_handles: Vec<futures::future::AbortHandle>,
     draft_reply: Option<input::DraftReply>,
+    reply_preview: Option<message::ReplyPreview>,
 }
 
 impl Default for State {
@@ -844,11 +844,16 @@ impl State {
             spinner_hovered: false,
             upload_abort_handles: Vec::new(),
             draft_reply: cache.and_then(|c| c.draft_reply).cloned(),
+            reply_preview: None,
         }
     }
 
     pub fn draft_reply(&self) -> Option<&input::DraftReply> {
         self.draft_reply.as_ref()
+    }
+
+    pub fn set_reply_preview(&mut self, reply_preview: message::ReplyPreview) {
+        self.reply_preview = Some(reply_preview);
     }
 
     pub fn update(
@@ -2159,6 +2164,7 @@ impl State {
                 ));
             }
 
+            self.reply_preview = None;
             self.draft_reply = None;
 
             history_task =
@@ -2553,6 +2559,7 @@ impl State {
                 }
             }
 
+            self.reply_preview = None;
             self.draft_reply = None;
 
             history_task =
@@ -2792,6 +2799,8 @@ impl State {
         history: &mut history::Manager,
         config: &Config,
     ) -> bool {
+        self.reply_preview = None;
+
         if self.draft_reply.is_some() {
             if config.buffer.reply.insert_nick
                 && let Some(draft_reply) = &self.draft_reply

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -147,20 +147,6 @@ pub fn view<'a>(
 
     let filehost_url = clients.get_filehost(server);
 
-    let reply_preview =
-        state.input_view.draft_reply().and_then(|draft_reply| {
-            let kind = history::Kind::from_target(
-                state.server.clone(),
-                Target::Query(state.target.clone()),
-            );
-
-            history.get_reply_preview(
-                kind,
-                &draft_reply.id,
-                &draft_reply.server_time,
-            )
-        });
-
     let text_input = show_text_input.then(|| {
         input_view::view(
             &state.input_view,
@@ -171,7 +157,6 @@ pub fn view<'a>(
             config,
             theme,
             filehost_url,
-            reply_preview,
         )
         .map(Message::InputView)
     });

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -313,7 +313,6 @@ pub fn view<'a>(
                 config,
                 theme,
                 filehost_url,
-                None,
             )
             .map(Message::InputView)
         ]

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -826,12 +826,16 @@ impl Dashboard {
                             {
                                 if let Some(draft_reply) =
                                     state.buffer.get_draft_reply()
+                                    && let Some(reply_preview) =
+                                        self.history.generate_reply_preview(
+                                            kind,
+                                            &draft_reply.id,
+                                            &draft_reply.server_time,
+                                        )
                                 {
-                                    self.history.generate_reply_preview(
-                                        kind,
-                                        &draft_reply.id,
-                                        &draft_reply.server_time,
-                                    );
+                                    state
+                                        .buffer
+                                        .set_reply_preview(reply_preview);
                                 }
 
                                 if state.buffer.has_pending_scroll_to() {
@@ -2229,12 +2233,14 @@ impl Dashboard {
                             pane.buffer.upstream().map(|buffer| {
                                 history::Kind::from_input_buffer(buffer.clone())
                             })
+                            && let Some(reply_preview) =
+                                self.history.generate_reply_preview(
+                                    kind,
+                                    &msgid,
+                                    &server_time,
+                                )
                         {
-                            self.history.generate_reply_preview(
-                                kind,
-                                &msgid,
-                                &server_time,
-                            );
+                            pane.buffer.set_reply_preview(reply_preview);
                         }
 
                         tasks.push(self.focus_pane(window, id));

--- a/src/widget/reply.rs
+++ b/src/widget/reply.rs
@@ -24,7 +24,7 @@ pub fn reply_preview_content<'a, Message: 'a + std::clone::Clone>(
 
     // the message may not be loaded
     let Some(reply) = reply else {
-        return text("Replied to a message")
+        return text("Replied to an unknown message")
             .style(theme::text::secondary)
             .size(text_size)
             .into();


### PR DESCRIPTION
- Fixes a regression added in #1988 (by me) where reply previews were being stored on messages rather than in the input view.  As a result, the in-buffer reply-preview would be overwritten and would display the draft reply-preview instead of the reply-preview the message is in reply to.
- Makes a minor fix/tweak by disabling the "Reply" context menu entry when the message is rerouted (since there's a good chance the message is not known or visible to anyone else in the channel).
- Tweaks the placeholder text from "Replied to a message" to "Replied to an unknown message" when the target message cannot be found.