### PR TITLE
Add keyring support for secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ Added:
 
 - Add clear buffer shortcut to title bar
 - Indicate in query if user is offline in its title bar
+- Add system keyring support for server, NickServ, channel, SASL, filehost credential, and proxy passwords
 
 Fixed:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,6 +819,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +962,15 @@ name = "caret"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bb840a063107846780a14acc022b55bf6c174997a393ffde8b58ff6630c1b56"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cc"
@@ -3602,6 +3620,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -6530,12 +6549,16 @@ version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a62d7f86047af0077255a29494136b9aaaf697c76ff70b8e49cded4e2623c14"
 dependencies = [
+ "aes",
+ "cbc",
  "futures-util",
  "generic-array",
  "getrandom 0.2.17",
+ "hkdf",
  "num",
  "once_cell",
  "serde",
+ "sha2 0.10.9",
  "zbus",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "apple-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7be2f067ccd8d4b4d4a66ddafe0f32a5dff31732f32dbff85fefc40929b1f72"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1528,6 +1539,7 @@ version = "0.1.0"
 dependencies = [
  "any_ascii",
  "anyhow",
+ "apple-native-keyring-store",
  "base64 0.22.1",
  "bytes",
  "chrono",
@@ -1550,6 +1562,7 @@ dependencies = [
  "infer",
  "irc",
  "itertools 0.15.0",
+ "keyring-core",
  "log",
  "mime_guess",
  "nom 8.0.0",
@@ -1578,7 +1591,9 @@ dependencies = [
  "unicode-segmentation",
  "url",
  "walkdir",
+ "windows-native-keyring-store",
  "xdg",
+ "zbus-secret-service-keyring-store",
 ]
 
 [[package]]
@@ -3861,6 +3876,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "khronos-egl"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4430,6 +4454,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4453,6 +4491,15 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -6475,6 +6522,21 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "secret-service"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a62d7f86047af0077255a29494136b9aaaf697c76ff70b8e49cded4e2623c14"
+dependencies = [
+ "futures-util",
+ "generic-array",
+ "getrandom 0.2.17",
+ "num",
+ "once_cell",
+ "serde",
+ "zbus",
 ]
 
 [[package]]
@@ -10004,6 +10066,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-native-keyring-store"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063426e76fdec7438d56bb777f67e318a84a25c707b07e575cb8b78e10c028f8"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10813,6 +10887,17 @@ dependencies = [
  "zbus_macros",
  "zbus_names",
  "zvariant",
+]
+
+[[package]]
+name = "zbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ccede190ba363386a24e8021c7f3848393976609ec9f5d1f8c6c09ef37075b4"
+dependencies = [
+ "keyring-core",
+ "secret-service",
+ "zbus",
 ]
 
 [[package]]

--- a/assets/flatpak/org.squidowl.halloy.json
+++ b/assets/flatpak/org.squidowl.halloy.json
@@ -14,7 +14,8 @@
         "--socket=fallback-x11",
         "--socket=pulseaudio",
         "--socket=wayland",
-        "--talk-name=org.freedesktop.Notifications"
+        "--talk-name=org.freedesktop.Notifications",
+        "--talk-name=org.freedesktop.secrets"
     ],
     "build-options": {
         "append-path" : "/usr/lib/sdk/rust-stable/bin"

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -82,7 +82,9 @@ apple-native-keyring-store = { version = "1", default-features = false, features
 ] }
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
-zbus-secret-service-keyring-store = "1"
+zbus-secret-service-keyring-store = { version = "1", features = [
+    "rt-tokio-crypto-rust",
+] }
 
 [target.'cfg(windows)'.dependencies]
 windows-native-keyring-store = { version = "1", default-features = false }

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -21,7 +21,7 @@ message_tests = ["iced/tokio"]
 [dependencies]
 thiserror = { workspace = true }
 futures = { workspace = true }
-tokio = { workspace = true, features = ["io-util", "fs"] }
+tokio = { workspace = true, features = ["io-util", "fs", "rt"] }
 chrono = { workspace = true }
 bytes = { workspace = true }
 strum = { workspace = true }

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -47,6 +47,7 @@ iced = { workspace = true, features = [
 ] }
 nom = { workspace = true }
 percent-encoding = { workspace = true }
+keyring-core = "1"
 
 base64 = "0.22.1"
 dirs-next = "2.0.0"
@@ -74,6 +75,17 @@ mime_guess = "2.0.5"
 any_ascii = "0.3.3"
 idna = "1.1.0"
 unicode-security = "0.1.2"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+apple-native-keyring-store = { version = "1", default-features = false, features = [
+    "keychain",
+] }
+
+[target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
+zbus-secret-service-keyring-store = "1"
+
+[target.'cfg(windows)'.dependencies]
+windows-native-keyring-store = { version = "1", default-features = false }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -567,10 +567,12 @@ impl Config {
 
         let mut proxy = proxy;
         if let Some(proxy) = &mut proxy {
-            proxy.set_password(
-                keyring::proxy_password_key,
-                "global proxy configuration",
-            )?;
+            proxy
+                .set_password(
+                    keyring::proxy_password_key,
+                    "global proxy configuration",
+                )
+                .await?;
         }
 
         let servers = ServerMap::new(

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -706,6 +706,21 @@ impl Config {
         Some(logs)
     }
 
+    pub fn load_font() -> Option<Font> {
+        #[derive(Default, Deserialize)]
+        #[serde(default)]
+        pub struct Configuration {
+            pub font: Font,
+        }
+
+        let path = Self::path();
+        let content = std::fs::read_to_string(path).ok()?;
+
+        let Configuration { font } = toml::from_str(content.as_ref()).ok()?;
+
+        Some(font)
+    }
+
     pub fn create_initial_config() {
         // Checks if a config file is there
         let config_file = Self::path();

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -860,9 +860,13 @@ pub enum Error {
     )]
     DuplicateProxyPassword { label: String, context: String },
     #[error(
-        "Exactly one of sasl.plain.password, sasl.plain.password_file, sasl.plain.password_command or sasl.plain.password_keyring must be set."
+        "Only one of password, password_file, password_command and password_keyring can be set for {label} in {context}."
     )]
-    DuplicateSaslPassword,
+    DuplicateSaslPassword { label: String, context: String },
+    #[error(
+        "{label} must be set for {context}; configure one of password, password_file, password_command or password_keyring."
+    )]
+    MissingSaslPassword { label: String, context: String },
     #[error("Keybind \"{}\" is assigned to multiple actions: {}", keybind.as_config_string(), actions.as_config_string())]
     KeyBindConflict { keybind: KeyBind, actions: Commands },
     #[error("{label} keyring entry `{key}` is missing for {context}.")]

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -52,6 +52,7 @@ pub mod file_transfer;
 pub mod filehost;
 pub mod highlights;
 pub mod inclusivities;
+pub mod keyring;
 pub mod keys;
 pub mod logs;
 pub mod metadata;
@@ -564,6 +565,14 @@ impl Config {
 
         keyboard.validate()?;
 
+        let mut proxy = proxy;
+        if let Some(proxy) = &mut proxy {
+            proxy.set_password(
+                keyring::proxy_password_key,
+                "global proxy configuration",
+            )?;
+        }
+
         let servers = ServerMap::new(
             servers,
             sidebar.order_channels_by,
@@ -833,19 +842,35 @@ pub enum Error {
     #[error(transparent)]
     LoadSounds(#[from] audio::LoadError),
     #[error(
-        "Only one of password, password_file and password_command can be set."
+        "Only one of password, password_file, password_command and password_keyring can be set."
     )]
     DuplicatePassword,
     #[error(
-        "Only one of nick_password, nick_password_file and nick_password_command can be set."
+        "Only one of nick_password, nick_password_file, nick_password_command and nick_password_keyring can be set."
     )]
     DuplicateNickPassword,
     #[error(
-        "Exactly one of sasl.plain.password, sasl.plain.password_file or sasl.plain.password_command must be set."
+        "Only one of channel_keys and channel_keys_keyring can be set for channel `{channel}` on server `{server}`."
+    )]
+    DuplicateChannelKey { server: String, channel: String },
+    #[error(
+        "Only one of password and password_keyring can be set for {label} in {context}."
+    )]
+    DuplicateProxyPassword { label: String, context: String },
+    #[error(
+        "Exactly one of sasl.plain.password, sasl.plain.password_file, sasl.plain.password_command or sasl.plain.password_keyring must be set."
     )]
     DuplicateSaslPassword,
     #[error("Keybind \"{}\" is assigned to multiple actions: {}", keybind.as_config_string(), actions.as_config_string())]
     KeyBindConflict { keybind: KeyBind, actions: Commands },
+    #[error("{label} keyring entry `{key}` is missing for {context}.")]
+    MissingKeyringPasswordEntry {
+        label: String,
+        context: String,
+        key: String,
+    },
+    #[error("could not access keyring entry `{key}`: {error}")]
+    Keyring { key: String, error: String },
     #[error("Config does not exist")]
     ConfigMissing,
 }

--- a/data/src/config/keyring.rs
+++ b/data/src/config/keyring.rs
@@ -86,7 +86,34 @@ pub fn server_proxy_password_key(server: &str, kind: &str) -> String {
     format!("servers.{server}.proxy.{kind}.password")
 }
 
-pub fn get_password(key: &str) -> Result<Option<String>, Error> {
+pub async fn get_password(key: &str) -> Result<Option<String>, Error> {
+    let key = key.to_string();
+    let task_key = key.clone();
+
+    tokio::task::spawn_blocking(move || get_password_blocking(&task_key))
+        .await
+        .map_err(|error| Error::Keyring {
+            key,
+            error: error.to_string(),
+        })?
+}
+
+pub async fn set_password(key: &str, password: &str) -> Result<(), Error> {
+    let key = key.to_string();
+    let password = password.to_string();
+    let task_key = key.clone();
+
+    tokio::task::spawn_blocking(move || {
+        set_password_blocking(&task_key, &password)
+    })
+    .await
+    .map_err(|error| Error::Keyring {
+        key,
+        error: error.to_string(),
+    })?
+}
+
+fn get_password_blocking(key: &str) -> Result<Option<String>, Error> {
     ensure_default_store(key)?;
 
     let entry = keyring_core::Entry::new(SERVICE, key).map_err(|error| {
@@ -106,7 +133,7 @@ pub fn get_password(key: &str) -> Result<Option<String>, Error> {
     }
 }
 
-pub fn set_password(key: &str, password: &str) -> Result<(), Error> {
+fn set_password_blocking(key: &str, password: &str) -> Result<(), Error> {
     ensure_default_store(key)?;
 
     let entry = keyring_core::Entry::new(SERVICE, key).map_err(|error| {

--- a/data/src/config/keyring.rs
+++ b/data/src/config/keyring.rs
@@ -220,6 +220,14 @@ mod tests {
     }
 
     #[test]
+    fn password_deserializes_disabled_boolean() {
+        let fixture: PasswordFixture =
+            toml::from_str("password_keyring = false").unwrap();
+
+        assert_eq!(fixture.password_keyring, Password::Disabled);
+    }
+
+    #[test]
     fn password_deserializes_custom_key() {
         let fixture: PasswordFixture =
             toml::from_str(r#"password_keyring = "custom.secret""#).unwrap();
@@ -227,6 +235,36 @@ mod tests {
         assert_eq!(
             fixture.password_keyring,
             Password::Key("custom.secret".to_string())
+        );
+    }
+
+    #[test]
+    fn password_enabled_uses_default_key() {
+        let password = Password::Enabled;
+
+        assert_eq!(
+            password.key_or_default(|| "default.secret".to_string()),
+            Some("default.secret".to_string())
+        );
+    }
+
+    #[test]
+    fn password_custom_key_overrides_default_key() {
+        let password = Password::Key("custom.secret".to_string());
+
+        assert_eq!(
+            password.key_or_default(|| "default.secret".to_string()),
+            Some("custom.secret".to_string())
+        );
+    }
+
+    #[test]
+    fn password_disabled_uses_no_key() {
+        let password = Password::Disabled;
+
+        assert_eq!(
+            password.key_or_default(|| "default.secret".to_string()),
+            None
         );
     }
 

--- a/data/src/config/keyring.rs
+++ b/data/src/config/keyring.rs
@@ -1,0 +1,257 @@
+use serde::{Deserialize, Deserializer};
+
+use super::Error;
+
+const SERVICE: &str = "chat.halloy";
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum Password {
+    #[default]
+    Disabled,
+    Enabled,
+    Key(String),
+}
+
+impl Password {
+    pub fn is_enabled(&self) -> bool {
+        !matches!(self, Password::Disabled)
+    }
+
+    pub fn key_or_default(
+        &self,
+        default: impl FnOnce() -> String,
+    ) -> Option<String> {
+        match self {
+            Password::Disabled => None,
+            Password::Enabled => Some(default()),
+            Password::Key(key) => Some(key.clone()),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Password {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Data {
+            Enabled(bool),
+            Key(String),
+        }
+
+        match Data::deserialize(deserializer)? {
+            Data::Enabled(true) => Ok(Password::Enabled),
+            Data::Enabled(false) => Ok(Password::Disabled),
+            Data::Key(key) => {
+                if key.is_empty() {
+                    Err(serde::de::Error::invalid_value(
+                        serde::de::Unexpected::Str(""),
+                        &"non-empty keyring entry name",
+                    ))
+                } else {
+                    Ok(Password::Key(key))
+                }
+            }
+        }
+    }
+}
+
+pub fn server_password_key(server: &str) -> String {
+    format!("servers.{server}.password")
+}
+
+pub fn nick_password_key(server: &str) -> String {
+    format!("servers.{server}.nick_password")
+}
+
+pub fn channel_key(server: &str, channel: &str) -> String {
+    format!("servers.{server}.channel_keys.{channel}")
+}
+
+pub fn sasl_plain_password_key(server: &str) -> String {
+    format!("servers.{server}.sasl.plain.password")
+}
+
+pub fn filehost_credentials_plain_password_key(server: &str) -> String {
+    format!("servers.{server}.filehost.credentials.plain.password")
+}
+
+pub fn proxy_password_key(kind: &str) -> String {
+    format!("proxy.{kind}.password")
+}
+
+pub fn server_proxy_password_key(server: &str, kind: &str) -> String {
+    format!("servers.{server}.proxy.{kind}.password")
+}
+
+pub fn get_password(key: &str) -> Result<Option<String>, Error> {
+    ensure_default_store(key)?;
+
+    let entry = keyring_core::Entry::new(SERVICE, key).map_err(|error| {
+        Error::Keyring {
+            key: key.to_string(),
+            error: error.to_string(),
+        }
+    })?;
+
+    match entry.get_password() {
+        Ok(password) => Ok(Some(password)),
+        Err(keyring_core::Error::NoEntry) => Ok(None),
+        Err(error) => Err(Error::Keyring {
+            key: key.to_string(),
+            error: error.to_string(),
+        }),
+    }
+}
+
+pub fn set_password(key: &str, password: &str) -> Result<(), Error> {
+    ensure_default_store(key)?;
+
+    let entry = keyring_core::Entry::new(SERVICE, key).map_err(|error| {
+        Error::Keyring {
+            key: key.to_string(),
+            error: error.to_string(),
+        }
+    })?;
+
+    entry
+        .set_password(password)
+        .map_err(|error| Error::Keyring {
+            key: key.to_string(),
+            error: error.to_string(),
+        })
+}
+
+fn ensure_default_store(key: &str) -> Result<(), Error> {
+    if keyring_core::get_default_store().is_some() {
+        return Ok(());
+    }
+
+    set_platform_default_store().map_err(|error| Error::Keyring {
+        key: key.to_string(),
+        error: error.to_string(),
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn set_platform_default_store() -> keyring_core::Result<()> {
+    use apple_native_keyring_store::keychain::Store;
+
+    keyring_core::set_default_store(Store::new()?);
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
+fn set_platform_default_store() -> keyring_core::Result<()> {
+    use zbus_secret_service_keyring_store::Store;
+
+    keyring_core::set_default_store(Store::new()?);
+    Ok(())
+}
+
+#[cfg(windows)]
+fn set_platform_default_store() -> keyring_core::Result<()> {
+    use windows_native_keyring_store::Store;
+
+    keyring_core::set_default_store(Store::new()?);
+    Ok(())
+}
+
+#[cfg(not(any(
+    target_os = "macos",
+    target_os = "linux",
+    target_os = "freebsd",
+    windows
+)))]
+fn set_platform_default_store() -> keyring_core::Result<()> {
+    Err(keyring_core::Error::NotSupportedByStore(
+        "No platform keyring store is configured for this target".to_string(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use serde::Deserialize;
+
+    use super::*;
+
+    #[derive(Debug, Deserialize)]
+    struct PasswordFixture {
+        password_keyring: Password,
+    }
+
+    #[test]
+    fn password_deserializes_enabled_boolean() {
+        let fixture: PasswordFixture =
+            toml::from_str("password_keyring = true").unwrap();
+
+        assert_eq!(fixture.password_keyring, Password::Enabled);
+    }
+
+    #[test]
+    fn password_deserializes_custom_key() {
+        let fixture: PasswordFixture =
+            toml::from_str(r#"password_keyring = "custom.secret""#).unwrap();
+
+        assert_eq!(
+            fixture.password_keyring,
+            Password::Key("custom.secret".to_string())
+        );
+    }
+
+    #[test]
+    fn password_rejects_empty_key() {
+        let error =
+            toml::from_str::<PasswordFixture>(r#"password_keyring = """#)
+                .unwrap_err();
+
+        assert!(
+            error.to_string().contains("non-empty keyring entry name"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn password_deserializes_map_values() {
+        #[derive(Debug, Deserialize)]
+        struct Fixture {
+            channel_keys_keyring: HashMap<String, Password>,
+        }
+
+        let fixture: Fixture =
+            toml::from_str(r##"channel_keys_keyring = { "#halloy" = true }"##)
+                .unwrap();
+
+        assert_eq!(
+            fixture.channel_keys_keyring.get("#halloy"),
+            Some(&Password::Enabled)
+        );
+    }
+
+    #[test]
+    fn default_key_names_are_stable() {
+        assert_eq!(server_password_key("libera"), "servers.libera.password");
+        assert_eq!(nick_password_key("libera"), "servers.libera.nick_password");
+        assert_eq!(
+            channel_key("libera", "#halloy"),
+            "servers.libera.channel_keys.#halloy"
+        );
+        assert_eq!(
+            sasl_plain_password_key("libera"),
+            "servers.libera.sasl.plain.password"
+        );
+        assert_eq!(
+            filehost_credentials_plain_password_key("libera"),
+            "servers.libera.filehost.credentials.plain.password"
+        );
+        assert_eq!(proxy_password_key("http"), "proxy.http.password");
+        assert_eq!(
+            server_proxy_password_key("libera", "socks5"),
+            "servers.libera.proxy.socks5.password"
+        );
+    }
+}

--- a/data/src/config/keyring.rs
+++ b/data/src/config/keyring.rs
@@ -92,10 +92,7 @@ pub async fn get_password(key: &str) -> Result<Option<String>, Error> {
 
     tokio::task::spawn_blocking(move || get_password_blocking(&task_key))
         .await
-        .map_err(|error| Error::Keyring {
-            key,
-            error: error.to_string(),
-        })?
+        .map_err(|error| keyring_error(key, error))?
 }
 
 pub async fn set_password(key: &str, password: &str) -> Result<(), Error> {
@@ -107,59 +104,46 @@ pub async fn set_password(key: &str, password: &str) -> Result<(), Error> {
         set_password_blocking(&task_key, &password)
     })
     .await
-    .map_err(|error| Error::Keyring {
-        key,
-        error: error.to_string(),
-    })?
+    .map_err(|error| keyring_error(key, error))?
 }
 
 fn get_password_blocking(key: &str) -> Result<Option<String>, Error> {
-    ensure_default_store(key)?;
+    ensure_default_store().map_err(|error| keyring_error(key, error))?;
 
-    let entry = keyring_core::Entry::new(SERVICE, key).map_err(|error| {
-        Error::Keyring {
-            key: key.to_string(),
-            error: error.to_string(),
-        }
-    })?;
+    let entry = keyring_core::Entry::new(SERVICE, key)
+        .map_err(|error| keyring_error(key, error))?;
 
     match entry.get_password() {
         Ok(password) => Ok(Some(password)),
         Err(keyring_core::Error::NoEntry) => Ok(None),
-        Err(error) => Err(Error::Keyring {
-            key: key.to_string(),
-            error: error.to_string(),
-        }),
+        Err(error) => Err(keyring_error(key, error)),
     }
 }
 
 fn set_password_blocking(key: &str, password: &str) -> Result<(), Error> {
-    ensure_default_store(key)?;
+    ensure_default_store().map_err(|error| keyring_error(key, error))?;
 
-    let entry = keyring_core::Entry::new(SERVICE, key).map_err(|error| {
-        Error::Keyring {
-            key: key.to_string(),
-            error: error.to_string(),
-        }
-    })?;
+    let entry = keyring_core::Entry::new(SERVICE, key)
+        .map_err(|error| keyring_error(key, error))?;
 
     entry
         .set_password(password)
-        .map_err(|error| Error::Keyring {
-            key: key.to_string(),
-            error: error.to_string(),
-        })
+        .map_err(|error| keyring_error(key, error))
 }
 
-fn ensure_default_store(key: &str) -> Result<(), Error> {
+fn ensure_default_store() -> keyring_core::Result<()> {
     if keyring_core::get_default_store().is_some() {
         return Ok(());
     }
 
-    set_platform_default_store().map_err(|error| Error::Keyring {
-        key: key.to_string(),
+    set_platform_default_store()
+}
+
+fn keyring_error(key: impl Into<String>, error: impl ToString) -> Error {
+    Error::Keyring {
+        key: key.into(),
         error: error.to_string(),
-    })
+    }
 }
 
 #[cfg(target_os = "macos")]

--- a/data/src/config/keyring.rs
+++ b/data/src/config/keyring.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Deserializer};
 use super::Error;
 
 const SERVICE: &str = "chat.halloy";
+#[cfg(any(windows, test))]
+const WINDOWS_MAX_USERNAME_LEN: usize = 513;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum Password {
@@ -108,6 +110,8 @@ pub async fn set_password(key: &str, password: &str) -> Result<(), Error> {
 }
 
 fn get_password_blocking(key: &str) -> Result<Option<String>, Error> {
+    #[cfg(windows)]
+    validate_key(key)?;
     ensure_default_store().map_err(|error| keyring_error(key, error))?;
 
     let entry = keyring_core::Entry::new(SERVICE, key)
@@ -121,6 +125,8 @@ fn get_password_blocking(key: &str) -> Result<Option<String>, Error> {
 }
 
 fn set_password_blocking(key: &str, password: &str) -> Result<(), Error> {
+    #[cfg(windows)]
+    validate_key(key)?;
     ensure_default_store().map_err(|error| keyring_error(key, error))?;
 
     let entry = keyring_core::Entry::new(SERVICE, key)
@@ -129,6 +135,26 @@ fn set_password_blocking(key: &str, password: &str) -> Result<(), Error> {
     entry
         .set_password(password)
         .map_err(|error| keyring_error(key, error))
+}
+
+#[cfg(windows)]
+fn validate_key(key: &str) -> Result<(), Error> {
+    if exceeds_windows_username_limit(key) {
+        return Err(keyring_error(
+            key,
+            format!(
+                "keyring identifier exceeds the Windows limit of \
+                 {WINDOWS_MAX_USERNAME_LEN} UTF-16 code units"
+            ),
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(any(windows, test))]
+fn exceeds_windows_username_limit(key: &str) -> bool {
+    key.encode_utf16().count() > WINDOWS_MAX_USERNAME_LEN
 }
 
 fn ensure_default_store() -> keyring_core::Result<()> {
@@ -223,6 +249,14 @@ mod tests {
     }
 
     #[test]
+    fn password_preserves_custom_key() {
+        let key = "Custom Key/日本語.한국어#MiXeD";
+        let password = Password::Key(key.to_string());
+
+        assert_eq!(password.key_or_default(String::new).as_deref(), Some(key));
+    }
+
+    #[test]
     fn password_enabled_uses_default_key() {
         let password = Password::Enabled;
 
@@ -302,5 +336,60 @@ mod tests {
             server_proxy_password_key("libera", "socks5"),
             "servers.libera.proxy.socks5.password"
         );
+    }
+
+    #[test]
+    fn default_key_names_preserve_special_characters_and_case() {
+        assert_eq!(
+            server_password_key("My Network"),
+            "servers.My Network.password"
+        );
+        assert_eq!(
+            server_password_key("example.org/channel"),
+            "servers.example.org/channel.password"
+        );
+        assert_eq!(
+            sasl_plain_password_key("日本語"),
+            "servers.日本語.sasl.plain.password"
+        );
+        assert_eq!(
+            nick_password_key("한국어-network"),
+            "servers.한국어-network.nick_password"
+        );
+        assert_eq!(
+            channel_key("libera", "#halloy"),
+            "servers.libera.channel_keys.#halloy"
+        );
+        assert_ne!(
+            server_password_key("Libera"),
+            server_password_key("libera")
+        );
+    }
+
+    #[test]
+    fn windows_username_length_counts_utf16_code_units() {
+        assert!(!exceeds_windows_username_limit(
+            &"a".repeat(WINDOWS_MAX_USERNAME_LEN)
+        ));
+        assert!(!exceeds_windows_username_limit(&"😀".repeat(256)));
+        assert!(exceeds_windows_username_limit(&"😀".repeat(257)));
+    }
+
+    #[test]
+    fn normal_identifier_is_within_windows_username_limit() {
+        let key = sasl_plain_password_key("libera");
+
+        assert!(key.encode_utf16().count() <= WINDOWS_MAX_USERNAME_LEN);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_identifier_length_is_validated() {
+        assert!(validate_key(&sasl_plain_password_key("libera")).is_ok());
+
+        let key = "😀".repeat(257);
+        let error = validate_key(&key).unwrap_err();
+
+        assert!(error.to_string().contains("513 UTF-16 code units"));
     }
 }

--- a/data/src/config/proxy.rs
+++ b/data/src/config/proxy.rs
@@ -28,7 +28,7 @@ pub enum Proxy {
 }
 
 impl Proxy {
-    pub fn set_password(
+    pub async fn set_password(
         &mut self,
         default_key: impl Fn(&str) -> String,
         context: &str,
@@ -38,24 +38,30 @@ impl Proxy {
                 password,
                 password_keyring,
                 ..
-            } => set_password(
-                password,
-                password_keyring,
-                default_key("http"),
-                "HTTP proxy password",
-                context,
-            ),
+            } => {
+                set_password(
+                    password,
+                    password_keyring,
+                    default_key("http"),
+                    "HTTP proxy password",
+                    context,
+                )
+                .await
+            }
             Proxy::Socks5 {
                 password,
                 password_keyring,
                 ..
-            } => set_password(
-                password,
-                password_keyring,
-                default_key("socks5"),
-                "SOCKS5 proxy password",
-                context,
-            ),
+            } => {
+                set_password(
+                    password,
+                    password_keyring,
+                    default_key("socks5"),
+                    "SOCKS5 proxy password",
+                    context,
+                )
+                .await
+            }
             #[cfg(feature = "tor")]
             Proxy::Tor => Ok(()),
         }
@@ -173,7 +179,7 @@ pub enum BuildError {
     Reqwest(#[from] reqwest::Error),
 }
 
-fn set_password(
+async fn set_password(
     password: &mut Option<String>,
     password_keyring: &keyring::Password,
     default_key: String,
@@ -191,7 +197,7 @@ fn set_password(
         });
     }
 
-    let pass = keyring::get_password(&key)?.ok_or_else(|| {
+    let pass = keyring::get_password(&key).await?.ok_or_else(|| {
         config::Error::MissingKeyringPasswordEntry {
             label: label.to_string(),
             context: context.to_string(),

--- a/data/src/config/proxy.rs
+++ b/data/src/config/proxy.rs
@@ -2,6 +2,8 @@ use std::fmt;
 
 use serde::Deserialize;
 
+use crate::config::{self, keyring};
+
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum Proxy {
@@ -10,15 +12,54 @@ pub enum Proxy {
         port: u16,
         username: Option<String>,
         password: Option<String>,
+        #[serde(default)]
+        password_keyring: keyring::Password,
     },
     Socks5 {
         host: String,
         port: u16,
         username: Option<String>,
         password: Option<String>,
+        #[serde(default)]
+        password_keyring: keyring::Password,
     },
     #[cfg(feature = "tor")]
     Tor,
+}
+
+impl Proxy {
+    pub fn set_password(
+        &mut self,
+        default_key: impl Fn(&str) -> String,
+        context: &str,
+    ) -> Result<(), config::Error> {
+        match self {
+            Proxy::Http {
+                password,
+                password_keyring,
+                ..
+            } => set_password(
+                password,
+                password_keyring,
+                default_key("http"),
+                "HTTP proxy password",
+                context,
+            ),
+            Proxy::Socks5 {
+                password,
+                password_keyring,
+                ..
+            } => set_password(
+                password,
+                password_keyring,
+                default_key("socks5"),
+                "SOCKS5 proxy password",
+                context,
+            ),
+            #[cfg(feature = "tor")]
+            Proxy::Tor => Ok(()),
+        }
+    }
 }
 
 impl From<Proxy> for irc::connection::Proxy {
@@ -29,6 +70,7 @@ impl From<Proxy> for irc::connection::Proxy {
                 port,
                 username,
                 password,
+                password_keyring: _,
             } => irc::connection::Proxy::Http {
                 host,
                 port,
@@ -40,6 +82,7 @@ impl From<Proxy> for irc::connection::Proxy {
                 port,
                 username,
                 password,
+                password_keyring: _,
             } => irc::connection::Proxy::Socks5 {
                 host,
                 port,
@@ -78,6 +121,7 @@ pub fn build_client(
             port,
             username,
             password,
+            password_keyring: _,
         }) => {
             let mut proxy =
                 reqwest::Proxy::all(format!("http://{host}:{port}"))?;
@@ -95,6 +139,7 @@ pub fn build_client(
             port,
             username,
             password,
+            password_keyring: _,
         }) => {
             let mut proxy =
                 reqwest::Proxy::all(format!("socks5://{host}:{port}"))?;
@@ -126,4 +171,35 @@ pub enum BuildError {
     Tor,
     #[error("reqwest error: {0}")]
     Reqwest(#[from] reqwest::Error),
+}
+
+fn set_password(
+    password: &mut Option<String>,
+    password_keyring: &keyring::Password,
+    default_key: String,
+    label: &'static str,
+    context: &str,
+) -> Result<(), config::Error> {
+    let Some(key) = password_keyring.key_or_default(|| default_key) else {
+        return Ok(());
+    };
+
+    if password.is_some() {
+        return Err(config::Error::DuplicateProxyPassword {
+            label: label.to_string(),
+            context: context.to_string(),
+        });
+    }
+
+    let pass = keyring::get_password(&key)?.ok_or_else(|| {
+        config::Error::MissingKeyringPasswordEntry {
+            label: label.to_string(),
+            context: context.to_string(),
+            key: key.clone(),
+        }
+    })?;
+
+    *password = Some(pass);
+
+    Ok(())
 }

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -421,6 +421,8 @@ impl Sasl {
         default_key: fn(&str) -> String,
         label: &'static str,
     ) -> Result<(), config::Error> {
+        let context = format!("server `{server}`");
+
         match self {
             Sasl::Plain {
                 password: Some(_),
@@ -439,14 +441,17 @@ impl Sasl {
                 let Some(key) =
                     password_keyring.key_or_default(|| default_key(server))
                 else {
-                    return Err(config::Error::DuplicateSaslPassword);
+                    return Err(config::Error::MissingSaslPassword {
+                        label: label.to_string(),
+                        context,
+                    });
                 };
 
                 let pass =
                     config::keyring::get_password(&key).await?.ok_or_else(
                         || config::Error::MissingKeyringPasswordEntry {
                             label: label.to_string(),
-                            context: format!("server `{server}`"),
+                            context: context.clone(),
                             key: key.clone(),
                         },
                     )?;
@@ -487,7 +492,10 @@ impl Sasl {
                 *password = Some(pass);
             }
             Sasl::Plain { .. } => {
-                return Err(config::Error::DuplicateSaslPassword);
+                return Err(config::Error::DuplicateSaslPassword {
+                    label: label.to_string(),
+                    context,
+                });
             }
             Sasl::External { .. } => {}
         }
@@ -779,7 +787,11 @@ mod tests {
             "SASL password",
         ));
 
-        assert!(matches!(result, Err(config::Error::DuplicateSaslPassword)));
+        assert!(matches!(
+            result,
+            Err(config::Error::DuplicateSaslPassword { label, context })
+                if label == "SASL password" && context == "server `libera`"
+        ));
     }
 
     #[test]
@@ -809,6 +821,43 @@ mod tests {
             config::keyring::Password::Enabled,
             None,
             Some("unused"),
+        ));
+    }
+
+    #[test]
+    fn sasl_plain_without_password_source_is_missing() {
+        let mut sasl =
+            plain_sasl(None, config::keyring::Password::Disabled, None, None);
+
+        let result = futures::executor::block_on(sasl.set_password(
+            "libera",
+            config::keyring::sasl_plain_password_key,
+            "SASL password",
+        ));
+
+        assert!(matches!(
+            result,
+            Err(config::Error::MissingSaslPassword { label, context })
+                if label == "SASL password" && context == "server `libera`"
+        ));
+    }
+
+    #[test]
+    fn filehost_plain_without_password_source_is_missing() {
+        let mut sasl =
+            plain_sasl(None, config::keyring::Password::Disabled, None, None);
+
+        let result = futures::executor::block_on(sasl.set_password(
+            "libera",
+            config::keyring::filehost_credentials_plain_password_key,
+            "Filehost credentials password",
+        ));
+
+        assert!(matches!(
+            result,
+            Err(config::Error::MissingSaslPassword { label, context })
+                if label == "Filehost credentials password"
+                    && context == "server `libera`"
         ));
     }
 }

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -44,6 +44,8 @@ pub struct Server {
     pub nickname: String,
     /// The client's NICKSERV password.
     pub nick_password: Option<String>,
+    /// The client's NICKSERV password keyring entry.
+    pub nick_password_keyring: config::keyring::Password,
     /// The client's NICKSERV password file.
     #[serde(
         deserialize_with = "deserialize_path_buf_with_path_transformations_maybe"
@@ -67,6 +69,8 @@ pub struct Server {
     pub port: Option<NonZeroU16>,
     /// The password to connect to the server.
     pub password: Option<String>,
+    /// The password keyring entry to connect to the server.
+    pub password_keyring: config::keyring::Password,
     /// The file with the password to connect to the server.
     #[serde(
         deserialize_with = "deserialize_path_buf_with_path_transformations_maybe"
@@ -84,6 +88,8 @@ pub struct Server {
     pub channels: Vec<String>,
     /// A mapping of channel names to keys for join-on-connect.
     pub channel_keys: HashMap<String, String>,
+    /// A mapping of channel names to keyring entries for join-on-connect.
+    pub channel_keys_keyring: HashMap<String, config::keyring::Password>,
     /// Order server's channels
     pub order_channels_by: Option<OrderChannelsBy>,
     /// A list of queries to add to the sidebar on connection.
@@ -225,12 +231,14 @@ impl Server {
     pub fn bouncer_config(&self) -> Self {
         Self {
             // nickserv info not relevant to the bounced network
+            nick_password_keyring: config::keyring::Password::default(),
             nick_password_file: Option::default(),
             nick_password_command: Option::default(),
             nick_identify_syntax: Option::default(),
 
             // channel_keys not relevant
             channel_keys: HashMap::default(),
+            channel_keys_keyring: HashMap::default(),
 
             // ghost sequence not relevant
             should_ghost: Default::default(),
@@ -262,6 +270,7 @@ impl Server {
             || self.password_file_first_line_only
                 != other.password_file_first_line_only
             || self.password_command != other.password_command
+            || self.password_keyring != other.password_keyring
             || self.sasl != other.sasl
             || self.irc_protocol_log != other.irc_protocol_log
     }
@@ -272,6 +281,7 @@ impl Default for Server {
         Self {
             nickname: String::default(),
             nick_password: Option::default(),
+            nick_password_keyring: config::keyring::Password::default(),
             nick_password_file: Option::default(),
             nick_password_file_first_line_only: true,
             nick_password_command: Option::default(),
@@ -282,6 +292,7 @@ impl Default for Server {
             server: String::default(),
             port: None,
             password: Option::default(),
+            password_keyring: config::keyring::Password::default(),
             password_file: Option::default(),
             password_file_first_line_only: true,
             password_command: Option::default(),
@@ -289,6 +300,7 @@ impl Default for Server {
             reroute: Reroute::default(),
             channels: Vec::default(),
             channel_keys: HashMap::default(),
+            channel_keys_keyring: HashMap::default(),
             order_channels_by: None,
             queries: Vec::default(),
             ping_time: 180,
@@ -340,6 +352,9 @@ pub enum Sasl {
         username: Option<String>,
         /// Account password,
         password: Option<String>,
+        /// Account password keyring entry
+        #[serde(default)]
+        password_keyring: config::keyring::Password,
         /// Account password file
         #[serde(
             default,
@@ -400,16 +415,47 @@ impl Sasl {
         }
     }
 
-    pub async fn set_password(&mut self) -> Result<(), config::Error> {
+    pub async fn set_password(
+        &mut self,
+        server: &str,
+        default_key: fn(&str) -> String,
+        label: &'static str,
+    ) -> Result<(), config::Error> {
         match self {
             Sasl::Plain {
                 password: Some(_),
+                password_keyring: config::keyring::Password::Disabled,
                 password_file: None,
                 password_command: None,
                 ..
             } => {}
             Sasl::Plain {
                 password: password @ None,
+                password_keyring,
+                password_file: None,
+                password_command: None,
+                ..
+            } => {
+                let Some(key) =
+                    password_keyring.key_or_default(|| default_key(server))
+                else {
+                    return Err(config::Error::DuplicateSaslPassword);
+                };
+
+                let pass =
+                    config::keyring::get_password(&key)?.ok_or_else(|| {
+                        config::Error::MissingKeyringPasswordEntry {
+                            label: label.to_string(),
+                            context: format!("server `{server}`"),
+                            key: key.clone(),
+                        }
+                    })?;
+
+                *password = Some(pass);
+            }
+            Sasl::Plain {
+                password: password @ None,
+                password_keyring: config::keyring::Password::Disabled,
                 password_file: Some(pass_file),
                 password_file_first_line_only,
                 password_command: None,
@@ -431,6 +477,7 @@ impl Sasl {
             }
             Sasl::Plain {
                 password: password @ None,
+                password_keyring: config::keyring::Password::Disabled,
                 password_file: None,
                 password_command: Some(pass_command),
                 ..

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -443,13 +443,13 @@ impl Sasl {
                 };
 
                 let pass =
-                    config::keyring::get_password(&key)?.ok_or_else(|| {
-                        config::Error::MissingKeyringPasswordEntry {
+                    config::keyring::get_password(&key).await?.ok_or_else(
+                        || config::Error::MissingKeyringPasswordEntry {
                             label: label.to_string(),
                             context: format!("server `{server}`"),
                             key: key.clone(),
-                        }
-                    })?;
+                        },
+                    )?;
 
                 *password = Some(pass);
             }

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -748,3 +748,67 @@ pub enum IrcProtocolLogFormat {
     Goguma,
     // TODO: ZNC format
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn plain_sasl(
+        password: Option<&str>,
+        password_keyring: config::keyring::Password,
+        password_file: Option<PathBuf>,
+        password_command: Option<&str>,
+    ) -> Sasl {
+        Sasl::Plain {
+            username: Some("user".to_string()),
+            password: password.map(str::to_string),
+            password_keyring,
+            password_file,
+            password_file_first_line_only: None,
+            password_command: password_command.map(str::to_string),
+            disconnect_on_failure: None,
+        }
+    }
+
+    fn assert_duplicate_sasl_password(mut sasl: Sasl) {
+        let result = futures::executor::block_on(sasl.set_password(
+            "libera",
+            config::keyring::sasl_plain_password_key,
+            "SASL password",
+        ));
+
+        assert!(matches!(result, Err(config::Error::DuplicateSaslPassword)));
+    }
+
+    #[test]
+    fn sasl_plain_password_and_keyring_are_duplicate() {
+        assert_duplicate_sasl_password(plain_sasl(
+            Some("password"),
+            config::keyring::Password::Enabled,
+            None,
+            None,
+        ));
+    }
+
+    #[test]
+    fn sasl_plain_password_file_and_keyring_are_duplicate() {
+        assert_duplicate_sasl_password(plain_sasl(
+            None,
+            config::keyring::Password::Enabled,
+            Some(PathBuf::from("unused")),
+            None,
+        ));
+    }
+
+    #[test]
+    fn sasl_plain_password_command_and_keyring_are_duplicate() {
+        assert_duplicate_sasl_password(plain_sasl(
+            None,
+            config::keyring::Password::Enabled,
+            None,
+            Some("unused"),
+        ));
+    }
+}

--- a/data/src/server.rs
+++ b/data/src/server.rs
@@ -166,14 +166,16 @@ impl ConfigMap {
                     Some(default_port(config.use_tls, config.use_websocket));
             }
             if let Some(proxy) = &mut config.proxy {
-                proxy.set_password(
-                    |kind| {
-                        config::keyring::server_proxy_password_key(
-                            &server, kind,
-                        )
-                    },
-                    &format!("server `{server}`"),
-                )?;
+                proxy
+                    .set_password(
+                        |kind| {
+                            config::keyring::server_proxy_password_key(
+                                &server, kind,
+                            )
+                        },
+                        &format!("server `{server}`"),
+                    )
+                    .await?;
             }
             if let Some(pass_file) = &config.password_file {
                 if config.password.is_some()
@@ -212,7 +214,8 @@ impl ConfigMap {
                     return Err(Error::DuplicatePassword);
                 }
 
-                let password = config::keyring::get_password(&key)?
+                let password = config::keyring::get_password(&key)
+                    .await?
                     .ok_or_else(|| Error::MissingKeyringPasswordEntry {
                         label: "Server password".to_string(),
                         context: format!("server `{server}`"),
@@ -260,7 +263,8 @@ impl ConfigMap {
                     return Err(Error::DuplicateNickPassword);
                 }
 
-                let password = config::keyring::get_password(&key)?
+                let password = config::keyring::get_password(&key)
+                    .await?
                     .ok_or_else(|| Error::MissingKeyringPasswordEntry {
                         label: "NickServ password".to_string(),
                         context: format!("server `{server}`"),
@@ -285,7 +289,8 @@ impl ConfigMap {
                     });
                 }
 
-                let password = config::keyring::get_password(&key)?
+                let password = config::keyring::get_password(&key)
+                    .await?
                     .ok_or_else(|| Error::MissingKeyringPasswordEntry {
                         label: format!("Channel key {channel}"),
                         context: format!("server `{server}`"),

--- a/data/src/server.rs
+++ b/data/src/server.rs
@@ -165,8 +165,19 @@ impl ConfigMap {
                 config.port =
                     Some(default_port(config.use_tls, config.use_websocket));
             }
+            if let Some(proxy) = &mut config.proxy {
+                proxy.set_password(
+                    |kind| {
+                        config::keyring::server_proxy_password_key(
+                            &server, kind,
+                        )
+                    },
+                    &format!("server `{server}`"),
+                )?;
+            }
             if let Some(pass_file) = &config.password_file {
                 if config.password.is_some()
+                    || config.password_keyring.is_enabled()
                     || config.password_command.is_some()
                 {
                     return Err(Error::DuplicatePassword);
@@ -187,13 +198,32 @@ impl ConfigMap {
                 config.password = Some(pass);
             }
             if let Some(pass_command) = &config.password_command {
-                if config.password.is_some() {
+                if config.password.is_some()
+                    || config.password_keyring.is_enabled()
+                {
                     return Err(Error::DuplicatePassword);
                 }
                 config.password = Some(read_from_command(pass_command).await?);
             }
+            if let Some(key) = config.password_keyring.key_or_default(|| {
+                config::keyring::server_password_key(&server)
+            }) {
+                if config.password.is_some() {
+                    return Err(Error::DuplicatePassword);
+                }
+
+                let password = config::keyring::get_password(&key)?
+                    .ok_or_else(|| Error::MissingKeyringPasswordEntry {
+                        label: "Server password".to_string(),
+                        context: format!("server `{server}`"),
+                        key: key.clone(),
+                    })?;
+
+                config.password = Some(password);
+            }
             if let Some(nick_pass_file) = &config.nick_password_file {
                 if config.nick_password.is_some()
+                    || config.nick_password_keyring.is_enabled()
                     || config.nick_password_command.is_some()
                 {
                     return Err(Error::DuplicateNickPassword);
@@ -214,21 +244,76 @@ impl ConfigMap {
                 config.nick_password = Some(nick_pass);
             }
             if let Some(nick_pass_command) = &config.nick_password_command {
-                if config.nick_password.is_some() {
+                if config.nick_password.is_some()
+                    || config.nick_password_keyring.is_enabled()
+                {
                     return Err(Error::DuplicateNickPassword);
                 }
                 config.nick_password =
                     Some(read_from_command(nick_pass_command).await?);
             }
+            if let Some(key) = config
+                .nick_password_keyring
+                .key_or_default(|| config::keyring::nick_password_key(&server))
+            {
+                if config.nick_password.is_some() {
+                    return Err(Error::DuplicateNickPassword);
+                }
+
+                let password = config::keyring::get_password(&key)?
+                    .ok_or_else(|| Error::MissingKeyringPasswordEntry {
+                        label: "NickServ password".to_string(),
+                        context: format!("server `{server}`"),
+                        key: key.clone(),
+                    })?;
+
+                config.nick_password = Some(password);
+            }
+            for (channel, password_keyring) in
+                config.channel_keys_keyring.clone()
+            {
+                let Some(key) = password_keyring.key_or_default(|| {
+                    config::keyring::channel_key(&server, &channel)
+                }) else {
+                    continue;
+                };
+
+                if config.channel_keys.contains_key(&channel) {
+                    return Err(Error::DuplicateChannelKey {
+                        server: server.to_string(),
+                        channel,
+                    });
+                }
+
+                let password = config::keyring::get_password(&key)?
+                    .ok_or_else(|| Error::MissingKeyringPasswordEntry {
+                        label: format!("Channel key {channel}"),
+                        context: format!("server `{server}`"),
+                        key: key.clone(),
+                    })?;
+
+                config.channel_keys.insert(channel, password);
+            }
             if let Some(sasl) = &mut config.sasl {
                 sasl.check_permissions(&server);
-                sasl.set_password().await?;
+                sasl.set_password(
+                    &server,
+                    config::keyring::sasl_plain_password_key,
+                    "SASL password",
+                )
+                .await?;
             }
             if let filehost::Credentials::Sasl(credentials) =
                 &mut config.filehost.credentials
             {
                 credentials.check_permissions(&server);
-                credentials.set_password().await?;
+                credentials
+                    .set_password(
+                        &server,
+                        config::keyring::filehost_credentials_plain_password_key,
+                        "Filehost credentials password",
+                    )
+                    .await?;
             }
 
             config.order_channels_by =

--- a/data/src/server.rs
+++ b/data/src/server.rs
@@ -461,3 +461,70 @@ impl Map {
         self.0.extract_if(0.., pred)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use super::*;
+
+    fn server_config() -> config::Server {
+        config::Server {
+            server: "irc.example.com".to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn load_server(config: config::Server) -> Result<ConfigMap, Error> {
+        futures::executor::block_on(ConfigMap::new(
+            vec![(Arc::<str>::from("libera"), config)],
+            OrderChannelsBy::Name,
+            Typing::default(),
+        ))
+    }
+
+    #[test]
+    fn password_and_keyring_are_duplicate() {
+        let mut config = server_config();
+        config.password = Some("password".to_string());
+        config.password_keyring = config::keyring::Password::Enabled;
+
+        assert!(matches!(load_server(config), Err(Error::DuplicatePassword)));
+    }
+
+    #[test]
+    fn password_file_and_keyring_are_duplicate() {
+        let mut config = server_config();
+        config.password_file = Some(PathBuf::from("unused"));
+        config.password_keyring = config::keyring::Password::Enabled;
+
+        assert!(matches!(load_server(config), Err(Error::DuplicatePassword)));
+    }
+
+    #[test]
+    fn password_command_and_keyring_are_duplicate() {
+        let mut config = server_config();
+        config.password_command = Some("unused".to_string());
+        config.password_keyring = config::keyring::Password::Enabled;
+
+        assert!(matches!(load_server(config), Err(Error::DuplicatePassword)));
+    }
+
+    #[test]
+    fn channel_key_and_keyring_are_duplicate_for_same_channel() {
+        let mut config = server_config();
+        config
+            .channel_keys
+            .insert("#halloy".to_string(), "password".to_string());
+        config
+            .channel_keys_keyring
+            .insert("#halloy".to_string(), config::keyring::Password::Enabled);
+
+        assert!(matches!(
+            load_server(config),
+            Err(Error::DuplicateChannelKey { server, channel })
+                if server == "libera" && channel == "#halloy"
+        ));
+    }
+}

--- a/data/src/server.rs
+++ b/data/src/server.rs
@@ -273,19 +273,17 @@ impl ConfigMap {
 
                 config.nick_password = Some(password);
             }
-            for (channel, password_keyring) in
-                config.channel_keys_keyring.clone()
-            {
+            for (channel, password_keyring) in &config.channel_keys_keyring {
                 let Some(key) = password_keyring.key_or_default(|| {
-                    config::keyring::channel_key(&server, &channel)
+                    config::keyring::channel_key(&server, channel)
                 }) else {
                     continue;
                 };
 
-                if config.channel_keys.contains_key(&channel) {
+                if config.channel_keys.contains_key(channel) {
                     return Err(Error::DuplicateChannelKey {
                         server: server.to_string(),
-                        channel,
+                        channel: channel.clone(),
                     });
                 }
 
@@ -297,7 +295,7 @@ impl ConfigMap {
                         key: key.clone(),
                     })?;
 
-                config.channel_keys.insert(channel, password);
+                config.channel_keys.insert(channel.clone(), password);
             }
             if let Some(sasl) = &mut config.sasl {
                 sasl.check_permissions(&server);

--- a/data/src/stream.rs
+++ b/data/src/stream.rs
@@ -498,7 +498,6 @@ async fn _run(
                                 default_proxy.as_ref(),
                             ) {
                                 connection_attempt = 0;
-
                                 let _ = sender.unbounded_send(
                                     Update::Disconnected {
                                         server: server.clone(),

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -38,6 +38,10 @@ const guidesItems = [
     text: "Storing Passwords in a File",
     link: "/guides/password-file",
   },
+  {
+    text: "Storing Passwords in the System Keyring",
+    link: "/guides/keyring",
+  },
   { text: "File Uploads", link: "/guides/filehost" },
   { text: "Unix Signals", link: "/guides/unix-signals" },
   { text: "Text Formatting", link: "/guides/text-formatting" },

--- a/docs/configuration/proxy.md
+++ b/docs/configuration/proxy.md
@@ -70,6 +70,21 @@ Proxy password.
 password = "password"
 ```
 
+### `password_keyring`
+
+Read `password` from the system keyring. Set to `true` to use the automatic keyring entry name `proxy.http.password`, or set a string to use a custom keyring entry name.
+
+```toml
+# Type: boolean or string
+# Values: true, false, or any non-empty string
+# Default: false
+
+# Optional
+
+[proxy.http]
+password_keyring = true
+```
+
 ## `socks5`
 
 Socks5 proxy settings.
@@ -132,6 +147,21 @@ Proxy password.
 
 [proxy.socks5]
 password = "password"
+```
+
+### `password_keyring`
+
+Read `password` from the system keyring. Set to `true` to use the automatic keyring entry name `proxy.socks5.password`, or set a string to use a custom keyring entry name.
+
+```toml
+# Type: boolean or string
+# Values: true, false, or any non-empty string
+# Default: false
+
+# Optional
+
+[proxy.socks5]
+password_keyring = true
 ```
 
 ## `tor`

--- a/docs/configuration/proxy.md
+++ b/docs/configuration/proxy.md
@@ -2,6 +2,13 @@
 
 Proxy settings for Halloy.
 
+::: info Keyring entry names
+Automatic keyring entry names are human-readable, and custom entry names are
+used unchanged. On Windows, entry names are limited to 513 UTF-16 code units
+and are case-insensitive, so names that differ only in capitalization refer to
+the same credential.
+:::
+
 ::: info
 [Preview](/configuration/preview) requests will be routed through the same proxy that the corresponding message is routed through (i.e. if a proxy is configured for a server, then all previews for messages on that server will be routed through the proxy).  Except for the for the [Tor](#tor) proxy;  when utilizing the Tor proxy preview requests are disabled.
 :::

--- a/docs/configuration/proxy.md
+++ b/docs/configuration/proxy.md
@@ -2,13 +2,6 @@
 
 Proxy settings for Halloy.
 
-::: info Keyring entry names
-Automatic keyring entry names are human-readable, and custom entry names are
-used unchanged. On Windows, entry names are limited to 513 UTF-16 code units
-and are case-insensitive, so names that differ only in capitalization refer to
-the same credential.
-:::
-
 ::: info
 [Preview](/configuration/preview) requests will be routed through the same proxy that the corresponding message is routed through (i.e. if a proxy is configured for a server, then all previews for messages on that server will be routed through the proxy).  Except for the for the [Tor](#tor) proxy;  when utilizing the Tor proxy preview requests are disabled.
 :::
@@ -79,7 +72,7 @@ password = "password"
 
 ### `password_keyring`
 
-Read `password` from the system keyring. Set to `true` to use the automatic keyring entry name `proxy.http.password`, or set a string to use a custom keyring entry name.
+Read `password` from the [system keyring](../guides/keyring.md). Set this to `true` to use `proxy.http.password`. Set a string to use a custom entry name.
 
 ```toml
 # Type: boolean or string
@@ -158,7 +151,7 @@ password = "password"
 
 ### `password_keyring`
 
-Read `password` from the system keyring. Set to `true` to use the automatic keyring entry name `proxy.socks5.password`, or set a string to use a custom keyring entry name.
+Read `password` from the [system keyring](../guides/keyring.md). Set this to `true` to use `proxy.socks5.password`. Set a string to use a custom entry name.
 
 ```toml
 # Type: boolean or string

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -35,6 +35,19 @@ The client's NICKSERV password. Whenever possible, using [`sasl.plain`](#sasl-pl
 nick_password = ""
 ```
 
+## `nick_password_keyring`
+
+Read `nick_password` from the system keyring. Set to `true` to use the automatic keyring entry name `servers.<name>.nick_password`, or set a string to use a custom keyring entry name.
+
+```toml
+# Type: boolean or string
+# Values: true, false, or any non-empty string
+# Default: false
+
+[servers.<name>]
+nick_password_keyring = true
+```
+
 ## `nick_password_file`
 
 Read `nick_password` from the file at the given path.[^1] [^2]
@@ -178,6 +191,19 @@ The password to connect to the server.
 password = ""
 ```
 
+## `password_keyring`
+
+Read `password` from the system keyring. Set to `true` to use the automatic keyring entry name `servers.<name>.password`, or set a string to use a custom keyring entry name.
+
+```toml
+# Type: boolean or string
+# Values: true, false, or any non-empty string
+# Default: false
+
+[servers.<name>]
+password_keyring = true
+```
+
 ## `password_file`
 
 Read password from the file at the given path.[^1] [^2]
@@ -253,6 +279,19 @@ A mapping of channel names to keys (passwords) for join-on-connect.
 
 [servers.<name>]
 channel_keys = { "#foo" = "password" }
+```
+
+## `channel_keys_keyring`
+
+A mapping of channel names to system keyring entries for join-on-connect. Set a channel to `true` to use the automatic keyring entry name `servers.<name>.channel_keys.<channel>`, or set a string to use a custom keyring entry name.
+
+```toml
+# Type: map
+# Values: map with string key and boolean or string value
+# Default: {}
+
+[servers.<name>]
+channel_keys_keyring = { "#foo" = true }
 ```
 
 ## `order_channels_by`
@@ -560,7 +599,7 @@ The configuration syntax and supported proxy types are similar to the global [Pr
 host = "192.168.1.100"
 port = 1080
 username = "username"
-password = "password"
+password_keyring = true
 ```
 
 or
@@ -570,8 +609,10 @@ or
 host = "192.168.1.100"
 port = 1080
 username = "username"
-password = "password"
+password_keyring = true
 ```
+
+With `password_keyring = true`, the automatic keyring entry names are `servers.<name>.proxy.http.password` and `servers.<name>.proxy.socks5.password`.
 
 ## `autoconnect`
 
@@ -754,6 +795,19 @@ The password associated with the account used for authentication.
 password = "password"
 ```
 
+### `password_keyring`
+
+Read `password` from the system keyring. Set to `true` to use the automatic keyring entry name `servers.<name>.sasl.plain.password`, or set a string to use a custom keyring entry name.
+
+```toml
+# Type: boolean or string
+# Values: true, false, or any non-empty string
+# Default: false
+
+[servers.<name>.sasl.plain]
+password_keyring = true
+```
+
 ### `password_file`
 
 Read `password` from the file at the given path.[^1] [^2]
@@ -928,6 +982,19 @@ The password associated with the account used for authentication.
 
 [servers.<name>.filehost.credentials.plain]
 password = "password"
+```
+
+##### `password_keyring`
+
+Read `password` from the system keyring. Set to `true` to use the automatic keyring entry name `servers.<name>.filehost.credentials.plain.password`, or set a string to use a custom keyring entry name.
+
+```toml
+# Type: boolean or string
+# Values: true, false, or any non-empty string
+# Default: false
+
+[servers.<name>.filehost.credentials.plain]
+password_keyring = true
 ```
 
 ##### `password_file`

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -9,13 +9,6 @@ Examples can be found in the following guides:
 - [Connect with soju](../guides/connect-with-soju.md)
 - [Connect with ZNC](../guides/connect-with-znc.md)
 
-::: info Keyring entry names
-Automatic keyring entry names are human-readable, and custom entry names are
-used unchanged. On Windows, entry names are limited to 513 UTF-16 code units
-and are case-insensitive, so names that differ only in capitalization refer to
-the same credential.
-:::
-
 ## `nickname`
 
 The client's nickname.
@@ -44,7 +37,7 @@ nick_password = ""
 
 ## `nick_password_keyring`
 
-Read `nick_password` from the system keyring. Set to `true` to use the automatic keyring entry name `servers.<name>.nick_password`, or set a string to use a custom keyring entry name.
+Read `nick_password` from the [system keyring](../guides/keyring.md). Set this to `true` to use `servers.<name>.nick_password`. Set a string to use a custom entry name.
 
 ```toml
 # Type: boolean or string
@@ -200,7 +193,7 @@ password = ""
 
 ## `password_keyring`
 
-Read `password` from the system keyring. Set to `true` to use the automatic keyring entry name `servers.<name>.password`, or set a string to use a custom keyring entry name.
+Read `password` from the [system keyring](../guides/keyring.md). Set this to `true` to use `servers.<name>.password`. Set a string to use a custom entry name.
 
 ```toml
 # Type: boolean or string
@@ -290,7 +283,7 @@ channel_keys = { "#foo" = "password" }
 
 ## `channel_keys_keyring`
 
-A mapping of channel names to system keyring entries for join-on-connect. Set a channel to `true` to use the automatic keyring entry name `servers.<name>.channel_keys.<channel>`, or set a string to use a custom keyring entry name.
+A map of channel names to [system keyring](../guides/keyring.md) entries. Set a channel to `true` to use `servers.<name>.channel_keys.<channel>`. Set a string to use a custom entry name.
 
 ```toml
 # Type: map
@@ -619,7 +612,7 @@ username = "username"
 password_keyring = true
 ```
 
-With `password_keyring = true`, the automatic keyring entry names are `servers.<name>.proxy.http.password` and `servers.<name>.proxy.socks5.password`.
+With `password_keyring = true`, Halloy uses `servers.<name>.proxy.http.password` or `servers.<name>.proxy.socks5.password`. See the [system keyring guide](../guides/keyring.md).
 
 ## `autoconnect`
 
@@ -804,7 +797,7 @@ password = "password"
 
 ### `password_keyring`
 
-Read `password` from the system keyring. Set to `true` to use the automatic keyring entry name `servers.<name>.sasl.plain.password`, or set a string to use a custom keyring entry name.
+Read `password` from the [system keyring](../guides/keyring.md). Set this to `true` to use `servers.<name>.sasl.plain.password`. Set a string to use a custom entry name.
 
 ```toml
 # Type: boolean or string
@@ -993,7 +986,7 @@ password = "password"
 
 ##### `password_keyring`
 
-Read `password` from the system keyring. Set to `true` to use the automatic keyring entry name `servers.<name>.filehost.credentials.plain.password`, or set a string to use a custom keyring entry name.
+Read `password` from the [system keyring](../guides/keyring.md). Set this to `true` to use `servers.<name>.filehost.credentials.plain.password`. Set a string to use a custom entry name.
 
 ```toml
 # Type: boolean or string

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -9,6 +9,13 @@ Examples can be found in the following guides:
 - [Connect with soju](../guides/connect-with-soju.md)
 - [Connect with ZNC](../guides/connect-with-znc.md)
 
+::: info Keyring entry names
+Automatic keyring entry names are human-readable, and custom entry names are
+used unchanged. On Windows, entry names are limited to 513 UTF-16 code units
+and are case-insensitive, so names that differ only in capitalization refer to
+the same credential.
+:::
+
 ## `nickname`
 
 The client's nickname.

--- a/docs/guides/keyring.md
+++ b/docs/guides/keyring.md
@@ -1,0 +1,39 @@
+# Storing Passwords in the System Keyring
+
+The system keyring keeps passwords out of your configuration file.
+
+Set a keyring option to `true`:
+
+```toml
+[servers.liberachat]
+password_keyring = true
+```
+
+If the entry is missing, Halloy asks for the password. Halloy then saves it in
+the system keyring.
+
+Use only one source for each password. For example, do not set both `password`
+and `password_keyring`.
+
+## Entry names
+
+The value `true` uses an automatic entry name. You can use your own name
+instead:
+
+```toml
+[servers.liberachat]
+password_keyring = "my-irc-password"
+```
+
+## System support
+
+Halloy uses these system stores:
+
+- macOS Keychain
+- Windows Credential Manager
+- Secret Service on Linux and FreeBSD
+
+On Windows, entry names are not case-sensitive.
+
+To replace a saved password, remove it from the system store. Halloy asks for
+it again when the configuration is loaded.

--- a/src/font.rs
+++ b/src/font.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::sync::{LazyLock, OnceLock};
 
 use data::appearance::theme::FontStyle;
-use data::{Config, config};
+use data::config;
 use iced::font;
 use iced::widget::text::LineHeight;
 
@@ -77,40 +77,33 @@ fn default_font() -> iced::Font {
     }
 }
 
-pub fn set(config: Option<&Config>) {
-    let font = config
-        .and_then(|config| config.font.family.clone())
-        .map_or_else(default_font, |family| {
-            iced::Font::with_family(family.as_str())
-        });
-    let stretch =
-        config.map_or(font::Stretch::Normal, |config| config.font.stretch);
-    let weight =
-        config.map_or(font::Weight::Normal, |config| config.font.weight);
-    let bold_weight = config
-        .and_then(|config| config.font.bold_weight)
-        .unwrap_or(match weight {
-            font::Weight::Thin => font::Weight::Normal,
-            font::Weight::ExtraLight => font::Weight::Medium,
-            font::Weight::Light => font::Weight::Semibold,
-            font::Weight::Normal => font::Weight::Bold,
-            font::Weight::Medium => font::Weight::ExtraBold,
-            font::Weight::Semibold
-            | font::Weight::Bold
-            | font::Weight::ExtraBold
-            | font::Weight::Black => font::Weight::Black,
-        });
+pub fn set(config: &config::Font) {
+    let font = config.family.as_ref().map_or_else(default_font, |family| {
+        iced::Font::with_family(family.as_str())
+    });
 
-    MONO.set(font, stretch, weight, bold_weight);
-    MONO_BOLD.set(font, stretch, weight, bold_weight);
-    MONO_ITALICS.set(font, stretch, weight, bold_weight);
-    MONO_BOLD_ITALICS.set(font, stretch, weight, bold_weight);
+    let bold_weight = config.bold_weight.unwrap_or(match config.weight {
+        font::Weight::Thin => font::Weight::Normal,
+        font::Weight::ExtraLight => font::Weight::Medium,
+        font::Weight::Light => font::Weight::Semibold,
+        font::Weight::Normal => font::Weight::Bold,
+        font::Weight::Medium => font::Weight::ExtraBold,
+        font::Weight::Semibold
+        | font::Weight::Bold
+        | font::Weight::ExtraBold
+        | font::Weight::Black => font::Weight::Black,
+    });
 
-    let lh = config
-        .and_then(|c| c.font.line_height)
+    MONO.set(font, config.stretch, config.weight, bold_weight);
+    MONO_BOLD.set(font, config.stretch, config.weight, bold_weight);
+    MONO_ITALICS.set(font, config.stretch, config.weight, bold_weight);
+    MONO_BOLD_ITALICS.set(font, config.stretch, config.weight, bold_weight);
+
+    let line_height = config
+        .line_height
         .map(LineHeight::Relative)
         .unwrap_or_default();
-    let _ = LINE_HEIGHT.set(lh);
+    let _ = LINE_HEIGHT.set(line_height);
 }
 
 pub fn load() -> Vec<Cow<'static, [u8]>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,9 +108,20 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     // shutdown_background without leaks
     rt.shutdown_background();
 
+    // If the config fails to load, then attempt to load the font alone
+    // in order to provide UI as close to configured as possible.
+    // Particularly of use while the font cannot be changed while
+    // the application is running.
+    let font_config = config_load
+        .as_ref()
+        .ok()
+        .map(|config| config.font.clone())
+        .or(Config::load_font())
+        .unwrap_or_default();
+
     // DANGER ZONE - font must be set using config
     // before we do any iced related stuff w/ it
-    font::set(config_load.as_ref().ok());
+    font::set(&font_config);
 
     let destination = data::Url::find_in(std::env::args());
     if let Some(loc) = &destination
@@ -119,7 +130,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let settings = settings(&config_load);
+    let settings = settings(&config_load, &font_config);
     let log_stream = Mutex::new(Some(log_stream));
 
     //tarkah: guess we need to move some stuff into the Halloy::new now.
@@ -155,12 +166,12 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn settings(config_load: &Result<Config, config::Error>) -> iced::Settings {
-    let default_text_size = config_load
-        .as_ref()
-        .ok()
-        .and_then(|config| config.font.size)
-        .map_or(theme::TEXT_SIZE, f32::from);
+fn settings(
+    config_load: &Result<Config, config::Error>,
+    font_config: &config::Font,
+) -> iced::Settings {
+    let default_text_size =
+        font_config.size.map_or(theme::TEXT_SIZE, f32::from);
 
     let runtime = config_load
         .as_ref()

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,12 +241,32 @@ struct Halloy {
 }
 
 impl Halloy {
+    fn modal_for_config_error(
+        config_load: &Result<Config, config::Error>,
+    ) -> Option<Modal> {
+        match config_load {
+            Err(config::Error::MissingKeyringPasswordEntry {
+                label,
+                context,
+                key,
+            }) => Some(Modal::KeyringPassword(
+                modal::keyring_password::KeyringPassword::new(
+                    label.clone(),
+                    context.clone(),
+                    key.clone(),
+                ),
+            )),
+            _ => None,
+        }
+    }
+
     pub fn load_from_state(
         main_window: window::Id,
         config_load: Result<Config, config::Error>,
         current_mode: appearance::Mode,
     ) -> (Halloy, Task<Message>) {
         let main_window = Window::new(main_window);
+        let modal = Self::modal_for_config_error(&config_load);
         let load_dashboard = |config: &Config| match data::Dashboard::load() {
             Ok(dashboard) => {
                 if config.pane.restore_on_launch {
@@ -315,7 +335,7 @@ impl Halloy {
                 servers,
                 controllers: stream::Map::default(),
                 config,
-                modal: None,
+                modal,
                 main_window,
                 focused_window: None,
                 pending_logs: vec![],
@@ -1120,6 +1140,26 @@ impl Halloy {
                                 ]);
                             }
                         }
+                        modal::Event::KeyringPasswordStored => {
+                            self.modal = None;
+
+                            let reload = if matches!(
+                                self.screen,
+                                Screen::Dashboard(_)
+                            ) {
+                                Task::perform(
+                                    Config::load(),
+                                    Message::ConfigReloaded,
+                                )
+                            } else {
+                                Task::perform(
+                                    Config::load(),
+                                    Message::ScreenConfigReloaded,
+                                )
+                            };
+
+                            return command.map(Message::Modal).chain(reload);
+                        }
                         modal::Event::AcceptNewServer => {
                             if let Some(Modal::ServerConnect {
                                 server,
@@ -1464,8 +1504,8 @@ impl Halloy {
 
             // Modals might have a id representing which window to be presented on.
             // If modal has no id, we show them on main_window.
-            match (&self.modal, &self.screen) {
-                (Some(modal), Screen::Dashboard(_))
+            match &self.modal {
+                Some(modal)
                     if modal.window_id() == Some(self.main_window.id)
                         || modal.window_id().is_none() =>
                 {
@@ -1677,7 +1717,18 @@ impl Halloy {
                 return runtime_task.unwrap_or_else(Task::none);
             }
             Err(error) => {
-                self.modal = Some(Modal::ReloadConfigurationError(error));
+                self.modal = match error {
+                    config::Error::MissingKeyringPasswordEntry {
+                        label,
+                        context,
+                        key,
+                    } => Some(Modal::KeyringPassword(
+                        modal::keyring_password::KeyringPassword::new(
+                            label, context, key,
+                        ),
+                    )),
+                    error => Some(Modal::ReloadConfigurationError(error)),
+                };
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,15 +241,15 @@ struct Halloy {
 }
 
 impl Halloy {
-    fn modal_for_config_error(
-        config_load: &Result<Config, config::Error>,
+    fn modal_for_missing_keyring_password(
+        error: &config::Error,
     ) -> Option<Modal> {
-        match config_load {
-            Err(config::Error::MissingKeyringPasswordEntry {
+        match error {
+            config::Error::MissingKeyringPasswordEntry {
                 label,
                 context,
                 key,
-            }) => Some(Modal::KeyringPassword(
+            } => Some(Modal::KeyringPassword(
                 modal::keyring_password::KeyringPassword::new(
                     label.clone(),
                     context.clone(),
@@ -266,7 +266,10 @@ impl Halloy {
         current_mode: appearance::Mode,
     ) -> (Halloy, Task<Message>) {
         let main_window = Window::new(main_window);
-        let modal = Self::modal_for_config_error(&config_load);
+        let modal = config_load
+            .as_ref()
+            .err()
+            .and_then(Self::modal_for_missing_keyring_password);
         let load_dashboard = |config: &Config| match data::Dashboard::load() {
             Ok(dashboard) => {
                 if config.pane.restore_on_launch {
@@ -1717,18 +1720,9 @@ impl Halloy {
                 return runtime_task.unwrap_or_else(Task::none);
             }
             Err(error) => {
-                self.modal = match error {
-                    config::Error::MissingKeyringPasswordEntry {
-                        label,
-                        context,
-                        key,
-                    } => Some(Modal::KeyringPassword(
-                        modal::keyring_password::KeyringPassword::new(
-                            label, context, key,
-                        ),
-                    )),
-                    error => Some(Modal::ReloadConfigurationError(error)),
-                };
+                let modal = Self::modal_for_missing_keyring_password(&error)
+                    .unwrap_or_else(|| Modal::ReloadConfigurationError(error));
+                self.modal = Some(modal);
             }
         }
 

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -11,6 +11,7 @@ pub mod about;
 pub mod confirm_file_upload;
 pub mod connect_to_server;
 pub mod image_preview;
+pub mod keyring_password;
 pub mod prompt_before_open_url;
 pub mod reload_configuration_error;
 
@@ -37,6 +38,7 @@ pub enum Modal {
         has_credentials: bool,
         window: window::Id,
     },
+    KeyringPassword(keyring_password::KeyringPassword),
 }
 
 #[derive(Debug, Clone)]
@@ -48,6 +50,7 @@ pub enum Message {
     ServerConnect(ServerConnect),
     About(about::Action),
     ImagePreview(ImagePreview),
+    KeyringPassword(keyring_password::Action),
 }
 
 #[derive(Debug, Clone)]
@@ -66,6 +69,7 @@ pub enum Event {
     CloseModal,
     AcceptNewServer,
     ConfirmFileUpload,
+    KeyringPasswordStored,
 }
 
 impl Modal {
@@ -81,6 +85,7 @@ impl Modal {
                 window,
             } => Some(*window),
             Modal::ConfirmFileUpload { window, .. } => Some(*window),
+            Modal::KeyringPassword(_) => None,
         }
     }
 
@@ -160,6 +165,13 @@ impl Modal {
                     (Task::none(), None)
                 }
             },
+            Message::KeyringPassword(action) => {
+                if let Modal::KeyringPassword(keyring_password) = self {
+                    keyring_password.update(action)
+                } else {
+                    (Task::none(), None)
+                }
+            }
         }
     }
 
@@ -185,6 +197,9 @@ impl Modal {
                 timer,
                 window: _,
             } => image_preview::view(image, timer, theme),
+            Modal::KeyringPassword(keyring_password) => {
+                keyring_password.view(theme)
+            }
         }
     }
 }

--- a/src/modal/keyring_password.rs
+++ b/src/modal/keyring_password.rs
@@ -1,0 +1,145 @@
+use data::config;
+use iced::widget::{button, column, container, text, text_input};
+use iced::{Length, Task, alignment};
+
+use super::{Event, Message};
+use crate::widget::Element;
+use crate::{Theme, font, theme};
+
+#[derive(Debug)]
+pub struct KeyringPassword {
+    pub label: String,
+    pub context: String,
+    pub key: String,
+    password: String,
+    error: Option<String>,
+    saving: bool,
+}
+
+#[derive(Debug, Clone)]
+pub enum Action {
+    PasswordChanged(String),
+    Save,
+    Saved(Result<(), String>),
+}
+
+impl KeyringPassword {
+    pub fn new(label: String, context: String, key: String) -> Self {
+        Self {
+            label,
+            context,
+            key,
+            password: String::new(),
+            error: None,
+            saving: false,
+        }
+    }
+
+    pub fn update(&mut self, action: Action) -> (Task<Message>, Option<Event>) {
+        match action {
+            Action::PasswordChanged(password) => {
+                self.password = password;
+                self.error = None;
+                (Task::none(), None)
+            }
+            Action::Save => {
+                if self.password.is_empty() || self.saving {
+                    return (Task::none(), None);
+                }
+
+                self.saving = true;
+                self.error = None;
+
+                let key = self.key.clone();
+                let password = self.password.clone();
+
+                (
+                    Task::perform(
+                        async move {
+                            config::keyring::set_password(&key, &password)
+                                .map_err(|error| error.to_string())
+                        },
+                        |result| {
+                            Message::KeyringPassword(Action::Saved(result))
+                        },
+                    ),
+                    None,
+                )
+            }
+            Action::Saved(Ok(())) => {
+                self.password.clear();
+                self.saving = false;
+                (Task::none(), Some(Event::KeyringPasswordStored))
+            }
+            Action::Saved(Err(error)) => {
+                self.error = Some(error);
+                self.saving = false;
+                (Task::none(), None)
+            }
+        }
+    }
+
+    pub fn view<'a>(&'a self, theme: &Theme) -> Element<'a, Message> {
+        let can_save = !self.password.is_empty() && !self.saving;
+        let save = can_save.then_some(Message::KeyringPassword(Action::Save));
+
+        let mut content = column![
+            text(format!("{} for {}", self.label, self.context)),
+            text(&self.key)
+                .style(theme::text::tertiary)
+                .font_maybe(theme::font_style::tertiary(theme).map(font::get)),
+            text_input("Password", &self.password)
+                .secure(true)
+                .on_input(|password| {
+                    Message::KeyringPassword(Action::PasswordChanged(password))
+                })
+                .on_submit_maybe(save.clone())
+                .width(Length::Fixed(300.0)),
+        ]
+        .spacing(12)
+        .align_x(iced::Alignment::Center);
+
+        if let Some(error) = &self.error {
+            content =
+                content.push(text(error).style(theme::text::error).font_maybe(
+                    theme::font_style::error(theme).map(font::get),
+                ));
+        }
+
+        let label = if self.saving { "Saving..." } else { "Save" };
+
+        content = content
+            .push(
+                button(
+                    container(text(label))
+                        .align_x(alignment::Horizontal::Center)
+                        .width(Length::Fill),
+                )
+                .padding(5)
+                .width(Length::Fixed(250.0))
+                .style(|theme, status| {
+                    theme::button::secondary(theme, status, false)
+                })
+                .on_press_maybe(save),
+            )
+            .push(
+                button(
+                    container(text("Cancel"))
+                        .align_x(alignment::Horizontal::Center)
+                        .width(Length::Fill),
+                )
+                .padding(5)
+                .width(Length::Fixed(250.0))
+                .style(|theme, status| {
+                    theme::button::secondary(theme, status, false)
+                })
+                .on_press(Message::Cancel),
+            );
+
+        container(content)
+            .width(Length::Shrink)
+            .style(theme::container::tooltip)
+            .padding(25)
+            .into()
+    }
+}

--- a/src/modal/keyring_password.rs
+++ b/src/modal/keyring_password.rs
@@ -57,6 +57,7 @@ impl KeyringPassword {
                     Task::perform(
                         async move {
                             config::keyring::set_password(&key, &password)
+                                .await
                                 .map_err(|error| error.to_string())
                         },
                         |result| {

--- a/src/modal/keyring_password.rs
+++ b/src/modal/keyring_password.rs
@@ -134,7 +134,7 @@ impl KeyringPassword {
                 .style(|theme, status| {
                     theme::button::secondary(theme, status, false)
                 })
-                .on_press(Message::Cancel),
+                .on_press_maybe((!self.saving).then_some(Message::Cancel)),
             );
 
         container(content)


### PR DESCRIPTION
This PR is introducing to allow secrets to be stored outside `config.toml` by adding system keyring support (Linux/FreeBSD, macOS, Windows) for SASL passwords and other passwords/secrets in the Halloy configuration file.

**It's need testing for all the cases X {Linux/FreeBSD, macOS, Windows}. See last topic**

## Add/Changes

- Added `keyring-core` with platform-specific stores for macOS, Linux/FreeBSD, and Windows.
- Added keyring config options for:
  - server passwords
  - NickServ passwords
  - channel keys
  - SASL PLAIN passwords
  - filehost PLAIN credentials
  - global and per-server proxy passwords
- Added automatic key names, for example:
  - `servers.libera.password`
  - `servers.libera.nick_password`
  - `servers.libera.sasl.plain.password`
  - `proxy.http.password`
- Added a generic password input modal for missing keyring entries.
- Extended duplicate secret-source validation and missing keyring-entry errors.
- Updated configuration docs and changelog.
- Added small unit tests for keyring config parsing and default key names.

## Things To Watch
- This does not migrate existing plaintext passwords automatically. Users need to enable `*_keyring = true` and remove the plaintext secret.
- Secrets are still resolved into the existing config structs at load time. This keeps the change small, but does not change the full in-memory secret lifecycle.
- `password`, `password_file`, `password_command`, and `password_keyring` are mutually exclusive.
- `channel_keys` and `channel_keys_keyring` cannot both be set for the same channel.
- Automatic channel key names include the channel prefix, e.g. `servers.libera.channel_keys.#halloy`.

## Request for Review & Testing
- Confirm that the default key names are intuitive.
- Confirm that the keyring service name `chat.halloy` is appropriate.
- Test the missing-keyring-entry flow:
  - set `password_keyring = true`
  - start Halloy
  - enter the password in the modal
  - verify that the config reloads successfully
- Test platform keyring behavior:
  - macOS Keychain
  - Linux Secret Service
  - Windows Credential Manager
- Test proxy passwords:
  - global proxy with `password_keyring`
  - per-server proxy with `password_keyring`
- Check reload behavior when changing a server’s `password_keyring`.


**As always: Feedback Welcome**

FR: #855 #681 
