### PR TITLE
Use `docsChannel` to indicate nightly

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -137,7 +137,7 @@ export default defineConfig({
   },
   themeConfig: {
     logo: "/logo.png",
-    siteTitle: `Halloy <span class="VPBadge info mobile-only">${releaseLabel}</span>`,
+    siteTitle: `Halloy <span class="VPBadge info mobile-only">${docsChannel}</span>`,
     search: {
       provider: "local",
     },


### PR DESCRIPTION
Using `docsChannel` instead of `releaseLabel` to cover indicating nightly docs when appropriate 🙏