### PR TITLE
Check Changelog Action

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,18 @@
+name: Changelog
+
+on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+    paths:
+      - "**.rs"
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+
+jobs:
+  check-changelog:
+    name: Check Changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tarides/changelog-check-action@0189fc7eedec3ef3e9648c713908f6f2a6e99057 # v3
+        with:
+          changelog: CHANGELOG.md


### PR DESCRIPTION
Changelog check action for pull requests that change code.  Can be skipped by applying the `no changelog` label to a pull request.