### PR TITLE
Align Unread/Highlight Indicators and Server Badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,9 @@ Changed:
 
 - On-join topic messages dropped by default (`buffer.server_messages.join_topic`), instead the topic banner is enabled by default (`buffer.channel.topic_banner`)
 - Topic messages manually requested via `/topic` have a distinct setting from topic messages received on join (`buffer.server_messages.topic` → `buffer.server_messages.request_topic` & `buffer.server_messages.join_topic`)
+- Badging on server icons used to indicate unread/highlight state (instead of the color of the server icon); unread indicators positioned to be aligned with server badge
 - Default `sidebar.server_icon.size` changed from `12` → `20`
+- Default `sidebar.unread_indicator.highlight_icon_size` changed from `8` → `6`
 - Default `sidebar.spacing.server` changed from `6` → `2`
 - Default `sidebar.padding.buffer` changed from `[4, 4]` to `[5, 4]`
 - For filehosts, localhost is now treated as a secure transport when using `servers.<name>.filehost.override_url`

--- a/data/src/config/sidebar.rs
+++ b/data/src/config/sidebar.rs
@@ -139,7 +139,7 @@ impl Default for UnreadIndicator {
             icon: Icon::Dot,
             icon_size: 6,
             highlight_icon: Icon::CircleEmpty,
-            highlight_icon_size: 8,
+            highlight_icon_size: 6,
             show_on_open_buffers: true,
             query_as_highlight: false,
             exclude: None,

--- a/docs/configuration/sidebar.md
+++ b/docs/configuration/sidebar.md
@@ -236,10 +236,10 @@ Note: If set larger than the line height of the specified [font](/configuration/
 ```toml
 # Type: integer
 # Values: any positive integer"
-# Default: 8
+# Default: 6
 
 [sidebar.unread_indicator]
-highlight_icon_size = 8
+highlight_icon_size = 6
 ```
 
 ### `show_on_open_buffers`

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -893,11 +893,35 @@ fn upstream_buffer_button<'a>(
 
     let buffer_title_font = theme::font_style::primary(theme).map(font::get);
 
+    let server_icon_size = match config.sidebar.server_icon {
+        data::config::sidebar::ServerIcon::Size(size) => size,
+        data::config::sidebar::ServerIcon::Hidden => 0,
+    };
+
+    let badge_padding = 2;
+    let badge_size = (server_icon_size / 3).max(4) + 2 * badge_padding;
+
+    let max_indicator_size = if server_icon_size > 0 { badge_size } else { 0 }
+        .max(if config.sidebar.unread_indicator.has_unread_icon() {
+            config.sidebar.unread_indicator.icon_size
+        } else {
+            0
+        })
+        .max(
+            if config.sidebar.unread_indicator.has_unread_highlight_icon() {
+                config.sidebar.unread_indicator.highlight_icon_size
+            } else {
+                0
+            },
+        );
+
     // check for server icon first (only for server buffers with icon size configured)
-    let icon_tuple = if let (
-        buffer::Upstream::Server(server),
-        data::config::sidebar::ServerIcon::Size(size),
-    ) = (&buffer, &config.sidebar.server_icon)
+    let (icon, icon_height, icon_left_spacing): (
+        Option<Element<'a, Message>>,
+        u32,
+        f32,
+    ) = if let buffer::Upstream::Server(server) = &buffer
+        && server_icon_size > 0
     {
         let server_icon_enabled = config
             .servers
@@ -921,8 +945,8 @@ fn upstream_buffer_button<'a>(
                 .into()
             },
         )
-        .width(*size)
-        .height(*size)
+        .width(server_icon_size)
+        .height(server_icon_size)
         .into();
 
         let badge = if connected {
@@ -953,8 +977,6 @@ fn upstream_buffer_button<'a>(
             )
         };
 
-        let badge_padding = 2;
-        let badge_size = (*size / 3).max(4) + 2 * badge_padding;
         let badge: Option<Element<'a, Message>> = badge.map(move |badge| {
             container(badge)
                 .style(move |theme| container::Style {
@@ -974,57 +996,76 @@ fn upstream_buffer_button<'a>(
                 .into()
         });
 
-        let icon_widget: Element<'a, Message> = stack![
-            row![
-                Space::new().width(badge_padding),
-                column![Space::new().height(badge_padding), icon_widget]
-            ]
-            .align_y(iced::Alignment::Center),
-            badge,
-        ]
-        .into();
-
-        Some((icon_widget, *size))
+        (
+            Some(
+                stack![
+                    row![
+                        Space::new().width(badge_padding),
+                        column![
+                            Space::new().height(badge_padding),
+                            icon_widget
+                        ]
+                    ]
+                    .align_y(iced::Alignment::Center),
+                    badge,
+                ]
+                .into(),
+            ),
+            server_icon_size,
+            max_indicator_size.saturating_sub(badge_size) as f32 / 2.0,
+        )
     }
     // fall through to unread/highlight icons for all buffers (including server)
     else if show_highlight_icon
         && let Some(highlight_icon) =
             icon::from_icon(config.sidebar.unread_indicator.highlight_icon)
     {
-        Some((
-            container(
-                highlight_icon
-                    .style(theme::svg::highlight_indicator)
-                    .width(Length::Shrink)
-                    .content_fit(ContentFit::Contain),
-            )
-            .width(config.sidebar.unread_indicator.highlight_icon_size)
-            .height(config.sidebar.unread_indicator.highlight_icon_size)
-            .into(),
+        (
+            Some(
+                container(
+                    highlight_icon
+                        .style(theme::svg::highlight_indicator)
+                        .width(Length::Shrink)
+                        .content_fit(ContentFit::Contain),
+                )
+                .width(config.sidebar.unread_indicator.highlight_icon_size)
+                .height(config.sidebar.unread_indicator.highlight_icon_size)
+                .into(),
+            ),
             config.sidebar.unread_indicator.highlight_icon_size,
-        ))
+            max_indicator_size.saturating_sub(
+                config.sidebar.unread_indicator.highlight_icon_size,
+            ) as f32
+                / 2.0,
+        )
     } else if show_unread_icon
         && let Some(unread_icon) =
             icon::from_icon(config.sidebar.unread_indicator.icon)
     {
-        Some((
-            container(
-                unread_icon
-                    .style(theme::svg::unread_indicator)
-                    .width(Length::Shrink)
-                    .content_fit(ContentFit::Contain),
-            )
-            .width(config.sidebar.unread_indicator.icon_size)
-            .height(config.sidebar.unread_indicator.icon_size)
-            .into(),
+        (
+            Some(
+                container(
+                    unread_icon
+                        .style(theme::svg::unread_indicator)
+                        .width(Length::Shrink)
+                        .content_fit(ContentFit::Contain),
+                )
+                .width(config.sidebar.unread_indicator.icon_size)
+                .height(config.sidebar.unread_indicator.icon_size)
+                .into(),
+            ),
             config.sidebar.unread_indicator.icon_size,
-        ))
+            max_indicator_size
+                .saturating_sub(config.sidebar.unread_indicator.icon_size)
+                as f32
+                / 2.0,
+        )
     } else {
-        None
+        (None, 1, 0.0)
     };
 
     let (icon_spacing, icon) = if config.sidebar.position.is_horizontal() {
-        icon_tuple.map_or((0, None), |(icon, _)| (8, Some(icon)))
+        icon.map_or((0, None), |icon| (8, Some(icon)))
     } else {
         let server_icon_size = match config.sidebar.server_icon {
             data::config::sidebar::ServerIcon::Size(size) => size,
@@ -1045,15 +1086,16 @@ fn upstream_buffer_button<'a>(
             );
         (
             8,
-            Some(icon_tuple.map_or(
-                Space::new().width(max_icon_size).into(),
-                |(icon, _)| {
-                    container(icon)
-                        .width(max_icon_size)
-                        .center_x(max_icon_size)
-                        .into()
-                },
-            )),
+            Some(
+                stack![
+                    Space::new().width(max_icon_size).height(icon_height),
+                    icon.map(|icon| row![
+                        Space::new().width(icon_left_spacing),
+                        icon
+                    ])
+                ]
+                .into(),
+            ),
         )
     };
 


### PR DESCRIPTION
Align unread/highlight indicators and server unread/highlight badge.
Shrink default highlight_icon_size such that it matches the server badge size by default.