### PR TITLE
Show `Display` in `Configuration` docs menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Added:
 Fixed:
 
 - Correctly support `RPL_METADATASYNCLATER`
+- Show `Display` in `Configuration` docs menu
 
 Changed:
 
@@ -17,6 +18,7 @@ Thanks:
 
 - Contributions: @luca020400, @englut, @furudean
 - Feature requests: @g00s
+- Bug reports: wwWraith
 
 # 2026.7.1 (2026-06-02)
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -2,12 +2,15 @@ import footnote from "markdown-it-footnote";
 import { defineConfig } from "vitepress";
 
 const releaseLabel = process.env.DOCS_VERSION ?? "Latest Release";
-const releaseLink = process.env.DOCS_CHANNEL === "nightly" ? "https://halloy.chat" : "/";
+const releaseLink =
+  process.env.DOCS_CHANNEL === "nightly" ? "https://halloy.chat" : "/";
 const nightlyLabel = process.env.DOCS_SHA
   ? `Nightly (${process.env.DOCS_SHA.slice(0, 7)})`
   : "Nightly";
-const nightlyLink = process.env.DOCS_CHANNEL === "nightly" ? "/" : "https://nightly.halloy.chat";
-const docsChannel = process.env.DOCS_CHANNEL === "nightly" ? nightlyLabel : releaseLabel;
+const nightlyLink =
+  process.env.DOCS_CHANNEL === "nightly" ? "/" : "https://nightly.halloy.chat";
+const docsChannel =
+  process.env.DOCS_CHANNEL === "nightly" ? nightlyLabel : releaseLabel;
 
 const guidesItems = [
   { text: "Building for Flatpak", link: "/guides/flatpaks" },
@@ -60,6 +63,7 @@ const configurationItems = [
     link: "/configuration/context-menu",
   },
   { text: "CTCP", link: "/configuration/cctp" },
+  { text: "Display", link: "/configuration/display" },
   {
     text: "File Transfer",
     link: "/configuration/file-transfer",
@@ -159,12 +163,13 @@ export default defineConfig({
       { icon: "github", link: "https://github.com/squidowl/halloy" },
     ],
     sidebar: {
-      '/configuration': [
+      "/configuration": [
         {
           items: [
             { text: "Installation", link: "/installation" },
             { text: "Getting Started", link: "/getting-started" },
-            { text: "Configuration",
+            {
+              text: "Configuration",
               link: "/configuration",
               collapsed: false,
               items: configurationItems,
@@ -179,12 +184,13 @@ export default defineConfig({
           ],
         },
       ],
-      '/': [
+      "/": [
         {
           items: [
             { text: "Installation", link: "/installation" },
             { text: "Getting Started", link: "/getting-started" },
-            { text: "Configuration",
+            {
+              text: "Configuration",
               link: "/configuration",
               collapsed: true,
               items: configurationItems,


### PR DESCRIPTION
Link `Display` docs in the side menu.

Reported by `#halloy` user `wwWraith`.