### PR TITLE
Miscellaneous Minor Settings Tweaks

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1466,7 +1466,7 @@ impl Client {
                         sasl.command()
                     );
 
-                    for param in sasl.params() {
+                    for param in sasl.params(&self.config.nickname) {
                         self.handle
                             .try_send(command!("AUTHENTICATE", param))?;
                     }
@@ -5310,10 +5310,18 @@ impl Map {
                         .and_then(|parent| self.get_filehost_auth(parent));
                 }
 
-                fileupload::Auth::try_from(client.config.sasl.as_ref()?).ok()
+                fileupload::Auth::from_sasl(
+                    client.config.sasl.as_ref()?,
+                    &client.config.nickname,
+                )
+                .ok()
             }
             filehost::Credentials::Sasl(credentials) => {
-                fileupload::Auth::try_from(credentials).ok()
+                fileupload::Auth::from_sasl(
+                    credentials,
+                    &client.config.nickname,
+                )
+                .ok()
             }
             filehost::Credentials::None => None,
         }

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -55,7 +55,7 @@ pub struct Server {
     pub nick_identify_syntax: Option<IdentifySyntax>,
     /// Alternative nicknames for the client, if the default is taken.
     pub alt_nicks: Vec<String>,
-    /// The client's username.
+    /// The client's username (falls back to nickname if needed & not provided).
     pub username: Option<String>,
     /// The client's real name.
     pub realname: Option<String>,
@@ -293,8 +293,8 @@ pub enum IdentifySyntax {
 #[serde(rename_all = "kebab-case")]
 pub enum Sasl {
     Plain {
-        /// Account name
-        username: String,
+        /// Account name (falls back to nickname if not provided)
+        username: Option<String>,
         /// Account password,
         password: Option<String>,
         /// Account password file
@@ -425,7 +425,7 @@ impl Sasl {
         }
     }
 
-    pub fn params(&self) -> Vec<String> {
+    pub fn params(&self, nickname: &str) -> Vec<String> {
         const CHUNK_SIZE: usize = 400;
 
         match self {
@@ -441,7 +441,12 @@ impl Sasl {
                 // Exclude authorization ID, to use the authentication ID as the authorization ID
                 // https://datatracker.ietf.org/doc/html/rfc4616#section-2
                 let encoding = base64::engine::general_purpose::STANDARD
-                    .encode(format!("\x00{username}\x00{password}"));
+                    .encode(format!(
+                        "\x00{}\x00{password}",
+                        username
+                            .as_ref()
+                            .map_or(nickname, |username| username.as_str())
+                    ));
 
                 let chunks = encoding
                     .as_bytes()

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -37,6 +37,7 @@ const DEFAULT_WSS_PORT: u16 = 443;
 #[serde(default)]
 pub struct Server {
     /// The client's nickname.
+    #[serde(alias = "nick")]
     pub nickname: String,
     /// The client's NICKSERV password.
     pub nick_password: Option<String>,

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -17,6 +17,7 @@ use crate::config::sidebar::OrderChannelsBy;
 use crate::serde::{
     deserialize_path_buf_with_path_transformations,
     deserialize_path_buf_with_path_transformations_maybe,
+    deserialize_u64_positive_integer,
 };
 use crate::{config, isupport, metadata, target};
 
@@ -86,8 +87,10 @@ pub struct Server {
     /// A list of queries to add to the sidebar on connection.
     pub queries: Vec<String>,
     /// The amount of inactivity in seconds before the client will ping the server.
+    #[serde(deserialize_with = "deserialize_u64_positive_integer")]
     pub ping_time: u64,
     /// The amount of time in seconds for a client to reconnect due to no ping response.
+    #[serde(deserialize_with = "deserialize_u64_positive_integer")]
     pub ping_timeout: u64,
     /// The amount of time in seconds before attempting to reconnect to the server when disconnected.
     #[serde(deserialize_with = "deserialize_duration_from_secs")]
@@ -587,7 +590,14 @@ where
 {
     let seconds: u64 = Deserialize::deserialize(deserializer)?;
 
-    Ok(Duration::from_secs(seconds))
+    if seconds == 0 {
+        Err(serde::de::Error::invalid_value(
+            serde::de::Unexpected::Unsigned(seconds),
+            &"any positive number of seconds",
+        ))
+    } else {
+        Ok(Duration::from_secs(seconds))
+    }
 }
 
 pub fn default_port(use_tls: bool, use_websocket: bool) -> NonZeroU16 {

--- a/data/src/fileupload.rs
+++ b/data/src/fileupload.rs
@@ -42,10 +42,11 @@ pub enum Auth {
     External { cert: PathBuf, key: Option<PathBuf> },
 }
 
-impl TryFrom<&Sasl> for Auth {
-    type Error = &'static str;
-
-    fn try_from(sasl: &Sasl) -> Result<Self, Self::Error> {
+impl Auth {
+    pub fn from_sasl(
+        sasl: &Sasl,
+        nickname: &str,
+    ) -> Result<Self, &'static str> {
         Ok(match sasl {
             Sasl::Plain {
                 username, password, ..
@@ -57,7 +58,10 @@ impl TryFrom<&Sasl> for Auth {
                 };
 
                 Self::Basic {
-                    username: username.clone(),
+                    username: username
+                        .as_ref()
+                        .map_or(nickname, |username| username.as_str())
+                        .to_string(),
                     password: password.clone(),
                 }
             }

--- a/data/src/serde.rs
+++ b/data/src/serde.rs
@@ -152,6 +152,24 @@ where
     }
 }
 
+pub fn deserialize_u64_positive_integer<'de, D>(
+    deserializer: D,
+) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let integer: u64 = Deserialize::deserialize(deserializer)?;
+
+    if integer == 0 {
+        Err(serde::de::Error::invalid_value(
+            serde::de::Unexpected::Unsigned(integer),
+            &"any positive integer",
+        ))
+    } else {
+        Ok(integer)
+    }
+}
+
 pub fn deserialize_usize_positive_integer<'de, D>(
     deserializer: D,
 ) -> Result<usize, D::Error>

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -298,7 +298,7 @@ The amount of inactivity in seconds before the client will ping the server.
 
 ```toml
 # Type: integer
-# Values: any non-negative integer
+# Values: any positive integer
 # Default: 180
 
 [servers.<name>]
@@ -311,7 +311,7 @@ The amount of time in seconds to wait for a ping response before attempting to r
 
 ```toml
 # Type: integer
-# Values: any non-negative integer
+# Values: any positive integer
 # Default: 20
 
 [servers.<name>]
@@ -324,7 +324,7 @@ The amount of time in seconds before attempting to reconnect to the server when 
 
 ```toml
 # Type: integer
-# Values: any non-negative integer
+# Values: any positive integer
 # Default: 10
 
 [servers.<name>]

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -102,7 +102,7 @@ alt_nicks = ["Foo", "Bar"]
 
 ## `username`
 
-The client's username.
+The client's username.  If not set, then the configured [`nickname`](#nickname) will be used.
 
 ```toml
 # Type: string
@@ -669,7 +669,7 @@ Plain SASL auth using a username and password. See the [guide by Libera.Chat](ht
 
 ### `username`
 
-The account name used for authentication.
+The account name used for authentication.  If not set, then the configured [`nickname`](#nickname) will be used.
 
 ```toml
 # Type: string


### PR DESCRIPTION
- Require non-zero values for `ping_time`, `ping_timeout`, and `reconnect_delay` (closes #1766)
- Add `nick` as an alias for `nickname` for convenience/ease (users who see e.g. `nick_password` might expect `nick` is valid)
- Fall back to `nickname` for `sasl.plain.username` when no username is provided
- Document that `username` falls back to `nickname`