### PR TITLE
More Conservative Handling of Message Server Time for Chathistory

### DIFF
--- a/data/src/capabilities.rs
+++ b/data/src/capabilities.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use std::string::ToString;
 use std::sync::LazyLock;
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, TimeDelta, Utc};
 use irc::proto::{self, Tags, command, format};
 
 use crate::message::formatting::{Modifier, update_formatting_with_modifier};
@@ -491,7 +491,26 @@ impl LabeledResponseContext {
         Self {
             // Prefix ':' to ensure it cannot match any valid message id
             label_as_id: format!(":label={label}").into(),
-            server_time: message.server_time_or_now(),
+            server_time: message.server_time_or_now().0,
         }
+    }
+}
+
+// Server time from a message that indicates entry to a server or channel (i.e.
+// RPL_LOGGEDIN or JOIN);  if the message does not have a server_time tag, then
+// the server_time generated from local time will be shifted into the future.
+// If the resultant server_time is ahead of the time on the server, then
+// deduplication should take care of any duplicate messages we receive.
+pub fn chathistory_entry_server_time(
+    message: message::Encoded,
+) -> DateTime<Utc> {
+    let (server_time, received_with_server_time) = message.server_time_or_now();
+
+    if received_with_server_time {
+        server_time
+    } else {
+        TimeDelta::try_minutes(90)
+            .and_then(|time_delta| server_time.checked_add_signed(time_delta))
+            .unwrap_or(server_time)
     }
 }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -20,7 +20,8 @@ pub use self::on_connect::on_connect;
 use crate::bouncer::{self, BouncerNetwork};
 use crate::capabilities::{
     self, Capabilities, Capability, LabeledResponseContext, MultilineBatchKind,
-    MultilineLimits, multiline_concat_lines, multiline_encoded,
+    MultilineLimits, chathistory_entry_server_time, multiline_concat_lines,
+    multiline_encoded,
 };
 use crate::config::server::filehost;
 use crate::environment::{SOURCE_WEBSITE, VERSION};
@@ -75,14 +76,16 @@ pub enum Broadcast {
         user: User,
         comment: Option<String>,
         channels: Vec<target::Channel>,
-        sent_time: DateTime<Utc>,
+        server_time: DateTime<Utc>,
+        received_with_server_time: bool,
     },
     Nickname {
         old_user: User,
         new_nick: Nick,
         ourself: bool,
         channels: Vec<target::Channel>,
-        sent_time: DateTime<Utc>,
+        server_time: DateTime<Utc>,
+        received_with_server_time: bool,
     },
     ChangeHost {
         old_user: User,
@@ -91,14 +94,16 @@ pub enum Broadcast {
         ourself: bool,
         logged_in: bool,
         channels: Vec<target::Channel>,
-        sent_time: DateTime<Utc>,
+        server_time: DateTime<Utc>,
+        received_with_server_time: bool,
     },
     Kick {
         kicker: User,
         victim: User,
         reason: Option<String>,
         channel: target::Channel,
-        sent_time: DateTime<Utc>,
+        server_time: DateTime<Utc>,
+        received_with_server_time: bool,
     },
 }
 
@@ -1530,7 +1535,9 @@ impl Client {
                     });
                 }
 
-                return Ok(vec![Event::LoggedIn(message.server_time_or_now())]);
+                return Ok(vec![Event::LoggedIn(
+                    chathistory_entry_server_time(message),
+                )]);
             }
             Command::Numeric(RPL_LOGGEDOUT, _) => {
                 log::info!("[{}] logged out", self.server);
@@ -1846,12 +1853,16 @@ impl Client {
                     }
                 });
 
+                let (server_time, received_with_server_time) =
+                    message.server_time_or_now();
+
                 return Ok(vec![Event::Broadcast(Broadcast::Nickname {
                     old_user,
                     new_nick,
                     ourself,
                     channels,
-                    sent_time: message.server_time_or_now(),
+                    server_time,
+                    received_with_server_time,
                 })]);
             }
             Command::Numeric(ERR_NICKNAMEINUSE | ERR_ERRONEUSNICKNAME, _)
@@ -1901,11 +1912,15 @@ impl Client {
                     channel.users.remove(&user);
                 });
 
+                let (server_time, received_with_server_time) =
+                    message.server_time_or_now();
+
                 return Ok(vec![Event::Broadcast(Broadcast::Quit {
                     user,
                     comment: comment.clone(),
                     channels,
-                    sent_time: message.server_time_or_now(),
+                    server_time,
+                    received_with_server_time,
                 })]);
             }
             Command::PART(channel, _) => {
@@ -1983,7 +1998,7 @@ impl Client {
 
                     return Ok(vec![Event::JoinedChannel(
                         target_channel,
-                        message.server_time_or_now(),
+                        chathistory_entry_server_time(message),
                     )]);
                 } else if let Some(channel) =
                     self.chanmap.get_mut(&target_channel)
@@ -2022,13 +2037,17 @@ impl Client {
                     {
                         self.chanmap.shift_remove(&channel);
 
+                        let (server_time, received_with_server_time) =
+                            message.server_time_or_now();
+
                         return Ok(vec![
                             Event::Broadcast(Broadcast::Kick {
                                 kicker: ok!(message.user(casemapping)),
                                 victim: User::from(self.nickname().to_owned()),
                                 reason: reason.clone(),
                                 channel,
-                                sent_time: message.server_time_or_now(),
+                                server_time,
+                                received_with_server_time,
                             }),
                             Event::Single {
                                 message,
@@ -2556,7 +2575,8 @@ impl Client {
                         channel.topic.content =
                             Some(message::parse_fragments(text.clone()));
                         channel.topic.who = message.user(casemapping);
-                        channel.topic.time = Some(message.server_time_or_now());
+                        channel.topic.time =
+                            Some(message.server_time_or_now().0);
                     } else {
                         channel.topic.content = None;
                         channel.topic.who = None;
@@ -2962,6 +2982,9 @@ impl Client {
 
                 let channels = self.user_channels(old_user.nickname());
 
+                let (server_time, received_with_server_time) =
+                    message.server_time_or_now();
+
                 return Ok(vec![Event::Broadcast(Broadcast::ChangeHost {
                     old_user,
                     new_username: new_username.clone(),
@@ -2969,7 +2992,8 @@ impl Client {
                     ourself,
                     logged_in: self.logged_in,
                     channels,
-                    sent_time: message.server_time_or_now(),
+                    server_time,
+                    received_with_server_time,
                 })]);
             }
             Command::Numeric(RPL_VISIBLEHOST, args) => {

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -784,7 +784,8 @@ impl Manager {
         casemapping: isupport::CaseMap,
         broadcast: Broadcast,
         config: &Config,
-        sent_time: DateTime<Utc>,
+        server_time: DateTime<Utc>,
+        received_with_server_time: bool,
     ) -> Vec<impl Future<Output = Message> + use<>> {
         let channels = self
             .data
@@ -812,7 +813,12 @@ impl Manager {
             .cloned();
 
         let messages = broadcast::into_messages(
-            broadcast, config, sent_time, channels, queries,
+            broadcast,
+            config,
+            server_time,
+            received_with_server_time,
+            channels,
+            queries,
         );
 
         messages

--- a/data/src/isupport.rs
+++ b/data/src/isupport.rs
@@ -948,15 +948,6 @@ pub enum MessageReference {
     MessageId(message::Id),
 }
 
-// impl fmt::Display for Option<MessageReference> {
-//     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-//         match self {
-//             Some(message_reference) => write!(f, "{message_reference}"),
-//             None => write!(f, "*"),
-//         }
-//     }
-// }
-
 impl fmt::Display for MessageReference {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -162,8 +162,14 @@ impl Encoded {
             .map(|dt| dt.with_timezone(&Utc))
     }
 
-    pub fn server_time_or_now(&self) -> DateTime<Utc> {
-        self.server_time().unwrap_or_else(Utc::now)
+    pub fn server_time_or_now(&self) -> (DateTime<Utc>, bool) {
+        let server_time = self.server_time();
+        let received_with_server_time = server_time.is_some();
+
+        (
+            server_time.unwrap_or_else(Utc::now),
+            received_with_server_time,
+        )
     }
 
     pub fn from_bot(&self) -> bool {
@@ -352,6 +358,7 @@ pub struct Message {
     pub hash: Hash,
     pub hidden_urls: HashSet<Url>,
     pub is_echo: bool, // Only relevant if direction == Direction::Received
+    pub received_with_server_time: bool, // Only relevant if direction == Direction::Received
     pub blocked: bool,
     pub condensed: Option<Arc<Message>>,
     pub expanded: bool, // Only relevant if can_condense or redaction.is_some()
@@ -409,7 +416,7 @@ impl Message {
             return false;
         }
 
-        true
+        self.received_with_server_time || self.id.is_some()
     }
 
     pub fn is_rerouted(&self) -> bool {
@@ -456,7 +463,8 @@ impl Message {
         casemapping: isupport::CaseMap,
         prefix: &[isupport::PrefixMap],
     ) -> Option<Message> {
-        let server_time = encoded.server_time_or_now();
+        let (server_time, received_with_server_time) =
+            encoded.server_time_or_now();
         let id = encoded.message_id();
         let reply_to = encoded.in_reply_to();
         let is_echo = encoded
@@ -500,6 +508,7 @@ impl Message {
             hash,
             hidden_urls: HashSet::default(),
             is_echo,
+            received_with_server_time,
             blocked: false,
             condensed: None,
             expanded: false,
@@ -526,7 +535,8 @@ impl Message {
         casemapping: isupport::CaseMap,
         prefix: &[isupport::PrefixMap],
     ) -> Option<(Message, Option<Highlight>, bool)> {
-        let server_time = encoded.server_time_or_now();
+        let (server_time, received_with_server_time) =
+            encoded.server_time_or_now();
         let id = encoded.message_id();
         let reply_to = encoded.in_reply_to();
         let is_echo = encoded
@@ -570,6 +580,7 @@ impl Message {
             hash,
             hidden_urls: HashSet::default(),
             is_echo,
+            received_with_server_time,
             blocked: false,
             condensed: None,
             expanded: false,
@@ -652,6 +663,7 @@ impl Message {
             hash,
             hidden_urls: HashSet::default(),
             is_echo: false,
+            received_with_server_time: false,
             blocked: false,
             condensed: None,
             expanded: false,
@@ -691,6 +703,7 @@ impl Message {
             hash,
             hidden_urls: HashSet::default(),
             is_echo: false,
+            received_with_server_time: false,
             blocked: false,
             condensed: None,
             expanded: false,
@@ -728,6 +741,7 @@ impl Message {
             hash,
             hidden_urls: HashSet::default(),
             is_echo: false,
+            received_with_server_time: false,
             blocked: false,
             condensed: None,
             expanded: false,
@@ -820,6 +834,7 @@ impl Message {
             hash,
             hidden_urls: HashSet::default(),
             is_echo: false,
+            received_with_server_time: false,
             blocked: false,
             condensed: None,
             expanded: false,
@@ -895,6 +910,7 @@ impl Serialize for Message {
             text: Cow<'a, str>,
             hidden_urls: &'a HashSet<url::Url>,
             is_echo: &'a bool,
+            received_with_server_time: &'a bool,
             command: &'a Option<command::Irc>,
             #[serde(skip_serializing_if = "<[_]>::is_empty")]
             reactions: &'a [Reaction],
@@ -913,6 +929,7 @@ impl Serialize for Message {
             text: self.content.text(),
             hidden_urls: &self.hidden_urls,
             is_echo: &self.is_echo,
+            received_with_server_time: &self.received_with_server_time,
             command: &self.command,
             reactions: &self.reactions,
             rerouted_from: &self.rerouted_from,
@@ -943,9 +960,10 @@ impl<'de> Deserialize<'de> for Message {
             reply_to: Option<Id>,
             #[serde(default)]
             hidden_urls: HashSet<url::Url>,
-            // New field, optional for upgrade compatibility
-            #[serde(default, deserialize_with = "fail_as_none")]
-            is_echo: Option<bool>,
+            #[serde(default)]
+            is_echo: bool,
+            #[serde(default)]
+            received_with_server_time: bool,
             #[serde(default, deserialize_with = "fail_as_none")]
             command: Option<command::Irc>,
             #[serde(default)]
@@ -967,6 +985,7 @@ impl<'de> Deserialize<'de> for Message {
             reply_to,
             hidden_urls,
             is_echo,
+            received_with_server_time,
             command,
             reactions,
             rerouted_from,
@@ -983,8 +1002,6 @@ impl<'de> Deserialize<'de> for Message {
             Content::Plain(String::new())
         };
 
-        let is_echo = is_echo.unwrap_or_default();
-
         let hash = Hash::new(&server_time, &content, &received_at);
 
         Ok(Message {
@@ -999,6 +1016,7 @@ impl<'de> Deserialize<'de> for Message {
             hash,
             hidden_urls,
             is_echo,
+            received_with_server_time,
             blocked: false,
             condensed: None,
             expanded: false,
@@ -1223,6 +1241,7 @@ pub fn condense(
             hash: first_message.hash,
             hidden_urls: HashSet::default(),
             is_echo: false,
+            received_with_server_time: false,
             blocked: false,
             condensed: None,
             expanded: false,
@@ -5006,6 +5025,7 @@ pub mod tests {
             broadcast,
             &Config::default(),
             Utc::now(),
+            false,
             channels,
             queries,
         )

--- a/data/src/message/broadcast.rs
+++ b/data/src/message/broadcast.rs
@@ -23,15 +23,16 @@ fn expand(
     include_server: bool,
     cause: Cause,
     content: Content,
-    sent_time: DateTime<Utc>,
+    server_time: DateTime<Utc>,
+    received_with_server_time: bool,
 ) -> Vec<Message> {
     let message = |target, content| -> Message {
         let received_at = Posix::now();
-        let hash = message::Hash::new(&sent_time, &content, &received_at);
+        let hash = message::Hash::new(&server_time, &content, &received_at);
 
         Message {
             received_at,
-            server_time: sent_time,
+            server_time,
             direction: Direction::Received,
             target,
             content,
@@ -41,6 +42,7 @@ fn expand(
             hash,
             hidden_urls: HashSet::default(),
             is_echo: false,
+            received_with_server_time,
             blocked: false,
             condensed: None,
             expanded: false,
@@ -99,6 +101,7 @@ pub fn connecting(sent_time: DateTime<Utc>) -> Vec<Message> {
         Cause::Status(source::Status::Success),
         content,
         sent_time,
+        false,
     )
 }
 
@@ -111,6 +114,7 @@ pub fn connected(sent_time: DateTime<Utc>) -> Vec<Message> {
         Cause::Status(source::Status::Success),
         content,
         sent_time,
+        false,
     )
 }
 
@@ -126,6 +130,7 @@ pub fn connection_failed(
         Cause::Status(source::Status::Error),
         content,
         sent_time,
+        false,
     )
 }
 
@@ -144,6 +149,7 @@ pub fn disconnected(
         Cause::Status(source::Status::Error),
         content,
         sent_time,
+        false,
     )
 }
 
@@ -160,6 +166,7 @@ pub fn reconnected(
         Cause::Status(source::Status::Success),
         content,
         sent_time,
+        false,
     )
 }
 
@@ -170,7 +177,8 @@ pub fn quit(
     comment: &Option<String>,
     config: &Config,
     casemapping: isupport::CaseMap,
-    sent_time: DateTime<Utc>,
+    server_time: DateTime<Utc>,
+    received_with_server_time: bool,
 ) -> Vec<Message> {
     let content = quit_text(user, comment, config, casemapping);
 
@@ -184,7 +192,8 @@ pub fn quit(
             None,
         ))),
         content,
-        sent_time,
+        server_time,
+        received_with_server_time,
     )
 }
 
@@ -195,7 +204,8 @@ pub fn nickname(
     new_nick: &Nick,
     ourself: bool,
     casemapping: isupport::CaseMap,
-    sent_time: DateTime<Utc>,
+    server_time: DateTime<Utc>,
+    received_with_server_time: bool,
 ) -> Vec<Message> {
     let content =
         nickname_text(old_nick.into(), new_nick.into(), ourself, casemapping);
@@ -206,7 +216,15 @@ pub fn nickname(
         Some(source::server::Change::Nick(new_nick.clone())),
     )));
 
-    expand(channels, queries, false, cause, content, sent_time)
+    expand(
+        channels,
+        queries,
+        false,
+        cause,
+        content,
+        server_time,
+        received_with_server_time,
+    )
 }
 
 pub fn change_host(
@@ -218,7 +236,8 @@ pub fn change_host(
     ourself: bool,
     logged_in: bool,
     casemapping: isupport::CaseMap,
-    sent_time: DateTime<Utc>,
+    server_time: DateTime<Utc>,
+    received_with_server_time: bool,
 ) -> Vec<Message> {
     let cause = Cause::Server(Some(source::Server::new(
         source::server::Kind::ChangeHost,
@@ -247,9 +266,25 @@ pub fn change_host(
     };
 
     if ourself && !logged_in {
-        expand([], [], true, cause, content, sent_time)
+        expand(
+            [],
+            [],
+            true,
+            cause,
+            content,
+            server_time,
+            received_with_server_time,
+        )
     } else {
-        expand(channels, queries, false, cause, content, sent_time)
+        expand(
+            channels,
+            queries,
+            false,
+            cause,
+            content,
+            server_time,
+            received_with_server_time,
+        )
     }
 }
 
@@ -260,7 +295,8 @@ pub fn kick(
     channel: target::Channel,
     config: &Config,
     casemapping: isupport::CaseMap,
-    sent_time: DateTime<Utc>,
+    server_time: DateTime<Utc>,
+    received_with_server_time: bool,
 ) -> Vec<Message> {
     let cause = Cause::Server(Some(source::Server::new(
         source::server::Kind::Kick,
@@ -278,7 +314,15 @@ pub fn kick(
         casemapping,
     );
 
-    expand([], [], true, cause, content, sent_time)
+    expand(
+        [],
+        [],
+        true,
+        cause,
+        content,
+        server_time,
+        received_with_server_time,
+    )
 }
 
 #[derive(Debug, Clone)]
@@ -330,21 +374,22 @@ pub enum Broadcast {
 pub fn into_messages(
     broadcast: Broadcast,
     config: &Config,
-    sent_time: DateTime<Utc>,
+    server_time: DateTime<Utc>,
+    received_with_server_time: bool,
     channels: impl IntoIterator<Item = target::Channel>,
     mut queries: impl IntoIterator<Item = target::Query>
     + std::iter::Iterator<Item = target::Query>,
 ) -> Vec<Message> {
     match broadcast {
-        Broadcast::Connecting => connecting(sent_time),
-        Broadcast::Connected => connected(sent_time),
+        Broadcast::Connecting => connecting(server_time),
+        Broadcast::Connected => connected(server_time),
         Broadcast::ConnectionFailed { error } => {
-            connection_failed(error, sent_time)
+            connection_failed(error, server_time)
         }
         Broadcast::Disconnected { error } => {
-            disconnected(channels, queries, error, sent_time)
+            disconnected(channels, queries, error, server_time)
         }
-        Broadcast::Reconnected => reconnected(channels, queries, sent_time),
+        Broadcast::Reconnected => reconnected(channels, queries, server_time),
         Broadcast::Quit {
             user,
             comment,
@@ -362,7 +407,8 @@ pub fn into_messages(
                 &comment,
                 config,
                 casemapping,
-                sent_time,
+                server_time,
+                received_with_server_time,
             )
         }
         Broadcast::Nickname {
@@ -381,7 +427,8 @@ pub fn into_messages(
                     &new_nick,
                     ourself,
                     casemapping,
-                    sent_time,
+                    server_time,
+                    received_with_server_time,
                 )
             } else {
                 // Otherwise just the query channel of the user w/ nick change
@@ -395,7 +442,8 @@ pub fn into_messages(
                     &new_nick,
                     ourself,
                     casemapping,
-                    sent_time,
+                    server_time,
+                    received_with_server_time,
                 )
             }
         }
@@ -419,7 +467,8 @@ pub fn into_messages(
                     ourself,
                     logged_in,
                     casemapping,
-                    sent_time,
+                    server_time,
+                    received_with_server_time,
                 )
             } else {
                 // Otherwise just the query channel of the user w/ host change
@@ -435,7 +484,8 @@ pub fn into_messages(
                     ourself,
                     logged_in,
                     casemapping,
-                    sent_time,
+                    server_time,
+                    received_with_server_time,
                 )
             }
         }
@@ -452,10 +502,11 @@ pub fn into_messages(
             channel,
             config,
             casemapping,
-            sent_time,
+            server_time,
+            received_with_server_time,
         ),
         Broadcast::FilehostUploadFailed { error, target } => {
-            upload_failed(error, target, sent_time)
+            upload_failed(error, target, server_time)
         }
     }
 }
@@ -474,6 +525,7 @@ pub fn upload_failed(
             Cause::Status(source::Status::Error),
             content,
             sent_time,
+            false,
         ),
         Some(target::Target::Query(query)) => expand(
             [],
@@ -482,6 +534,7 @@ pub fn upload_failed(
             Cause::Status(source::Status::Error),
             content,
             sent_time,
+            false,
         ),
         None => expand(
             [],
@@ -490,6 +543,7 @@ pub fn upload_failed(
             Cause::Status(source::Status::Error),
             content,
             sent_time,
+            false,
         ),
     }
 }

--- a/data/src/reaction.rs
+++ b/data/src/reaction.rs
@@ -59,7 +59,7 @@ impl Reaction {
         }
         let in_reply_to = message.in_reply_to()?;
         let id = message.message_id();
-        let server_time = message.server_time_or_now();
+        let server_time = message.server_time_or_now().0;
 
         let (Command::PRIVMSG(target, _) | Command::TAGMSG(target)) =
             message.0.command

--- a/data/src/redaction.rs
+++ b/data/src/redaction.rs
@@ -41,7 +41,7 @@ impl Redaction {
         casemapping: isupport::CaseMap,
     ) -> Option<Context> {
         let user = message.user(casemapping)?;
-        let server_time = message.server_time_or_now();
+        let server_time = message.server_time_or_now().0;
 
         let Command::REDACT(target, msgid, reason) = message.0.command else {
             return None;

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -2066,7 +2066,7 @@ impl State {
         let labeled_response_context = if let Some(last_encoded) =
             encoded.last()
         {
-            let sent_time = last_encoded.server_time_or_now();
+            let sent_time = last_encoded.server_time_or_now().0;
 
             let reply_id = self
                 .draft_reply
@@ -2539,7 +2539,7 @@ impl State {
 
             encoded.set_reply_to(reply_id);
 
-            let sent_time = encoded.server_time_or_now();
+            let sent_time = encoded.server_time_or_now().0;
 
             let labeled_response_context =
                 clients.send(buffer, encoded, TokenPriority::User);

--- a/src/main.rs
+++ b/src/main.rs
@@ -817,6 +817,7 @@ impl Halloy {
                                         ),
                                     &self.config,
                                     sent_time,
+                                    false,
                                     Broadcast::Disconnected { error },
                                 )
                                 .map(Message::Dashboard),
@@ -842,6 +843,7 @@ impl Halloy {
                                 .get_server_casemapping_or_default(&server),
                             &self.config,
                             sent_time,
+                            false,
                             Broadcast::Connecting,
                         )
                         .map(Message::Dashboard)
@@ -890,6 +892,7 @@ impl Halloy {
                                 .get_server_casemapping_or_default(&server),
                             &self.config,
                             sent_time,
+                            false,
                             broadcast_kind,
                         )
                         .map(Message::Dashboard);
@@ -921,6 +924,7 @@ impl Halloy {
                                 .get_server_casemapping_or_default(&server),
                             &self.config,
                             sent_time,
+                            false,
                             Broadcast::ConnectionFailed { error },
                         )
                         .map(Message::Dashboard)
@@ -2405,12 +2409,14 @@ fn handle_broadcast(
             user,
             comment,
             channels,
-            sent_time,
+            server_time,
+            received_with_server_time,
         } => dashboard.broadcast(
             server,
             casemapping,
             config,
-            sent_time,
+            server_time,
+            received_with_server_time,
             Broadcast::Quit {
                 user,
                 comment,
@@ -2423,14 +2429,16 @@ fn handle_broadcast(
             new_nick,
             ourself,
             channels,
-            sent_time,
+            server_time,
+            received_with_server_time,
         } => {
             let old_nick = old_user.nickname().to_owned();
             dashboard.broadcast(
                 server,
                 casemapping,
                 config,
-                sent_time,
+                server_time,
+                received_with_server_time,
                 Broadcast::Nickname {
                     old_nick,
                     new_nick,
@@ -2447,12 +2455,14 @@ fn handle_broadcast(
             ourself,
             logged_in,
             channels,
-            sent_time,
+            server_time,
+            received_with_server_time,
         } => dashboard.broadcast(
             server,
             casemapping,
             config,
-            sent_time,
+            server_time,
+            received_with_server_time,
             Broadcast::ChangeHost {
                 old_user,
                 new_username,
@@ -2468,12 +2478,14 @@ fn handle_broadcast(
             victim,
             reason,
             channel,
-            sent_time,
+            server_time,
+            received_with_server_time,
         } => dashboard.broadcast(
             server,
             casemapping,
             config,
-            sent_time,
+            server_time,
+            received_with_server_time,
             Broadcast::Kick {
                 kicker,
                 victim,

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -2564,6 +2564,7 @@ impl Dashboard {
                         casemapping,
                         config,
                         Utc::now(),
+                        false,
                         Broadcast::FilehostUploadFailed {
                             error: format!(
                                 "no filehost configured for server {server}"
@@ -2669,6 +2670,7 @@ impl Dashboard {
                     casemapping,
                     config,
                     Utc::now(),
+                    false,
                     Broadcast::FilehostUploadFailed {
                         error,
                         target: target.clone(),
@@ -3685,12 +3687,20 @@ impl Dashboard {
         server: &Server,
         casemapping: isupport::CaseMap,
         config: &Config,
-        sent_time: DateTime<Utc>,
+        server_time: DateTime<Utc>,
+        received_with_server_time: bool,
         broadcast: Broadcast,
     ) -> Task<Message> {
         Task::batch(
             self.history
-                .broadcast(server, casemapping, broadcast, config, sent_time)
+                .broadcast(
+                    server,
+                    casemapping,
+                    broadcast,
+                    config,
+                    server_time,
+                    received_with_server_time,
+                )
                 .into_iter()
                 .map(|task| Task::perform(task, Message::History)),
         )


### PR DESCRIPTION
Record whether server-time was received as a tag with the message or was generated from local time, since presence cannot be simply inferred from non-tag contents of the message.  If generated, then it is not used as a chathistory reference.  When joining a channel or server, the corresponding JOIN/RPL_LOGGEDIN is utilized as a reference;  in that case, if there is no server-time tag on the message then the generated server-time is offset into the future in case the local time is before the server's time (any repeat messages that might result from the offset should be handled by chathistory deduplication).