### PR TITLE
More Sidebar Tweaks

### DIFF
--- a/data/src/config/pane.rs
+++ b/data/src/config/pane.rs
@@ -27,7 +27,7 @@ impl Default for Pane {
 #[serde(default)]
 pub struct Gap {
     pub inner: u32,
-    pub outer: u16,
+    pub outer: u32,
 }
 
 impl Default for Gap {

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -27,7 +27,7 @@ use data::{
 };
 use iced::widget::pane_grid::{self, PaneGrid};
 use iced::widget::{Space, center, column, container, row, stack, text};
-use iced::{Length, Padding, Size, Task, Vector, advanced, clipboard};
+use iced::{Length, Size, Task, Vector, advanced, clipboard, padding};
 use irc::proto;
 
 use self::command_bar::CommandBar;
@@ -1604,9 +1604,8 @@ impl Dashboard {
         if let Some(state) = self.panes.popout.get(&window) {
             let pane_gap = config.pane.gap.outer;
             let top_padding =
-                platform_specific::popped_out_window_padding(config)
-                    + u32::from(pane_gap);
-            let padding = Padding::new(pane_gap.into()).top(top_padding as f32);
+                platform_specific::popped_out_window_padding(config) + pane_gap;
+            let padding = padding::all(pane_gap).top(top_padding as f32);
 
             let content = container(
                 PaneGrid::new(state, |id, pane, _maximized| {
@@ -1699,13 +1698,29 @@ impl Dashboard {
             .spacing(config.pane.gap.inner)
             .into();
 
+        let pane_padding = match config.sidebar.position {
+            data::config::sidebar::Position::Left => {
+                padding::all(config.pane.gap.outer).left(config.pane.gap.inner)
+            }
+            data::config::sidebar::Position::Top => {
+                padding::all(config.pane.gap.outer).top(config.pane.gap.inner)
+            }
+            data::config::sidebar::Position::Right => {
+                padding::all(config.pane.gap.outer).right(config.pane.gap.inner)
+            }
+            data::config::sidebar::Position::Bottom => {
+                padding::all(config.pane.gap.outer)
+                    .bottom(config.pane.gap.inner)
+            }
+        };
+
         let pane_grid =
             container(pane_grid.map(move |message| {
                 Message::Pane(self.main_window(), message)
             }))
             .width(Length::Fill)
             .height(Length::Fill)
-            .padding(config.pane.gap.outer);
+            .padding(pane_padding);
 
         let side_menu = self
             .side_menu

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -597,10 +597,21 @@ impl Sidebar {
 
             match config.sidebar.position {
                 sidebar::Position::Left | sidebar::Position::Right => {
+                    let column_padding = if matches!(
+                        config.sidebar.position,
+                        sidebar::Position::Left
+                    ) {
+                        padding::right(2)
+                    } else {
+                        padding::left(2)
+                    };
+
                     // Add buffers to a column.
                     let buffers = column![
                         Scrollable::new(
-                            Column::with_children(buffers).spacing(1)
+                            Column::with_children(buffers)
+                                .spacing(1)
+                                .padding(column_padding)
                         )
                         .direction(
                             scrollable::Direction::Vertical(
@@ -609,6 +620,7 @@ impl Sidebar {
                                     .scroller_width(
                                         config.sidebar.scrollbar.scroller_width
                                     )
+                                    .spacing(4)
                             )
                         )
                     ];
@@ -624,14 +636,21 @@ impl Sidebar {
                 sidebar::Position::Top | sidebar::Position::Bottom => {
                     // Add buffers to a row.
                     let buffers = row![
-                        Scrollable::new(Row::with_children(buffers).spacing(2))
-                            .direction(scrollable::Direction::Horizontal(
+                        Scrollable::new(
+                            Row::with_children(buffers)
+                                .spacing(2)
+                                .align_y(Alignment::Center)
+                        )
+                        .direction(
+                            scrollable::Direction::Horizontal(
                                 scrollable::Scrollbar::default()
                                     .width(config.sidebar.scrollbar.width)
                                     .scroller_width(
                                         config.sidebar.scrollbar.scroller_width
                                     )
-                            ))
+                                    .spacing(4)
+                            )
+                        )
                     ];
 
                     // Wrap buffers in a row with user_menu_button


### PR DESCRIPTION
Adjust sidebar padding/spacing to avoid obscuring sidebar buttons with the scrollbar.

Fix button alignment when sidebar is in top/bottom position.