### PR TITLE
Decode html strings in preview card descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Added:
 
 - Improved legibility of the returned values of `MONITOR` list (`/monitor L`)
+- Config option (`preview.card.description_decode_html`) to decode html strings in preview card descriptions
 
 Fixed:
 

--- a/data/src/config/preview.rs
+++ b/data/src/config/preview.rs
@@ -241,6 +241,8 @@ pub struct Card {
     pub description_max_height: f32,
     /// Maximum height of the image in pixels
     pub image_max_height: f32,
+    /// Decode non-standard encoding of html entities
+    pub description_decode_html: Enabled,
 }
 
 impl Default for Card {
@@ -254,6 +256,7 @@ impl Default for Card {
             max_width: 400.0,
             description_max_height: 100.0,
             image_max_height: 200.0,
+            description_decode_html: Enabled::Boolean(false),
         }
     }
 }

--- a/data/src/preview.rs
+++ b/data/src/preview.rs
@@ -18,7 +18,7 @@ use url::Url;
 
 pub use self::card::Card;
 use crate::cache::{self, Asset, CacheState, CachedAsset, FileCache};
-use crate::config::preview::Visibility;
+use crate::config::preview::{Enabled, Visibility};
 use crate::image::Image;
 use crate::message::Source;
 use crate::server::Server;
@@ -321,6 +321,22 @@ async fn load_uncached(
                 fetch(image_url, client, config, cache).await?
             else {
                 return Err(LoadError::NotImage);
+            };
+
+            let description = match &config.card.description_decode_html {
+                Enabled::Boolean(true) => description
+                    .map(|description| decode_html_string(&description)),
+                Enabled::Regex(regexes) => {
+                    if regexes.iter().any(|regex| {
+                        regex.is_match(url.as_str()).unwrap_or(false)
+                    }) {
+                        description
+                            .map(|description| decode_html_string(&description))
+                    } else {
+                        description
+                    }
+                }
+                _ => description,
             };
 
             Ok(Preview::Card(Card {

--- a/docs/configuration/preview.md
+++ b/docs/configuration/preview.md
@@ -26,7 +26,7 @@ Without literal strings, you'd have to write the above as `"\\bfoo'd\\b"`
 ```toml
 [preview]
 enabled = [
-    '''https?://(www\.)?imgur\.com/.*''', 
+    '''https?://(www\.)?imgur\.com/.*''',
     '''https?://(www\.)?dr\.dk/.*'''
 ]
 ```
@@ -55,7 +55,7 @@ Without literal strings, you'd have to write the above as `"\\bfoo'd\\b"`
 ```toml
 [preview]
 exclude = [
-    '''https?://(www\.)?example\.com/.*''', 
+    '''https?://(www\.)?example\.com/.*''',
     '''https?://(www\.)?spam-site\.net/.*'''
 ]
 ```
@@ -198,6 +198,41 @@ explicitly excluded, so this setting is only relevant when combined with the
 include = { users = ["BridgeBot"] }
 ```
 
+### `description_decode_html`
+
+`og:description` is always a string, but due to it being in HTML it needs to be
+escaped. Sometimes you may get double-escaped entries in this field, this
+setting will allow you to handle this scenario.
+
+::: warning
+Using this option may break purposely created `og:description` entries meant to include
+HTML escape codes.
+:::
+
+```toml
+# Type: boolean or array of strings
+# Values: true, false, or array of regex patterns
+# Default: false
+
+[preview.card]
+description_decode_html = true
+```
+
+To whitelist specific domains, you can use an array of regex patterns.
+
+::: tip
+Use toml multi-line literal strings `'''\bfoo'd\b'''` when writing a regex. This allows you to write the regex without escaping. You can also use a literal string `'\bfoo\b'`, but then you can't use `'` inside the string.
+
+Without literal strings, you'd have to write the above as `"\\bfoo'd\\b"`
+:::
+
+```toml
+[preview.card]
+description_decode_html = [
+    '''https?://(www\.)?github\.com/.*''',
+]
+```
+
 ## `image`
 
 Specific image preview settings.
@@ -312,11 +347,11 @@ include = { users = ["BridgeBot"] }
 
 ## `image_cache`
 
-Settings to control how the image cache is managed.  The cache is stored in:
+Settings to control how the image cache is managed. The cache is stored in:
 
-* Windows: `%AppData%\Roaming\Local\halloy\previews\images\`
-* Mac: `~/Library/Caches/halloy/previews/images/` or `$HOME/.cache/halloy/previews/images/`
-* Linux: `$XDG_CACHE_HOME/halloy/previews/images/`, `$HOME/.cache/halloy/previews/images/`, or `$HOME/.var/app/org.squidowl.halloy/cache/halloy/previews/images/` (Flatpak)
+- Windows: `%AppData%\Roaming\Local\halloy\previews\images\`
+- Mac: `~/Library/Caches/halloy/previews/images/` or `$HOME/.cache/halloy/previews/images/`
+- Linux: `$XDG_CACHE_HOME/halloy/previews/images/`, `$HOME/.cache/halloy/previews/images/`, or `$HOME/.var/app/org.squidowl.halloy/cache/halloy/previews/images/` (Flatpak)
 
 ### `max_size`
 
@@ -373,7 +408,7 @@ Request timeout in milliseconds. Defaults is 10s.
 [preview.request]
 timeout_ms = 10000
 ```
- 
+
 ### `max_image_size`
 
 Max image size in bytes. This prevents downloading responses that are too big. Default is 10mb.


### PR DESCRIPTION
Re-opening #2087 with a new config option:

added ability to decode html strings in preview card descriptions

```toml
# Type: boolean
# Values: true, false
# Default: false

[preview.card]
description_decode_html = true
```

Only decode html in preview descriptions for matching URLs:

```toml
[preview.card]
description_decode_html = [
    '''https?://(www\.)?github\.com/.*''',
]
```
| Before | After |
|--------|--------|
| <img width="731" height="641" alt="Screenshot_20260608_190347" src="https://github.com/user-attachments/assets/4e26e0ac-67b1-42e4-a1d3-146e83877511" /> | <img width="715" height="636" alt="Screenshot_20260608_190507" src="https://github.com/user-attachments/assets/a8b78459-e651-4102-9afc-33279844b681" /> | 