### PR TITLE
only show tooltip for completing nicks if there is more than one option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Fixed:
 - Minor issues where input tooltips could fail to reflect current caret position, highlight the correct active argument, show when first the input is first loaded, etc
 - Show `Display` in `Configuration` docs menu
 - Document that `servers.<name>.username` setting will fall back to `servers.<name>.nickname` if not set
+- Nick completion tooltip no longer shows when there is only a single match
 
 Changed:
 

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -2262,7 +2262,7 @@ impl Words {
                 highlighted,
                 filtered,
                 ..
-            } => {
+            } if filtered.len() > 1 => {
                 let skip = {
                     let index = if let Some(index) = highlighted {
                         *index


### PR DESCRIPTION
it seems redundant to show it if we aren't disambiguating