### PR TITLE
cap token bucket refill at capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Changed:
 
 Thanks:
 
-- Contributions: @englut, @luca020400, @classabbyamp
+- Contributions: @englut, @luca020400, @classabbyamp, @KaiKorla
 - Bug reports: @luca020400, agent314
 
 # 2026.7.2 (2026-06-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Fixed:
 - Do not send `MARKREAD` for non-`PRIVMSG`/`NOTICE` messages when the server does not support echoes
 - Do not show unread/highlight indicators for ignored messages
 - Do not copy empty selections to the primary clipboard (i.e. do not clear the primary clipboard when a non-selection action is performed, such as moving the cursor or focusing the text input on some systems)
+- Prevent anti-flood rate limiting from refilling the token bucket beyond its configured capacity
 
 Changed:
 

--- a/data/src/rate_limit.rs
+++ b/data/src/rate_limit.rs
@@ -127,7 +127,7 @@ impl<T> TokenBucket<T> {
                         .saturating_add(
                             new_permits.try_into().unwrap_or(self.capacity),
                         )
-                        .max(self.capacity);
+                        .min(self.capacity);
 
                     self.last = Some(now);
                 }
@@ -195,4 +195,21 @@ pub enum TokenPriority {
     Low,  // Polls & other automated messages for retrieving metadata
     High, // Most automated messages
     User, // Messages that the user triggers directly
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_bucket_refill_does_not_exceed_capacity() {
+        let start = Instant::now();
+        let mut bucket = TokenBucket::<usize>::new(Duration::from_secs(1), 3);
+        bucket.available_permits = 1;
+        bucket.last = Some(start);
+
+        bucket.add_permits(start + Duration::from_secs(10));
+
+        assert_eq!(bucket.available_permits, 3);
+    }
 }


### PR DESCRIPTION
Use min instead of max when replenishing permits so the bucket refills gradually and never exceeds its configured capacity.

Add test for capacity clamping.