### PR TITLE
Minor Nightly Actions Tweaks

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,9 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository == 'squidowl/halloy'
     name: Build
+
     strategy:
       matrix:
         target:
@@ -36,7 +38,9 @@ jobs:
             make: bash scripts/package-linux.sh package
             artifact_path: |
               echo "ARTIFACT_PATH=$(bash scripts/package-linux.sh archive_path)" >> "$GITHUB_ENV"
+
     runs-on: ${{ matrix.target.os }}
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -106,6 +110,7 @@ jobs:
   update-release:
     needs: build
     name: Update Release
+
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,11 +20,15 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository == 'squidowl/halloy'
+    name: Build
+
     runs-on: ubuntu-latest
     env:
       DOCS_CHANNEL: nightly
       DOCS_SHA: ${{ github.sha }}
       DOCS_BASE: /
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -52,10 +56,13 @@ jobs:
 
   deploy:
     needs: build
+    name: Deploy
+
     runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -12,11 +12,16 @@ APP_BINARY="$RELEASE_DIR/$TARGET"
 APP_BINARY_DIR="$APP_DIR/$APP_NAME/Contents/MacOS"
 APP_EXTRAS_DIR="$APP_DIR/$APP_NAME/Contents/Resources"
 
-DMG_NAME="halloy.dmg"
-DMG_DIR="$RELEASE_DIR/macos"
-
 VERSION=$(grep -q '\..*\.' VERSION && cat VERSION || echo "$(cat VERSION).0")
+NIGHTLY=$(cat NIGHTLY)
 BUILD=$(git describe --always --dirty --exclude='*')
+
+if [ "$VERSION" = "$NIGHTLY" ]; then
+  DMG_NAME="halloy-nightly.dmg"
+else
+  DMG_NAME="halloy.dmg"
+fi
+DMG_DIR="$RELEASE_DIR/macos"
 
 # update version and build
 sed -i '' -e "s/{{ VERSION }}/$VERSION/g" "$APP_TEMPLATE_PLIST"


### PR DESCRIPTION
- Adds a conditional on the nightly release & nightly documentation actions to only run for this repository.  The expectation being that some forks might want the check actions to run, but would be unlikely to also want the nightly actions to run (those that do can always re-enable the actions).
- Renames the macOS dmg for the nightly release to indicate it is a nightly release, in line with the other compiled assets.