### PR TITLE
Miscellaneous Completion Fixes

### DIFF
--- a/data/src/command.rs
+++ b/data/src/command.rs
@@ -2175,7 +2175,7 @@ fn fmt_channel_name_requirements(chantypes: &[char]) -> String {
     let mut requirements = String::from("must start with ");
 
     for (index, chantype) in chantypes.iter().enumerate() {
-        if index == 1 {
+        if index == 0 {
             requirements.push_str(&format!("'{chantype}'"));
         } else if index == chantypes.len() {
             if chantypes.len() == 2 {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -96,6 +96,7 @@ pub enum Event {
 impl Buffer {
     pub fn from_data(
         buffer: data::Buffer,
+        clients: &data::client::Map,
         history: &history::Manager,
         pane_size: Size,
         config: &Config,
@@ -103,14 +104,18 @@ impl Buffer {
         match buffer {
             data::Buffer::Upstream(upstream) => match upstream {
                 buffer::Upstream::Server(server) => Self::Server(Server::new(
-                    server, history, pane_size, config,
+                    server, clients, history, pane_size, config,
                 )),
-                buffer::Upstream::Channel(server, channel) => Self::Channel(
-                    Channel::new(server, channel, history, pane_size, config),
-                ),
-                buffer::Upstream::Query(server, query) => Self::Query(
-                    Query::new(server, query, history, pane_size, config),
-                ),
+                buffer::Upstream::Channel(server, channel) => {
+                    Self::Channel(Channel::new(
+                        server, channel, clients, history, pane_size, config,
+                    ))
+                }
+                buffer::Upstream::Query(server, query) => {
+                    Self::Query(Query::new(
+                        server, query, clients, history, pane_size, config,
+                    ))
+                }
             },
             data::Buffer::Internal(internal) => match internal {
                 buffer::Internal::FileTransfers => {
@@ -725,6 +730,45 @@ impl Buffer {
                 history,
                 autocomplete,
             ),
+        }
+    }
+
+    pub fn process_input_completion_and_notice(
+        &mut self,
+        clients: &data::client::Map,
+        history: &history::Manager,
+        config: &Config,
+    ) {
+        match self {
+            Buffer::Empty
+            | Buffer::FileTransfers(_)
+            | Buffer::Logs(_)
+            | Buffer::Highlights(_)
+            | Buffer::ChannelDiscovery(_) => (),
+            Buffer::Server(state) => {
+                state.input_view.process_completion_and_notice(
+                    &state.buffer,
+                    clients,
+                    history,
+                    config,
+                );
+            }
+            Buffer::Channel(state) => {
+                state.input_view.process_completion_and_notice(
+                    &state.buffer,
+                    clients,
+                    history,
+                    config,
+                );
+            }
+            Buffer::Query(state) => {
+                state.input_view.process_completion_and_notice(
+                    &state.buffer,
+                    clients,
+                    history,
+                    config,
+                );
+            }
         }
     }
 

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -272,6 +272,7 @@ impl Channel {
     pub fn new(
         server: Server,
         target: target::Channel,
+        clients: &data::client::Map,
         history: &history::Manager,
         pane_size: Size,
         config: &Config,
@@ -279,7 +280,13 @@ impl Channel {
         let buffer = buffer::Upstream::Channel(server.clone(), target.clone());
 
         Self {
-            input_view: input_view::State::new(Some(history.input(&buffer))),
+            input_view: input_view::State::new(
+                history.input(&buffer),
+                &buffer,
+                clients,
+                history,
+                config,
+            ),
             buffer,
             server,
             target,

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -836,19 +836,9 @@ pub struct State {
 
 impl Default for State {
     fn default() -> Self {
-        Self::new(None)
-    }
-}
-
-impl State {
-    pub fn new(cache: Option<input::Cache<'_>>) -> Self {
         Self {
             input_id: widget::Id::unique(),
-            input_content: cache
-                .filter(|c| !c.draft_message.is_empty())
-                .map_or(text_editor::Content::new(), |c| {
-                    text_editor::Content::with_text(c.draft_message)
-                }),
+            input_content: text_editor::Content::new(),
             parsed: Vec::new(),
             notice: None,
             completion: Completion::default(),
@@ -859,9 +849,33 @@ impl State {
             upload_anim: 0.0,
             spinner_hovered: false,
             upload_abort_handles: Vec::new(),
-            draft_reply: cache.and_then(|c| c.draft_reply).cloned(),
+            draft_reply: None,
             reply_preview: None,
         }
+    }
+}
+
+impl State {
+    pub fn new(
+        cache: input::Cache<'_>,
+        buffer: &buffer::Upstream,
+        clients: &client::Map,
+        history: &history::Manager,
+        config: &Config,
+    ) -> Self {
+        let mut state = Self {
+            input_content: if cache.draft_message.is_empty() {
+                text_editor::Content::new()
+            } else {
+                text_editor::Content::with_text(cache.draft_message)
+            },
+            draft_reply: cache.draft_reply.cloned(),
+            ..Self::default()
+        };
+
+        state.process_completion_and_notice(buffer, clients, history, config);
+
+        state
     }
 
     pub fn draft_reply(&self) -> Option<&input::DraftReply> {
@@ -2640,7 +2654,7 @@ impl State {
         )
     }
 
-    fn process_completion_and_notice(
+    pub fn process_completion_and_notice(
         &mut self,
         buffer: &buffer::Upstream,
         clients: &client::Map,

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -710,9 +710,12 @@ pub fn view<'a>(
 
     if config.tooltips.show_for_autocomplete() {
         let overlay = || -> Element<'a, Message> {
+            let cursor = state.input_content.cursor();
+
             column![
                 state.completion.view(
                     state.input_content.text().as_str(),
+                    cursor.selection.is_some(),
                     server,
                     config,
                     theme,
@@ -1664,15 +1667,14 @@ impl State {
                             buffer, clients, config,
                         );
 
-                        let cursor_position =
-                            self.input_content.cursor().position;
+                        let cursor = self.input_content.cursor();
 
                         self.notice = None;
                         self.selected_history = None;
 
                         if let Some(line) = self
                             .input_content
-                            .line(cursor_position.line)
+                            .line(cursor.position.line)
                             .map(|line| line.text)
                         {
                             let users = buffer.channel().and_then(|channel| {
@@ -1691,7 +1693,8 @@ impl State {
 
                             self.completion.process(
                                 &line,
-                                cursor_position.column,
+                                cursor.position.column,
+                                cursor.selection.is_some(),
                                 clients.nickname(buffer.server()),
                                 users,
                                 filters,
@@ -1707,9 +1710,9 @@ impl State {
 
                             let actions = self
                                 .completion
-                                .complete_emoji(&line, cursor_position.column);
+                                .complete_emoji(&line, cursor.position.column);
 
-                            self.set_notice(cursor_position.line);
+                            self.set_notice(cursor.position.line);
 
                             if let Some(actions) = actions {
                                 for action in actions.into_iter() {
@@ -1729,7 +1732,12 @@ impl State {
                         (Task::none(), None)
                     }
                     text_editor::Action::Move(_)
-                    | text_editor::Action::Click(_) => {
+                    | text_editor::Action::Click(_)
+                    | text_editor::Action::Drag(_)
+                    | text_editor::Action::Select(_)
+                    | text_editor::Action::SelectWord
+                    | text_editor::Action::SelectLine
+                    | text_editor::Action::SelectAll => {
                         self.process_completion_and_notice(
                             buffer, clients, history, config,
                         );
@@ -2635,15 +2643,15 @@ impl State {
     fn process_completion_and_notice(
         &mut self,
         buffer: &buffer::Upstream,
-        clients: &mut client::Map,
-        history: &mut history::Manager,
+        clients: &client::Map,
+        history: &history::Manager,
         config: &Config,
     ) {
-        let cursor_position = self.input_content.cursor().position;
+        let cursor = self.input_content.cursor();
 
         if let Some(line) = self
             .input_content
-            .line(cursor_position.line)
+            .line(cursor.position.line)
             .map(|line| line.text)
         {
             let current_target = buffer.target();
@@ -2651,14 +2659,15 @@ impl State {
                 clients.get_channel_users(buffer.server(), channel)
             });
             let last_seen = history.get_last_seen(buffer);
-            let filters = FilterChain::borrow(history.get_filters());
+            let filters = FilterChain::borrow(history.filters());
             let is_connected = clients.get_server_is_connected(buffer.server());
             let isupport = clients.get_isupport_ref(buffer.server());
             let features = clients.get_features_ref(buffer.server());
 
             self.completion.process(
                 &line,
-                cursor_position.column,
+                cursor.position.column,
+                cursor.selection.is_some(),
                 clients.nickname(buffer.server()),
                 users,
                 filters,
@@ -2675,7 +2684,7 @@ impl State {
             // Reset notice state
             self.notice = None;
 
-            self.set_notice(cursor_position.line);
+            self.set_notice(cursor.position.line);
         }
     }
 

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -863,12 +863,18 @@ impl State {
         history: &history::Manager,
         config: &Config,
     ) -> Self {
+        let mut input_content = if cache.draft_message.is_empty() {
+            text_editor::Content::new()
+        } else {
+            text_editor::Content::with_text(cache.draft_message)
+        };
+
+        input_content.perform(text_editor::Action::Move(
+            text_editor::Motion::DocumentEnd,
+        ));
+
         let mut state = Self {
-            input_content: if cache.draft_message.is_empty() {
-                text_editor::Content::new()
-            } else {
-                text_editor::Content::with_text(cache.draft_message)
-            },
+            input_content,
             draft_reply: cache.draft_reply.cloned(),
             ..Self::default()
         };

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -715,6 +715,7 @@ pub fn view<'a>(
             column![
                 state.completion.view(
                     state.input_content.text().as_str(),
+                    cursor.position.column,
                     cursor.selection.is_some(),
                     server,
                     config,

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -571,7 +571,7 @@ pub fn view<'a>(
     )
     .into();
 
-    let maybe_our_user = || -> Option<Element<'a, Message>> {
+    let new_maybe_our_user = || -> Option<Element<'a, Message>> {
         if config.buffer.text_input.nickname.enabled {
             our_user.map(|user| {
                 let user_display = UserDisplay::new(
@@ -586,29 +586,37 @@ pub fn view<'a>(
                     true,
                 );
 
-                row![
-                    container(user_display.into_element(
-                        user,
-                        user.is_away(),
-                        false,
-                        None,
-                        None,
-                        false,
-                        false,
-                        theme,
-                        config,
-                    ))
-                    .padding(padding::right(4)),
-                    rule::vertical(1.0),
-                ]
-                .align_y(Alignment::Center)
-                .spacing(INPUT_ROW_SPACING)
+                container(user_display.into_element(
+                    user,
+                    user.is_away(),
+                    false,
+                    None,
+                    None,
+                    false,
+                    false,
+                    theme,
+                    config,
+                ))
+                .padding(padding::right(4))
                 .into()
             })
         } else {
             None
         }
     };
+
+    let new_maybe_vertical_rule = |maybe_our_user: &Option<
+        Element<'a, Message>,
+    >|
+     -> Option<Element<'a, Message>> {
+        maybe_our_user
+            .is_some()
+            .then_some(rule::vertical(1.0).into())
+    };
+
+    let maybe_our_user = new_maybe_our_user();
+
+    let maybe_vertical_rule = new_maybe_vertical_rule(&maybe_our_user);
 
     let maybe_upload_spinner: Option<crate::widget::Element<'a, Message>> =
         (filehost_url.is_some() && state.uploading > 0).then(|| {
@@ -681,7 +689,8 @@ pub fn view<'a>(
 
     let input_row = container(
         row![
-            maybe_our_user(),
+            maybe_our_user,
+            maybe_vertical_rule,
             wrapped_input,
             maybe_upload_spinner,
             maybe_upload_button,
@@ -732,8 +741,13 @@ pub fn view<'a>(
             .into()
         };
 
+        let maybe_our_user = new_maybe_our_user();
+
+        let maybe_vertical_rule = new_maybe_vertical_rule(&maybe_our_user);
+
         let overlay = double_pass(
-            row![maybe_our_user(), overlay()].spacing(INPUT_ROW_SPACING),
+            row![maybe_our_user, maybe_vertical_rule, overlay()]
+                .spacing(INPUT_ROW_SPACING),
             row![Space::new().width(Length::Fill), overlay()],
         );
 

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -533,7 +533,11 @@ impl Commands {
                             isupport::get_chantypes_or_default(isupport);
 
                         if let Some(channel_arg) = command.args.get_mut(0) {
-                            let skip = !proto::is_channel(channel, chantypes);
+                            let skip =
+                                matches!(
+                                    current_target,
+                                    Some(Target::Channel(_))
+                                ) && !proto::is_channel(channel, chantypes);
 
                             channel_arg.kind.skip(skip);
                         }

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -69,6 +69,7 @@ impl Completion {
         if is_command {
             self.commands.process(
                 input,
+                cursor_position,
                 cursor_is_selection,
                 our_nickname,
                 channels.iter().copied(),
@@ -358,6 +359,7 @@ impl Commands {
     fn process<'a>(
         &mut self,
         input: &str,
+        cursor_position: usize,
         cursor_is_selection: bool,
         our_nickname: Option<NickRef>,
         channels: impl IntoIterator<Item = &'a target::Channel>,
@@ -379,10 +381,15 @@ impl Commands {
             return;
         }
 
-        let (cmd, has_space) = if let Some(index) = rest.find(' ') {
-            (&rest[0..index], true)
+        let editing_command = !rest
+            .get(..cursor_position.saturating_sub(1))
+            .unwrap_or(rest)
+            .contains(' ');
+
+        let cmd = if let Some(index) = rest.find(' ') {
+            &rest[0..index]
         } else {
-            (rest, false)
+            rest
         };
 
         let aliases = command::alias::list(config);
@@ -407,7 +414,7 @@ impl Commands {
 
         match self {
             // Command not fully typed, show filtered entries
-            _ if !has_space => {
+            _ if editing_command => {
                 if let Some(command) = command_list.iter().find(|command| {
                     command.title().to_lowercase() == cmd.to_lowercase()
                         || command.aliases().iter().any(|alias| {
@@ -1728,8 +1735,6 @@ impl Command {
         config: &Config,
         theme: &'a Theme,
     ) -> Element<'a, Message> {
-        let command_prefix = format!("/{}", self.title.to_lowercase());
-
         let num_skipped =
             self.args.iter().filter(|arg| arg.kind.skipped()).count()
                 + subcommand.map_or(0, |subcommand| {
@@ -1745,25 +1750,20 @@ impl Command {
         } else {
             input.split_at_checked(cursor_position).and_then(
                 |(before_cursor, _)| {
-                    before_cursor
-                        .to_lowercase()
-                        .strip_prefix(&command_prefix)
-                        .and_then(|before_cursor| {
-                            let index = ["_", before_cursor, "_"]
-                                .concat()
-                                .split_ascii_whitespace()
-                                .count()
-                                .saturating_add(num_skipped)
-                                .saturating_sub(1)
-                                .min(
-                                    self.args.len()
-                                        + subcommand.map_or(0, |subcommand| {
-                                            subcommand.args.len()
-                                        }),
-                                );
+                    let index = [before_cursor, "_"]
+                        .concat()
+                        .split_ascii_whitespace()
+                        .count()
+                        .saturating_add(num_skipped)
+                        .saturating_sub(1)
+                        .min(
+                            self.args.len()
+                                + subcommand.map_or(0, |subcommand| {
+                                    subcommand.args.len()
+                                }),
+                        );
 
-                            (index > 0).then_some(index.saturating_sub(1))
-                        })
+                    (index > 0).then_some(index.saturating_sub(1))
                 },
             )
         };

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -50,6 +50,7 @@ impl Completion {
         &mut self,
         input: &str,
         cursor_position: usize,
+        cursor_is_selection: bool,
         our_nickname: Option<NickRef>,
         users: Option<&ChannelUsers>,
         filters: FilterChain,
@@ -68,6 +69,7 @@ impl Completion {
         if is_command {
             self.commands.process(
                 input,
+                cursor_is_selection,
                 our_nickname,
                 channels.iter().copied(),
                 current_target,
@@ -88,6 +90,15 @@ impl Completion {
             }
         } else {
             self.commands = Commands::default();
+        }
+
+        // If the text input has a selection, then don't show pickers
+        if cursor_is_selection {
+            self.words = Words::default();
+            self.emojis = Emojis::default();
+            self.paths = Paths::default();
+
+            return;
         }
 
         if let Some(shortcode) = (config.buffer.emojis.show_picker
@@ -210,14 +221,20 @@ impl Completion {
     pub fn view<'a, Message: Clone + 'a>(
         &'a self,
         input: &str,
+        cursor_is_selection: bool,
         server: &Server,
         config: &Config,
         theme: &'a Theme,
         on_select_command: impl Fn(usize) -> Message + Copy + 'a,
     ) -> Option<Element<'a, Message>> {
-        let command_view =
-            self.commands
-                .view(input, server, config, theme, on_select_command);
+        let command_view = self.commands.view(
+            input,
+            cursor_is_selection,
+            server,
+            config,
+            theme,
+            on_select_command,
+        );
         let emojis_view = self.emojis.view(config, on_select_command);
         let paths_view = self.paths.view(on_select_command);
         let words_view = self.words.view(on_select_command);
@@ -339,6 +356,7 @@ impl Commands {
     fn process<'a>(
         &mut self,
         input: &str,
+        cursor_is_selection: bool,
         our_nickname: Option<NickRef>,
         channels: impl IntoIterator<Item = &'a target::Channel>,
         current_target: Option<&Target>,
@@ -616,6 +634,10 @@ impl Commands {
                 }
             }
         }
+
+        if cursor_is_selection && !matches!(self, Self::Selected { .. }) {
+            *self = Self::Idle;
+        }
     }
 
     fn select(&mut self) -> Option<String> {
@@ -687,6 +709,7 @@ impl Commands {
     fn view<'a, Message: Clone + 'a>(
         &'a self,
         input: &str,
+        cursor_is_selection: bool,
         server: &Server,
         config: &Config,
         theme: &'a Theme,
@@ -738,7 +761,14 @@ impl Commands {
                 let description = if config.buffer.commands.show_description {
                     highlighted.and_then(|index| {
                         filtered.get(index).map(|(_, command)| {
-                            command.view(input, None, server, config, theme)
+                            command.view(
+                                input,
+                                cursor_is_selection,
+                                None,
+                                server,
+                                config,
+                                theme,
+                            )
                         })
                     })
                 } else {
@@ -770,6 +800,7 @@ impl Commands {
                 if config.buffer.commands.show_description {
                     Some(command.view(
                         input,
+                        cursor_is_selection,
                         subcommand.as_ref(),
                         server,
                         config,
@@ -1685,6 +1716,7 @@ impl Command {
     fn view<'a, Message: 'a>(
         &self,
         input: &str,
+        cursor_is_selection: bool,
         subcommand: Option<&'a Command>,
         server: &Server,
         config: &Config,
@@ -1702,31 +1734,42 @@ impl Command {
                         .count()
                 });
 
-        let active_arg = [
-            "_",
-            input
-                .to_lowercase()
-                .strip_prefix(&command_prefix)
-                .unwrap_or(input),
-            "_",
-        ]
-        .concat()
-        .split_ascii_whitespace()
-        .count()
-        .saturating_add(num_skipped)
-        .saturating_sub(2)
-        .min(
-            (self.args.len()
-                + subcommand.map_or(0, |subcommand| subcommand.args.len()))
-            .saturating_sub(1),
-        );
+        let active_arg = if cursor_is_selection {
+            None
+        } else {
+            Some(
+                [
+                    "_",
+                    input
+                        .to_lowercase()
+                        .strip_prefix(&command_prefix)
+                        .unwrap_or(input),
+                    "_",
+                ]
+                .concat()
+                .split_ascii_whitespace()
+                .count()
+                .saturating_add(num_skipped)
+                .saturating_sub(2)
+                .min(
+                    (self.args.len()
+                        + subcommand
+                            .map_or(0, |subcommand| subcommand.args.len()))
+                    .saturating_sub(1),
+                ),
+            )
+        };
 
         let title = Some(Element::from(text(self.title.to_string())));
+
+        let is_active_arg = move |index: usize| -> bool {
+            active_arg.is_some_and(|active_arg| active_arg == index)
+        };
 
         let arg_text = |index: usize, arg: &Argument| {
             let content = text(format!("{arg}"))
                 .style(move |theme| {
-                    if index == active_arg {
+                    if is_active_arg(index) {
                         theme::text::tertiary(theme)
                     } else {
                         theme::text::none(theme)
@@ -1734,14 +1777,14 @@ impl Command {
                 })
                 .font_maybe(
                     theme::font_style::tertiary(theme)
-                        .filter(|_| index == active_arg)
+                        .filter(|_| is_active_arg(index))
                         .map(font::get),
                 );
 
             if let Some(arg_tooltip) = &arg.tooltip {
                 let tooltip_indicator = text("*")
                     .style(move |theme| {
-                        if index == active_arg {
+                        if is_active_arg(index) {
                             theme::text::tertiary(theme)
                         } else {
                             theme::text::none(theme)
@@ -1749,7 +1792,7 @@ impl Command {
                     })
                     .font_maybe(
                         theme::font_style::tertiary(theme)
-                            .filter(|_| index == active_arg)
+                            .filter(|_| is_active_arg(index))
                             .map(font::get),
                     )
                     .size(8);
@@ -1762,13 +1805,13 @@ impl Command {
                         container(
                             text(arg_tooltip.clone())
                                 .style(move |theme| {
-                                    if index == active_arg {
+                                    if is_active_arg(index) {
                                         theme::text::tertiary(theme)
                                     } else {
                                         theme::text::secondary(theme)
                                     }
                                 })
-                                .font_maybe(if index == active_arg {
+                                .font_maybe(if is_active_arg(index) {
                                     theme::font_style::tertiary(theme)
                                         .map(font::get)
                                 } else {
@@ -1802,7 +1845,7 @@ impl Command {
                                 .unwrap_or_default(),
                         )
                         .style(move |theme| {
-                            if 0 == active_arg {
+                            if is_active_arg(0) {
                                 theme::text::tertiary(theme)
                             } else {
                                 theme::text::none(theme)

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -221,6 +221,7 @@ impl Completion {
     pub fn view<'a, Message: Clone + 'a>(
         &'a self,
         input: &str,
+        cursor_position: usize,
         cursor_is_selection: bool,
         server: &Server,
         config: &Config,
@@ -229,6 +230,7 @@ impl Completion {
     ) -> Option<Element<'a, Message>> {
         let command_view = self.commands.view(
             input,
+            cursor_position,
             cursor_is_selection,
             server,
             config,
@@ -709,6 +711,7 @@ impl Commands {
     fn view<'a, Message: Clone + 'a>(
         &'a self,
         input: &str,
+        cursor_position: usize,
         cursor_is_selection: bool,
         server: &Server,
         config: &Config,
@@ -763,6 +766,7 @@ impl Commands {
                         filtered.get(index).map(|(_, command)| {
                             command.view(
                                 input,
+                                cursor_position,
                                 cursor_is_selection,
                                 None,
                                 server,
@@ -800,6 +804,7 @@ impl Commands {
                 if config.buffer.commands.show_description {
                     Some(command.view(
                         input,
+                        cursor_position,
                         cursor_is_selection,
                         subcommand.as_ref(),
                         server,
@@ -1716,6 +1721,7 @@ impl Command {
     fn view<'a, Message: 'a>(
         &self,
         input: &str,
+        cursor_position: usize,
         cursor_is_selection: bool,
         subcommand: Option<&'a Command>,
         server: &Server,
@@ -1737,26 +1743,28 @@ impl Command {
         let active_arg = if cursor_is_selection {
             None
         } else {
-            Some(
-                [
-                    "_",
-                    input
+            input.split_at_checked(cursor_position).and_then(
+                |(before_cursor, _)| {
+                    before_cursor
                         .to_lowercase()
                         .strip_prefix(&command_prefix)
-                        .unwrap_or(input),
-                    "_",
-                ]
-                .concat()
-                .split_ascii_whitespace()
-                .count()
-                .saturating_add(num_skipped)
-                .saturating_sub(2)
-                .min(
-                    (self.args.len()
-                        + subcommand
-                            .map_or(0, |subcommand| subcommand.args.len()))
-                    .saturating_sub(1),
-                ),
+                        .and_then(|before_cursor| {
+                            let index = ["_", before_cursor, "_"]
+                                .concat()
+                                .split_ascii_whitespace()
+                                .count()
+                                .saturating_add(num_skipped)
+                                .saturating_sub(1)
+                                .min(
+                                    self.args.len()
+                                        + subcommand.map_or(0, |subcommand| {
+                                            subcommand.args.len()
+                                        }),
+                                );
+
+                            (index > 0).then_some(index.saturating_sub(1))
+                        })
+                },
             )
         };
 
@@ -3871,10 +3879,40 @@ pub enum Arrow {
 }
 
 fn get_word(input: &str, cursor_position: usize) -> Option<&str> {
+    get_word_bounds(input, cursor_position).and_then(|word_bounds| {
+        input.get(*word_bounds.start()..*word_bounds.end())
+    })
+}
+
+fn get_word_bounds(
+    input: &str,
+    cursor_position: usize,
+) -> Option<RangeInclusive<usize>> {
     let mut previous_word_bounds = Option::<RangeInclusive<usize>>::None;
 
     if cursor_position == input.len() {
-        return input.split(' ').rfind(|word| !word.is_empty());
+        let mut trailing_spaces = 0;
+
+        let word_bounds_start = input
+            .split(' ')
+            .rfind(|word| {
+                if word.is_empty() {
+                    trailing_spaces += 1;
+                    false
+                } else {
+                    true
+                }
+            })
+            .map(|word| {
+                input.len().saturating_sub(word.len() + trailing_spaces)
+            });
+
+        return word_bounds_start.map(|word_bounds_start| {
+            RangeInclusive::new(
+                word_bounds_start,
+                input.len().saturating_sub(trailing_spaces),
+            )
+        });
     }
 
     for word in input.split(' ') {
@@ -3889,7 +3927,7 @@ fn get_word(input: &str, cursor_position: usize) -> Option<&str> {
             };
 
         if word_bounds.contains(&cursor_position) {
-            return (!word.is_empty()).then_some(word);
+            return Some(word_bounds);
         }
 
         previous_word_bounds = Some(word_bounds);

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -203,6 +203,7 @@ impl Query {
     pub fn new(
         server: Server,
         target: target::Query,
+        clients: &data::client::Map,
         history: &history::Manager,
         pane_size: Size,
         config: &Config,
@@ -210,7 +211,13 @@ impl Query {
         let buffer = buffer::Upstream::Query(server.clone(), target.clone());
 
         Self {
-            input_view: input_view::State::new(Some(history.input(&buffer))),
+            input_view: input_view::State::new(
+                history.input(&buffer),
+                &buffer,
+                clients,
+                history,
+                config,
+            ),
             buffer,
             server,
             target,

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -3,7 +3,9 @@ use data::buffer::RightAlignmentWidths;
 use data::dashboard::BufferAction;
 use data::target::Target;
 use data::user::Nick;
-use data::{Config, Image, Preview, User, buffer, history, message, preview};
+use data::{
+    Config, Image, Preview, User, buffer, client, history, message, preview,
+};
 use iced::advanced::text;
 use iced::widget::{Space, column, container, row, space};
 use iced::{Color, Length, Size, Task, padding};
@@ -341,6 +343,7 @@ pub struct Server {
 impl Server {
     pub fn new(
         server: data::server::Server,
+        clients: &client::Map,
         history: &history::Manager,
         pane_size: Size,
         config: &Config,
@@ -348,7 +351,13 @@ impl Server {
         let buffer = buffer::Upstream::Server(server.clone());
 
         Self {
-            input_view: input_view::State::new(Some(history.input(&buffer))),
+            input_view: input_view::State::new(
+                history.input(&buffer),
+                &buffer,
+                clients,
+                history,
+                config,
+            ),
             buffer,
             server,
             scroll_view: scroll_view::State::new(pane_size, config),

--- a/src/main.rs
+++ b/src/main.rs
@@ -785,6 +785,12 @@ impl Halloy {
                         return Task::none();
                     };
 
+                    dashboard.process_server_inputs_completion_and_notice(
+                        &server,
+                        &self.clients,
+                        &self.config,
+                    );
+
                     if is_initial {
                         Task::none()
                     } else {
@@ -851,6 +857,12 @@ impl Halloy {
                     let Screen::Dashboard(dashboard) = &mut self.screen else {
                         return Task::none();
                     };
+
+                    dashboard.process_server_inputs_completion_and_notice(
+                        &server,
+                        &self.clients,
+                        &self.config,
+                    );
 
                     let (notification, broadcast_kind) = if is_initial {
                         (Notification::Connected, Broadcast::Connected)

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1084,6 +1084,7 @@ impl Dashboard {
 
                             state.buffer = Buffer::from_data(
                                 data::Buffer::Upstream(buffer),
+                                clients,
                                 history,
                                 state.size,
                                 config,
@@ -1113,6 +1114,7 @@ impl Dashboard {
 
                             state.buffer = Buffer::from_data(
                                 data::Buffer::Upstream(buffer),
+                                clients,
                                 history,
                                 state.size,
                                 config,
@@ -1357,6 +1359,7 @@ impl Dashboard {
 
                             state.buffer = Buffer::from_data(
                                 data::Buffer::Upstream(buffer),
+                                clients,
                                 history,
                                 state.size,
                                 config,
@@ -1387,6 +1390,7 @@ impl Dashboard {
 
                             state.buffer = Buffer::from_data(
                                 data::Buffer::Upstream(buffer),
+                                clients,
                                 history,
                                 state.size,
                                 config,
@@ -3014,6 +3018,7 @@ impl Dashboard {
 
                     state.buffer = Buffer::from_data(
                         buffer,
+                        clients,
                         &self.history,
                         state.size,
                         config,
@@ -3046,6 +3051,7 @@ impl Dashboard {
                             self.panes.main.panes.entry(*id).and_modify(|p| {
                                 p.buffer = Buffer::from_data(
                                     buffer.clone(),
+                                    clients,
                                     &self.history,
                                     p.size,
                                     config,
@@ -3118,6 +3124,7 @@ impl Dashboard {
                     pane_to_split,
                     Pane::new(Buffer::from_data(
                         buffer,
+                        clients,
                         &self.history,
                         pane_to_split_state.size,
                         config,
@@ -3134,6 +3141,7 @@ impl Dashboard {
                 iced::window::position(self.main_window()).then({
                     let pane = Pane::new(Buffer::from_data(
                         buffer.clone(),
+                        clients,
                         &self.history,
                         Size::default(),
                         config,
@@ -4434,6 +4442,7 @@ impl Dashboard {
 
         fn configuration(
             pane: data::Pane,
+            clients: &data::client::Map,
             history: &history::Manager,
             config: &Config,
         ) -> Configuration<Pane> {
@@ -4449,13 +4458,18 @@ impl Dashboard {
                             }
                         },
                         ratio,
-                        a: Box::new(configuration(*a, history, config)),
-                        b: Box::new(configuration(*b, history, config)),
+                        a: Box::new(configuration(
+                            *a, clients, history, config,
+                        )),
+                        b: Box::new(configuration(
+                            *b, clients, history, config,
+                        )),
                     }
                 }
                 data::Pane::Buffer { buffer } => {
                     Configuration::Pane(Pane::new(Buffer::from_data(
                         buffer,
+                        clients,
                         history,
                         Size::default(),
                         config,
@@ -4475,7 +4489,10 @@ impl Dashboard {
         let panes = Panes {
             main_window: main_window.id,
             main: pane_grid::State::with_configuration(configuration(
-                data.pane, &history, config,
+                data.pane,
+                &data::client::Map::default(),
+                &history,
+                config,
             )),
             popout: HashMap::new(),
         };
@@ -4524,9 +4541,12 @@ impl Dashboard {
 
         for pane in data.popout_panes {
             // Popouts are only a single pane
-            let Configuration::Pane(pane) =
-                configuration(pane, &dashboard.history, config)
-            else {
+            let Configuration::Pane(pane) = configuration(
+                pane,
+                &data::client::Map::default(),
+                &dashboard.history,
+                config,
+            ) else {
                 continue;
             };
 
@@ -4821,6 +4841,27 @@ impl Dashboard {
                 .is_some_and(|pane_server| pane_server == *server)
                 .then_some(window_id)
         })
+    }
+
+    pub fn process_server_inputs_completion_and_notice(
+        &mut self,
+        server: &Server,
+        clients: &client::Map,
+        config: &Config,
+    ) {
+        for buffer in self.panes.iter_mut().filter_map(|(_, _, state)| {
+            state
+                .buffer
+                .server()
+                .is_some_and(|pane_server| pane_server == *server)
+                .then_some(&mut state.buffer)
+        }) {
+            buffer.process_input_completion_and_notice(
+                clients,
+                &self.history,
+                config,
+            );
+        }
     }
 
     fn main_window(&self) -> window::Id {


### PR DESCRIPTION
Various minor completion fixes discovered while working on #1992:
- Process completion on loading an input and for all relevant inputs when server connection/disconnection
- Move cursor to end of input on creation
- Hide pickers when there's an active selection
- Select active argument of command based on cursor position, and fix active argument determination when using a command alias
- Show command picker when editing the command even when argument(s) have been written
- Minor fixes in argument counting for `/topic` tooltip

~~Draft until #1992 is merged.~~