### PR TITLE
Decode html strings in preview card descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Unreleased
 
+Fixed:
+
+- Decode html strings in preview card descriptions
+
+Thanks:
+
+- Contributions: @englut
+
 # 2026.7.2 (2026-06-08)
 
 Added:

--- a/data/src/preview.rs
+++ b/data/src/preview.rs
@@ -329,7 +329,8 @@ async fn load_uncached(
                     .ok_or(LoadError::MissingProperty("url"))?,
                 image,
                 title: title.ok_or(LoadError::MissingProperty("title"))?,
-                description,
+                description: description
+                    .map(|description| decode_html_string(&description)),
             }))
         }
     }


### PR DESCRIPTION
added decoding html strings to preview card descriptions


| Before | After |
|--------|--------|
| <img width="731" height="641" alt="Screenshot_20260608_190347" src="https://github.com/user-attachments/assets/4e26e0ac-67b1-42e4-a1d3-146e83877511" /> | <img width="715" height="636" alt="Screenshot_20260608_190507" src="https://github.com/user-attachments/assets/a8b78459-e651-4102-9afc-33279844b681" /> | 
