### PR TITLE
Add explicit portable mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Added:
 - Keyboard shortcuts validation (e.g no duplicate key binds)
 - `actions.buffer.click_nickname` and `actions.nicklist.click_nickname` can be used to specify whether a nickname will: open query and how the query is opened, insert nickname in the input box, or no action (`"no-action"` or `"noop"`); takes over functionality from `buffer.nickname.click` and `buffer.channel.nicklist.click` and adds the ability to perform no action
 - `actions.buffer.click_channel_name` and `actions.buffer.click_highlight` can be set to no action (`"no-action"` or `"noop"`) to not open the channel when clicking on the channel name
+- Explicit portable mode
 
 Fixed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Changed:
 
 Thanks:
 
-- Contributions: @englut, @luca020400, @classabbyamp, @KaiKorla
+- Contributions: @englut, @luca020400, @classabbyamp, @KaiKorla, @TheDcoder
 - Bug reports: @luca020400, agent314
 
 # 2026.7.2 (2026-06-08)

--- a/data/src/environment.rs
+++ b/data/src/environment.rs
@@ -38,9 +38,19 @@ pub fn cache_dir() -> PathBuf {
         .join("halloy")
 }
 
-/// Checks if a config file exists in the same directory as the executable.
+/// Checks if a portable dir is explicitly set or if a config file
+/// exists in the same directory as the executable.
 /// If so, it'll use that directory for both config & data dirs.
 fn portable_dir() -> Option<PathBuf> {
+    if let Some(path) = env::var_os("HALLOY_PORTABLE_DIR") {
+        let path = PathBuf::from(path);
+        if path.is_dir() {
+            return Some(path);
+        } else {
+            panic!("Given portable directory isn't valid!");
+        }
+    }
+
     let exe = env::current_exe().ok()?;
     let dir = exe.parent()?;
 

--- a/docs/guides/portable-mode.md
+++ b/docs/guides/portable-mode.md
@@ -7,3 +7,5 @@ To enable portable mode for Halloy, simply place the `config.toml` file in the s
 ├── Halloy.app
 └── config.toml
 ```
+
+Or you can set the `HALLOY_PORTABLE_DIR` environment variable to a valid directory path explicitly.


### PR DESCRIPTION
Just a quick change to add support for explicitly enabling portable mode by setting a data directory, do we need to consider anything else for this feature? If no, does this need any more polishing or is it GTM as-is?