### PR TITLE
Documentation Navigation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -41,8 +41,8 @@ export default defineConfig({
       {
         text: docsChannel,
         items: [
-          { text: releaseLabel, link: releaseLink },
-          { text: nightlyLabel, link: nightlyLink },
+          { text: releaseLabel, link: releaseLink, target: "_self" },
+          { text: nightlyLabel, link: nightlyLink, target: "_self" },
         ],
       },
       {


### PR DESCRIPTION
Set target when navigating between documentation, to avoid opening a new tab when switching.