### PR TITLE
Query offline indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 Added:
 
 - Add clear buffer shortcut to title bar
+- Indicate in query if user is offline
 
 Thanks:
 
-- Contributions: @luca020400
+- Contributions: @luca020400, @englut
 - Feature requests: @g00s
 
 # 2026.7.1 (2026-06-02)

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -99,6 +99,13 @@ impl Upstream {
             Self::Server(_) => None,
         }
     }
+
+    pub fn query(&self) -> Option<Target> {
+        match self {
+            Self::Query(_, query) => Some(Target::Query(query.clone())),
+            _ => None,
+        }
+    }
 }
 
 impl Internal {

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -2900,6 +2900,15 @@ impl Client {
                         }
                         if should_notify { Some(user) } else { None }
                     })
+                    .filter_map(|user| {
+                        self.config
+                            .monitor
+                            .iter()
+                            .any(|monitored_user| {
+                                monitored_user == user.as_normalized_str()
+                            })
+                            .then_some(user)
+                    })
                     .collect::<Vec<_>>();
 
                 return Ok(vec![
@@ -2939,6 +2948,15 @@ impl Client {
                         }
 
                         if should_notify { Some(nick) } else { None }
+                    })
+                    .filter_map(|nick| {
+                        self.config
+                            .monitor
+                            .iter()
+                            .any(|monitored_user| {
+                                monitored_user == nick.as_normalized_str()
+                            })
+                            .then_some(nick)
                     })
                     .collect::<Vec<_>>();
 
@@ -4556,6 +4574,12 @@ impl Client {
 
     pub fn multiline_limits(&self) -> Option<MultilineLimits> {
         self.capabilities.multiline_limits()
+    }
+
+    pub fn is_monitored_user_online(&self, user: &User) -> bool {
+        self.monitored_users
+            .get(user)
+            .is_some_and(|monitored_user| monitored_user.online)
     }
 }
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -693,6 +693,8 @@ impl Client {
         let labeled_response_context =
             self.set_labeled_response_context(buffer, &mut message);
 
+        let mut restore_automated_monitored_users: Vec<String> = vec![];
+
         if matches!(priority, TokenPriority::User) {
             match &message.command {
                 Command::LIST(..) => {
@@ -793,7 +795,12 @@ impl Client {
                             }
                         }
                         (_, "C" | "c") => {
-                            self.monitored_users.clear();
+                            for (user, _) in self.monitored_users.iter().filter(
+                                |(_, monitored_user)| monitored_user.automated,
+                            ) {
+                                restore_automated_monitored_users
+                                    .push(user.as_normalized_str().to_owned());
+                            }
                         }
                         _ => (),
                     }
@@ -806,6 +813,26 @@ impl Client {
             anti_flood.add_token(message, priority);
         } else if let Err(e) = self.handle.try_send(message.into()) {
             log::warn!("[{}] Error sending message: {e}", self.server);
+        }
+
+        if !restore_automated_monitored_users.is_empty()
+            && let Some(isupport::Parameter::MONITOR(monitor_limit)) =
+                self.isupport.get(&isupport::Kind::MONITOR)
+        {
+            let messages = group_monitors(
+                &restore_automated_monitored_users,
+                *monitor_limit,
+                find_target_limit(&self.isupport, "MONITOR"),
+                &self.server,
+                None,
+            );
+            for message in messages {
+                if let Some(ref mut anti_flood) = self.anti_flood {
+                    anti_flood.add_token(message.into(), priority);
+                } else if let Err(e) = self.handle.try_send(message) {
+                    log::warn!("[{}] Error sending message: {e}", self.server);
+                }
+            }
         }
 
         labeled_response_context

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -2883,38 +2883,32 @@ impl Client {
                             User::parse(target, casemapping, prefix).unwrap_or(
                                 User::from(Nick::from_str(target, casemapping)),
                             );
-
-                        if let Some(monitored_user) =
-                            self.monitored_users.get_mut(&user)
-                        {
-                            monitored_user.online = true;
-                            if !monitored_user.query {
-                                Some(user)
-                            } else {
-                                None
-                            }
-                        } else {
-                            self.monitored_users.insert(
-                                user.clone(),
-                                MonitoredUser {
-                                    online: true,
-                                    query: false,
-                                },
-                            );
-                            Some(user)
-                        }
+                        let entry = self
+                            .monitored_users
+                            .entry(user.clone())
+                            .and_modify(|monitored_user| {
+                                monitored_user.online = true;
+                            })
+                            .or_insert_with(|| MonitoredUser {
+                                online: true,
+                                query: false,
+                            });
+                        (!entry.query).then_some(user)
                     })
                     .collect::<Vec<_>>();
 
-                let mut events = vec![];
-                if !targets.is_empty() {
-                    events.push(Event::Single {
-                        message: message.clone(),
-                        our_nick: self.nickname().to_owned(),
-                        deduplicate: false,
-                    });
-                    events.push(Event::MonitoredOnline(targets));
-                }
+                let events = if !targets.is_empty() {
+                    vec![
+                        Event::Single {
+                            message: message.clone(),
+                            our_nick: self.nickname().to_owned(),
+                            deduplicate: false,
+                        },
+                        Event::MonitoredOnline(targets),
+                    ]
+                } else {
+                    vec![]
+                };
                 return Ok(events);
             }
             Command::Numeric(RPL_MONOFFLINE, args) => {
@@ -2925,40 +2919,35 @@ impl Client {
                     .split(',')
                     .filter_map(|target| {
                         let nick = Nick::from_str(target, casemapping);
-                        let user = User::parse(target, casemapping, prefix)
-                            .unwrap_or(nick.clone().into());
-
-                        if let Some(monitored_user) =
-                            self.monitored_users.get_mut(&user)
-                        {
-                            monitored_user.online = false;
-                            if !monitored_user.query {
-                                Some(nick)
-                            } else {
-                                None
-                            }
-                        } else {
-                            self.monitored_users.insert(
-                                user.clone(),
-                                MonitoredUser {
-                                    online: false,
-                                    query: false,
-                                },
-                            );
-                            Some(nick)
-                        }
+                        let entry = self
+                            .monitored_users
+                            .entry(
+                                User::parse(target, casemapping, prefix)
+                                    .unwrap_or(nick.clone().into()),
+                            )
+                            .and_modify(|monitored_user| {
+                                monitored_user.online = false;
+                            })
+                            .or_insert_with(|| MonitoredUser {
+                                online: false,
+                                query: false,
+                            });
+                        (!entry.query).then_some(nick)
                     })
                     .collect::<Vec<_>>();
 
-                let mut events = vec![];
-                if !targets.is_empty() {
-                    events.push(Event::Single {
-                        message: message.clone(),
-                        our_nick: self.nickname().to_owned(),
-                        deduplicate: false,
-                    });
-                    events.push(Event::MonitoredOffline(targets));
-                }
+                let events = if !targets.is_empty() {
+                    vec![
+                        Event::Single {
+                            message: message.clone(),
+                            our_nick: self.nickname().to_owned(),
+                            deduplicate: false,
+                        },
+                        Event::MonitoredOffline(targets),
+                    ]
+                } else {
+                    vec![]
+                };
                 return Ok(events);
             }
             Command::Numeric(RPL_ENDOFMONLIST, _) => {
@@ -4568,13 +4557,13 @@ impl Client {
         self.capabilities.multiline_limits()
     }
 
-    pub fn has_monitor_support(&self) -> bool {
+    pub fn has_isupport_monitor(&self) -> bool {
         self.isupport.contains_key(&isupport::Kind::MONITOR)
     }
 
     pub fn is_monitored_user_online(&self, user: &User) -> bool {
         // falling back to assume nick is `online` if we don't have monitor support
-        !self.has_monitor_support()
+        !self.has_isupport_monitor()
             || self
                 .monitored_users
                 .get(user)
@@ -4595,7 +4584,7 @@ impl Client {
                 query: true,
             },
         );
-        if self.has_monitor_support() {
+        if self.has_isupport_monitor() {
             let message = command!("MONITOR", "+", user.as_normalized_str());
             if let Err(e) = self.handle.try_send(message) {
                 log::warn!("[{}] Error sending monitor: {e}", self.server);
@@ -4605,7 +4594,7 @@ impl Client {
 
     pub fn remove_monitored_user(&mut self, user: &User) {
         self.monitored_users.remove(user);
-        if self.has_monitor_support() {
+        if self.has_isupport_monitor() {
             let message = command!("MONITOR", "-", user.as_normalized_str());
             if let Err(e) = self.handle.try_send(message) {
                 log::warn!("[{}] Error sending monitor: {e}", self.server);

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -2901,17 +2901,18 @@ impl Client {
                                     query: false,
                                 },
                             );
-                            None
+                            Some(user)
                         }
                     })
                     .collect::<Vec<_>>();
 
-                let mut events = vec![Event::Single {
-                    message: message.clone(),
-                    our_nick: self.nickname().to_owned(),
-                    deduplicate: false,
-                }];
+                let mut events = vec![];
                 if !targets.is_empty() {
+                    events.push(Event::Single {
+                        message: message.clone(),
+                        our_nick: self.nickname().to_owned(),
+                        deduplicate: false,
+                    });
                     events.push(Event::MonitoredOnline(targets));
                 }
                 return Ok(events);
@@ -2944,17 +2945,18 @@ impl Client {
                                     query: false,
                                 },
                             );
-                            None
+                            Some(nick)
                         }
                     })
                     .collect::<Vec<_>>();
 
-                let mut events = vec![Event::Single {
-                    message: message.clone(),
-                    our_nick: self.nickname().to_owned(),
-                    deduplicate: false,
-                }];
+                let mut events = vec![];
                 if !targets.is_empty() {
+                    events.push(Event::Single {
+                        message: message.clone(),
+                        our_nick: self.nickname().to_owned(),
+                        deduplicate: false,
+                    });
                     events.push(Event::MonitoredOffline(targets));
                 }
                 return Ok(events);
@@ -4579,10 +4581,11 @@ impl Client {
     }
 
     pub fn add_monitored_user_query(&mut self, user: &User) {
+        let is_online = self.is_monitored_user_online(user);
         self.monitored_users.insert(
             user.clone(),
             MonitoredUser {
-                online: false,
+                online: is_online,
                 query: true,
             },
         );

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -379,28 +379,29 @@ impl Client {
                         .config
                         .monitor
                         .iter()
-                        .filter(|existing_monitor| {
-                            let user = User::parse(
+                        .filter_map(|existing_monitor| {
+                            let user = User::parse_or_force(
                                 existing_monitor,
                                 casemapping,
                                 prefix,
-                            )
-                            .unwrap_or(User::from(Nick::from_str(
-                                existing_monitor,
-                                casemapping,
-                            )));
-                            !config.monitor.contains(existing_monitor)
+                            );
+                            if !config.monitor.contains(existing_monitor)
                                 && !self.is_monitored_user_automated(&user)
+                            {
+                                Some(user)
+                            } else {
+                                None
+                            }
                         })
-                        .cloned()
                         .collect::<Vec<_>>();
 
                     let monitored_users_keys: Vec<User> =
                         self.monitored_users.keys().cloned().collect();
                     for user in monitored_users_keys {
-                        if remove_monitors.iter().any(|remove_monitor| {
-                            remove_monitor == user.as_normalized_str()
-                        }) {
+                        if remove_monitors
+                            .iter()
+                            .any(|remove_monitor| remove_monitor == &user)
+                        {
                             self.monitored_users.remove(&user);
                         } else {
                             self.monitored_users.entry(user).and_modify(
@@ -416,7 +417,7 @@ impl Client {
                         *monitor_limit,
                         find_target_limit(&self.isupport, "MONITOR"),
                         &self.server,
-                        Some(self.monitored_users.len()),
+                        self.monitored_users.len(),
                     )
                     .collect::<Vec<_>>();
 
@@ -424,7 +425,10 @@ impl Client {
                         messages.push(command!(
                             "MONITOR",
                             "-",
-                            remove_monitors.into_iter().join(",")
+                            remove_monitors
+                                .iter()
+                                .map(super::user::User::as_normalized_str)
+                                .join(",")
                         ));
                     }
 
@@ -756,17 +760,11 @@ impl Client {
                             let prefix = isupport::get_prefix(&self.isupport);
                             for target in targets.split(",") {
                                 self.monitored_users
-                                    .entry(
-                                        User::parse(
-                                            target,
-                                            casemapping,
-                                            prefix,
-                                        )
-                                        .unwrap_or(User::from(Nick::from_str(
-                                            target,
-                                            casemapping,
-                                        ))),
-                                    )
+                                    .entry(User::parse_or_force(
+                                        target,
+                                        casemapping,
+                                        prefix,
+                                    ))
                                     .and_modify(|monitored_user| {
                                         monitored_user.automated = false;
                                     })
@@ -786,21 +784,27 @@ impl Client {
                                 targets.split(',').filter(|s| !s.is_empty())
                             {
                                 self.monitored_users.remove(
-                                    &User::parse(target, casemapping, prefix)
-                                        .unwrap_or(User::from(Nick::from_str(
-                                            target,
-                                            casemapping,
-                                        ))),
+                                    &User::parse_or_force(
+                                        target,
+                                        casemapping,
+                                        prefix,
+                                    ),
                                 );
                             }
                         }
                         (_, "C" | "c") => {
-                            for (user, _) in self.monitored_users.iter().filter(
-                                |(_, monitored_user)| monitored_user.automated,
-                            ) {
-                                restore_automated_monitored_users
-                                    .push(user.as_normalized_str().to_owned());
-                            }
+                            self.monitored_users.retain(
+                                |user, monitored_user| {
+                                    if monitored_user.automated {
+                                        restore_automated_monitored_users.push(
+                                            user.as_normalized_str().to_owned(),
+                                        );
+                                        true
+                                    } else {
+                                        false
+                                    }
+                                },
+                            );
                         }
                         _ => (),
                     }
@@ -824,11 +828,11 @@ impl Client {
                 *monitor_limit,
                 find_target_limit(&self.isupport, "MONITOR"),
                 &self.server,
-                None,
+                0,
             );
             for message in messages {
                 if let Some(ref mut anti_flood) = self.anti_flood {
-                    anti_flood.add_token(message.into(), priority);
+                    anti_flood.add_token(message.into(), TokenPriority::Low);
                 } else if let Err(e) = self.handle.try_send(message) {
                     log::warn!("[{}] Error sending message: {e}", self.server);
                 }
@@ -3002,9 +3006,7 @@ impl Client {
                     .split(',')
                     .filter_map(|target| {
                         let user =
-                            User::parse(target, casemapping, prefix).unwrap_or(
-                                User::from(Nick::from_str(target, casemapping)),
-                            );
+                            User::parse_or_force(target, casemapping, prefix);
                         let entry = self
                             .monitored_users
                             .entry(user.clone())
@@ -3043,10 +3045,11 @@ impl Client {
                         let nick = Nick::from_str(target, casemapping);
                         let entry = self
                             .monitored_users
-                            .entry(
-                                User::parse(target, casemapping, prefix)
-                                    .unwrap_or(nick.clone().into()),
-                            )
+                            .entry(User::parse_or_force(
+                                target,
+                                casemapping,
+                                prefix,
+                            ))
                             .and_modify(|monitored_user| {
                                 monitored_user.online = false;
                             })
@@ -3358,7 +3361,7 @@ impl Client {
                             *monitor_limit,
                             find_target_limit(&self.isupport, "MONITOR"),
                             &self.server,
-                            None,
+                            0,
                         );
                         for message in messages {
                             self.handle.try_send(message)?;
@@ -4704,14 +4707,14 @@ impl Client {
     }
 
     pub fn add_monitored_user_automated(&mut self, user: &User) {
-        self.monitored_users.insert(
-            user.clone(),
-            MonitoredUser {
-                online: self.is_monitored_user_online(user),
-                automated: true,
-            },
-        );
         if self.has_isupport_monitor() {
+            self.monitored_users.insert(
+                user.clone(),
+                MonitoredUser {
+                    online: self.is_monitored_user_online(user),
+                    automated: true,
+                },
+            );
             self.send(
                 None,
                 command!("MONITOR", "+", user.as_normalized_str()).into(),
@@ -4721,8 +4724,8 @@ impl Client {
     }
 
     pub fn remove_monitored_user(&mut self, user: &User) {
-        self.monitored_users.remove(user);
         if self.has_isupport_monitor() {
+            self.monitored_users.remove(user);
             self.send(
                 None,
                 command!("MONITOR", "-", user.as_normalized_str()).into(),
@@ -6011,27 +6014,24 @@ fn group_monitors<'a>(
     monitor_limit: Option<u16>,
     target_limit: Option<u16>,
     server: &Server,
-    num_existing_monitors: Option<usize>,
+    num_existing_monitors: usize,
 ) -> impl Iterator<Item = proto::Message> + 'a {
     const MAX_LEN: usize = proto::format::BYTE_LIMIT - b"MONITOR + \r\n".len();
 
     if let Some(monitor_limit) = monitor_limit.map(usize::from) {
-        let mut total_monitor_count = users.len();
-        if let Some(num_existing_monitors) = num_existing_monitors {
-            total_monitor_count += num_existing_monitors;
-        }
-        if monitor_limit < total_monitor_count {
+        let total_monitor_count = users.len() + num_existing_monitors;
+        let remove_target_count = total_monitor_count.saturating_sub(monitor_limit);
+        if remove_target_count > 0 {
             log::warn!(
                 "[{server}] More users in monitor list than permitted by the server \
                       ({total_monitor_count} users in monitor list, {monitor_limit} permitted)",
             );
         }
 
-        &users[0..std::cmp::min(monitor_limit, users.len())]
+        users.iter().take(users.len().saturating_sub(remove_target_count))
     } else {
-        users
+        users.iter().take(users.len())
     }
-    .iter()
     .scan((0, 0, 0), |(char_count, target_count, chunk), target| {
         // Target + a comma
         *char_count += target.len() + 1;

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -179,6 +179,11 @@ pub enum Event {
     UpdateIcon,
 }
 
+struct MonitoredUser {
+    online: bool,
+    query: bool,
+}
+
 struct ChatHistoryRequest {
     subcommand: ChatHistorySubcommand,
     requested_at: Instant,
@@ -221,6 +226,7 @@ pub struct Client {
     channel_discovery_manager: channel_discovery::Manager,
     http_client: Option<Arc<reqwest::Client>>, // Only Some if config.proxy.is_some()
     registry: metadata::ServerRegistry,
+    monitored_users: HashMap<User, MonitoredUser>,
 }
 
 impl fmt::Debug for Client {
@@ -292,6 +298,7 @@ impl Client {
             config,
             channel_discovery_manager: channel_discovery::Manager::new(),
             registry: metadata::ServerRegistry::new(),
+            monitored_users: HashMap::new(),
         }
     }
 
@@ -2870,10 +2877,28 @@ impl Client {
 
                 let targets = ok!(args.get(1))
                     .split(',')
-                    .map(|target| {
-                        User::parse(target, casemapping, prefix).unwrap_or(
-                            User::from(Nick::from_str(target, casemapping)),
-                        )
+                    .filter_map(|target| {
+                        let user =
+                            User::parse(target, casemapping, prefix).unwrap_or(
+                                User::from(Nick::from_str(target, casemapping)),
+                            );
+
+                        let mut should_notify = true;
+                        if let Some(monitored_user) =
+                            self.monitored_users.get_mut(&user)
+                        {
+                            monitored_user.online = true;
+                            should_notify = !monitored_user.query;
+                        } else {
+                            self.monitored_users.insert(
+                                user.clone(),
+                                MonitoredUser {
+                                    online: true,
+                                    query: false,
+                                },
+                            );
+                        }
+                        if should_notify { Some(user) } else { None }
                     })
                     .collect::<Vec<_>>();
 
@@ -2887,9 +2912,34 @@ impl Client {
                 ]);
             }
             Command::Numeric(RPL_MONOFFLINE, args) => {
+                let casemapping =
+                    isupport::get_casemapping_or_default(&self.isupport);
+                let prefix = isupport::get_prefix(&self.isupport);
                 let targets = ok!(args.get(1))
                     .split(',')
-                    .map(|target| Nick::from_str(target, self.casemapping()))
+                    .filter_map(|target| {
+                        let nick = Nick::from_str(target, casemapping);
+                        let user = User::parse(target, casemapping, prefix)
+                            .unwrap_or(nick.clone().into());
+
+                        let mut should_notify = true;
+                        if let Some(monitored_user) =
+                            self.monitored_users.get_mut(&user)
+                        {
+                            monitored_user.online = false;
+                            should_notify = !monitored_user.query;
+                        } else {
+                            self.monitored_users.insert(
+                                user.clone(),
+                                MonitoredUser {
+                                    online: false,
+                                    query: false,
+                                },
+                            );
+                        }
+
+                        if should_notify { Some(nick) } else { None }
+                    })
                     .collect::<Vec<_>>();
 
                 return Ok(vec![

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -179,15 +179,16 @@ pub enum Event {
     UpdateIcon,
 }
 
-struct MonitoredUser {
-    online: bool,
-    query: bool,
-}
-
 struct ChatHistoryRequest {
     subcommand: ChatHistorySubcommand,
     requested_at: Instant,
     autorequest: bool,
+}
+
+#[derive(Debug)]
+struct MonitoredUser {
+    online: bool,
+    query: bool,
 }
 
 pub struct Client {
@@ -2883,12 +2884,15 @@ impl Client {
                                 User::from(Nick::from_str(target, casemapping)),
                             );
 
-                        let mut should_notify = true;
                         if let Some(monitored_user) =
                             self.monitored_users.get_mut(&user)
                         {
                             monitored_user.online = true;
-                            should_notify = !monitored_user.query;
+                            if !monitored_user.query {
+                                Some(user)
+                            } else {
+                                None
+                            }
                         } else {
                             self.monitored_users.insert(
                                 user.clone(),
@@ -2897,28 +2901,20 @@ impl Client {
                                     query: false,
                                 },
                             );
+                            None
                         }
-                        if should_notify { Some(user) } else { None }
-                    })
-                    .filter_map(|user| {
-                        self.config
-                            .monitor
-                            .iter()
-                            .any(|monitored_user| {
-                                monitored_user == user.as_normalized_str()
-                            })
-                            .then_some(user)
                     })
                     .collect::<Vec<_>>();
 
-                return Ok(vec![
-                    Event::Single {
-                        message: message.clone(),
-                        our_nick: self.nickname().to_owned(),
-                        deduplicate: false,
-                    },
-                    Event::MonitoredOnline(targets),
-                ]);
+                let mut events = vec![Event::Single {
+                    message: message.clone(),
+                    our_nick: self.nickname().to_owned(),
+                    deduplicate: false,
+                }];
+                if !targets.is_empty() {
+                    events.push(Event::MonitoredOnline(targets));
+                }
+                return Ok(events);
             }
             Command::Numeric(RPL_MONOFFLINE, args) => {
                 let casemapping =
@@ -2931,12 +2927,15 @@ impl Client {
                         let user = User::parse(target, casemapping, prefix)
                             .unwrap_or(nick.clone().into());
 
-                        let mut should_notify = true;
                         if let Some(monitored_user) =
                             self.monitored_users.get_mut(&user)
                         {
                             monitored_user.online = false;
-                            should_notify = !monitored_user.query;
+                            if !monitored_user.query {
+                                Some(nick)
+                            } else {
+                                None
+                            }
                         } else {
                             self.monitored_users.insert(
                                 user.clone(),
@@ -2945,29 +2944,20 @@ impl Client {
                                     query: false,
                                 },
                             );
+                            None
                         }
-
-                        if should_notify { Some(nick) } else { None }
-                    })
-                    .filter_map(|nick| {
-                        self.config
-                            .monitor
-                            .iter()
-                            .any(|monitored_user| {
-                                monitored_user == nick.as_normalized_str()
-                            })
-                            .then_some(nick)
                     })
                     .collect::<Vec<_>>();
 
-                return Ok(vec![
-                    Event::Single {
-                        message: message.clone(),
-                        our_nick: self.nickname().to_owned(),
-                        deduplicate: false,
-                    },
-                    Event::MonitoredOffline(targets),
-                ]);
+                let mut events = vec![Event::Single {
+                    message: message.clone(),
+                    our_nick: self.nickname().to_owned(),
+                    deduplicate: false,
+                }];
+                if !targets.is_empty() {
+                    events.push(Event::MonitoredOffline(targets));
+                }
+                return Ok(events);
             }
             Command::Numeric(RPL_ENDOFMONLIST, _) => {
                 return Ok(vec![]);
@@ -4580,6 +4570,35 @@ impl Client {
         self.monitored_users
             .get(user)
             .is_some_and(|monitored_user| monitored_user.online)
+    }
+
+    pub fn is_monitored_user_query(&self, user: &User) -> bool {
+        self.monitored_users
+            .get(user)
+            .is_some_and(|monitored_user| monitored_user.query)
+    }
+
+    pub fn add_monitored_user_query(&mut self, user: &User) {
+        self.monitored_users.insert(
+            user.clone(),
+            MonitoredUser {
+                online: false,
+                query: true,
+            },
+        );
+
+        let message = command!("MONITOR", "+", user.as_normalized_str());
+        if let Err(e) = self.handle.try_send(message) {
+            log::warn!("[{}] Error sending monitor: {e}", self.server);
+        }
+    }
+
+    pub fn remove_monitored_user(&mut self, user: &User) {
+        self.monitored_users.remove(user);
+        let message = command!("MONITOR", "-", user.as_normalized_str());
+        if let Err(e) = self.handle.try_send(message) {
+            log::warn!("[{}] Error sending monitor: {e}", self.server);
+        }
     }
 }
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -185,10 +185,10 @@ struct ChatHistoryRequest {
     autorequest: bool,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct MonitoredUser {
     online: bool,
-    query: bool,
+    automated: bool,
 }
 
 pub struct Client {
@@ -371,21 +371,62 @@ impl Client {
                 if let Some(isupport::Parameter::MONITOR(monitor_limit)) =
                     self.isupport.get(&isupport::Kind::MONITOR)
                 {
-                    if let Err(e) =
-                        self.handle.try_send(command!("MONITOR", "C"))
-                    {
-                        log::warn!(
-                            "[{}] Error clearing monitor: {e}",
-                            self.server
-                        );
+                    let casemapping =
+                        isupport::get_casemapping_or_default(&self.isupport);
+                    let prefix = isupport::get_prefix(&self.isupport);
+
+                    let remove_monitors = self
+                        .config
+                        .monitor
+                        .iter()
+                        .filter(|existing_monitor| {
+                            let user = User::parse(
+                                existing_monitor,
+                                casemapping,
+                                prefix,
+                            )
+                            .unwrap_or(User::from(Nick::from_str(
+                                existing_monitor,
+                                casemapping,
+                            )));
+                            !config.monitor.contains(existing_monitor)
+                                && !self.is_monitored_user_automated(&user)
+                        })
+                        .cloned()
+                        .collect::<Vec<_>>();
+
+                    let monitored_users_keys: Vec<User> =
+                        self.monitored_users.keys().cloned().collect();
+                    for user in monitored_users_keys {
+                        if remove_monitors.iter().any(|remove_monitor| {
+                            remove_monitor == user.as_normalized_str()
+                        }) {
+                            self.monitored_users.remove(&user);
+                        } else {
+                            self.monitored_users.entry(user).and_modify(
+                                |monitored_user| {
+                                    monitored_user.automated = false;
+                                },
+                            );
+                        }
                     }
 
-                    let messages = group_monitors(
+                    let mut messages = group_monitors(
                         &config.monitor,
                         *monitor_limit,
                         find_target_limit(&self.isupport, "MONITOR"),
                         &self.server,
-                    );
+                        Some(self.monitored_users.len()),
+                    )
+                    .collect::<Vec<_>>();
+
+                    if !remove_monitors.is_empty() {
+                        messages.push(command!(
+                            "MONITOR",
+                            "-",
+                            remove_monitors.into_iter().join(",")
+                        ));
+                    }
 
                     for message in messages {
                         if let Err(e) = self.handle.try_send(message) {
@@ -701,6 +742,60 @@ impl Client {
                                     .push_front(WhoPoll { channel, status });
                             }
                         }
+                    }
+                }
+                Command::MONITOR(subcommand, targets) => {
+                    match (targets, subcommand.as_str()) {
+                        (Some(targets), "+") => {
+                            let casemapping =
+                                isupport::get_casemapping_or_default(
+                                    &self.isupport,
+                                );
+                            let prefix = isupport::get_prefix(&self.isupport);
+                            for target in targets.split(",") {
+                                self.monitored_users
+                                    .entry(
+                                        User::parse(
+                                            target,
+                                            casemapping,
+                                            prefix,
+                                        )
+                                        .unwrap_or(User::from(Nick::from_str(
+                                            target,
+                                            casemapping,
+                                        ))),
+                                    )
+                                    .and_modify(|monitored_user| {
+                                        monitored_user.automated = false;
+                                    })
+                                    .or_insert_with(|| MonitoredUser {
+                                        online: false,
+                                        automated: false,
+                                    });
+                            }
+                        }
+                        (Some(targets), "-") => {
+                            let casemapping =
+                                isupport::get_casemapping_or_default(
+                                    &self.isupport,
+                                );
+                            let prefix = isupport::get_prefix(&self.isupport);
+                            for target in
+                                targets.split(',').filter(|s| !s.is_empty())
+                            {
+                                self.monitored_users.remove(
+                                    &User::parse(target, casemapping, prefix)
+                                        .unwrap_or(User::from(Nick::from_str(
+                                            target,
+                                            casemapping,
+                                        ))),
+                                );
+                            }
+                        }
+                        (_, "C" | "c") => {
+                            self.monitored_users.clear();
+                        }
+                        _ => (),
                     }
                 }
                 _ => (),
@@ -2891,9 +2986,9 @@ impl Client {
                             })
                             .or_insert_with(|| MonitoredUser {
                                 online: true,
-                                query: false,
+                                automated: false,
                             });
-                        (!entry.query).then_some(user)
+                        (!entry.automated).then_some(user)
                     })
                     .collect::<Vec<_>>();
 
@@ -2930,9 +3025,9 @@ impl Client {
                             })
                             .or_insert_with(|| MonitoredUser {
                                 online: false,
-                                query: false,
+                                automated: false,
                             });
-                        (!entry.query).then_some(nick)
+                        (!entry.automated).then_some(nick)
                     })
                     .collect::<Vec<_>>();
 
@@ -3236,6 +3331,7 @@ impl Client {
                             *monitor_limit,
                             find_target_limit(&self.isupport, "MONITOR"),
                             &self.server,
+                            None,
                         );
                         for message in messages {
                             self.handle.try_send(message)?;
@@ -4561,6 +4657,10 @@ impl Client {
         self.isupport.contains_key(&isupport::Kind::MONITOR)
     }
 
+    pub fn is_monitored_user(&self, user: &User) -> bool {
+        self.monitored_users.contains_key(user)
+    }
+
     pub fn is_monitored_user_online(&self, user: &User) -> bool {
         // falling back to assume nick is `online` if we don't have monitor support
         !self.has_isupport_monitor()
@@ -4570,35 +4670,37 @@ impl Client {
                 .is_some_and(|monitored_user| monitored_user.online)
     }
 
-    pub fn is_monitored_user_query(&self, user: &User) -> bool {
+    pub fn is_monitored_user_automated(&self, user: &User) -> bool {
         self.monitored_users
             .get(user)
-            .is_some_and(|monitored_user| monitored_user.query)
+            .is_some_and(|monitored_user| monitored_user.automated)
     }
 
-    pub fn add_monitored_user_query(&mut self, user: &User) {
+    pub fn add_monitored_user_automated(&mut self, user: &User) {
         self.monitored_users.insert(
             user.clone(),
             MonitoredUser {
                 online: self.is_monitored_user_online(user),
-                query: true,
+                automated: true,
             },
         );
         if self.has_isupport_monitor() {
-            let message = command!("MONITOR", "+", user.as_normalized_str());
-            if let Err(e) = self.handle.try_send(message) {
-                log::warn!("[{}] Error sending monitor: {e}", self.server);
-            }
+            self.send(
+                None,
+                command!("MONITOR", "+", user.as_normalized_str()).into(),
+                TokenPriority::Low,
+            );
         }
     }
 
     pub fn remove_monitored_user(&mut self, user: &User) {
         self.monitored_users.remove(user);
         if self.has_isupport_monitor() {
-            let message = command!("MONITOR", "-", user.as_normalized_str());
-            if let Err(e) = self.handle.try_send(message) {
-                log::warn!("[{}] Error sending monitor: {e}", self.server);
-            }
+            self.send(
+                None,
+                command!("MONITOR", "-", user.as_normalized_str()).into(),
+                TokenPriority::Low,
+            );
         }
     }
 }
@@ -5882,16 +5984,19 @@ fn group_monitors<'a>(
     monitor_limit: Option<u16>,
     target_limit: Option<u16>,
     server: &Server,
+    num_existing_monitors: Option<usize>,
 ) -> impl Iterator<Item = proto::Message> + 'a {
     const MAX_LEN: usize = proto::format::BYTE_LIMIT - b"MONITOR + \r\n".len();
 
     if let Some(monitor_limit) = monitor_limit.map(usize::from) {
-        if monitor_limit < users.len() {
+        let mut total_monitor_count = users.len();
+        if let Some(num_existing_monitors) = num_existing_monitors {
+            total_monitor_count += num_existing_monitors;
+        }
+        if monitor_limit < total_monitor_count {
             log::warn!(
-                "[{}] More users in monitor list than permitted by the server \
-                      ({} users in monitor list, {monitor_limit} permitted)",
-                server,
-                users.len(),
+                "[{server}] More users in monitor list than permitted by the server \
+                      ({total_monitor_count} users in monitor list, {monitor_limit} permitted)",
             );
         }
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -4568,10 +4568,17 @@ impl Client {
         self.capabilities.multiline_limits()
     }
 
+    pub fn has_monitor_support(&self) -> bool {
+        self.isupport.contains_key(&isupport::Kind::MONITOR)
+    }
+
     pub fn is_monitored_user_online(&self, user: &User) -> bool {
-        self.monitored_users
-            .get(user)
-            .is_some_and(|monitored_user| monitored_user.online)
+        // falling back to assume nick is `online` if we don't have monitor support
+        !self.has_monitor_support()
+            || self
+                .monitored_users
+                .get(user)
+                .is_some_and(|monitored_user| monitored_user.online)
     }
 
     pub fn is_monitored_user_query(&self, user: &User) -> bool {
@@ -4581,26 +4588,28 @@ impl Client {
     }
 
     pub fn add_monitored_user_query(&mut self, user: &User) {
-        let is_online = self.is_monitored_user_online(user);
         self.monitored_users.insert(
             user.clone(),
             MonitoredUser {
-                online: is_online,
+                online: self.is_monitored_user_online(user),
                 query: true,
             },
         );
-
-        let message = command!("MONITOR", "+", user.as_normalized_str());
-        if let Err(e) = self.handle.try_send(message) {
-            log::warn!("[{}] Error sending monitor: {e}", self.server);
+        if self.has_monitor_support() {
+            let message = command!("MONITOR", "+", user.as_normalized_str());
+            if let Err(e) = self.handle.try_send(message) {
+                log::warn!("[{}] Error sending monitor: {e}", self.server);
+            }
         }
     }
 
     pub fn remove_monitored_user(&mut self, user: &User) {
         self.monitored_users.remove(user);
-        let message = command!("MONITOR", "-", user.as_normalized_str());
-        if let Err(e) = self.handle.try_send(message) {
-            log::warn!("[{}] Error sending monitor: {e}", self.server);
+        if self.has_monitor_support() {
+            let message = command!("MONITOR", "-", user.as_normalized_str());
+            if let Err(e) = self.handle.try_send(message) {
+                log::warn!("[{}] Error sending monitor: {e}", self.server);
+            }
         }
     }
 }

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -446,6 +446,15 @@ impl User {
             bot: false,
         })
     }
+
+    pub fn parse_or_force(
+        value: &str,
+        casemapping: isupport::CaseMap,
+        prefix: Option<&[isupport::PrefixMap]>,
+    ) -> User {
+        User::parse(value, casemapping, prefix)
+            .unwrap_or(User::from(Nick::from_str(value, casemapping)))
+    }
 }
 
 fn parse_user_names(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1894,12 +1894,11 @@ fn handle_client_events(
             Event::OnConnect(on_connect) => {
                 let server = server.clone();
                 for query in dashboard.open_pane_server_queries(&server) {
-                    if let Some(client) = clients.client_mut(&server)
-                        && let user = User::from(Nick::from_str(
+                    if let Some(client) = clients.client_mut(&server) {
+                        let user = User::from(Nick::from_str(
                             query.as_str(),
                             client.casemapping(),
-                        ))
-                    {
+                        ));
                         client.add_monitored_user_query(&user);
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1893,6 +1893,16 @@ fn handle_client_events(
             }
             Event::OnConnect(on_connect) => {
                 let server = server.clone();
+                for query in dashboard.open_pane_server_queries(&server) {
+                    if let Some(client) = clients.client_mut(&server)
+                        && let user = User::from(Nick::from_str(
+                            query.as_str(),
+                            client.casemapping(),
+                        ))
+                    {
+                        client.add_monitored_user_query(&user);
+                    }
+                }
                 commands.push(Task::stream(on_connect).map(move |event| {
                     Message::OnConnect(server.clone(), event)
                 }));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1895,10 +1895,7 @@ fn handle_client_events(
                 let server = server.clone();
                 for query in dashboard.open_pane_server_queries(&server) {
                     if let Some(client) = clients.client_mut(&server) {
-                        let user = User::from(Nick::from_str(
-                            query.as_str(),
-                            client.casemapping(),
-                        ));
+                        let user = User::from(Nick::from(query));
                         client.add_monitored_user_automated(&user);
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1899,7 +1899,7 @@ fn handle_client_events(
                             query.as_str(),
                             client.casemapping(),
                         ));
-                        client.add_monitored_user_query(&user);
+                        client.add_monitored_user_automated(&user);
                     }
                 }
                 commands.push(Task::stream(on_connect).map(move |event| {

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -2980,17 +2980,9 @@ impl Dashboard {
 
         self.last_changed = Some(Instant::now());
 
-        if let Some(upstream) = buffer.upstream()
-            && let server = upstream.server()
-            && let Some(query) = upstream.query()
+        if let Some(buffer::Upstream::Query(server, query)) = buffer.upstream()
             && let Some(client) = clients.client_mut(server)
-            && let user =
-                User::from(Nick::from_str(query.as_str(), client.casemapping()))
-            && let Some(server_config) = config.servers.get(server)
-            && !server_config
-                .monitor
-                .iter()
-                .any(|nick| nick == user.as_normalized_str())
+            && let user = User::from(Nick::from(query))
             && !client.is_monitored_user(&user)
         {
             client.add_monitored_user_automated(&user);
@@ -3241,10 +3233,7 @@ impl Dashboard {
             }
             buffer::Upstream::Query(server, nick) => {
                 if let Some(client) = clients.client_mut(&server)
-                    && let user = User::from(Nick::from_str(
-                        nick.as_str(),
-                        client.casemapping(),
-                    ))
+                    && let user = User::from(Nick::from(&nick))
                     && client.is_monitored_user_automated(&user)
                 {
                     client.remove_monitored_user(&user);

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -20,6 +20,7 @@ use data::isupport::{self, ChatHistorySubcommand, MessageReference};
 use data::message::{self, Broadcast};
 use data::rate_limit::TokenPriority;
 use data::target::{self, Target};
+use data::user::Nick;
 use data::{
     Config, Image, Notification, Server, User, Version, cache, client, command,
     config, environment, file_transfer, history, preview, reaction, redaction,
@@ -2979,6 +2980,17 @@ impl Dashboard {
 
         self.last_changed = Some(Instant::now());
 
+        if let Some(upstream) = buffer.upstream()
+            && let server = upstream.server()
+            && let Some(query) = upstream.query()
+            && let Some(client) = clients.client_mut(server)
+            && let user =
+                User::from(Nick::from_str(query.as_str(), client.casemapping()))
+            && !client.is_monitored_user_query(&user)
+        {
+            client.add_monitored_user_query(&user);
+        }
+
         match buffer_action {
             BufferAction::ReplacePane => {
                 // If buffer already is open, we swap it with focused pane.
@@ -3223,6 +3235,16 @@ impl Dashboard {
                 (Task::batch(tasks), None)
             }
             buffer::Upstream::Query(server, nick) => {
+                if let Some(client) = clients.client_mut(&server)
+                    && let user = User::from(Nick::from_str(
+                        nick.as_str(),
+                        client.casemapping(),
+                    ))
+                    && client.is_monitored_user_query(&user)
+                {
+                    client.remove_monitored_user(&user);
+                }
+
                 tasks.push(
                     self.history
                         .close(history::Kind::Query(server, nick), clients)

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -2991,8 +2991,9 @@ impl Dashboard {
                 .monitor
                 .iter()
                 .any(|nick| nick == user.as_normalized_str())
+            && !client.is_monitored_user(&user)
         {
-            client.add_monitored_user_query(&user);
+            client.add_monitored_user_automated(&user);
         }
 
         match buffer_action {
@@ -3244,7 +3245,7 @@ impl Dashboard {
                         nick.as_str(),
                         client.casemapping(),
                     ))
-                    && client.is_monitored_user_query(&user)
+                    && client.is_monitored_user_automated(&user)
                 {
                     client.remove_monitored_user(&user);
                 }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -2986,7 +2986,11 @@ impl Dashboard {
             && let Some(client) = clients.client_mut(server)
             && let user =
                 User::from(Nick::from_str(query.as_str(), client.casemapping()))
-            && !client.is_monitored_user_query(&user)
+            && let Some(server_config) = config.servers.get(server)
+            && !server_config
+                .monitor
+                .iter()
+                .any(|nick| nick == user.as_normalized_str())
         {
             client.add_monitored_user_query(&user);
         }
@@ -4883,6 +4887,23 @@ impl Dashboard {
                     .then_some(pane.buffer.to_string())
             })
         }
+    }
+
+    pub fn open_pane_server_queries(
+        &self,
+        server: &Server,
+    ) -> Vec<&target::Query> {
+        self.panes
+            .iter()
+            .filter_map(|(_, _, pane)| match pane.buffer.upstream() {
+                Some(buffer::Upstream::Query(buffer_server, query))
+                    if buffer_server == server =>
+                {
+                    Some(query)
+                }
+                _ => None,
+            })
+            .collect()
     }
 }
 

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -586,8 +586,6 @@ fn query_title<'a>(
         .is_away(current_user.is_some_and(User::is_away));
     let is_user_offline = config.buffer.nickname.offline.is_offline(
         shared_channels.is_empty()
-            && current_user.is_none()
-            && current_user.and_then(User::accountname).is_none()
             && !clients
                 .client(server)
                 .is_some_and(|client| client.is_monitored_user_online(&user)),

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -2,7 +2,7 @@ use data::user::{ChannelUsers, User};
 use data::{Config, file_transfer, history, preview};
 use iced::widget::text::Wrapping;
 use iced::widget::{button, center, column, container, pane_grid, row, text};
-use iced::{Length, Size, Task, padding};
+use iced::{Length, Padding, Size, Task, padding};
 
 use super::sidebar;
 use crate::buffer::{self, Buffer};
@@ -584,11 +584,27 @@ fn query_title<'a>(
         .nickname
         .away
         .is_away(current_user.is_some_and(User::is_away));
-    // It's generally not possible to tell whether another user is offline or
-    // just not in the any shared channels.  Unless/until user offline status is
-    // monitored (via IRCv3 MONITOR or otherwise), do not display users as
-    // offline in query titles as it may be misleading.
-    let is_user_offline = config.buffer.nickname.offline.is_offline(false);
+    let is_user_offline = config.buffer.nickname.offline.is_offline(
+        shared_channels.is_empty()
+            && current_user.is_none()
+            && current_user.and_then(User::accountname).is_none()
+            && !clients
+                .client(server)
+                .is_some_and(|client| client.is_monitored_user_online(&user)),
+    );
+
+    let state = if is_user_offline {
+        Some(
+            container(
+                text("(Offline)").style(theme::text::secondary).font_maybe(
+                    theme::font_style::secondary(theme).map(font::get),
+                ),
+            )
+            .padding(Padding::default().left(5)),
+        )
+    } else {
+        None
+    };
 
     let nickname = text(resolved_query.as_str())
         .style(move |_| {
@@ -651,6 +667,7 @@ fn query_title<'a>(
                 .into()
             }
         ),
+        state,
         text(format!(" @ {server}"))
             .style(theme::text::buffer_title_bar)
             .font_maybe(


### PR DESCRIPTION
Re-imagining #1911

Smarter approach for indicating if user in query buffer is offline.

Thanks to @andymandias for the idea! Adding monitoring to nicks when you open a query. Monitoring is cleaned up when query buffer is closed as well.

The various calls checks to see if monitoring is supported by the server.

<img width="300" height="43" alt="Screenshot_20260531_113757" src="https://github.com/user-attachments/assets/f44cddd6-aabf-4066-8b9d-6bdb918f86b4" />
