### PR TITLE
skip `buffer.reply.insert_nick` for query buffers and self-reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ Fixed:
 
 - Correctly support `RPL_METADATASYNCLATER`
 
+Changed:
+
+- `buffer.reply.insert_nick` no longer inserts nick when replying in query buffers or to yourself
+
 Thanks:
 
-- Contributions: @luca020400, @englut
+- Contributions: @luca020400, @englut, @furudean
 - Feature requests: @g00s
 
 # 2026.7.1 (2026-06-02)

--- a/src/buffer/context_menu.rs
+++ b/src/buffer/context_menu.rs
@@ -614,7 +614,7 @@ impl Entry {
                         Some(Message::Reply {
                             msgid: msgid.clone(),
                             server_time: message.server_time,
-                            to_nick: user.nickname().to_string(),
+                            to_nick: user.nickname().to_owned(),
                         }),
                         length,
                         theme,
@@ -753,7 +753,7 @@ pub enum Message {
     Reply {
         msgid: message::Id,
         server_time: DateTime<Utc>,
-        to_nick: String,
+        to_nick: Nick,
     },
     LoadUserAvatar(Server, url::Url),
     Link(message::Link),
@@ -785,7 +785,7 @@ pub enum Event {
     Reply {
         msgid: message::Id,
         server_time: DateTime<Utc>,
-        to_nick: String,
+        to_nick: Nick,
     },
     LoadUserAvatar(Server, url::Url),
     ExpandMessage(DateTime<Utc>, message::Hash),

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -117,7 +117,7 @@ pub enum Message {
     SetDraftReply {
         msgid: message::Id,
         server_time: DateTime<Utc>,
-        to_nick: String,
+        to_nick: Nick,
     },
     ClearDraftReply,
 }
@@ -1436,7 +1436,7 @@ impl State {
             } => {
                 let is_self_reply = clients
                     .nickname(buffer.server())
-                    .is_some_and(|own| own.as_str() == to_nick);
+                    .is_some_and(|own| own == to_nick);
                 let should_insert_nick = config.buffer.reply.insert_nick
                     && !matches!(buffer, buffer::Upstream::Query(..))
                     && !is_self_reply;
@@ -1468,7 +1468,7 @@ impl State {
                 self.draft_reply = Some(input::DraftReply {
                     id: msgid,
                     server_time,
-                    nick: to_nick.clone(),
+                    nick: to_nick.to_string(),
                 });
 
                 if should_insert_nick {

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -1434,12 +1434,18 @@ impl State {
                 server_time,
                 to_nick,
             } => {
-                let is_insert_nick = config.buffer.reply.insert_nick;
+                let is_self_reply = clients
+                    .nickname(buffer.server())
+                    .is_some_and(|own| own.as_str() == to_nick);
+                let should_insert_nick = config.buffer.reply.insert_nick
+                    && !matches!(buffer, buffer::Upstream::Query(..))
+                    && !is_self_reply;
                 let suffix =
                     &config.buffer.text_input.autocomplete.completion_suffixes
                         [0];
                 // Strip old nick prefix if replacing an existing reply
-                if is_insert_nick && let Some(old_reply) = &self.draft_reply {
+                if should_insert_nick && let Some(old_reply) = &self.draft_reply
+                {
                     let old_prefix_str = format!("{}{suffix}", old_reply.nick);
                     let current_text = self.input_content.text();
                     if current_text.starts_with(&old_prefix_str) {
@@ -1465,7 +1471,7 @@ impl State {
                     nick: to_nick.clone(),
                 });
 
-                if is_insert_nick {
+                if should_insert_nick {
                     let prefix_str = format!("{to_nick}{suffix}");
                     let current_text = self.input_content.text();
                     if !current_text.starts_with(&prefix_str) {
@@ -2812,6 +2818,7 @@ impl State {
 
         if self.draft_reply.is_some() {
             if config.buffer.reply.insert_nick
+                && !matches!(buffer, buffer::Upstream::Query(..))
                 && let Some(draft_reply) = &self.draft_reply
             {
                 let suffix =


### PR DESCRIPTION
fixes two cases where inserting a nick does not make sense:
- in query buffers there are only two users, so the need for insert_nick is lessened
- since the purpose of the text is to notify a user, there is no need to insert it for your own messages