### PR TITLE
Use Stable Minus 3 Releases for Check, Clippy, & Test Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,20 +46,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-debug-
 
+      - uses: dtolnay/rust-toolchain@master # recommended when specifying toolchain
+        with:
+          toolchain: stable minus 3 releases
+          components: clippy
       - name: Check
-        run: cargo check --locked --profile ci
-
+        run: cargo check --locked --profile ci; cargo version
       - name: Clippy
-        run: cargo clippy --locked --profile ci --workspace --all-targets -- -D warnings
+        run: cargo clippy --locked --profile ci --workspace --all-targets -- -D warnings; cargo version
 
       - uses: taiki-e/install-action@e0eafa9a0d485c37f97c0f7beb930a58a2facbac # v2
         with:
           tool: cargo-nextest
       - name: Test
-        run: cargo nextest run --locked --profile ci --workspace --all-targets
+        run: cargo nextest run --locked --profile ci --workspace --all-targets; cargo version
 
-      - uses: dtolnay/rust-toolchain@0f1b44df7e9cbb178d781a242338dfa5e243ad7f # nightly
+      - uses: dtolnay/rust-toolchain@master # recommended when specifying toolchain
         with:
+          toolchain: nightly
           components: rustfmt
       - name: Format
-        run: cargo +nightly fmt --all -- --check --color=always
+        run: cargo +nightly fmt --all -- --check --color=always; cargo version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ Changed:
 Thanks:
 
 - Contributions: @bb010g, @furudean, @englut, @luca020400, @4e554c4c, @stephenfin, @achille, @ncfavier
-- Bug reports: @bb010g, daniiooo, @e00E, belthesar, @Fingel, @death916, @furudean, @ncfavier, @WinnerWind, @alexaandru, @kasper93
+- Bug reports: @bb010g, daniiooo, @e00E, belthesar, @Fingel, @death916, @furudean, @ncfavier, @WinnerWind, @alexaandru, @kasper93, tranzystorekk
 - Feature requests: @WinnerWind, Shyny, @classabbyamp, @4e554c4c, @furudean, @englut, @esden, @Erroneuz
 
 # 2026.6 (2026-04-21)

--- a/src/buffer/context_menu.rs
+++ b/src/buffer/context_menu.rs
@@ -585,14 +585,18 @@ impl Entry {
                     message: Some(message),
                     ..
                 },
-            ) if let Some(redaction) = message.redaction.as_ref() => {
-                menu_button(
-                    "Copy redaction".to_string(),
-                    Some(Message::CopyText(redaction.message())),
-                    length,
-                    theme,
-                    config,
-                )
+            ) => {
+                if let Some(redaction) = message.redaction.as_ref() {
+                    menu_button(
+                        "Copy redaction".to_string(),
+                        Some(Message::CopyText(redaction.message())),
+                        length,
+                        theme,
+                        config,
+                    )
+                } else {
+                    row![].into()
+                }
             }
             (
                 Entry::Reply,
@@ -601,20 +605,24 @@ impl Entry {
                     message: Some(message),
                     ..
                 },
-            ) if let Some(msgid) = message.id.as_ref()
-                && let Some(user) = message.target.source().user() =>
-            {
-                menu_button(
-                    "Reply".to_string(),
-                    Some(Message::Reply {
-                        msgid: msgid.clone(),
-                        server_time: message.server_time,
-                        to_nick: user.nickname().to_string(),
-                    }),
-                    length,
-                    theme,
-                    config,
-                )
+            ) => {
+                if let Some(msgid) = message.id.as_ref()
+                    && let Some(user) = message.target.source().user()
+                {
+                    menu_button(
+                        "Reply".to_string(),
+                        Some(Message::Reply {
+                            msgid: msgid.clone(),
+                            server_time: message.server_time,
+                            to_nick: user.nickname().to_string(),
+                        }),
+                        length,
+                        theme,
+                        config,
+                    )
+                } else {
+                    row![].into()
+                }
             }
             (
                 Entry::AddReaction,
@@ -623,16 +631,22 @@ impl Entry {
                     selected_reactions,
                     ..
                 },
-            ) if let Some(msgid) = message.id.as_ref() => menu_button(
-                "Add reaction".to_string(),
-                Some(Message::OpenReactionModal(
-                    msgid.clone(),
-                    selected_reactions.to_vec(),
-                )),
-                length,
-                theme,
-                config,
-            ),
+            ) => {
+                if let Some(msgid) = message.id.as_ref() {
+                    menu_button(
+                        "Add reaction".to_string(),
+                        Some(Message::OpenReactionModal(
+                            msgid.clone(),
+                            selected_reactions.to_vec(),
+                        )),
+                        length,
+                        theme,
+                        config,
+                    )
+                } else {
+                    row![].into()
+                }
+            }
             (
                 Entry::AddReaction,
                 Context::Url {
@@ -640,19 +654,25 @@ impl Entry {
                     selected_reactions,
                     ..
                 },
-            ) if let Some(msgid) = message.id.as_ref() => menu_button(
-                "Add reaction".to_string(),
-                Some(Message::OpenReactionModal(
-                    msgid.clone(),
-                    selected_reactions
-                        .into_iter()
-                        .map(ToString::to_string)
-                        .collect(),
-                )),
-                length,
-                theme,
-                config,
-            ),
+            ) => {
+                if let Some(msgid) = message.id.as_ref() {
+                    menu_button(
+                        "Add reaction".to_string(),
+                        Some(Message::OpenReactionModal(
+                            msgid.clone(),
+                            selected_reactions
+                                .into_iter()
+                                .map(ToString::to_string)
+                                .collect(),
+                        )),
+                        length,
+                        theme,
+                        config,
+                    )
+                } else {
+                    row![].into()
+                }
+            }
             (
                 Entry::Redact,
                 Context::Message { message, .. }
@@ -660,13 +680,19 @@ impl Entry {
                     message: Some(message),
                     ..
                 },
-            ) if let Some(msgid) = message.id.as_ref() => menu_button(
-                "Redact message".to_string(),
-                Some(Message::Redact(msgid.clone())),
-                length,
-                theme,
-                config,
-            ),
+            ) => {
+                if let Some(msgid) = message.id.as_ref() {
+                    menu_button(
+                        "Redact message".to_string(),
+                        Some(Message::Redact(msgid.clone())),
+                        length,
+                        theme,
+                        config,
+                    )
+                } else {
+                    row![].into()
+                }
+            }
             (
                 Entry::HideWithRedaction,
                 Context::Message { message, .. }


### PR DESCRIPTION
Modify the check, clippy, & test steps of the Build GH Action to use the "stable minus 3 releases" toolchain (currently resolves to 1.93.1), in order to give a larger Rust upgrade window for downstream.

Checking with `cargo-msrv` no dependencies report a MSRV greater than 1.92, so hopefully the test changes (and minor modifications to existing code so tests pass) will be sufficient for now.