### PR TITLE
build(windows): replace MSI package with Inno Setup installer

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,9 +28,9 @@ jobs:
               echo "ARTIFACT_PATH=target/packaging/macos/halloy.dmg" >> "$GITHUB_ENV"
           - target: windows
             os: windows-latest
-            make: bash scripts/build-windows-installer.sh
+            make: bash scripts/build-windows-installer.sh --nightly
             artifact_path: |
-              echo "ARTIFACT_PATH=target/packaging/halloy-installer.msi" >> $env:GITHUB_ENV
+              echo "ARTIFACT_PATH=target/packaging/halloy-nightly-installer.exe" >> $env:GITHUB_ENV
           - target: linux
             os: ubuntu-latest
             make: bash scripts/package-linux.sh package
@@ -70,6 +70,10 @@ jobs:
         uses: taiki-e/install-action@4bc351f7f2614e48088386e2a0ad917ca3a7e4ba # v2
         with:
           tool: cargo-edit
+
+      - name: Install Inno Setup
+        if: matrix.target.target == 'windows'
+        run: choco install innosetup --no-progress --yes
 
       - name: Build
         run: ${{ matrix.target.make }}
@@ -138,7 +142,7 @@ jobs:
             asset_type: application/octet-stream
           - artifact: windows
             artifact_name: |
-              echo "ARTIFACT_NAME=halloy-installer.msi" >> "$GITHUB_ENV"
+              echo "ARTIFACT_NAME=halloy-nightly-installer.exe" >> "$GITHUB_ENV"
             asset_type: application/x-dosexec
           - artifact: linux
             artifact_name: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
             os: windows-latest
             make: bash scripts/build-windows-installer.sh
             artifact_path: |
-              echo "ARTIFACT_PATH=target/packaging/halloy-installer.msi" >> $env:GITHUB_ENV
+              echo "ARTIFACT_PATH=target/packaging/halloy-installer.exe" >> $env:GITHUB_ENV
           - target: linux
             os: ubuntu-latest
             make: bash scripts/package-linux.sh package
@@ -58,6 +58,10 @@ jobs:
         uses: taiki-e/install-action@4bc351f7f2614e48088386e2a0ad917ca3a7e4ba # v2
         with:
           tool: cargo-edit
+
+      - name: Install Inno Setup
+        if: matrix.target.target == 'windows'
+        run: choco install innosetup --no-progress --yes
 
       - name: Build
         run: ${{ matrix.target.make }}
@@ -117,7 +121,7 @@ jobs:
             asset_type: application/octet-stream
           - artifact: windows
             artifact_name: |
-              echo "ARTIFACT_NAME=halloy-installer.msi" >> "$GITHUB_ENV"
+              echo "ARTIFACT_NAME=halloy-installer.exe" >> "$GITHUB_ENV"
             asset_type: application/x-dosexec
           - artifact: linux
             artifact_name: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changed:
 - `buffer.reply.insert_nick` no longer inserts nick when replying in query buffers or to yourself
 - Input tooltips are aligned with the input (i.e. inset when `text_input.nickname.enabled = true`)
 - `servers.<name>.sasl.plain.username` setting will fall back to `servers.<name>.nickname` if not set
+- Replace the Windows MSI package with a per-user Inno Setup installer
 
 Thanks:
 

--- a/inno/halloy.iss
+++ b/inno/halloy.iss
@@ -1,0 +1,193 @@
+#define AppName "Halloy"
+#define AppPublisher "Squidowl"
+#define AppExeName "halloy.exe"
+#define AppId "{{3ED18662-FB43-4803-A4F9-89BBBC0B6D01}"
+#define AppVersion GetEnv("HALLOY_VERSION")
+#define SourceDir GetEnv("HALLOY_SOURCE_DIR")
+#define OutputDir GetEnv("HALLOY_OUTPUT_DIR")
+#define OutputBaseFilename GetEnv("HALLOY_OUTPUT_BASE_FILENAME")
+
+[Setup]
+AppId={#AppId}
+AppName={#AppName}
+AppVersion={#AppVersion}
+AppVerName={#AppName} {#AppVersion}
+AppPublisher={#AppPublisher}
+AppPublisherURL=https://halloy.chat/
+AppSupportURL=https://halloy.chat/
+AppUpdatesURL=https://halloy.chat/
+DefaultDirName={localappdata}\Programs\{#AppName}
+DefaultGroupName={#AppName}
+DisableProgramGroupPage=yes
+LicenseFile={#SourceDir}\wix\license.rtf
+OutputDir={#OutputDir}
+OutputBaseFilename={#OutputBaseFilename}
+SetupIconFile={#SourceDir}\assets\windows\halloy.ico
+UninstallDisplayIcon={app}\{#AppExeName}
+VersionInfoVersion={#AppVersion}
+VersionInfoCompany={#AppPublisher}
+VersionInfoDescription={#AppName} Installer
+VersionInfoProductName={#AppName}
+VersionInfoProductVersion={#AppVersion}
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+PrivilegesRequired=lowest
+CloseApplications=yes
+RestartApplications=no
+ChangesAssociations=yes
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Files]
+Source: "{#SourceDir}\target\packaging\{#AppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+
+[Icons]
+Name: "{group}\{#AppName}"; Filename: "{app}\{#AppExeName}"; WorkingDir: "{app}"; AppUserModelID: "org.squidowl.halloy"
+Name: "{autodesktop}\{#AppName}"; Filename: "{app}\{#AppExeName}"; WorkingDir: "{app}"; Tasks: desktopicon; AppUserModelID: "org.squidowl.halloy"
+
+[Registry]
+Root: HKCU; Subkey: "Software\Halloy\Capabilities"; ValueType: string; ValueName: "ApplicationDescription"; ValueData: "Halloy - IRC client"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Halloy\Capabilities"; ValueType: string; ValueName: "ApplicationIcon"; ValueData: "{app}\{#AppExeName},0"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Halloy\Capabilities"; ValueType: string; ValueName: "ApplicationName"; ValueData: "Halloy"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Halloy\Capabilities\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\{#AppExeName},1"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Halloy\Capabilities\URLAssociations"; ValueType: string; ValueName: "halloy"; ValueData: "halloy"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Halloy\Capabilities\URLAssociations"; ValueType: string; ValueName: "irc"; ValueData: "irc"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Halloy\Capabilities\URLAssociations"; ValueType: string; ValueName: "ircs"; ValueData: "ircs"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\RegisteredApplications"; ValueType: string; ValueName: "Halloy"; ValueData: "Software\Halloy\Capabilities"; Flags: uninsdeletevalue
+
+Root: HKCU; Subkey: "Software\Classes\halloy"; ValueType: string; ValueName: ""; ValueData: "URL:Halloy"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\halloy"; ValueType: string; ValueName: "FriendlyTypeName"; ValueData: "Halloy URL"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\halloy"; ValueType: string; ValueName: "URL Protocol"; ValueData: ""; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\halloy\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\{#AppExeName},1"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\halloy\shell"; ValueType: string; ValueName: ""; ValueData: "open"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\halloy\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#AppExeName}"" ""%1"""; Flags: uninsdeletekey
+
+Root: HKCU; Subkey: "Software\Classes\irc"; ValueType: string; ValueName: ""; ValueData: "URL:Internet Relay Chat"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\irc"; ValueType: string; ValueName: "FriendlyTypeName"; ValueData: "Internet Relay Chat URL"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\irc"; ValueType: string; ValueName: "URL Protocol"; ValueData: ""; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\irc\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\{#AppExeName},1"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\irc\shell"; ValueType: string; ValueName: ""; ValueData: "open"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\irc\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#AppExeName}"" ""%1"""; Flags: uninsdeletekey
+
+Root: HKCU; Subkey: "Software\Classes\ircs"; ValueType: string; ValueName: ""; ValueData: "URL:Internet Relay Chat with Privacy"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\ircs"; ValueType: string; ValueName: "FriendlyTypeName"; ValueData: "Internet Relay Chat with Privacy URL"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\ircs"; ValueType: string; ValueName: "URL Protocol"; ValueData: ""; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\ircs\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\{#AppExeName},1"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\ircs\shell"; ValueType: string; ValueName: ""; ValueData: "open"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\ircs\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#AppExeName}"" ""%1"""; Flags: uninsdeletekey
+
+[Run]
+Filename: "{app}\{#AppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(AppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
+
+[Code]
+const
+  UninstallKey = 'Software\Microsoft\Windows\CurrentVersion\Uninstall';
+
+function IsHalloyMsiInstall(Root: Integer; Subkey: String): Boolean;
+var
+  DisplayName: String;
+  Publisher: String;
+  WindowsInstaller: Cardinal;
+begin
+  Result := False;
+  WindowsInstaller := 0;
+
+  if not RegQueryStringValue(Root, UninstallKey + '\' + Subkey, 'DisplayName', DisplayName) then
+    Exit;
+
+  if CompareText(DisplayName, 'Halloy') <> 0 then
+    Exit;
+
+  RegQueryStringValue(Root, UninstallKey + '\' + Subkey, 'Publisher', Publisher);
+  RegQueryDWordValue(Root, UninstallKey + '\' + Subkey, 'WindowsInstaller', WindowsInstaller);
+
+  Result := (CompareText(Publisher, 'Squidowl') = 0) and (WindowsInstaller = 1);
+end;
+
+function FindHalloyMsiInstall(Root: Integer; var ProductCode: String): Boolean;
+var
+  Subkeys: TArrayOfString;
+  Index: Integer;
+begin
+  Result := False;
+
+  if not RegGetSubkeyNames(Root, UninstallKey, Subkeys) then
+    Exit;
+
+  for Index := 0 to GetArrayLength(Subkeys) - 1 do
+  begin
+    if IsHalloyMsiInstall(Root, Subkeys[Index])
+      and (Length(Subkeys[Index]) = 38)
+      and (Pos('{', Subkeys[Index]) = 1)
+      and (Subkeys[Index][38] = '}') then
+    begin
+      ProductCode := Subkeys[Index];
+      Result := True;
+      Exit;
+    end;
+  end;
+end;
+
+function UninstallHalloyMsi(ProductCode: String): Boolean;
+var
+  ResultCode: Integer;
+begin
+  Result :=
+    ShellExec('runas', ExpandConstant('{sys}\msiexec.exe'), '/x ' + ProductCode + ' /passive /norestart',
+      '', SW_SHOW, ewWaitUntilTerminated, ResultCode)
+    and ((ResultCode = 0) or (ResultCode = 3010));
+end;
+
+procedure CloseRunningHalloy();
+var
+  ResultCode: Integer;
+begin
+  Log('Closing any running Halloy process before installing files.');
+  Exec(ExpandConstant('{sys}\taskkill.exe'), '/im {#AppExeName} /t',
+    '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+end;
+
+function InitializeSetup(): Boolean;
+var
+  ProductCode: String;
+  Root: Integer;
+begin
+  Result := True;
+
+  if FindHalloyMsiInstall(HKLM64, ProductCode) then
+    Root := HKLM64
+  else if FindHalloyMsiInstall(HKLM32, ProductCode) then
+    Root := HKLM32
+  else
+    Exit;
+
+  Log('Found existing Halloy MSI installation in registry root ' + IntToStr(Root) + ': ' + ProductCode);
+
+  if MsgBox('Setup found an existing Halloy MSI installation. It must be removed before installing this per-user version.' #13#13 +
+            'Setup will ask Windows for permission to uninstall the existing MSI installation.',
+            mbConfirmation, MB_YESNO) <> IDYES then
+  begin
+    Result := False;
+    Exit;
+  end;
+
+  if not UninstallHalloyMsi(ProductCode) then
+  begin
+    MsgBox('Setup could not uninstall the existing Halloy MSI installation. Please approve the Windows permission prompt, or remove Halloy from Windows Settings and run this installer again.',
+      mbError, MB_OK);
+    Result := False;
+  end;
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if CurStep = ssInstall then
+    CloseRunningHalloy();
+end;

--- a/scripts/build-windows-installer.sh
+++ b/scripts/build-windows-installer.sh
@@ -1,16 +1,51 @@
 #!/bin/bash
-WXS_FILE="wix/main.wxs"
+set -euo pipefail
+
+ISS_FILE="inno/halloy.iss"
 HALLOY_VERSION=$(grep -q '\..*\.' VERSION && cat VERSION || echo "$(cat VERSION).0")
 PROFILE="packaging"
+NIGHTLY=0
+
+find_iscc() {
+    if [ -n "${ISCC:-}" ]; then
+        echo "$ISCC"
+    elif command -v iscc &> /dev/null; then
+        command -v iscc
+    fi
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --nightly)
+            NIGHTLY=1
+            ;;
+        *)
+            echo "Unknown argument: $arg" >&2
+            exit 1
+            ;;
+    esac
+done
 
 # build the binary
 scripts/build-windows.sh
 
-# install latest wix
-dotnet tool install --global wix --version 6.0.2
+ISCC_BIN="$(find_iscc)"
 
-# add required wix extension
-wix extension add WixToolset.UI.wixext/6.0.2
+if [ -z "$ISCC_BIN" ]; then
+    echo "Could not find ISCC.exe. Install Inno Setup 6 or set ISCC to the compiler path." >&2
+    exit 1
+fi
+
+export HALLOY_VERSION
+export HALLOY_SOURCE_DIR="$PWD"
+export HALLOY_OUTPUT_DIR="$PWD/target/$PROFILE"
+
+if [ "$NIGHTLY" = "1" ]; then
+    DEFAULT_OUTPUT_BASE_FILENAME="halloy-nightly-installer"
+else
+    DEFAULT_OUTPUT_BASE_FILENAME="halloy-installer"
+fi
+export HALLOY_OUTPUT_BASE_FILENAME="${HALLOY_OUTPUT_BASE_FILENAME:-$DEFAULT_OUTPUT_BASE_FILENAME}"
 
 # build the installer
-wix build -pdbtype none -arch x64 -d PackageVersion=$HALLOY_VERSION $WXS_FILE -o target/$PROFILE/halloy-installer.msi -ext WixToolset.UI.wixext
+"$ISCC_BIN" "$ISS_FILE"

--- a/scripts/build-windows.sh
+++ b/scripts/build-windows.sh
@@ -1,7 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
 # Deprecated for now.
 # We should later use it for portable version of Halloy.
 
-#!/bin/bash
 EXE_NAME="halloy.exe"
 TARGET="x86_64-pc-windows-msvc"
 HALLOY_VERSION=$(grep -q '\..*\.' VERSION && cat VERSION || echo "$(cat VERSION).0")


### PR DESCRIPTION
This replaces the Windows Wix/MSI package with a per-user Inno Setup installer.
I tried to make it convenience as possible. It's needs testing by some Windows users.

## Changes

- Add a new Inno Setup installer definition for Windows.
- Install Halloy into the current user profile without requiring admin rights.
- Detect existing Wix/MSI Halloy installations and uninstall them before installing the new per-user version.
- Request elevation only for uninstalling an existing per-machine MSI installation.
- Close a running `halloy.exe` before replacing installed files.
- Update Windows release artifacts from `halloy-installer.msi` to `halloy-installer.exe`.
- Update nightly Windows artifacts to `halloy-nightly-installer.exe`.
- Install Inno Setup in the Windows GitHub Actions jobs via Chocolatey.
- Add Nightly-aware Windows build handling.

## Notes

The new installer uses the same application identity for stable and nightly builds, so installing a nightly build upgrades or replaces the existing Halloy installation in place. This matches the existing single-installation channel behavior.

Existing per-machine MSI installations may require a UAC prompt during migration, but the new Inno Setup installation itself remains per-user.