### PR TITLE
Miscellaneous Fixes/Tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,10 @@ Changed:
 - For filehosts, localhost is now treated as a secure transport when using `servers.<name>.filehost.override_url`
 - `buffer.mark_as_read.on_message = true` is now equivalent to `buffer.mark_as_read.on_message = "open"` (previously equivalent to `buffer.mark_as_read.on_message = "focused"`)
 - Tooltips have had their spacing tightened
-- Nicks in reactions have a new layout, and are now colored
+- Reactions are listed in the order they were first added to the message
+- Reaction tooltips:
+  - Display the reaction text in a larger font size (uses `font.only_emojis_size` if set and the reaction is an emoji)
+  - Lists nicks with a new layout, where nicks are now colored and are listed in order of when they reacted
 
 Thanks:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,9 +61,9 @@ Changed:
 
 Thanks:
 
-- Contributions: @bb010g, @furudean, @englut, @luca020400, @4e554c4c, @stephenfin, @achille
-- Bug reports: @bb010g, daniiooo, @e00E, belthesar, @Fingel, @death916, @furudean, @ncfavier
-- Feature requests: @WinnerWind, Shyny, @classabbyamp, @4e554c4c, @furudean, @englut, @esden
+- Contributions: @bb010g, @furudean, @englut, @luca020400, @4e554c4c, @stephenfin, @achille, @ncfavier
+- Bug reports: @bb010g, daniiooo, @e00E, belthesar, @Fingel, @death916, @furudean, @ncfavier, @WinnerWind, @alexaandru, @kasper93
+- Feature requests: @WinnerWind, Shyny, @classabbyamp, @4e554c4c, @furudean, @englut, @esden, @Erroneuz
 
 # 2026.6 (2026-04-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,21 +27,22 @@ Fixed:
 - Issue where duplicate messages could appear for sent messages when connecting to a soju bouncer
 - Issue where ZNC playback would produce duplicate messages
 - Record `NICK` and `QUIT` messages returned by `draft/event-playback` (`chathistory`)
-- Allow multiple file uploads when pasting on macOs
+- Allow multiple file uploads when pasting on macOS
+- Preview inclusion conditions would require both channel and user/server_message be specified, when one or the other should be sufficient
 - Matching against `users` for some include/exclude conditions
 - Do not hide consecutive nicknames if the user's displayed access levels or bot mode changes
-- Channel link matching on single line only
-- Fix link matching for both end of line delimiters & punctuations
-- Handle URLs ending with paired delimiters chars when matching links
-- Handle leading delimiters when parsing link fragments to match nicks after quotes
+- Link matching:
+  - Channel link matching on single line only
+  - Fix link matching for both end of line delimiters & punctuations
+  - Handle URLs ending with paired delimiters chars when matching links
+  - Handle leading delimiters when parsing link fragments to match nicks after quotes
+- Issue where a shorter highlight word would match instead of a longer one sharing the same prefix
 - Issue where unread indicator could appear in sidebar for an open pane that does not have unread messages
 - Issue where backlog divider in highlights or logs pane would not update when marking the pane as read
 - `VERSION` and `JOIN` commands on connect are skipped if server is primary soju server
 - `tor` enabled builds
-- Issue where a shorter highlight word would match instead of a longer one sharing the same prefix
 - Emoji pickers not finding newer emoji like 🙂‍↕️
 - Selection expansion will take precedence over input history navigation (i.e. shift + ↑ will expand the selection to include the top line of input, rather than navigate to the previous input history entry)
-- Preview inclusion conditions would require both channel and user/server_message be specified, when one or the other should be sufficient
 - Window title displays buffer name after closing previously last pane
 
 Changed:

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -708,7 +708,7 @@ impl Message {
         let received_at = Posix::now();
         let server_time = Utc::now();
         let content =
-            plain(format!("offering to send {} \"{filename}\"", to.nickname()));
+            plain(format!("Offering to send {} \"{filename}\"", to.nickname()));
         let hash = Hash::new(&server_time, &content, &received_at);
 
         Message {
@@ -3851,7 +3851,7 @@ fn invite_text(
         if invitee.nickname() == *our_nick {
             format!("{} has invited you to {channel}", inviter.as_str())
         } else if inviter.nickname() == *our_nick {
-            format!("you have invited {} to {channel}", invitee.as_str())
+            format!("You have invited {} to {channel}", invitee.as_str())
         } else {
             format!(
                 "{} has been invited to {channel} by {}",
@@ -3874,11 +3874,7 @@ fn kick_text(
     casemapping: isupport::CaseMap,
 ) -> Content {
     let target = if ourself {
-        if channel.is_some() {
-            "You have".to_string()
-        } else {
-            "you have".to_string()
-        }
+        "You have".to_string()
     } else {
         format!("{} has", victim.nickname())
     };
@@ -3934,10 +3930,10 @@ fn monitored_targets_text(targets: Vec<String>) -> Option<String> {
     if targets.is_empty() {
         None
     } else if targets.len() == 1 {
-        Some(format!("user {} is", targets.first()?))
+        Some(format!("User {} is", targets.first()?))
     } else {
         Some(format!(
-            "users {} are",
+            "Users {} are",
             join_targets(targets.iter().map(String::as_ref).collect())
         ))
     }

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -91,7 +91,7 @@ fn expand(
 }
 
 pub fn connecting(sent_time: DateTime<Utc>) -> Vec<Message> {
-    let content = plain("connecting to server...".into());
+    let content = plain("Connecting to server...".into());
     expand(
         [],
         [],
@@ -103,7 +103,7 @@ pub fn connecting(sent_time: DateTime<Utc>) -> Vec<Message> {
 }
 
 pub fn connected(sent_time: DateTime<Utc>) -> Vec<Message> {
-    let content = plain("connected".into());
+    let content = plain("Connected".into());
     expand(
         [],
         [],
@@ -118,7 +118,7 @@ pub fn connection_failed(
     error: String,
     sent_time: DateTime<Utc>,
 ) -> Vec<Message> {
-    let content = plain(format!("connection to server failed ({error})"));
+    let content = plain(format!("Connection to server failed ({error})"));
     expand(
         [],
         [],
@@ -136,7 +136,7 @@ pub fn disconnected(
     sent_time: DateTime<Utc>,
 ) -> Vec<Message> {
     let error = error.map(|error| format!(" ({error})")).unwrap_or_default();
-    let content = plain(format!("connection to server lost{error}"));
+    let content = plain(format!("Connection to server lost{error}"));
     expand(
         channels,
         queries,
@@ -152,7 +152,7 @@ pub fn reconnected(
     queries: impl IntoIterator<Item = target::Query>,
     sent_time: DateTime<Utc>,
 ) -> Vec<Message> {
-    let content = plain("connection to server restored".into());
+    let content = plain("Connection to server restored".into());
     expand(
         channels,
         queries,
@@ -465,7 +465,7 @@ pub fn upload_failed(
     target: Option<target::Target>,
     sent_time: DateTime<Utc>,
 ) -> Vec<Message> {
-    let content = plain(format!("upload failed: {error}"));
+    let content = plain(format!("Upload failed: {error}"));
     match target {
         Some(target::Target::Channel(channel)) => expand(
             [channel],

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -228,7 +228,7 @@ impl Completion {
             || words_view.is_some()
         {
             Some(
-                column![emojis_view, paths_view, command_view, words_view]
+                column![emojis_view, paths_view, words_view, command_view]
                     .spacing(4)
                     .into(),
             )

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -475,7 +475,7 @@ impl<'a> ChannelQueryLayout<'a> {
                 self.config
                     .tooltips
                     .show_for_buttons()
-                    .then_some("Hide Preview"),
+                    .then_some("Hide preview"),
                 tooltip::Position::Top,
                 self.theme,
             ))

--- a/src/modal/image_preview.rs
+++ b/src/modal/image_preview.rs
@@ -47,7 +47,7 @@ pub fn view<'a>(
                                     )
                                 }
                             ),
-                            Some("Save Image"),
+                            Some("Save image"),
                             tooltip::Position::Bottom,
                             theme,
                         ),
@@ -64,7 +64,7 @@ pub fn view<'a>(
                                         theme, status, false,
                                     )
                                 }),
-                            Some("Open in Browser"),
+                            Some("Open in browser"),
                             tooltip::Position::Bottom,
                             theme,
                         ),

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -363,7 +363,7 @@ impl TitleBar {
 
                     let topic_button_with_tooltip = tooltip(
                         topic_button,
-                        show_tooltips.then_some("Topic Banner"),
+                        show_tooltips.then_some("Topic banner"),
                         tooltip::Position::Bottom,
                         theme,
                     );
@@ -460,7 +460,7 @@ impl TitleBar {
 
                 let popout_button_with_tooltip = tooltip(
                     popout_button,
-                    show_tooltips.then_some("Pop Out"),
+                    show_tooltips.then_some("Pop out"),
                     tooltip::Position::Bottom,
                     theme,
                 );

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -391,7 +391,11 @@ impl TitleBar {
 
                     let topic_button_with_tooltip = tooltip(
                         topic_button,
-                        show_tooltips.then_some("Topic banner"),
+                        show_tooltips.then_some(if topic_enabled {
+                            "Hide topic banner"
+                        } else {
+                            "Show topic banner"
+                        }),
                         tooltip::Position::Bottom,
                         theme,
                     );
@@ -423,7 +427,11 @@ impl TitleBar {
 
                 let nicklist_button_with_tooltip = tooltip(
                     nicklist_button,
-                    show_tooltips.then_some("Nicklist"),
+                    show_tooltips.then_some(if nicklist_enabled {
+                        "Hide nicklist"
+                    } else {
+                        "Show nicklist"
+                    }),
                     tooltip::Position::Bottom,
                     theme,
                 );

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -1,5 +1,6 @@
 use data::user::{ChannelUsers, User};
 use data::{Config, file_transfer, history, preview};
+use iced::widget::text::Wrapping;
 use iced::widget::{button, center, column, container, pane_grid, row, text};
 use iced::{Length, Size, Task, padding};
 
@@ -82,9 +83,13 @@ impl Pane {
 
                 let server = &state.server;
                 row![
-                    text(display_channel).style(theme::text::url).font_maybe(
-                        theme::font_style::url(theme).map(font::get),
-                    ),
+                    text(display_channel)
+                        .style(theme::text::url)
+                        .font_maybe(
+                            theme::font_style::url(theme).map(font::get),
+                        )
+                        .wrapping(Wrapping::None)
+                        .ellipsis(text::Ellipsis::End),
                     if let Some(mode) =
                         clients.get_channel_mode(&state.server, &state.target)
                     {
@@ -94,8 +99,12 @@ impl Pane {
                             .unwrap_or_default();
 
                         text(format!(" ({mode}) @ {server} - {users} users"))
+                            .wrapping(Wrapping::None)
+                            .ellipsis(text::Ellipsis::End)
                     } else {
                         text(format!(" @ {server}"))
+                            .wrapping(Wrapping::None)
+                            .ellipsis(text::Ellipsis::End)
                     }
                 ]
                 .into()
@@ -105,6 +114,8 @@ impl Pane {
                 .font_maybe(
                     theme::font_style::server(theme, None).map(font::get),
                 )
+                .wrapping(Wrapping::None)
+                .ellipsis(text::Ellipsis::End)
                 .into(),
             Buffer::Query(state) => query_title(
                 &state.server,
@@ -113,7 +124,10 @@ impl Pane {
                 config,
                 theme,
             ),
-            Buffer::FileTransfers(_) => text("File Transfers").into(),
+            Buffer::FileTransfers(_) => text("File Transfers")
+                .wrapping(Wrapping::None)
+                .ellipsis(text::Ellipsis::End)
+                .into(),
             Buffer::ChannelDiscovery(state) => {
                 let base = "Channel Discovery";
                 if let Some(server) = state.server.as_ref() {
@@ -124,16 +138,30 @@ impl Pane {
                         .unwrap_or_default();
                     if channel_count > 0 {
                         text(format!("{base} - {channel_count} channels"))
+                            .wrapping(Wrapping::None)
+                            .ellipsis(text::Ellipsis::End)
                             .into()
                     } else {
-                        text(base).into()
+                        text(base)
+                            .wrapping(Wrapping::None)
+                            .ellipsis(text::Ellipsis::End)
+                            .into()
                     }
                 } else {
-                    text(base).into()
+                    text(base)
+                        .wrapping(Wrapping::None)
+                        .ellipsis(text::Ellipsis::End)
+                        .into()
                 }
             }
-            Buffer::Logs(_) => text("Logs").into(),
-            Buffer::Highlights(_) => text("Highlights").into(),
+            Buffer::Logs(_) => text("Logs")
+                .wrapping(Wrapping::None)
+                .ellipsis(text::Ellipsis::End)
+                .into(),
+            Buffer::Highlights(_) => text("Highlights")
+                .wrapping(Wrapping::None)
+                .ellipsis(text::Ellipsis::End)
+                .into(),
         };
 
         let title_bar = self.title_bar.view(
@@ -544,7 +572,9 @@ fn query_title<'a>(
         .font_maybe(
             theme::font_style::nickname(theme, is_user_offline).map(font::get),
         )
-        .shaping(text::Shaping::Advanced);
+        .shaping(text::Shaping::Advanced)
+        .wrapping(Wrapping::None)
+        .ellipsis(text::Ellipsis::End);
 
     row![
         nickname,
@@ -564,6 +594,8 @@ fn query_title<'a>(
                                 )
                             })
                             .line_height(1.0)
+                            .wrapping(Wrapping::None)
+                            .ellipsis(text::Ellipsis::End)
                     ]
                     .padding(padding::horizontal(4))
                     .align_y(iced::Alignment::Center),
@@ -576,7 +608,9 @@ fn query_title<'a>(
                             .font_maybe(
                                 theme::font_style::secondary(theme)
                                     .map(font::get),
-                            ),
+                            )
+                            .wrapping(Wrapping::None)
+                            .ellipsis(text::Ellipsis::End),
                     )
                     .style(theme::container::tooltip)
                     .padding(8),
@@ -591,7 +625,9 @@ fn query_title<'a>(
             .font_maybe(
                 theme::font_style::buffer_title_bar(theme).map(font::get)
             )
-            .shaping(text::Shaping::Advanced),
+            .shaping(text::Shaping::Advanced)
+            .wrapping(Wrapping::None)
+            .ellipsis(text::Ellipsis::End),
     ]
     .width(Length::Shrink)
     .align_y(iced::Alignment::Center)

--- a/src/screen/dashboard/theme_editor.rs
+++ b/src/screen/dashboard/theme_editor.rs
@@ -299,9 +299,9 @@ impl ThemeEditor {
         let undo = icon(
             icon::undo(),
             if font_style.is_some() {
-                "Revert Color & Font Style"
+                "Revert color & font style"
             } else {
-                "Revert Color"
+                "Revert color"
             },
             Message::Revert,
             theme,
@@ -322,7 +322,7 @@ impl ThemeEditor {
 
         let share = icon(
             icon::share(),
-            "Share Theme with community",
+            "Share theme with community",
             Message::Share,
             theme,
         );

--- a/src/widget/reaction_row.rs
+++ b/src/widget/reaction_row.rs
@@ -128,7 +128,11 @@ where
                 // trailing separator attached to nicks so it never starts a new line alone
                 let position = i + 1;
                 let trailing = if position + 1 == total && hidden_count == 0 {
-                    Some(" and")
+                    if total > 2 {
+                        Some(", and")
+                    } else {
+                        Some(" and")
+                    }
                 } else if position < displayed.len() {
                     Some(",")
                 } else {

--- a/src/widget/user_display.rs
+++ b/src/widget/user_display.rs
@@ -138,7 +138,7 @@ impl UserDisplay {
                             config,
                             iced::widget::text::LineHeight::Relative(1.0),
                         ),
-                        text(String::from(" has marked itself as a bot"))
+                        text(String::from(" is marked as a bot"))
                             .style(theme::text::secondary)
                             .line_height(
                                 iced::widget::text::LineHeight::Relative(1.0),


### PR DESCRIPTION
A collection of minor fixes/tweaks:
- Add some missing CHANGELOG entries, and re-order the changes a bit to group similar changes together.
- Place word picker above the command picker (similar to the emoji/path picker)
- Consistency pass for style:
  - Use sentence casing for tooltips
  - Use Oxford comma
  - Use sentence casing for server/internal messages
- Make the bot tooltip a little more terse
- Truncate pane titles instead of wrapping (fixes #2016)