### PR TITLE
Don't dup message bytes before parsing

### DIFF
--- a/irc/proto/src/parse.rs
+++ b/irc/proto/src/parse.rs
@@ -12,8 +12,8 @@ use nom::{Finish, IResult, Parser};
 
 use crate::{Command, Message, Source, Tags, User};
 
-pub fn message_bytes(bytes: Vec<u8>) -> Result<Message, Error> {
-    let input = String::from_utf8_lossy(&bytes);
+pub fn message_bytes(bytes: &[u8]) -> Result<Message, Error> {
+    let input = String::from_utf8_lossy(bytes);
     message(&input)
 }
 
@@ -496,7 +496,7 @@ mod test {
         ];
 
         for (test, expected) in tests {
-            let message = super::message_bytes(test).unwrap();
+            let message = super::message_bytes(&test).unwrap();
             assert_eq!(message, expected);
         }
     }

--- a/irc/src/codec.rs
+++ b/irc/src/codec.rs
@@ -20,9 +20,7 @@ impl Decoder for Codec {
             return Ok(None);
         };
 
-        let bytes = Vec::from(src.split_to(pos + 2));
-
-        Ok(Some(parse::message_bytes(bytes)))
+        Ok(Some(parse::message_bytes(&src.split_to(pos + 2))))
     }
 }
 


### PR DESCRIPTION
The first allocation may happen if the slice
isn't a valid UTF-8 string or when we run
the nom parser over it.
