### PR TITLE
Display version badge next to title on mobile

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -137,6 +137,7 @@ export default defineConfig({
   },
   themeConfig: {
     logo: "/logo.png",
+    siteTitle: `Halloy <span class="VPBadge info mobile-only">${releaseLabel}</span>`,
     search: {
       provider: "local",
     },

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -174,8 +174,10 @@ body,
   color: #f6b6c9;
   background: rgba(50, 48, 52, 0.9);
 }
+.mobile-only { display: none; }
 
 @media (max-width: 640px) {
+  .mobile-only { display: inline-block; }
   .vp-doc div[class*="language-"] {
     margin-left: 0;
     margin-right: 0;

--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -4,6 +4,7 @@
   "workspaces": {
     "": {
       "devDependencies": {
+        "@types/node": "^25.9.2",
         "markdown-it-footnote": "^4.0.0",
         "vitepress": "^2.0.0-alpha.16",
       },
@@ -162,6 +163,8 @@
 
     "@types/mdurl": ["@types/mdurl@2.0.0", "", {}, "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="],
 
+    "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/web-bluetooth": ["@types/web-bluetooth@0.0.21", "", {}, "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA=="],
@@ -297,6 +300,8 @@
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -23,7 +23,7 @@ Bug reports should be reported on our repository on GitHub in the [issue tracker
 
 All patches have to be sent on GitHub as [pull requests](https://github.com/squidowl/halloy/pulls).
 
-Should you wish to work on an issue, please leave a comment on it or let us know on ircs://irc.libera.chat/\#halloy in order to claim the issue.  Significant new features, especially those not specified by IRCv3, should be discussed before submission to ensure they fit with the project.
+Should you wish to work on an issue, please leave a comment on it or let us know on <ircs://irc.libera.chat/#halloy> in order to claim the issue.  Significant new features, especially those not specified by IRCv3, should be discussed before submission to ensure they fit with the project.
 
 If you are looking for a place to start contributing, take a look at the [easy](https://github.com/squidowl/halloy/issues?q=is%3Aissue%20state%3Aopen%20label%3Aeasy) issues.
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {},
   "devDependencies": {
+    "@types/node": "^25.9.2",
     "markdown-it-footnote": "^4.0.0",
     "vitepress": "^2.0.0-alpha.16"
   },


### PR DESCRIPTION
Added a badge to display the version of the docs on mobile:

<img width="529" height="918" alt="Screenshot_20260608_132052" src="https://github.com/user-attachments/assets/be38fb75-7500-4db1-8815-69e1171567e3" />

Also added `@types/node` as a dev dependency so that node types are properly used in IDE.

Reasoning is that it's not obvious what version the docs are for when viewing from mobile.

Currently, you can only view the version by opening up the hamburger menu:
<img width="534" height="424" alt="image" src="https://github.com/user-attachments/assets/396582c9-5140-466d-8fdc-a8c8ac4650a6" />
