### PR TITLE
Miscellaneous Fixes/Tweaks

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,7 @@ jobs:
             os: macos-latest
             make: bash scripts/build-macos.sh
             artifact_path: |
-              echo "ARTIFACT_PATH=target/packaging/macos/halloy.dmg" >> "$GITHUB_ENV"
+              echo "ARTIFACT_PATH=target/packaging/macos/halloy-nightly.dmg" >> "$GITHUB_ENV"
           - target: windows
             os: windows-latest
             make: bash scripts/build-windows-installer.sh --nightly
@@ -143,7 +143,7 @@ jobs:
         target:
           - artifact: macos
             artifact_name: |
-              echo "ARTIFACT_NAME=halloy.dmg" >> "$GITHUB_ENV"
+              echo "ARTIFACT_NAME=halloy-nightly.dmg" >> "$GITHUB_ENV"
             asset_type: application/octet-stream
           - artifact: windows
             artifact_name: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,21 @@
 # Unreleased
 
+Added:
+
+- Improved legibility of the returned values of `MONITOR` list (`/monitor L`)
+
 Fixed:
 
 - Nick highlight improvements
   - Handle nick possessives `<nick>'s` (`<nick>` should be parsed)
   - Skip parsing nicks inside abbreviations (`e.g.` shouldn't have highlights)
+- Do not send duplicate `JOIN` message when using `/join`
+- Do not send `MARKREAD` for non-`PRIVMSG`/`NOTICE` messages when the server does not support echoes
+- Do not show unread/highlight indicators for ignored messages
+
+Changed:
+
+- `change_mode` server messages are categorized as `actions` (i.e. `actions_dimmed` controls whether they are dimmed by default)
 
 Thanks:
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -3102,9 +3102,6 @@ impl Client {
                 };
                 return Ok(events);
             }
-            Command::Numeric(RPL_ENDOFMONLIST, _) => {
-                return Ok(vec![]);
-            }
             Command::MARKREAD(target, Some(timestamp)) => {
                 if let Some(read_marker) = timestamp
                     .strip_prefix("timestamp=")

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -385,6 +385,7 @@ impl Message {
                 }
                 _ => false,
             }
+            && !self.blocked
     }
 
     pub fn triggers_highlight(&self) -> bool {
@@ -397,6 +398,7 @@ impl Message {
                     Fragment::HighlightNick(_, _) | Fragment::HighlightMatch(_)
                 )
             })
+            && !self.blocked
         {
             true
         } else {

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -3675,6 +3675,18 @@ fn content<'a>(
                 None,
             ))
         }
+        Command::Numeric(RPL_MONLIST, params) => {
+            let user = User::from(Nick::from_str(params.get(1)?, casemapping));
+
+            Some((
+                parse_fragments_with_user(
+                    format!("{} is being monitored", user.nickname()),
+                    &user,
+                    casemapping,
+                ),
+                None,
+            ))
+        }
         Command::CHATHISTORY(sub, args) => {
             if sub == "TARGETS" {
                 let target = args.first()?;

--- a/data/src/message/source.rs
+++ b/data/src/message/source.rs
@@ -158,7 +158,6 @@ pub mod server {
                 | Kind::Quit
                 | Kind::JoinTopic
                 | Kind::ChangeHost
-                | Kind::ChangeMode
                 | Kind::ChangeNick
                 | Kind::Away => false,
                 Kind::MonitoredOnline
@@ -166,6 +165,7 @@ pub mod server {
                 | Kind::StandardReply(_)
                 | Kind::WAllOps
                 | Kind::Kick
+                | Kind::ChangeMode
                 | Kind::ChangeTopic
                 | Kind::Invite
                 | Kind::RequestTopic => true,

--- a/docs/configuration/buffer.md
+++ b/docs/configuration/buffer.md
@@ -1073,14 +1073,15 @@ The default server message type (`buffer.server_messages.default`) splits this s
 | ---------------------- | ---------------------------- | --------------------- |
 | **Setting**            | `passive_dimmed` or `dimmed` | `actions_dimmed`      |
 | **Default**            | `true`                       | `false`               |
-| **Event Types**        | `away`                       | `change_topic`        |
-|                        | `change_host`                | `invite`              |
-|                        | `change_mode`                | `kick`                |
-|                        | `change_nick`                | `monitored_offline`   |
-|                        | `join`                       | `monitored_online`    |
-|                        | `join_topic`                 | `request_topic`       |
-|                        | `quit`                       | `standard_reply_fail` |
-|                        | `part`                       | `standard_reply_note` |
+| **Event Types**        | `away`                       | `change_mode`         |
+|                        | `change_host`                | `change_topic`        |
+|                        | `change_nick`                | `invite`              |
+|                        | `join`                       | `kick`                |
+|                        | `join_topic`                 | `monitored_offline`   |
+|                        | `part`                       | `monitored_online`    |
+|                        | `quit`                       | `request_topic`       |
+|                        |                              | `standard_reply_fail` |
+|                        |                              | `standard_reply_note` |
 |                        |                              | `standard_reply_warn` |
 |                        |                              | `wallops`             |
 :::

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -16,13 +16,6 @@ VERSION=$(grep -q '\..*\.' VERSION && cat VERSION || echo "$(cat VERSION).0")
 NIGHTLY=$(cat NIGHTLY)
 BUILD=$(git describe --always --dirty --exclude='*')
 
-if [ "$VERSION" = "$NIGHTLY" ]; then
-  DMG_NAME="halloy-nightly.dmg"
-else
-  DMG_NAME="halloy.dmg"
-fi
-DMG_DIR="$RELEASE_DIR/macos"
-
 # update version and build
 sed -i '' -e "s/{{ VERSION }}/$VERSION/g" "$APP_TEMPLATE_PLIST"
 sed -i '' -e "s/{{ BUILD }}/$BUILD/g" "$APP_TEMPLATE_PLIST"

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -4,7 +4,13 @@ PROFILE="packaging"
 RELEASE_DIR="target/$PROFILE"
 APP_DIR="$RELEASE_DIR/macos"
 APP_NAME="Halloy.app"
-DMG_NAME="halloy.dmg"
+VERSION=$(grep -q '\..*\.' VERSION && cat VERSION || echo "$(cat VERSION).0")
+NIGHTLY=$(cat NIGHTLY)
+if [ "$VERSION" = "$NIGHTLY" ]; then
+  DMG_NAME="halloy-nightly.dmg"
+else
+  DMG_NAME="halloy.dmg"
+fi
 DMG_DIR="$RELEASE_DIR/macos"
 
 # package dmg

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -571,53 +571,6 @@ pub fn view<'a>(
     )
     .into();
 
-    let new_maybe_our_user = || -> Option<Element<'a, Message>> {
-        if config.buffer.text_input.nickname.enabled {
-            our_user.map(|user| {
-                let user_display = UserDisplay::new(
-                    user,
-                    config.buffer.text_input.nickname.show_access_levels,
-                    config.buffer.nickname.show_bot_icon,
-                    registry,
-                    &config.display.nickname,
-                    None,
-                    config.display.truncation_character,
-                    None,
-                    true,
-                );
-
-                container(user_display.into_element(
-                    user,
-                    user.is_away(),
-                    false,
-                    None,
-                    None,
-                    false,
-                    false,
-                    theme,
-                    config,
-                ))
-                .padding(padding::right(4))
-                .into()
-            })
-        } else {
-            None
-        }
-    };
-
-    let new_maybe_vertical_rule = |maybe_our_user: &Option<
-        Element<'a, Message>,
-    >|
-     -> Option<Element<'a, Message>> {
-        maybe_our_user
-            .is_some()
-            .then_some(rule::vertical(1.0).into())
-    };
-
-    let maybe_our_user = new_maybe_our_user();
-
-    let maybe_vertical_rule = new_maybe_vertical_rule(&maybe_our_user);
-
     let maybe_upload_spinner: Option<crate::widget::Element<'a, Message>> =
         (filehost_url.is_some() && state.uploading > 0).then(|| {
             let icon: crate::widget::Element<'a, Message> =
@@ -688,16 +641,13 @@ pub fn view<'a>(
     });
 
     let input_row = container(
-        row![
-            maybe_our_user,
-            maybe_vertical_rule,
-            wrapped_input,
-            maybe_upload_spinner,
-            maybe_upload_button,
-        ]
-        .spacing(INPUT_ROW_SPACING)
-        .height(Length::Shrink)
-        .align_y(Alignment::Center),
+        row![]
+            .extend(maybe_our_user(our_user, registry, config, theme))
+            .push(wrapped_input)
+            .extend(maybe_upload_spinner.into_iter().chain(maybe_upload_button))
+            .spacing(INPUT_ROW_SPACING)
+            .height(Length::Shrink)
+            .align_y(Alignment::Center),
     )
     .max_height((7.55 * theme::resolve_line_height(&config.font).ceil()).ceil())
     .padding(8);
@@ -741,12 +691,10 @@ pub fn view<'a>(
             .into()
         };
 
-        let maybe_our_user = new_maybe_our_user();
-
-        let maybe_vertical_rule = new_maybe_vertical_rule(&maybe_our_user);
-
         let overlay = double_pass(
-            row![maybe_our_user, maybe_vertical_rule, overlay()]
+            row![]
+                .extend(maybe_our_user(our_user, registry, config, theme))
+                .push(overlay())
                 .spacing(INPUT_ROW_SPACING),
             row![Space::new().width(Length::Fill), overlay()],
         );
@@ -763,6 +711,50 @@ pub fn view<'a>(
     }
 }
 
+fn maybe_our_user<'a>(
+    our_user: Option<&User>,
+    registry: &'a dyn metadata::Registry,
+    config: &'a Config,
+    theme: &'a Theme,
+) -> impl IntoIterator<Item = Element<'a, Message>> {
+    if config.buffer.text_input.nickname.enabled {
+        our_user
+            .map(|user| {
+                let user_display = UserDisplay::new(
+                    user,
+                    config.buffer.text_input.nickname.show_access_levels,
+                    config.buffer.nickname.show_bot_icon,
+                    registry,
+                    &config.display.nickname,
+                    None,
+                    config.display.truncation_character,
+                    None,
+                    true,
+                );
+
+                vec![
+                    container(user_display.into_element(
+                        user,
+                        user.is_away(),
+                        false,
+                        None,
+                        None,
+                        false,
+                        false,
+                        theme,
+                        config,
+                    ))
+                    .padding(padding::right(4))
+                    .into(),
+                    rule::vertical(1.0).into(),
+                ]
+            })
+            .unwrap_or_default()
+    } else {
+        vec![]
+    }
+    .into_iter()
+}
 fn reply_bar<'a>(
     reply_preview: &'a message::ReplyPreview,
     channel_users: Option<&'a ChannelUsers>,

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -2529,52 +2529,58 @@ impl State {
             }
         };
 
-        let labeled_response_context = if let Some(mut encoded) =
-            input.encoded()
-        {
-            let reply_id = self
-                .draft_reply
-                .as_ref()
-                .map(|input::DraftReply { id, .. }| id);
+        let labeled_response_context =
+            if let Some(mut encoded) = input.encoded() {
+                let reply_id = self
+                    .draft_reply
+                    .as_ref()
+                    .map(|input::DraftReply { id, .. }| id);
 
-            encoded.set_reply_to(reply_id);
+                encoded.set_reply_to(reply_id);
 
-            let sent_time = encoded.server_time_or_now().0;
+                let sent_time = encoded.server_time_or_now().0;
 
-            let labeled_response_context =
-                clients.send(buffer, encoded, TokenPriority::User);
+                let labeled_response_context =
+                    clients.send(buffer, encoded, TokenPriority::User);
 
-            let supports_echoes =
-                clients.get_server_supports_echoes(buffer.server());
+                let supports_echoes =
+                    clients.get_server_supports_echoes(buffer.server());
 
-            // If the server supports echoes, then send MARKREAD on echo only
-            // (not when recording the input)
-            if config.buffer.mark_as_read.on_message_sent && !supports_echoes {
-                let chantypes =
-                    clients.get_server_chantypes_or_default(buffer.server());
-                let statusmsg =
-                    clients.get_server_statusmsg_or_default(buffer.server());
-                let casemapping =
-                    clients.get_server_casemapping_or_default(buffer.server());
-
-                if let Some(targets) =
-                    input.targets(chantypes, statusmsg, casemapping)
+                // If the server supports echoes, then send MARKREAD on echo only
+                // (not when recording the input)
+                if config.buffer.mark_as_read.on_message_sent
+                    && matches!(
+                        input.command(),
+                        Some(command::Irc::Msg(_, _))
+                            | Some(command::Irc::Notice(_, _))
+                    )
+                    && !supports_echoes
                 {
-                    for target in targets {
-                        clients.send_markread(
-                            buffer.server(),
-                            target,
-                            ReadMarker::from(sent_time),
-                            TokenPriority::High,
-                        );
+                    let chantypes = clients
+                        .get_server_chantypes_or_default(buffer.server());
+                    let statusmsg = clients
+                        .get_server_statusmsg_or_default(buffer.server());
+                    let casemapping = clients
+                        .get_server_casemapping_or_default(buffer.server());
+
+                    if let Some(targets) =
+                        input.targets(chantypes, statusmsg, casemapping)
+                    {
+                        for target in targets {
+                            clients.send_markread(
+                                buffer.server(),
+                                target,
+                                ReadMarker::from(sent_time),
+                                TokenPriority::High,
+                            );
+                        }
                     }
                 }
-            }
 
-            labeled_response_context
-        } else {
-            None
-        };
+                labeled_response_context
+            } else {
+                None
+            };
 
         let mut history_task = Task::none();
 

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1,9 +1,9 @@
 use std::collections::{HashMap, HashSet, VecDeque, hash_map};
+use std::convert;
 use std::ops::RangeInclusive;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use std::{convert, slice};
 
 use chrono::{DateTime, Utc};
 use data::capabilities::{
@@ -4755,29 +4755,6 @@ impl Dashboard {
         )
     }
 
-    fn open_channel(
-        &mut self,
-        server: Server,
-        channel: target::Channel,
-        clients: &mut data::client::Map,
-        buffer_action: BufferAction,
-        config: &Config,
-    ) -> Task<Message> {
-        let buffer = buffer::Upstream::Channel(server.clone(), channel.clone());
-
-        // Need to join channel
-        if !clients.contains_channel(&server, &channel) {
-            clients.join(&server, slice::from_ref(&channel));
-        }
-
-        self.open_buffer(
-            data::Buffer::Upstream(buffer),
-            buffer_action,
-            clients,
-            config,
-        )
-    }
-
     pub fn open_target(
         &mut self,
         server: Server,
@@ -4787,19 +4764,19 @@ impl Dashboard {
         config: &Config,
     ) -> Task<Message> {
         match target {
-            Target::Channel(channel) => self.open_channel(
-                server,
-                channel,
-                clients,
-                buffer_action,
-                config,
-            ),
+            Target::Channel(channel) => {
+                let buffer = data::Buffer::Upstream(buffer::Upstream::Channel(
+                    server, channel,
+                ));
+
+                self.open_buffer(buffer, buffer_action, clients, config)
+            }
             Target::Query(query) => {
                 let buffer = data::Buffer::Upstream(buffer::Upstream::Query(
                     server, query,
                 ));
 
-                self.open_buffer(buffer.clone(), buffer_action, clients, config)
+                self.open_buffer(buffer, buffer_action, clients, config)
             }
         }
     }


### PR DESCRIPTION
A collection of minor fixes/tweaks:
- Improved legibility of the returned values of `MONITOR` list (`/monitor L`)
- Do not send duplicate `JOIN` message when using `/join`
- Do not send `MARKREAD` for non-`PRIVMSG`/`NOTICE` messages when the server does not support echoes
- Do not show unread/highlight indicators for ignored messages
- `change_mode` server messages are categorized as `actions` (i.e. `actions_dimmed` controls whether they are dimmed by default)
- Updates nightly build with `-nightly` naming across all assets