### PR TITLE
Move highlights button out of hamburger menu

### DIFF
--- a/data/src/config/sidebar.rs
+++ b/data/src/config/sidebar.rs
@@ -31,6 +31,7 @@ pub struct Sidebar {
     #[serde(alias = "server_font_size")]
     pub primary_font_size: Option<u8>,
     pub user_menu: UserMenu,
+    pub highlights_button: HighlightsButton,
     pub padding: Padding,
     pub spacing: Spacing,
     pub order_channels_by: OrderChannelsBy,
@@ -136,6 +137,18 @@ pub struct UserMenu {
 }
 
 impl Default for UserMenu {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Deserialize)]
+#[serde(default)]
+pub struct HighlightsButton {
+    pub enabled: bool,
+}
+
+impl Default for HighlightsButton {
     fn default() -> Self {
         Self { enabled: true }
     }

--- a/docs/configuration/sidebar.md
+++ b/docs/configuration/sidebar.md
@@ -359,6 +359,23 @@ Controls whether the user menu is shown in the sidebar or hidden
 enabled = true
 ```
 
+## `highlights_button`
+
+Highlights button in sidebar settings.
+
+### `enabled`
+
+Controls whether the highlights button is shown in the sidebar or hidden
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: true
+
+[sidebar.highlights_button]
+enabled = true
+```
+
 ## `padding`
 
 Adjust padding for sidebar

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -496,7 +496,10 @@ impl Sidebar {
         }
 
         let content = |width| {
-            let highlights_button = self.highlights_button(history);
+            let highlights_button =
+                config.sidebar.highlights_button.enabled.then(|| {
+                    self.highlights_button(history)
+                });
 
             let user_menu_button =
                 config.sidebar.user_menu.enabled.then(|| {

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -208,6 +208,16 @@ impl Sidebar {
         }
     }
 
+    fn highlights_button<'a>(&self) -> Element<'a, Message> {
+        button(icon::highlights().size(theme::ICON_SIZE + 2.0))
+            .padding(5)
+            .width(Length::Shrink)
+            .on_press(Message::ToggleInternalBuffer(
+                buffer::Internal::Highlights,
+            ))
+            .into()
+    }
+
     fn user_menu_button<'a>(
         &self,
         config: &'a Config,
@@ -343,14 +353,6 @@ impl Sidebar {
                                     buffer::Internal::FileTransfers,
                                 ),
                             ),
-                            Menu::Highlights => context_button(
-                                text("Highlights"),
-                                Some(&keyboard.highlights),
-                                icon::highlights().style(theme::svg::primary),
-                                Message::ToggleInternalBuffer(
-                                    buffer::Internal::Highlights,
-                                ),
-                            ),
                             Menu::ChannelDiscovery => context_button(
                                 text("Channel Discovery"),
                                 None,
@@ -473,6 +475,8 @@ impl Sidebar {
         }
 
         let content = |width| {
+            let highlights_button = self.highlights_button();
+
             let user_menu_button =
                 config.sidebar.user_menu.enabled.then(|| {
                     self.user_menu_button(
@@ -693,10 +697,10 @@ impl Sidebar {
                         )
                     ];
 
-                    // Wrap buffers in a column with user_menu_button
+                    // Wrap buffers in a column with highlights and user_menu_button side by side
                     let content = column![
                         container(buffers).height(Length::Fill),
-                        user_menu_button,
+                        row![user_menu_button, highlights_button],
                     ];
 
                     container(content)
@@ -721,9 +725,10 @@ impl Sidebar {
                         )
                     ];
 
-                    // Wrap buffers in a row with user_menu_button
+                    // Wrap buffers in a row with highlights and user_menu_button
                     let content = row![
                         container(buffers).width(Length::Fill),
+                        highlights_button,
                         user_menu_button,
                     ]
                     .align_y(Alignment::Center);
@@ -781,7 +786,6 @@ enum Menu {
     RefreshConfig,
     CommandBar,
     ThemeEditor,
-    Highlights,
     ChannelDiscovery,
     Logs,
     FileTransfers,
@@ -813,7 +817,6 @@ impl Menu {
 
         list.extend([
             Self::ChannelDiscovery,
-            Self::Highlights,
             Self::Logs,
             Self::OpenConfigFile,
             Self::RefreshConfig,

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -208,14 +208,35 @@ impl Sidebar {
         }
     }
 
-    fn highlights_button<'a>(&self) -> Element<'a, Message> {
-        button(icon::highlights().size(theme::ICON_SIZE + 2.0))
+    fn highlights_button<'a>(
+        &self,
+        history: &'a history::Manager,
+    ) -> Element<'a, Message> {
+        let has_unread = history.has_highlight(&history::Kind::Highlights);
+
+        let base = button(icon::highlights().size(theme::ICON_SIZE + 2.0))
             .padding(5)
             .width(Length::Shrink)
             .on_press(Message::ToggleInternalBuffer(
                 buffer::Internal::Highlights,
-            ))
-            .into()
+            ));
+
+        stack![
+            base,
+            if has_unread {
+                Some(
+                    container(
+                        icon::dot()
+                            .style(theme::text::highlight_indicator)
+                            .size(8),
+                    )
+                    .padding(padding::left(13).top(2)),
+                )
+            } else {
+                None
+            },
+        ]
+        .into()
     }
 
     fn user_menu_button<'a>(
@@ -475,7 +496,7 @@ impl Sidebar {
         }
 
         let content = |width| {
-            let highlights_button = self.highlights_button();
+            let highlights_button = self.highlights_button(history);
 
             let user_menu_button =
                 config.sidebar.user_menu.enabled.then(|| {


### PR DESCRIPTION
Move the highlights button out of the hamburger menu and place it beside it instead. Add a visual notifier (based on the one used for channels with unread highlights) when there are unread highlights.

Fixes #1987

> [!NOTE]
> I am not a Rust developer by trade, so I can't say whether this is the best way to approach this. I'm happy to iterate on this with feedback. I'm also happy to close it out if it's particularly bad or the request is not a priority.
