### PR TITLE
Fix for thread 'main' panic due to a char boundary.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 Fixed:
 
+- Panic when a reply contains a multibyte character near the start of message
 - Ensure messages don't get formatted if channel has +c mode (colour filter)
 - User highlighting incorrectly matching contraction suffixes
 
 Thanks:
 
-- Contributions: @luca020400
-- Bug reports: @WinnerWind, @sco1, @classabbyamp
+- Contributions: @luca020400, @aniketkotal
+- Bug reports: @WinnerWind, @sco1, @classabbyamp, @aniketkotal
 
 # 2026.7 (2026-05-28)
 

--- a/src/widget/message_content.rs
+++ b/src/widget/message_content.rs
@@ -403,12 +403,9 @@ pub(crate) fn strip_leading_nick<'a>(
     text: &'a str,
     nick: &str,
 ) -> Option<&'a str> {
-    let prefix_len = nick.len() + 2;
-    if text.len() >= prefix_len
-        && text[..nick.len()].eq_ignore_ascii_case(nick)
-        && text[nick.len()..].starts_with(": ")
-    {
-        Some(&text[prefix_len..])
+    let (head, rest) = text.split_at_checked(nick.len())?;
+    if head.eq_ignore_ascii_case(nick) {
+        rest.strip_prefix(": ")
     } else {
         None
     }


### PR DESCRIPTION
i had the following error, causing halloy to crash and not open if the buffer with the message is in view

```
thread 'main' (2569419) panicked at src/widget/message_content.rs:408:16:
end byte index 5 is not a char boundary; it is inside '\u{fe0f}' (bytes 3..6) of `☁️ 06:00 15°C │ 🌧 09:00 20°C │ ☁️ 12:00 21°C`
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
this pr fixes a panic in `strip_leading_nick` caused by slicing `text` at raw byte offsets, which broke when a message started with a multi-byte character like an emoji and `nick.len()` landed mid-character.