### PR TITLE
Minor Documentation Fixes

### DIFF
--- a/.config/lychee-internal.toml
+++ b/.config/lychee-internal.toml
@@ -7,4 +7,7 @@ exclude_path = ["docs/node_modules/**", "docs/.vitepress/**"]
 include_fragments = true
 
 exclude_all_private = true
-exclude = [ '^http://.*', '^https://.*', '^irc://.*', '^ircs://.*' ]
+exclude = [ '^http://.*', '^https://.*', '^irc://.*', '^ircs://.*',
+						'/configuration/servers.md#sasl-plain',   # Incorrectly flagged as invalid
+						'/configuration/servers.md#sasl-external' # Incorrectly flagged as invalid
+					]

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -24,7 +24,7 @@ nickname = ""
 
 ## `nick_password`
 
-The client's NICKSERV password. Whenever possible, using [`sasl.plain`](#saslplain) or [`sasl.external`](#saslexternal) instead of NICKSERV is recommended.
+The client's NICKSERV password. Whenever possible, using [`sasl.plain`](#sasl-plain) or [`sasl.external`](#sasl-external) instead of NICKSERV is recommended.
 
 ```toml
 # Type: string

--- a/docs/guides/password-file.md
+++ b/docs/guides/password-file.md
@@ -1,20 +1,38 @@
 # Storing Passwords in a File
 
-If you need to commit your configuration file to a public repository, you can keep your passwords in a separate file for security. Below is an example of using a file for nickname password for NICKSERV.
+If you need to commit your configuration file to a public repository, you can keep your passwords in separate file(s) for security.
 
-
-::: warning
-Avoid adding extra lines in the password file, as they will be treated as part of the password.
+::: info
+By default, only the first line of the file is used as the password.  If a newline needs to be included in the password, then the corresponding `*_file_first_line_only` setting should be set to `false`.  E.g. set `sasl.plain.password_file_first_line_only` to `false` if the password stored in `sasl.plain.password_file` contains a newline.
 :::
 
 ::: tip
 Windows path strings should usually be specified as literal strings (e.g. `'C:\Users\Default\'`), otherwise directory separators will need to be escaped (e.g. `"C:\\Users\\Default\\"`).
 :::
 
+## Examples
+
+Using a file for a SASL PLAIN authentication:
+
 ```toml
 [servers.liberachat]
+server = "irc.libera.chat"
+
+nickname = "foobar"
+sasl.plain.username = "foobar"
+sasl.plain.password_file = "~/.config/halloy/password"
+
+channels = ["#halloy"]
+```
+
+Using a file for nickname password authentication with NickServ:
+
+```toml
+[servers.liberachat]
+server = "irc.libera.chat"
+
 nickname = "foobar"
 nick_password_file = "~/.config/halloy/password"
-server = "irc.libera.chat"
+
 channels = ["#halloy"]
 ```


### PR DESCRIPTION
- Fixes fragment links to SASL sections in https://halloy.chat/configuration/servers
- Updates https://halloy.chat/guides/password-file to reflect current settings behavior and recommendations