### PR TITLE
Add local search and common-channel commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,87 +1,362 @@
-# Halloy - IRC Client
+# Halloy Search And Common Channel Feature Guide
 
-<img src="./assets/banner.png" alt="banner" title="Icon by Rune Seir">
+Updated: 2026-06-16 EDT
 
-![halloy](./assets/animation.gif)
+This fork branch demonstrates local-only search and common-channel inspection
+features for the Halloy IRC client. It is intended as a reviewable design and
+implementation branch: the commands are implemented in Halloy, documented here,
+and kept security-first by defaulting to local in-memory or already-loaded data.
 
-Halloy is an open-source IRC client for Mac, Windows, and Linux, focused on being simple and fast.
+Added feature areas:
 
-Documentation: [halloy.chat](https://halloy.chat)
+- `/search`: local loaded-history search with selectors, boolean expressions,
+  string modifiers, spans, context, output options, and result panes.
+- `/last`: a retained convenience command for current-buffer search, designed
+  to become read-marker aware in a later slice.
+- `/common`: common-channel inspection using Halloy's already-known channel
+  membership state, with `scope=global|network`.
+- Documentation and portability notes for future implementations in clients
+  such as Konversation or Uplink.
 
-Join **#halloy** on libera.chat if you have questions or need help.
+Original Halloy project: <https://github.com/squidowl/halloy>
 
-## Installation
+## Table Of Contents
 
-[Installation documentation](https://halloy.chat/installation.html)
+- [Security Model](#security-model)
+- [`/search`](#search)
+- [`/last`](#last)
+- [Search Selectors](#search-selectors)
+- [Boolean Expressions](#boolean-expressions)
+- [String Modifiers](#string-modifiers)
+- [Quoting And Escapes](#quoting-and-escapes)
+- [Span](#span)
+- [Search Output Options](#search-output-options)
+- [Highlighting](#highlighting)
+- [`/common`](#common)
+- [`/common` Scope](#common-scope)
+- [Future `/common` Identity Enrichment](#future-common-identity-enrichment)
+- [Halloy Implementation Notes](#halloy-implementation-notes)
+- [Upstream Contribution Notes](#upstream-contribution-notes)
+- [Porting Notes](#porting-notes)
 
-<a href="https://repology.org/project/halloy/versions">
-    <img src="https://repology.org/badge/vertical-allrepos/halloy.svg" alt="Packaging status">
-</a>
+This document describes the local `/search`, `/last`, and `/common` features
+added in the Halloy feature branch. It is written as both user documentation
+and a portable design reference for possible future implementations in other
+IRC clients such as Konversation or Uplink.
 
-Halloy is also available from [Flathub](https://flathub.org/apps/org.squidowl.halloy) and [Snap Store](https://snapcraft.io/halloy).
+## Security Model
 
-## IRCv3 Capabilities
+These commands are local inspection tools. They must not send IRC traffic by
+default.
 
-We strive to be a leading irc client with a rich IRCv3 feature set. Currently supported capabilities:
+- `/search` and `/last` inspect already-loaded local Halloy history only.
+- `/common` inspects already-known in-memory channel membership only.
+- `/common` does not issue `WHOIS`, `WHO`, `NAMES`, or other network refreshes.
+- Search result output is local status output or a local result pane.
+- Saved searches, filesystem scans, persistent result storage, and active
+  identity refresh are separate future features.
 
-- [account-notify](https://ircv3.net/specs/extensions/account-notify)
-- [away-notify](https://ircv3.net/specs/extensions/away-notify)
-- [batch](https://ircv3.net/specs/extensions/batch)
-- [bot mode](https://ircv3.net/specs/extensions/bot-mode)
-- [cap-notify](https://ircv3.net/specs/extensions/capability-negotiation.html#cap-notify)
-- [channel-context](https://ircv3.net/specs/client-tags/channel-context)
-- [chathistory](https://ircv3.net/specs/extensions/chathistory)
-- [chghost](https://ircv3.net/specs/extensions/chghost)
-- [echo-message](https://ircv3.net/specs/extensions/echo-message)
-- [extended-join](https://ircv3.net/specs/extensions/extended-join)
-- [invite-notify](https://ircv3.net/specs/extensions/invite-notify)
-- [labeled-response](https://ircv3.net/specs/extensions/labeled-response)
-- [message-redaction](https://ircv3.net/specs/extensions/message-redaction)
-- [message-tags](https://ircv3.net/specs/extensions/message-tags)
-- [metadata](https://ircv3.net/specs/extensions/metadata)
-  - `display-name`
-  - `avatar`
-  - `pronouns`
-  - `homepage`
-  - `color`
-  - `status`
-- [Monitor](https://ircv3.net/specs/extensions/monitor)
-- [msgid](https://ircv3.net/specs/extensions/message-ids)
-- [multi-prefix](https://ircv3.net/specs/extensions/multi-prefix)
-- [multiline](https://ircv3.net/specs/extensions/multiline)
-- [network-icon](https://ircv3.net/specs/extensions/network-icon)
-- [react](https://ircv3.net/specs/client-tags/react.html)
-- [read-marker](https://ircv3.net/specs/extensions/read-marker)
-- [reply](https://ircv3.net/specs/client-tags/reply)
-- [sasl-3.1](https://ircv3.net/specs/extensions/sasl-3.1)
-- [server-time](https://ircv3.net/specs/extensions/server-time)
-- [setname](https://ircv3.net/specs/extensions/setname.html)
-- [Standard Replies](https://ircv3.net/specs/extensions/standard-replies)
-- [typing](https://ircv3.net/specs/client-tags/typing)
-- [userhost-in-names](https://ircv3.net/specs/extensions/userhost-in-names)
-- [`UTF8ONLY`](https://ircv3.net/specs/extensions/utf8-only)
-- [`WHOX`](https://ircv3.net/specs/extensions/whox)
-- [`soju.im/bouncer-networks`](https://soju.im/bouncer-networks)
-- [`soju.im/filehost`](https://soju.im/filehost)
+Future network-enrichment modes, such as `/common --whois`, should be explicit,
+rate-limited, and documented as active network behavior.
 
-## Why?
+## `/search`
 
-<a href="https://xkcd.com/1782/">
-  <img src="https://imgs.xkcd.com/comics/team_chat.png" title="2078: He announces that he's finally making the jump from screen+irssi to tmux+weechat.">
-</a>
+`/search` searches the current buffer's loaded visible history.
 
-## Contributing
+```text
+/search text=timeout
+/search itext=timeout
+/search regex="tim(e|ed) out"
+/search origin=alice text=deploy
+```
 
-See the [contributing guide](https://halloy.chat/contributing) to get started.
+Bare text is treated as a message-body search:
 
-## License
+```text
+/search timeout
+```
 
-Halloy is released under the GPL-3.0 License. For more details, see the [LICENSE](LICENSE) file.
+Selector text inside quotes is literal body text:
 
-## Contact
+```text
+/search origin="alice"
+/search "origin=alice"
+```
 
-For any questions, suggestions, or issues, please open an issue on the [GitHub repository](https://github.com/squidowl/halloy/issues).
+The first command filters by origin. The second command searches message text
+for the literal string `origin=alice`.
 
-<a href="https://github.com/iced-rs/iced">
-  <img src="https://gist.githubusercontent.com/hecrj/ad7ecd38f6e47ff3688a38c79fd108f0/raw/74384875ecbad02ae2a926425e9bcafd0695bade/color.svg" width="130px">
-</a>
+## `/last`
+
+`/last` is retained as a convenience form of search for the current buffer.
+In the current implementation it searches the current buffer's loaded visible
+history. It is not yet anchored to a HexChat-style read marker.
+
+Planned future behavior: once read markers exist, `/last` should search from
+the last-viewed/read-marker boundary to the present by default.
+
+## Search Selectors
+
+| Selector | Aliases | Value |
+| --- | --- | --- |
+| `text` | `itext`, `regex`, `iregex`, `regexp`, `re`, `rx`, `exp` | string |
+| `origin` | `from`, `sender`, `nick`, `name` | nickname |
+| `target` | `to` | nickname or channel |
+| `type` | `kind` | message type |
+| `span` | `since` | duration |
+| `reaction` | `react` | reaction name |
+
+Examples:
+
+```text
+/search nick=alice
+/search react=love
+/search reaction=thumbsup
+/search type=action text=deploy
+```
+
+## Boolean Expressions
+
+Search expressions support explicit boolean operators and parentheses.
+
+```text
+/search text=deploy AND origin=alice
+/search text=deploy OR text=rollback
+/search text=deploy AND NOT origin=bob
+/search (text=deploy OR text=rollback) AND origin=alice
+```
+
+Adjacent predicates default to `AND`:
+
+```text
+/search origin=alice text=deploy
+```
+
+## String Modifiers
+
+Any string-valued selector can use compact modifiers before a quoted value:
+
+| Modifier | Meaning |
+| --- | --- |
+| `i` | case-insensitive |
+| `n` | negated |
+| `a` | comma-list values use AND |
+| `o` | comma-list values use OR |
+| `x` | regular expression |
+
+Examples:
+
+```text
+/search text=i"timeout"
+/search text=x"tim(e|ed) out"
+/search text=ix"tim(e|ed) out"
+/search text=n"noise"
+/search reaction=o"love,thumbsup"
+```
+
+The modifier form is intended to be portable across selectors:
+
+```text
+/search origin=i"alice"
+/search target=i"#rust"
+/search reaction=i"love"
+```
+
+## Quoting And Escapes
+
+Inside quoted values:
+
+- `\"` means a literal double quote.
+- `\\` means a literal backslash.
+- Unknown escape sequences preserve the backslash and following character.
+
+Examples:
+
+```text
+/search text="he said \"hello\""
+/search text="path C:\\tmp"
+```
+
+## Span
+
+`span=` accepts positive duration values with a required unit:
+
+| Example | Meaning |
+| --- | --- |
+| `span=3d` | last 3 days |
+| `span=2h` | last 2 hours |
+| `span=5m` | last 5 minutes |
+
+Examples:
+
+```text
+/search span=3d text=release
+/last span=2h itext=error
+```
+
+## Search Output Options
+
+| Option | Meaning |
+| --- | --- |
+| `--textonly` | strips IRC formatting controls and ANSI color/control sequences |
+| `--notimestamp` | omits timestamps from output |
+| `--other` | excludes messages uttered by the local user |
+| `context=<lines>` | includes loaded lines before and after each match |
+| `view=inline` | outputs local status lines in the current buffer |
+| `view=pane` | opens a transient local result pane |
+| `view=tab` | parsed but not implemented yet |
+
+Examples:
+
+```text
+/search --textonly itext=error
+/search --notimestamp text=deploy
+/search --other text=deploy
+/search context=2 text=panic
+/search view=pane itext=timeout
+```
+
+Timestamps are displayed to whole seconds:
+
+```text
+[2026-06-16 16:01:17 UTC] <alice> example
+```
+
+With `--notimestamp`:
+
+```text
+<alice> example
+```
+
+## Highlighting
+
+`view=pane` highlights positive message-body text predicate matches.
+
+Examples:
+
+```text
+/search view=pane text=timeout
+/search view=pane itext=timeout
+/search view=pane regex="tim(e|ed) out"
+```
+
+Current scope:
+
+- Highlights body text matches.
+- Highlights repeated matches.
+- Highlights multiple positive text predicates.
+- Does not yet highlight origin, target, type, or reaction fields.
+- Inline output is plain local status text.
+
+## `/common`
+
+`/common` lists users in the current channel who share other known channels with
+you. It uses Halloy's in-memory membership state only.
+
+```text
+/common
+/common scope=network
+/common scope=global
+```
+
+`scope=global` is the default.
+
+## `/common` Scope
+
+| Scope | Meaning | Display |
+| --- | --- | --- |
+| `scope=network` | current network only | `nick: #channel` |
+| `scope=global` | all connected networks | `network/nick: #channel` |
+
+Examples:
+
+```text
+/common scope=network
+alice: #rust, #linux
+```
+
+```text
+/common
+libera/alice: #rust
+oftc/alice: #debian
+```
+
+Rules:
+
+- `/common` works only from a channel buffer.
+- The local user's nick is excluded.
+- The current channel is excluded from the displayed overlap.
+- Users with no other shared known channels are omitted.
+- Shared channel names are sorted alphabetically.
+- Result rows are sorted by display nick.
+- No network refresh is performed.
+
+## Future `/common` Identity Enrichment
+
+The current `/common` implementation matches by nick across known membership
+state. A future enrichment slice can improve identity matching by using
+attributes Halloy already has in memory:
+
+- nick
+- username
+- hostname
+- account name
+
+An active `WHOIS` pass can provide stronger correlation on some networks, but
+it should be opt-in, explicit, and rate-limited:
+
+```text
+/common --whois
+```
+
+This future mode should clearly indicate that it sends IRC traffic.
+
+## Halloy Implementation Notes
+
+The current Halloy implementation keeps most feature logic in added modules:
+
+- `data/src/command/search/`
+- `data/src/command/common.rs`
+- `src/buffer/common.rs`
+- `src/buffer/search_results.rs`
+
+Existing Halloy files are used mainly for parser registration, command
+dispatch, buffer event plumbing, and pane rendering.
+
+The current implementation intentionally avoids:
+
+- persistent saved search storage;
+- active log/file scans;
+- active WHOIS fan-out;
+- first-class `view=tab` search-result buffers;
+- read-marker based `/last`.
+
+## Upstream Contribution Notes
+
+Halloy's current contribution guidance says significant new features should be
+discussed before submission and that patches are submitted through GitHub pull
+requests. If this work adds user-facing settings later, the related website
+Markdown documentation should be updated along with the code.
+
+Halloy's contribution page also currently says submitted AI-generated content
+is not allowed. This document is therefore a private design/support artifact for
+review, discussion, and possible porting. Any upstream submission should be
+human-owned, reviewed, and rewritten as needed to comply with the project's
+rules at the time of submission.
+
+Reference: <https://halloy.chat/contributing#patches-pull-requests>
+
+## Porting Notes
+
+For Konversation, Uplink, or another IRC client, keep the same major seams:
+
+- parse command syntax into typed selectors/options;
+- evaluate only local history or explicitly requested network data;
+- keep formatting/highlighting separate from evaluation;
+- make network-enriching modes opt-in;
+- keep default behavior local and side-effect free;
+- expose `scope=network|global` for common-channel matching.
+
+The portable command grammar is more important than the Halloy-specific UI
+wiring. A different client can render results in a tab, pane, dialog, or inline
+buffer while retaining the same parser and security model.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Original Halloy project: <https://github.com/squidowl/halloy>
 - [Halloy Implementation Notes](#halloy-implementation-notes)
 - [Upstream Contribution Notes](#upstream-contribution-notes)
 - [Porting Notes](#porting-notes)
+- [Development Guidelines Used](#development-guidelines-used)
 
 This document describes the local `/search`, `/last`, and `/common` features
 added in the Halloy feature branch. It is written as both user documentation
@@ -360,3 +361,45 @@ For Konversation, Uplink, or another IRC client, keep the same major seams:
 The portable command grammar is more important than the Halloy-specific UI
 wiring. A different client can render results in a tab, pane, dialog, or inline
 buffer while retaining the same parser and security model.
+
+## Development Guidelines Used
+
+This branch was developed under a small set of explicit engineering guidelines:
+
+- Security first. New commands default to local-only behavior and must not send
+  IRC traffic unless a future option explicitly says it does.
+- Minimize upstream disruption. Existing Halloy files are touched mainly for
+  command registration, dispatch, buffer plumbing, and rendering hooks.
+- Keep feature logic localized. Parser, evaluator, formatter, and `/common`
+  scan logic live in added modules so reviewers can inspect the new behavior in
+  a small number of places.
+- Match Halloy style. Naming, module structure, parser patterns, and UI wiring
+  follow nearby Halloy conventions where practical.
+- Refactor only our added code aggressively. Upstream code is not reshaped just
+  to support this feature branch.
+- Keep files reviewable. Added production modules are split below the 500-line
+  refactoring-review trigger; the search test module is the remaining known
+  split candidate.
+- Prefer typed parsing and explicit errors. Command input is parsed into typed
+  selectors, modifiers, options, and expression trees instead of ad hoc string
+  handling during execution.
+- Use existing libraries where appropriate. Regex validation and escaping use
+  the existing regex crate support instead of custom metacharacter ladders.
+- Test parser and evaluator behavior directly. Unit tests cover selectors,
+  boolean grouping, modifiers, span parsing, escaping, output flags, filtering,
+  formatting, highlighting, and `/common` summary behavior.
+- Document non-obvious code. Added functions include comments describing their
+  purpose, callers, inputs, return values, and side effects or lack of side
+  effects.
+- Preserve privacy. Local config files and credentials are not committed, and
+  the staged diff is checked before publication.
+- Keep future network behavior explicit. Identity enrichment, saved searches,
+  result persistence, `view=tab`, and read-marker aware `/last` are documented
+  as separate slices rather than hidden inside this implementation.
+- Respect upstream process. This branch is presented as a draft/discussion
+  artifact, and any upstreamable patch should follow Halloy's contribution
+  rules at the time it is submitted.
+- Acknowledge AI assistance. This branch and document were produced with Codex
+  assistance under the guidelines above: security-first behavior, localized
+  changes, explicit tests, reviewable module boundaries, documented tradeoffs,
+  and human review before any upstream submission.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Added feature areas:
 - Buffer close focus recovery: closing a channel or query returns focus to a
   useful related buffer instead of leaving the main pane on an empty
   "Select buffer" state.
-- Documentation and portability notes for future implementations in clients
-  such as Konversation or Uplink.
+- Documentation and portability notes for "Rich Search Functionality" in other
+  IRC clients such as Zoitechat, Konversation, and Uplink.
 
 Original Halloy project: <https://github.com/squidowl/halloy>
 
@@ -47,7 +47,8 @@ Original Halloy project: <https://github.com/squidowl/halloy>
 This document describes the local `/search`, `/last`, and `/common` features
 added in the Halloy feature branch. It is written as both user documentation
 and a portable design reference for possible future implementations in other
-IRC clients such as Konversation or Uplink.
+IRC clients such as Zoitechat, Konversation, and Uplink. The portable feature
+set is referred to below as **Rich Search Functionality** for IRC clients.
 
 ## Security Model
 
@@ -371,7 +372,8 @@ Reference: <https://halloy.chat/contributing#patches-pull-requests>
 
 ## Porting Notes
 
-For Konversation, Uplink, or another IRC client, keep the same major seams:
+For Zoitechat, Konversation, Uplink, or another IRC client, keep the same major
+seams:
 
 - parse command syntax into typed selectors/options;
 - evaluate only local history or explicitly requested network data;
@@ -383,6 +385,33 @@ For Konversation, Uplink, or another IRC client, keep the same major seams:
 The portable command grammar is more important than the Halloy-specific UI
 wiring. A different client can render results in a tab, pane, dialog, or inline
 buffer while retaining the same parser and security model.
+
+### Rich Search Functionality Port Targets
+
+The portable feature name for this work is **Rich Search Functionality**. The
+goal is to carry the command grammar, local-only security model, common-channel
+logic, and result rendering concepts across multiple IRC clients while adapting
+the data access and UI layers to each codebase.
+
+Likely implementation targets:
+
+| Client | Likely implementation language/style | Porting shape |
+| --- | --- | --- |
+| Zoitechat | likely C/GTK3 | Native plugin or client patch, depending on its extension API. |
+| Konversation | C++/KDE/Qt | Native C++ patch or script/plugin if its scripting API exposes enough message and channel state. |
+| Uplink | C++/Qt6 | Native C++/Qt6 implementation, ideally with a reusable parser/evaluator library. |
+
+The preferred architecture for each port is:
+
+- a small parser/evaluator core for the Rich Search Functionality grammar;
+- a client-specific message-history adapter;
+- a client-specific known-channel/user adapter for `/common`;
+- a result renderer that matches the client's native UI conventions;
+- an optional, explicit network-enrichment layer for `WHOIS`/`319` support.
+
+The default mode should remain local-only in every client. If a port adds
+active server queries, those should be exposed as explicit options rather than
+implicit behavior.
 
 ## Development Guidelines Used
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Added feature areas:
   to become read-marker aware in a later slice.
 - `/common`: common-channel inspection using Halloy's already-known channel
   membership state, with `scope=global|network`.
+- Buffer close focus recovery: closing a channel or query returns focus to a
+  useful related buffer instead of leaving the main pane on an empty
+  "Select buffer" state.
 - Documentation and portability notes for future implementations in clients
   such as Konversation or Uplink.
 
@@ -34,6 +37,7 @@ Original Halloy project: <https://github.com/squidowl/halloy>
 - [Highlighting](#highlighting)
 - [`/common`](#common)
 - [`/common` Scope](#common-scope)
+- [Buffer Close Focus Recovery](#buffer-close-focus-recovery)
 - [Future `/common` Identity Enrichment](#future-common-identity-enrichment)
 - [Halloy Implementation Notes](#halloy-implementation-notes)
 - [Upstream Contribution Notes](#upstream-contribution-notes)
@@ -291,6 +295,24 @@ Rules:
 - Shared channel names are sorted alphabetically.
 - Result rows are sorted by display nick.
 - No network refresh is performed.
+
+## Buffer Close Focus Recovery
+
+This branch also fixes a usability issue when closing buffers. Previously,
+closing a channel or direct conversation could leave Halloy showing an empty
+"Select buffer" pane even though useful nearby buffers were still available.
+
+The new focus-selection behavior chooses a replacement buffer locally:
+
+- prefer the parent/spawning buffer when that relationship is known;
+- otherwise prefer the most recent suitable buffer on the same network;
+- fall back to the same-network server buffer when appropriate;
+- avoid crossing networks while choosing a replacement;
+- use the empty selection state only when there is no suitable replacement.
+
+This is intentionally independent from `/search` and `/common`, but it supports
+the same workflow goal: commands or buffer actions that open or close panes
+should leave focus somewhere predictable and useful.
 
 ## Future `/common` Identity Enrichment
 

--- a/data/src/client/on_connect.rs
+++ b/data/src/client/on_connect.rs
@@ -111,8 +111,10 @@ pub fn on_connect(
                             command::Internal::ClearBuffer
                             | command::Internal::ChannelDiscovery
                             | command::Internal::Connect(_)
+                            | command::Internal::Common(_)
                             | command::Internal::Exec(_)
                             | command::Internal::Hop(_, _)
+                            | command::Internal::Search(_)
                             | command::Internal::SysInfo
                             | command::Internal::Reconnect
                             | command::Internal::Upload(_) => None,

--- a/data/src/command.rs
+++ b/data/src/command.rs
@@ -21,6 +21,8 @@ use crate::user::{ChannelUsers, NickRef};
 use crate::{Config, Message, Server, Target, Url, User, ctcp, target};
 
 pub mod alias;
+pub mod common;
+pub mod search;
 
 pub use self::alias::Alias;
 
@@ -48,6 +50,8 @@ pub enum Internal {
     Reconnect,
     Upload(String),
     Exec(String),
+    Common(common::Command),
+    Search(search::Command),
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
@@ -284,6 +288,9 @@ pub enum Kind {
     Upload,
     MassMessage,
     Exec,
+    Search,
+    Last,
+    Common,
     Raw,
 }
 
@@ -331,6 +338,9 @@ impl FromStr for Kind {
             "upload" => Ok(Kind::Upload),
             "massmessage" | "mm" => Ok(Kind::MassMessage),
             "exec" => Ok(Kind::Exec),
+            "search" => Ok(Kind::Search),
+            "last" => Ok(Kind::Last),
+            "common" => Ok(Kind::Common),
             _ => Err(()),
         }
     }
@@ -1751,6 +1761,22 @@ fn parse_command(
                     Ok(Command::Internal(Internal::Exec(command.to_string())))
                 }
             }
+            Kind::Search | Kind::Last => {
+                let kind = match kind {
+                    Kind::Search => search::Kind::Search,
+                    Kind::Last => search::Kind::Last,
+                    _ => unreachable!(),
+                };
+
+                search::parse(kind, raw)
+                    .map(Internal::Search)
+                    .map(Command::Internal)
+                    .map_err(Error::Search)
+            }
+            Kind::Common => common::parse(raw)
+                .map(Internal::Common)
+                .map(Command::Internal)
+                .map_err(Error::Common),
         },
         Err(()) => Ok(unknown()),
     }
@@ -2144,6 +2170,10 @@ pub enum Error {
     },
     #[error("/{command} is not enabled in configuration")]
     CommandNotEnabled { command: &'static str },
+    #[error("{0}")]
+    Common(common::Error),
+    #[error("{0}")]
+    Search(search::Error),
 }
 
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
@@ -2198,6 +2228,7 @@ mod tests {
     use super::{AutoFormat, Command, Error, Internal, isupport, parse};
     use crate::Config;
     use crate::capabilities::Capabilities;
+    use crate::command::common;
     use crate::features::Features;
 
     #[test]
@@ -2287,6 +2318,30 @@ mod tests {
             command,
             Command::Internal(Internal::Exec(command))
                 if command == "printf '/me hello world'"
+        ));
+    }
+
+    #[test]
+    fn parse_common_command() {
+        let command = parse(
+            "/common",
+            None,
+            None,
+            AutoFormat::default(),
+            true,
+            &isupport::DEFAULT,
+            &Capabilities::default(),
+            &Features::default(),
+            None,
+            &Config::default(),
+        )
+        .unwrap();
+
+        assert!(matches!(
+            command,
+            Command::Internal(Internal::Common(common::Command {
+                scope: common::Scope::Global,
+            }))
         ));
     }
 

--- a/data/src/command/common.rs
+++ b/data/src/command/common.rs
@@ -1,0 +1,98 @@
+#[cfg(test)]
+mod tests;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Command {
+    pub scope: Scope,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum Scope {
+    Network,
+    #[default]
+    Global,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Entry {
+    pub nick: String,
+    pub channels: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Error {
+    UnknownOption(String),
+    MissingScope,
+    InvalidScope(String),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownOption(option) => {
+                write!(f, "invalid common option: {option}")
+            }
+            Self::MissingScope => {
+                write!(f, "invalid common syntax: expected scope value")
+            }
+            Self::InvalidScope(scope) => {
+                write!(
+                    f,
+                    "invalid common scope: {scope}; expected network or global"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// Parses the `/common` option string.
+///
+/// Used by the top-level command parser. `raw` is the argument tail after
+/// `/common`. Returns a typed command with `scope=global` as the default, or a
+/// syntax error for unknown options or unsupported scope values. Produces no
+/// output or side effects.
+pub fn parse(raw: &str) -> Result<Command, Error> {
+    let mut command = Command::default();
+
+    for option in raw.split_whitespace() {
+        let Some((key, value)) = option.split_once('=') else {
+            return Err(Error::UnknownOption(option.to_string()));
+        };
+
+        if key != "scope" {
+            return Err(Error::UnknownOption(option.to_string()));
+        }
+
+        command.scope = match value {
+            "network" => Scope::Network,
+            "global" => Scope::Global,
+            "" => return Err(Error::MissingScope),
+            _ => return Err(Error::InvalidScope(value.to_string())),
+        };
+    }
+
+    Ok(command)
+}
+
+/// Normalizes `/common` result entries for display.
+///
+/// Used by buffer-side `/common` execution after membership scanning. `entries`
+/// are candidate nick/channel rows. Returns entries with sorted/deduplicated
+/// channel lists, users without shared channels removed, and rows sorted by
+/// display nick. Produces no output or side effects.
+pub fn summarize(entries: impl IntoIterator<Item = Entry>) -> Vec<Entry> {
+    let mut entries: Vec<_> = entries
+        .into_iter()
+        .filter_map(|mut entry| {
+            entry.channels.sort();
+            entry.channels.dedup();
+
+            (!entry.channels.is_empty()).then_some(entry)
+        })
+        .collect();
+
+    entries.sort_by(|a, b| a.nick.cmp(&b.nick));
+    entries
+}

--- a/data/src/command/common/tests.rs
+++ b/data/src/command/common/tests.rs
@@ -1,0 +1,102 @@
+use super::*;
+
+#[test]
+fn parse_defaults_to_global_scope() {
+    assert_eq!(
+        parse("").expect("common command"),
+        Command {
+            scope: Scope::Global,
+        }
+    );
+}
+
+#[test]
+fn parse_network_scope() {
+    assert_eq!(
+        parse("scope=network").expect("common command"),
+        Command {
+            scope: Scope::Network,
+        }
+    );
+}
+
+#[test]
+fn parse_global_scope() {
+    assert_eq!(
+        parse("scope=global").expect("common command"),
+        Command {
+            scope: Scope::Global,
+        }
+    );
+}
+
+#[test]
+fn parse_rejects_invalid_scope() {
+    assert_eq!(parse("scope=all"), Err(Error::InvalidScope("all".into())));
+}
+
+#[test]
+fn summarize_sorts_users_and_channels() {
+    let entries = summarize([
+        Entry {
+            nick: "zara".into(),
+            channels: vec!["#rust".into(), "#halloy".into()],
+        },
+        Entry {
+            nick: "alice".into(),
+            channels: vec!["#linux".into()],
+        },
+    ]);
+
+    assert_eq!(
+        entries,
+        vec![
+            Entry {
+                nick: "alice".into(),
+                channels: vec!["#linux".into()],
+            },
+            Entry {
+                nick: "zara".into(),
+                channels: vec!["#halloy".into(), "#rust".into()],
+            },
+        ]
+    );
+}
+
+#[test]
+fn summarize_omits_users_without_common_channels() {
+    let entries = summarize([
+        Entry {
+            nick: "alice".into(),
+            channels: vec![],
+        },
+        Entry {
+            nick: "bob".into(),
+            channels: vec!["#halloy".into()],
+        },
+    ]);
+
+    assert_eq!(
+        entries,
+        vec![Entry {
+            nick: "bob".into(),
+            channels: vec!["#halloy".into()],
+        }]
+    );
+}
+
+#[test]
+fn summarize_deduplicates_channels() {
+    let entries = summarize([Entry {
+        nick: "alice".into(),
+        channels: vec!["#halloy".into(), "#halloy".into()],
+    }]);
+
+    assert_eq!(
+        entries,
+        vec![Entry {
+            nick: "alice".into(),
+            channels: vec!["#halloy".into()],
+        }]
+    );
+}

--- a/data/src/command/search/display.rs
+++ b/data/src/command/search/display.rs
@@ -1,0 +1,286 @@
+use std::ops::Range;
+
+use chrono::{DateTime, Utc};
+use fancy_regex::Regex;
+
+use super::{Command, Expr, Modifiers, Output, Selector};
+
+#[derive(Debug, Clone)]
+pub struct DisplayMatch {
+    pub prefix: String,
+    pub text: String,
+    pub text_highlights: Vec<Range<usize>>,
+}
+
+/// Formats one search result as a plain line for inline status output.
+///
+/// Used by the input view when `view=inline`. `message` is the matched Halloy
+/// message and `output` carries display flags such as `--textonly` and
+/// `--notimestamp`. Returns the complete rendered line. Produces no output or
+/// side effects.
+pub fn format_match(message: &crate::Message, output: Output) -> String {
+    // Build the structured display form first so inline and pane output share
+    // one timestamp/text-stripping path.
+    let display = format_display_match(message, output, None);
+
+    format!("{}{}", display.prefix, display.text)
+}
+
+/// Formats one search result as structured text plus highlight ranges.
+///
+/// Used by the search result pane renderer. `message` is the matched Halloy
+/// message, `output` carries display flags, and `command` optionally supplies
+/// the query whose positive text predicates should be highlighted. Returns the
+/// prefix, body text, and body-text highlight byte ranges. Produces no output
+/// or side effects.
+pub fn format_display_match(
+    message: &crate::Message,
+    output: Output,
+    command: Option<&Command>,
+) -> DisplayMatch {
+    // Status/internal messages do not have a user source, so display them with
+    // the same `status` pseudo-origin Halloy already uses elsewhere.
+    let origin = message.user().map_or_else(
+        || "status".to_string(),
+        |user| user.nickname().to_string(),
+    );
+
+    // `--textonly` is an output transform, not a search transform: match
+    // semantics stay tied to Halloy's stored message content, while display
+    // strips IRC and ANSI control bytes from the rendered result line.
+    let text = if output.text_only {
+        strip_control_codes(&message.text())
+    } else {
+        message.text().into_owned()
+    };
+
+    // Highlighting is deliberately tied to display text, so `--textonly`
+    // cannot produce byte ranges that point into stripped control bytes.
+    let text_highlights = command
+        .map(|command| highlight_ranges(command.query.as_ref(), &text))
+        .unwrap_or_default();
+
+    DisplayMatch {
+        // `--notimestamp` removes only the timestamp prefix. The origin remains
+        // visible so result lines stay attributable.
+        prefix: if output.no_timestamp {
+            format!("<{}> ", origin)
+        } else {
+            format!(
+                "[{}] <{}> ",
+                format_server_time(message.server_time),
+                origin
+            )
+        },
+        text,
+        text_highlights,
+    }
+}
+
+/// Formats a server timestamp for search output.
+///
+/// Used by `format_display_match`. `server_time` is a UTC message timestamp.
+/// Returns a seconds-only UTC timestamp string. Produces no output or side
+/// effects.
+fn format_server_time(server_time: DateTime<Utc>) -> String {
+    // Search result timestamps intentionally stop at seconds. Milliseconds
+    // make manual scanning harder and were not wanted for this output surface.
+    server_time.format("%Y-%m-%d %H:%M:%S UTC").to_string()
+}
+
+/// Computes highlight ranges for positive body-text predicates.
+///
+/// Used by `format_display_match`. `expr` is the optional search expression and
+/// `text` is the rendered message body after any `--textonly` transform.
+/// Returns merged byte ranges into `text`. Produces no output or side effects.
+fn highlight_ranges(expr: Option<&Expr>, text: &str) -> Vec<Range<usize>> {
+    // Collect first, then merge, because separate positive predicates may
+    // overlap or repeat the same literal text.
+    let mut ranges = Vec::new();
+    collect_text_highlights(expr, text, &mut ranges);
+    merge_ranges(ranges)
+}
+
+/// Recursively collects raw text-highlight ranges from an expression tree.
+///
+/// Used by `highlight_ranges`. `expr` is the current expression node, `text` is
+/// the rendered message body, and `ranges` receives unmerged byte ranges.
+/// Returns through mutation of `ranges`. Produces no output or side effects.
+fn collect_text_highlights(
+    expr: Option<&Expr>,
+    text: &str,
+    ranges: &mut Vec<Range<usize>>,
+) {
+    match expr {
+        Some(Expr::Predicate(predicate))
+            if predicate.selector == Selector::Text
+                && !predicate.modifiers.negated =>
+        {
+            // Only positive body-text predicates produce highlights. Field
+            // predicates such as origin/reaction do not map cleanly into the
+            // message body span rendered by the current pane.
+            for value in predicate.value.iter() {
+                ranges.extend(text_ranges(text, value, predicate.modifiers));
+            }
+        }
+        Some(Expr::Predicate(_)) | None => {}
+        Some(Expr::Not(_)) => {}
+        Some(Expr::And(exprs)) | Some(Expr::Or(exprs)) => {
+            // Boolean containers do not affect where literal text occurs, so
+            // recurse into their children and let merge_ranges normalize spans.
+            for expr in exprs {
+                collect_text_highlights(Some(expr), text, ranges);
+            }
+        }
+    }
+}
+
+/// Finds all body-text ranges matched by one text predicate value.
+///
+/// Used by `collect_text_highlights`. `haystack` is the rendered body text,
+/// `needle` is a literal or regex pattern, and `modifiers` controls regex and
+/// case sensitivity. Returns non-empty byte ranges. Produces no output or side
+/// effects.
+fn text_ranges(
+    haystack: &str,
+    needle: &str,
+    modifiers: Modifiers,
+) -> Vec<Range<usize>> {
+    // Empty highlights are visually meaningless and can create zero-width
+    // spans in iced rich text.
+    if needle.is_empty() {
+        return vec![];
+    }
+
+    // Literal text is escaped into a regex so the same range collector can
+    // handle both regex and non-regex predicates.
+    let pattern = if modifiers.regex {
+        needle.to_string()
+    } else {
+        fancy_regex::escape(needle).to_string()
+    };
+
+    // Case-insensitive matching is expressed as a scoped regex flag so the
+    // original haystack can be used without allocating a lowercase copy.
+    let pattern = if modifiers.case_insensitive {
+        format!("(?i:{pattern})")
+    } else {
+        pattern
+    };
+
+    Regex::new(&pattern)
+        .ok()
+        .map(|regex| {
+            regex
+                .find_iter(haystack)
+                .filter_map(Result::ok)
+                .map(|match_| match_.start()..match_.end())
+                .filter(|range| !range.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Sorts and merges overlapping highlight ranges.
+///
+/// Used by `highlight_ranges`. `ranges` is an unsorted list of byte ranges.
+/// Returns normalized ranges suitable for sequential rendering. Produces no
+/// output or side effects.
+fn merge_ranges(mut ranges: Vec<Range<usize>>) -> Vec<Range<usize>> {
+    // Sort by start/end so adjacent overlapping ranges can be collapsed in one
+    // linear pass.
+    ranges.sort_by_key(|range| (range.start, range.end));
+
+    let mut merged: Vec<Range<usize>> = Vec::new();
+
+    for range in ranges {
+        let Some(last) = merged.last_mut() else {
+            merged.push(range);
+            continue;
+        };
+
+        if range.start <= last.end {
+            last.end = last.end.max(range.end);
+        } else {
+            merged.push(range);
+        }
+    }
+
+    merged
+}
+
+/// Removes IRC formatting controls and ANSI color sequences from display text.
+///
+/// Used by `format_display_match` for `--textonly`. `text` is the stored
+/// message body. Returns display text with presentation controls removed.
+/// Produces no output or side effects.
+fn strip_control_codes(text: &str) -> String {
+    // Remove presentation controls only. This is intentionally conservative:
+    // malformed color/ANSI sequences are consumed only as far as their control
+    // grammar allows, then normal text resumes.
+    let mut stripped = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\x02' | '\x0f' | '\x16' | '\x1d' | '\x1f' => {}
+            '\x03' => {
+                skip_mirc_color(&mut chars);
+            }
+            '\x1b' if chars.peek() == Some(&'[') => {
+                chars.next();
+                skip_ansi_sequence(&mut chars);
+            }
+            _ => stripped.push(ch),
+        }
+    }
+
+    stripped
+}
+
+/// Consumes the optional numeric payload of one mIRC color control.
+///
+/// Used by `strip_control_codes` after it sees `\x03`. `chars` is the
+/// remaining character stream and is advanced past foreground/background color
+/// digits when present. Returns through iterator mutation. Produces no output
+/// or external side effects.
+fn skip_mirc_color<I>(chars: &mut std::iter::Peekable<I>)
+where
+    I: Iterator<Item = char>,
+{
+    // mIRC foreground colors are at most two digits.
+    for _ in 0..2 {
+        if chars.peek().is_some_and(char::is_ascii_digit) {
+            chars.next();
+        }
+    }
+
+    // A comma introduces an optional background color, also at most two digits.
+    if chars.peek() == Some(&',') {
+        chars.next();
+
+        for _ in 0..2 {
+            if chars.peek().is_some_and(char::is_ascii_digit) {
+                chars.next();
+            }
+        }
+    }
+}
+
+/// Consumes one ANSI CSI sequence after the introducer.
+///
+/// Used by `strip_control_codes` after it sees ESC `[`. `chars` is advanced
+/// through the command terminator byte. Returns through iterator mutation.
+/// Produces no output or external side effects.
+fn skip_ansi_sequence<I>(chars: &mut std::iter::Peekable<I>)
+where
+    I: Iterator<Item = char>,
+{
+    // ANSI CSI sequences end at an alphabetic command byte. Unknown or partial
+    // sequences are consumed conservatively until that terminator appears.
+    for ch in chars.by_ref() {
+        if ch.is_ascii_alphabetic() {
+            break;
+        }
+    }
+}

--- a/data/src/command/search/eval.rs
+++ b/data/src/command/search/eval.rs
@@ -1,0 +1,263 @@
+use chrono::{DateTime, Duration, Utc};
+use fancy_regex::Regex;
+
+use super::{
+    Command, Error, Expr, Join, Modifiers, Predicate, Selector, Value,
+};
+use crate::user::NickRef;
+
+const MAX_RESULTS: usize = 50;
+
+#[derive(Debug)]
+pub struct Matches<'a> {
+    pub messages: Vec<&'a crate::Message>,
+    pub total: usize,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ExecutionContext<'a> {
+    pub own_nick: Option<NickRef<'a>>,
+}
+
+/// Evaluates a parsed search command against Halloy's loaded in-memory history.
+///
+/// Used by the input view command dispatcher for `/search` and `/last`.
+/// `command` supplies the parsed query and output controls, `view` supplies the
+/// currently loaded visible history window, and `context` supplies local client
+/// details such as the current nick for `--other`. Returns matching messages,
+/// the count of actual matches before context-line expansion, and whether the
+/// display cap truncated output. Produces no network, filesystem, or
+/// persistence side effects.
+pub fn find<'a>(
+    command: &Command,
+    view: &'a crate::history::View<'a>,
+    context: ExecutionContext<'_>,
+) -> Result<Matches<'a>, Error> {
+    // Search only the already-visible in-memory view. This first execution
+    // slice avoids filesystem scans, network access, and persistence.
+    let now = Utc::now();
+    let visible = view
+        .old_messages
+        .iter()
+        .chain(view.new_messages.iter())
+        .copied()
+        .collect::<Vec<_>>();
+    let matching = visible
+        .iter()
+        .enumerate()
+        .filter_map(|(index, message)| {
+            if command.output.other && is_own_utterance(message, context) {
+                return None;
+            }
+
+            command
+                .query
+                .as_ref()
+                .is_none_or(|expr| matches_expr(expr, message, now))
+                .then_some(index)
+        })
+        .collect::<Vec<_>>();
+
+    let total = matching.len();
+    let mut messages = Vec::new();
+    let mut last_included = None;
+    let mut truncated = false;
+
+    for index in matching {
+        let start = index.saturating_sub(command.output.context);
+        let end = (index + command.output.context + 1).min(visible.len());
+
+        for (include, message) in
+            visible.iter().enumerate().take(end).skip(start)
+        {
+            if last_included.is_some_and(|last| include <= last) {
+                continue;
+            }
+
+            if messages.len() < MAX_RESULTS {
+                messages.push(*message);
+            } else {
+                truncated = true;
+            }
+
+            last_included = Some(include);
+        }
+    }
+
+    Ok(Matches {
+        truncated,
+        messages,
+        total,
+    })
+}
+
+/// Determines whether a message should be excluded by `--other`.
+///
+/// Used only by `find`. `message` is the candidate history message and
+/// `context` contains the optional local nick for received echo detection.
+/// Returns true for sent messages, echo messages, or received messages whose
+/// source nick matches the local nick. Produces no output or side effects.
+fn is_own_utterance(
+    message: &crate::Message,
+    context: ExecutionContext<'_>,
+) -> bool {
+    matches!(message.direction, crate::message::Direction::Sent)
+        || message.is_echo
+        || context.own_nick.is_some_and(|own_nick| {
+            message
+                .user()
+                .is_some_and(|user| user.nickname() == own_nick)
+        })
+}
+
+/// Recursively evaluates a boolean search expression against one message.
+///
+/// Used by `find` for each candidate message. `expr` is the parsed query tree,
+/// `message` is the candidate, and `now` anchors relative `span=` predicates.
+/// Returns true when the full expression matches. Produces no output or side
+/// effects.
+fn matches_expr(
+    expr: &Expr,
+    message: &crate::Message,
+    now: DateTime<Utc>,
+) -> bool {
+    match expr {
+        Expr::Predicate(predicate) => {
+            matches_predicate(predicate, message, now)
+        }
+        Expr::Not(expr) => !matches_expr(expr, message, now),
+        Expr::And(exprs) => {
+            exprs.iter().all(|expr| matches_expr(expr, message, now))
+        }
+        Expr::Or(exprs) => {
+            exprs.iter().any(|expr| matches_expr(expr, message, now))
+        }
+    }
+}
+
+/// Evaluates a single selector predicate against one message.
+///
+/// Used by `matches_expr`. `predicate` contains the selector, value, and
+/// modifiers; `message` is the candidate; `now` anchors relative span checks.
+/// Returns true when the predicate matches after applying local negation.
+/// Produces no output or side effects.
+fn matches_predicate(
+    predicate: &Predicate,
+    message: &crate::Message,
+    now: DateTime<Utc>,
+) -> bool {
+    // Selector matching stays intentionally local and side-effect free. That
+    // makes the security boundary easy to audit: no selector can trigger I/O,
+    // command execution, or external expansion.
+    let matched = match predicate.selector {
+        Selector::Text => {
+            let haystack = message.text();
+            value_matches(&haystack, &predicate.value, predicate.modifiers)
+        }
+        Selector::Origin => message.user().is_some_and(|user| {
+            value_matches(
+                user.nickname().as_str(),
+                &predicate.value,
+                predicate.modifiers,
+            )
+        }),
+        Selector::Target => message.target.raw().is_some_and(|target| {
+            value_matches(target, &predicate.value, predicate.modifiers)
+        }),
+        Selector::Type => {
+            let kind = match message.target.source() {
+                crate::message::Source::User(_) => "message",
+                crate::message::Source::Action(_) => "action",
+                crate::message::Source::Server(_) => "server",
+                crate::message::Source::Internal(_) => "internal",
+            };
+
+            value_matches(kind, &predicate.value, predicate.modifiers)
+        }
+        Selector::Reaction => message.reactions.iter().any(|reaction| {
+            !reaction.unreact
+                && value_matches(
+                    &reaction.text,
+                    &predicate.value,
+                    predicate.modifiers,
+                )
+        }),
+        Selector::Span => predicate.value.iter().any(|value| {
+            parse_span(value)
+                .is_ok_and(|duration| message.server_time >= now - duration)
+        }),
+    };
+
+    if predicate.modifiers.negated {
+        !matched
+    } else {
+        matched
+    }
+}
+
+/// Parses the `span=` duration grammar.
+///
+/// Used by parser validation and runtime span evaluation. `value` is expected
+/// to be `Nd`, `Nh`, or `Nm` with a positive integer prefix. Returns a chrono
+/// duration or `Error::InvalidSpan`. Produces no output or side effects.
+pub(super) fn parse_span(value: &str) -> Result<Duration, Error> {
+    let (amount, unit) = value.split_at(value.len().saturating_sub(1));
+    let amount = amount.parse::<i64>().map_err(|_| Error::InvalidSpan)?;
+
+    if amount <= 0 {
+        return Err(Error::InvalidSpan);
+    }
+
+    match unit {
+        "d" => Ok(Duration::days(amount)),
+        "h" => Ok(Duration::hours(amount)),
+        "m" => Ok(Duration::minutes(amount)),
+        _ => Err(Error::InvalidSpan),
+    }
+}
+
+/// Applies a possibly-list-valued predicate value to a text haystack.
+///
+/// Used by selector evaluation. `haystack` is the field being searched,
+/// `value` is either a single string or comma-list, and `modifiers` controls
+/// AND/OR, regex, and case sensitivity. Returns true when the configured list
+/// semantics match. Produces no output or side effects.
+fn value_matches(haystack: &str, value: &Value, modifiers: Modifiers) -> bool {
+    let matches = |needle| string_matches(haystack, needle, modifiers);
+
+    match modifiers.join {
+        Some(Join::And) => value.iter().all(matches),
+        Some(Join::Or) | None => value.iter().any(matches),
+    }
+}
+
+/// Matches one string or regex needle against one haystack.
+///
+/// Used by `value_matches`. `haystack` is the message field, `needle` is the
+/// literal or regex pattern, and `modifiers` selects regex and
+/// case-insensitive behavior. Returns true on match; invalid runtime regex
+/// behavior is treated as a non-match. Produces no output or side effects.
+fn string_matches(haystack: &str, needle: &str, modifiers: Modifiers) -> bool {
+    if modifiers.regex {
+        // Regexes are validated during parsing, then recompiled here for
+        // execution. fancy-regex can report runtime errors for advanced
+        // features, so runtime errors are treated as non-matches.
+        let pattern = if modifiers.case_insensitive {
+            format!("(?i:{needle})")
+        } else {
+            needle.to_string()
+        };
+
+        return Regex::new(&pattern)
+            .ok()
+            .and_then(|regex| regex.is_match(haystack).ok())
+            .unwrap_or(false);
+    }
+
+    if modifiers.case_insensitive {
+        haystack.to_lowercase().contains(&needle.to_lowercase())
+    } else {
+        haystack.contains(needle)
+    }
+}

--- a/data/src/command/search/mod.rs
+++ b/data/src/command/search/mod.rs
@@ -1,0 +1,184 @@
+#[cfg(test)]
+mod tests;
+
+mod display;
+mod eval;
+mod parser;
+mod token;
+
+pub use self::display::{DisplayMatch, format_display_match, format_match};
+pub use self::eval::{ExecutionContext, Matches, find};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Command {
+    pub kind: Kind,
+    pub output: Output,
+    pub query: Option<Expr>,
+    pub default_span: DefaultSpan,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Kind {
+    Search,
+    Last,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Output {
+    pub text_only: bool,
+    pub no_timestamp: bool,
+    pub other: bool,
+    pub context: usize,
+    pub view: View,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum View {
+    #[default]
+    Inline,
+    Pane,
+    Tab,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DefaultSpan {
+    None,
+    CurrentBuffer,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Expr {
+    Predicate(Predicate),
+    Not(Box<Expr>),
+    And(Vec<Expr>),
+    Or(Vec<Expr>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Predicate {
+    pub selector: Selector,
+    pub value: Value,
+    pub modifiers: Modifiers,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Selector {
+    Text,
+    Origin,
+    Target,
+    Type,
+    Span,
+    Reaction,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Value {
+    String(String),
+    List(Vec<String>),
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Modifiers {
+    pub case_insensitive: bool,
+    pub negated: bool,
+    pub regex: bool,
+    pub join: Option<Join>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Join {
+    And,
+    Or,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum Error {
+    #[error("invalid search syntax: {0}")]
+    Syntax(&'static str),
+    #[error("unknown search selector: {0}")]
+    UnknownSelector(String),
+    #[error("invalid search string modifier: {0}")]
+    InvalidModifier(char),
+    #[error("invalid search regex: {0}")]
+    InvalidRegex(String),
+    #[error("invalid search span: expected Nd, Nh, or Nm")]
+    InvalidSpan,
+    #[error("invalid search view: expected inline, pane, or tab")]
+    InvalidView,
+    #[error("invalid search context: expected a non-negative line count")]
+    InvalidContext,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SelectorMetadata {
+    pub canonical: &'static str,
+    pub aliases: &'static [&'static str],
+    pub value: &'static str,
+}
+
+pub const SELECTORS: &[SelectorMetadata] = &[
+    SelectorMetadata {
+        canonical: "text",
+        aliases: &["itext", "regex", "iregex", "regexp", "re", "rx", "exp"],
+        value: "string",
+    },
+    SelectorMetadata {
+        canonical: "origin",
+        aliases: &["from", "sender", "nick", "name"],
+        value: "nickname",
+    },
+    SelectorMetadata {
+        canonical: "target",
+        aliases: &["to"],
+        value: "nickname or channel",
+    },
+    SelectorMetadata {
+        canonical: "type",
+        aliases: &["kind"],
+        value: "message type list",
+    },
+    SelectorMetadata {
+        canonical: "span",
+        aliases: &["since"],
+        value: "duration",
+    },
+    SelectorMetadata {
+        canonical: "reaction",
+        aliases: &["react"],
+        value: "reaction name list",
+    },
+];
+
+/// Parses `/search` or `/last` arguments into a typed search command.
+///
+/// Used by the top-level command parser. `kind` identifies whether the command
+/// was `/search` or `/last`, and `raw` is the argument tail. Returns a command
+/// containing output options, optional query expression, and the default span
+/// behavior. Produces no output or side effects.
+pub fn parse(kind: Kind, raw: &str) -> Result<Command, Error> {
+    let (output, query) = parser::parse_tail(raw)?;
+
+    Ok(Command {
+        kind,
+        output,
+        query,
+        default_span: match kind {
+            Kind::Search => DefaultSpan::None,
+            Kind::Last => DefaultSpan::CurrentBuffer,
+        },
+    })
+}
+
+impl Value {
+    /// Iterates over the string values inside a scalar or list value.
+    ///
+    /// Used by validation, evaluation, and highlighting. Returns an iterator
+    /// over borrowed strings. Produces no output or side effects.
+    pub fn iter(&self) -> impl Iterator<Item = &str> {
+        match self {
+            Self::String(value) => std::slice::from_ref(value).iter(),
+            Self::List(values) => values.iter(),
+        }
+        .map(String::as_str)
+    }
+}

--- a/data/src/command/search/parser.rs
+++ b/data/src/command/search/parser.rs
@@ -1,0 +1,478 @@
+use fancy_regex::Regex;
+
+use super::eval::parse_span;
+use super::token::{Token, tokenize, unescape_quoted, unquote};
+use super::{
+    Error, Expr, Join, Modifiers, Output, Predicate, Selector, Value, View,
+};
+
+/// Parses search output options and the optional query expression.
+///
+/// Used by the public search command parser. `raw` is the command argument
+/// tail after `/search` or `/last`. Returns display options plus an optional
+/// expression tree. Produces no output or side effects.
+pub(super) fn parse_tail(raw: &str) -> Result<(Output, Option<Expr>), Error> {
+    let tokens = tokenize(raw)?;
+    let (output, tokens) = parse_options(tokens)?;
+    let query = if tokens.is_empty() {
+        None
+    } else {
+        Some(Parser::new(tokens).parse()?)
+    };
+
+    Ok((output, query))
+}
+
+/// Separates output flags/options from query expression tokens.
+///
+/// Used by `parse_tail`. `tokens` is the tokenized command tail. Returns the
+/// parsed output settings and the remaining query tokens. Produces no output or
+/// side effects.
+fn parse_options(tokens: Vec<Token>) -> Result<(Output, Vec<Token>), Error> {
+    let mut output = Output::default();
+    let mut query = Vec::new();
+    let mut tokens = tokens.into_iter().peekable();
+
+    while let Some(token) = tokens.next() {
+        match token {
+            Token::Word(word) if word == "--textonly" => {
+                output.text_only = true;
+            }
+            Token::Word(word) if word == "--notimestamp" => {
+                output.no_timestamp = true;
+            }
+            Token::Word(word) if word == "--other" => {
+                output.other = true;
+            }
+            Token::Word(word)
+                if word.eq_ignore_ascii_case("view")
+                    && tokens.peek() == Some(&Token::Equal) =>
+            {
+                tokens.next();
+
+                let Some(Token::Word(value)) = tokens.next() else {
+                    return Err(Error::InvalidView);
+                };
+
+                output.view = parse_view(&value)?;
+            }
+            Token::Word(word)
+                if word.eq_ignore_ascii_case("context")
+                    && tokens.peek() == Some(&Token::Equal) =>
+            {
+                tokens.next();
+
+                let Some(Token::Word(value)) = tokens.next() else {
+                    return Err(Error::InvalidContext);
+                };
+
+                output.context = parse_context(&value)?;
+            }
+            Token::Word(word) if word.starts_with("--") => {
+                return Err(Error::Syntax("unknown output option"));
+            }
+            token => query.push(token),
+        }
+    }
+
+    Ok((output, query))
+}
+
+/// Parses the `view=` output option.
+///
+/// Used by `parse_options`. `value` is the raw option value. Returns a typed
+/// view enum or `Error::InvalidView`. Produces no output or side effects.
+fn parse_view(value: &str) -> Result<View, Error> {
+    match value.to_ascii_lowercase().as_str() {
+        "inline" => Ok(View::Inline),
+        "pane" => Ok(View::Pane),
+        "tab" => Ok(View::Tab),
+        _ => Err(Error::InvalidView),
+    }
+}
+
+/// Parses the `context=` output option.
+///
+/// Used by `parse_options`. `value` is the raw line-count string. Returns the
+/// number of context lines or `Error::InvalidContext`. Produces no output or
+/// side effects.
+fn parse_context(value: &str) -> Result<usize, Error> {
+    value.parse().map_err(|_| Error::InvalidContext)
+}
+
+struct Parser {
+    tokens: Vec<Token>,
+    position: usize,
+}
+
+impl Parser {
+    /// Creates a parser over query-expression tokens.
+    ///
+    /// Used by `parse_tail`. `tokens` are the non-option tokens from the
+    /// command tail. Returns a parser positioned at the first token. Produces
+    /// no output or side effects.
+    fn new(tokens: Vec<Token>) -> Self {
+        Self {
+            tokens,
+            position: 0,
+        }
+    }
+
+    /// Parses a complete search expression.
+    ///
+    /// Used by `parse_tail`. Takes ownership of the parser and returns an
+    /// expression tree, rejecting trailing tokens. Produces no output or side
+    /// effects.
+    fn parse(mut self) -> Result<Expr, Error> {
+        let expr = self.parse_or()?;
+
+        if self.peek().is_some() {
+            return Err(Error::Syntax("unexpected token after expression"));
+        }
+
+        Ok(expr)
+    }
+
+    /// Parses the lowest-precedence OR expression layer.
+    ///
+    /// Used by `parse` and parenthesized subexpressions. Reads from the current
+    /// parser position and returns an expression tree. Produces no output or
+    /// side effects.
+    fn parse_or(&mut self) -> Result<Expr, Error> {
+        let mut exprs = vec![self.parse_and()?];
+
+        while self.consume_keyword("OR") {
+            exprs.push(self.parse_and()?);
+        }
+
+        Ok(flatten_bool(exprs, Expr::Or))
+    }
+
+    /// Parses the AND expression layer, including implicit adjacent AND.
+    ///
+    /// Used by `parse_or`. Reads from the current parser position and returns
+    /// an expression tree. Produces no output or side effects.
+    fn parse_and(&mut self) -> Result<Expr, Error> {
+        let mut exprs = vec![self.parse_unary()?];
+
+        loop {
+            if self.consume_keyword("AND") || self.starts_primary() {
+                exprs.push(self.parse_unary()?);
+            } else {
+                break;
+            }
+        }
+
+        Ok(flatten_bool(exprs, Expr::And))
+    }
+
+    /// Parses unary operators such as `NOT`.
+    ///
+    /// Used by `parse_and`. Reads from the current parser position and returns
+    /// the unary expression or primary expression. Produces no output or side
+    /// effects.
+    fn parse_unary(&mut self) -> Result<Expr, Error> {
+        if self.consume_keyword("NOT") {
+            Ok(Expr::Not(Box::new(self.parse_unary()?)))
+        } else {
+            self.parse_primary()
+        }
+    }
+
+    /// Parses a parenthesized expression or predicate.
+    ///
+    /// Used by `parse_unary`. Reads from the current parser position and
+    /// returns a primary expression. Produces no output or side effects.
+    fn parse_primary(&mut self) -> Result<Expr, Error> {
+        if self.consume(Token::LeftParen) {
+            let expr = self.parse_or()?;
+            if !self.consume(Token::RightParen) {
+                return Err(Error::Syntax("missing closing parenthesis"));
+            }
+
+            return Ok(expr);
+        }
+
+        self.parse_predicate().map(Expr::Predicate)
+    }
+
+    /// Parses one selector predicate or bare text predicate.
+    ///
+    /// Used by `parse_primary`. Reads from the current parser position and
+    /// returns a typed predicate. Produces no output or side effects.
+    fn parse_predicate(&mut self) -> Result<Predicate, Error> {
+        let Some(token) = self.next() else {
+            return Err(Error::Syntax("expected predicate"));
+        };
+
+        let Token::Word(word) = token else {
+            return Err(Error::Syntax("expected predicate"));
+        };
+
+        if self.consume(Token::Equal) {
+            let (selector, mut modifiers) = selector(&word)?;
+            let value = self.parse_value(&mut modifiers)?;
+
+            validate_predicate(selector, &value, modifiers)?;
+
+            Ok(Predicate {
+                selector,
+                value,
+                modifiers,
+            })
+        } else {
+            Ok(Predicate {
+                selector: Selector::Text,
+                value: Value::String(unquote(word)?),
+                modifiers: Modifiers::default(),
+            })
+        }
+    }
+
+    /// Parses the value side of a selector predicate.
+    ///
+    /// Used by `parse_predicate`. `modifiers` carries selector-level modifiers
+    /// and is updated with quoted string modifiers when present. Returns a
+    /// string or comma-list value. Produces no output or side effects.
+    fn parse_value(
+        &mut self,
+        modifiers: &mut Modifiers,
+    ) -> Result<Value, Error> {
+        let Some(token) = self.next() else {
+            return Err(Error::Syntax("expected selector value"));
+        };
+
+        let Token::Word(mut value) = token else {
+            return Err(Error::Syntax("expected selector value"));
+        };
+
+        if let Some((parsed_modifiers, parsed_value)) = parse_modified(&value)?
+        {
+            *modifiers = modifiers.merge(parsed_modifiers);
+            value = parsed_value;
+        }
+
+        Ok(list_or_string(unquote(value)?))
+    }
+
+    /// Reports whether the next token can start a primary expression.
+    ///
+    /// Used by `parse_and` to implement implicit AND between adjacent
+    /// predicates. Returns true when parsing can continue. Produces no output
+    /// or side effects.
+    fn starts_primary(&self) -> bool {
+        match self.peek() {
+            Some(Token::LeftParen) => true,
+            Some(Token::Word(word)) => !is_keyword(word, "OR"),
+            _ => false,
+        }
+    }
+
+    /// Consumes a case-insensitive keyword when it is next.
+    ///
+    /// Used by expression parsing. `keyword` is the expected keyword. Returns
+    /// true and advances when matched, otherwise false. Produces no output or
+    /// side effects.
+    fn consume_keyword(&mut self, keyword: &str) -> bool {
+        match self.peek() {
+            Some(Token::Word(word)) if is_keyword(word, keyword) => {
+                self.position += 1;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Consumes an exact token when it is next.
+    ///
+    /// Used by expression parsing. `token` is the expected token. Returns true
+    /// and advances when matched, otherwise false. Produces no output or side
+    /// effects.
+    fn consume(&mut self, token: Token) -> bool {
+        if self.peek() == Some(&token) {
+            self.position += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Removes and returns the next token.
+    ///
+    /// Used by predicate/value parsing. Returns the next token when available
+    /// and advances the parser position. Produces no output or side effects.
+    fn next(&mut self) -> Option<Token> {
+        let token = self.peek()?.clone();
+        self.position += 1;
+        Some(token)
+    }
+
+    /// Borrows the next token without advancing.
+    ///
+    /// Used throughout expression parsing. Returns the next token reference or
+    /// `None` at end of input. Produces no output or side effects.
+    fn peek(&self) -> Option<&Token> {
+        self.tokens.get(self.position)
+    }
+}
+
+impl Modifiers {
+    /// Combines selector-level and value-level string modifiers.
+    ///
+    /// Used by value parsing. `self` is the existing modifier set and `other`
+    /// is the modifier set parsed from a quoted value prefix. Returns the
+    /// merged modifiers. Produces no output or side effects.
+    fn merge(self, other: Self) -> Self {
+        Self {
+            case_insensitive: self.case_insensitive || other.case_insensitive,
+            negated: self.negated || other.negated,
+            regex: self.regex || other.regex,
+            join: other.join.or(self.join),
+        }
+    }
+}
+
+/// Collapses one-child boolean expressions into the child expression.
+///
+/// Used by `parse_or` and `parse_and`. `exprs` are parsed child expressions and
+/// `make` constructs the boolean node when more than one child exists. Returns
+/// the simplified expression. Produces no output or side effects.
+fn flatten_bool(
+    mut exprs: Vec<Expr>,
+    make: impl FnOnce(Vec<Expr>) -> Expr,
+) -> Expr {
+    if exprs.len() == 1 {
+        exprs.remove(0)
+    } else {
+        make(exprs)
+    }
+}
+
+/// Parses a selector name and any selector-implied modifiers.
+///
+/// Used by predicate parsing. `name` is the raw selector token. Returns the
+/// canonical selector plus modifiers implied by aliases such as `itext` or
+/// `regex`. Produces no output or side effects.
+fn selector(name: &str) -> Result<(Selector, Modifiers), Error> {
+    let mut modifiers = Modifiers::default();
+    let selector = match name.to_ascii_lowercase().as_str() {
+        "text" => Selector::Text,
+        "itext" => {
+            modifiers.case_insensitive = true;
+            Selector::Text
+        }
+        "regex" | "regexp" | "re" | "rx" | "exp" => {
+            modifiers.regex = true;
+            Selector::Text
+        }
+        "iregex" => {
+            modifiers.case_insensitive = true;
+            modifiers.regex = true;
+            Selector::Text
+        }
+        "origin" | "from" | "sender" | "nick" | "name" => Selector::Origin,
+        "target" | "to" => Selector::Target,
+        "type" | "kind" => Selector::Type,
+        "span" | "since" => Selector::Span,
+        "reaction" | "react" => Selector::Reaction,
+        _ => return Err(Error::UnknownSelector(name.to_string())),
+    };
+
+    Ok((selector, modifiers))
+}
+
+/// Parses compact string modifiers before a quoted value.
+///
+/// Used by selector value parsing. `value` is the raw value token. Returns
+/// modifiers plus the unescaped quoted value when the token has a modifier
+/// prefix, `None` when it is an ordinary value, or a syntax error. Produces no
+/// output or side effects.
+fn parse_modified(value: &str) -> Result<Option<(Modifiers, String)>, Error> {
+    let Some(quote_index) = value.find('"') else {
+        return Ok(None);
+    };
+
+    if !value.ends_with('"') {
+        return Err(Error::Syntax("unterminated quoted value"));
+    }
+
+    let (raw_modifiers, quoted) = value.split_at(quote_index);
+    if raw_modifiers.is_empty() {
+        return Ok(None);
+    }
+
+    let mut modifiers = Modifiers::default();
+    for modifier in raw_modifiers.chars() {
+        match modifier {
+            'i' => modifiers.case_insensitive = true,
+            'n' => modifiers.negated = true,
+            'a' => modifiers.join = Some(Join::And),
+            'o' => modifiers.join = Some(Join::Or),
+            'x' => modifiers.regex = true,
+            _ => return Err(Error::InvalidModifier(modifier)),
+        }
+    }
+
+    Ok(Some((
+        modifiers,
+        unescape_quoted(
+            quoted
+                .strip_prefix('"')
+                .and_then(|value| value.strip_suffix('"'))
+                .unwrap_or_default(),
+        ),
+    )))
+}
+
+/// Converts a parsed string into a scalar or comma-list value.
+///
+/// Used by value parsing. `value` is the unquoted selector value. Returns a
+/// list when commas are present, otherwise a scalar string. Produces no output
+/// or side effects.
+fn list_or_string(value: String) -> Value {
+    if value.contains(',') {
+        Value::List(value.split(',').map(ToString::to_string).collect())
+    } else {
+        Value::String(value)
+    }
+}
+
+/// Validates selector-specific predicate constraints after parsing.
+///
+/// Used by predicate parsing. `selector`, `value`, and `modifiers` describe the
+/// candidate predicate. Returns `Ok` when regex/span constraints are valid.
+/// Produces no output or side effects.
+fn validate_predicate(
+    selector: Selector,
+    value: &Value,
+    modifiers: Modifiers,
+) -> Result<(), Error> {
+    if selector == Selector::Text && modifiers.regex {
+        for value in value.iter() {
+            Regex::new(value).map_err(|err| {
+                Error::InvalidRegex(format!("{value}: {err}"))
+            })?;
+        }
+    }
+
+    if selector == Selector::Span {
+        if !matches!(value, Value::String(_)) {
+            return Err(Error::InvalidSpan);
+        }
+
+        for value in value.iter() {
+            parse_span(value)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Compares a token to a parser keyword case-insensitively.
+///
+/// Used by expression parsing. `word` is a token string and `keyword` is the
+/// expected keyword. Returns true when they are equal ignoring ASCII case.
+/// Produces no output or side effects.
+fn is_keyword(word: &str, keyword: &str) -> bool {
+    word.eq_ignore_ascii_case(keyword)
+}

--- a/data/src/command/search/tests.rs
+++ b/data/src/command/search/tests.rs
@@ -1,0 +1,574 @@
+use super::*;
+use std::collections::HashSet;
+
+use chrono::{Duration, Utc};
+
+use crate::history;
+use crate::message;
+use crate::reaction::Reaction;
+use crate::time::Posix;
+use crate::user::Nick;
+
+fn search(raw: &str) -> Command {
+    parse(Kind::Search, raw).expect("valid search")
+}
+
+fn query(raw: &str) -> Expr {
+    search(raw).query.expect("query")
+}
+
+#[test]
+fn parses_simple_selector() {
+    assert_eq!(
+        query("text=rust"),
+        Expr::Predicate(Predicate {
+            selector: Selector::Text,
+            value: Value::String("rust".into()),
+            modifiers: Modifiers::default(),
+        })
+    );
+}
+
+#[test]
+fn quoted_selector_like_text_is_literal_text() {
+    assert_eq!(
+        query("\"origin=alice\""),
+        Expr::Predicate(Predicate {
+            selector: Selector::Text,
+            value: Value::String("origin=alice".into()),
+            modifiers: Modifiers::default(),
+        })
+    );
+
+    assert_eq!(
+        query("origin=\"alice\""),
+        Expr::Predicate(Predicate {
+            selector: Selector::Origin,
+            value: Value::String("alice".into()),
+            modifiers: Modifiers::default(),
+        })
+    );
+}
+
+#[test]
+fn quoted_values_support_quote_and_backslash_escapes() {
+    assert_eq!(
+        query("text=\"say \\\"hello\\\"\""),
+        Expr::Predicate(Predicate {
+            selector: Selector::Text,
+            value: Value::String("say \"hello\"".into()),
+            modifiers: Modifiers::default(),
+        })
+    );
+
+    assert_eq!(
+        query("\"path \\\\tmp\""),
+        Expr::Predicate(Predicate {
+            selector: Selector::Text,
+            value: Value::String("path \\tmp".into()),
+            modifiers: Modifiers::default(),
+        })
+    );
+}
+
+#[test]
+fn parses_parenthesized_boolean_expression() {
+    assert!(matches!(
+        query("origin=alice AND (text=rust OR text=python)"),
+        Expr::And(parts)
+            if parts.len() == 2 && matches!(parts[1], Expr::Or(_))
+    ));
+}
+
+#[test]
+fn parses_not_keyword() {
+    assert!(matches!(
+        query("NOT reaction=love"),
+        Expr::Not(expr)
+            if matches!(*expr, Expr::Predicate(Predicate {
+                selector: Selector::Reaction,
+                ..
+            }))
+    ));
+}
+
+#[test]
+fn normalizes_react_alias() {
+    assert!(matches!(
+        query("react=love"),
+        Expr::Predicate(Predicate {
+            selector: Selector::Reaction,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn parses_string_modifiers() {
+    assert_eq!(
+        query("text=ix\"timeout.*socket\""),
+        Expr::Predicate(Predicate {
+            selector: Selector::Text,
+            value: Value::String("timeout.*socket".into()),
+            modifiers: Modifiers {
+                case_insensitive: true,
+                regex: true,
+                ..Modifiers::default()
+            },
+        })
+    );
+}
+
+#[test]
+fn parses_textonly_output_option() {
+    let command = search("--textonly text=hello");
+
+    assert!(command.output.text_only);
+    assert!(command.query.is_some());
+}
+
+#[test]
+fn parses_notimestamp_output_option() {
+    let command = search("--notimestamp text=hello");
+
+    assert!(command.output.no_timestamp);
+    assert!(command.query.is_some());
+}
+
+#[test]
+fn parses_other_output_option() {
+    let command = search("--other text=hello");
+
+    assert!(command.output.other);
+    assert!(command.query.is_some());
+}
+
+#[test]
+fn parses_context_output_option() {
+    let command = search("context=2 text=hello");
+
+    assert_eq!(command.output.context, 2);
+    assert!(command.query.is_some());
+}
+
+#[test]
+fn rejects_invalid_context_option() {
+    assert!(matches!(
+        parse(Kind::Search, "context=abc text=hello"),
+        Err(Error::InvalidContext)
+    ));
+}
+
+#[test]
+fn defaults_to_inline_view() {
+    let command = search("text=hello");
+
+    assert_eq!(command.output.view, View::Inline);
+}
+
+#[test]
+fn parses_result_view_option() {
+    let command = search("view=pane text=hello");
+
+    assert_eq!(command.output.view, View::Pane);
+    assert!(command.query.is_some());
+}
+
+#[test]
+fn rejects_invalid_result_view() {
+    assert!(matches!(
+        parse(Kind::Search, "view=sidebar text=hello"),
+        Err(Error::InvalidView)
+    ));
+}
+
+#[test]
+fn last_uses_current_buffer_default_span() {
+    let command = parse(Kind::Last, "text=hello").expect("valid last");
+
+    assert_eq!(command.kind, Kind::Last);
+    assert_eq!(command.default_span, DefaultSpan::CurrentBuffer);
+}
+
+#[test]
+fn adjacent_predicates_default_to_and() {
+    assert!(matches!(
+        query("origin=alice text=python"),
+        Expr::And(parts) if parts.len() == 2
+    ));
+}
+
+#[test]
+fn rejects_invalid_regex() {
+    assert!(matches!(
+        parse(Kind::Search, "regex=\"(\""),
+        Err(Error::InvalidRegex(_))
+    ));
+}
+
+#[test]
+fn finds_visible_messages_with_boolean_expression() {
+    let messages = vec![
+        message("Rust socket timeout", vec![]),
+        message("Python socket timeout", vec![]),
+        message("Rust parser", vec![]),
+    ];
+    let view = view(&messages);
+    let command = search("itext=rust AND text=timeout");
+
+    let matches = find(&command, &view, ExecutionContext::default())
+        .expect("search matches");
+
+    assert_eq!(matches.total, 1);
+    assert_eq!(matches.messages[0].text(), "Rust socket timeout");
+}
+
+#[test]
+fn finds_messages_with_case_insensitive_regex() {
+    let messages = vec![message("Socket timed out", vec![])];
+    let view = view(&messages);
+    let command = search("text=ix\"socket.*OUT\"");
+
+    let matches = find(&command, &view, ExecutionContext::default())
+        .expect("search matches");
+
+    assert_eq!(matches.total, 1);
+}
+
+#[test]
+fn finds_messages_by_reaction_alias() {
+    let messages = vec![message("ship it", vec![reaction("love")])];
+    let view = view(&messages);
+    let command = search("react=love");
+
+    let matches = find(&command, &view, ExecutionContext::default())
+        .expect("search matches");
+
+    assert_eq!(matches.total, 1);
+}
+
+#[test]
+fn other_excludes_own_utterances() {
+    let messages = vec![
+        message_with_flags("from me", message::Direction::Sent, false, vec![]),
+        message_with_flags(
+            "echo from me",
+            message::Direction::Received,
+            true,
+            vec![],
+        ),
+        message("from someone else", vec![]),
+    ];
+    let view = view(&messages);
+    let command = search("--other itext=from");
+
+    let matches = find(&command, &view, ExecutionContext::default())
+        .expect("search matches");
+
+    assert_eq!(matches.total, 1);
+    assert_eq!(matches.messages[0].text(), "from someone else");
+}
+
+#[test]
+fn other_excludes_received_messages_from_own_nick() {
+    let own_nick = Nick::from_str("Roey", crate::isupport::CaseMap::default());
+    let messages = vec![
+        user_message("from me in history", own_nick.clone()),
+        user_message(
+            "from someone else",
+            Nick::from_str("Alice", crate::isupport::CaseMap::default()),
+        ),
+    ];
+    let view = view(&messages);
+    let command = search("--other itext=from");
+
+    let matches = find(
+        &command,
+        &view,
+        ExecutionContext {
+            own_nick: Some(own_nick.as_nickref()),
+        },
+    )
+    .expect("search matches");
+
+    assert_eq!(matches.total, 1);
+    assert_eq!(matches.messages[0].text(), "from someone else");
+}
+
+#[test]
+fn context_includes_neighboring_loaded_lines() {
+    let messages = vec![
+        message("before", vec![]),
+        message("needle", vec![]),
+        message("after", vec![]),
+    ];
+    let view = view(&messages);
+    let command = search("context=1 text=needle");
+
+    let matches = find(&command, &view, ExecutionContext::default())
+        .expect("search matches");
+
+    assert_eq!(matches.total, 1);
+    assert_eq!(matches.messages.len(), 3);
+    assert_eq!(matches.messages[0].text(), "before");
+    assert_eq!(matches.messages[1].text(), "needle");
+    assert_eq!(matches.messages[2].text(), "after");
+}
+
+#[test]
+fn parses_supported_span_units() {
+    assert!(parse(Kind::Search, "span=3d").is_ok());
+    assert!(parse(Kind::Search, "span=2h").is_ok());
+    assert!(parse(Kind::Search, "span=5m").is_ok());
+}
+
+#[test]
+fn rejects_invalid_span_values() {
+    assert!(matches!(
+        parse(Kind::Search, "span=3w"),
+        Err(Error::InvalidSpan)
+    ));
+    assert!(matches!(
+        parse(Kind::Search, "span=0h"),
+        Err(Error::InvalidSpan)
+    ));
+    assert!(matches!(
+        parse(Kind::Search, "span=abc"),
+        Err(Error::InvalidSpan)
+    ));
+}
+
+#[test]
+fn filters_messages_by_span() {
+    let messages = vec![
+        message_at("recent", Utc::now() - Duration::minutes(30), vec![]),
+        message_at("old", Utc::now() - Duration::hours(3), vec![]),
+    ];
+    let view = view(&messages);
+    let command = search("span=2h");
+
+    let matches = find(&command, &view, ExecutionContext::default())
+        .expect("search matches");
+
+    assert_eq!(matches.total, 1);
+    assert_eq!(matches.messages[0].text(), "recent");
+}
+
+#[test]
+fn formats_textonly_without_control_codes() {
+    let server_time =
+        chrono::DateTime::parse_from_rfc3339("2026-06-16T16:01:17.068Z")
+            .expect("timestamp")
+            .with_timezone(&Utc);
+    let message = message_at(
+        "\u{2}bold\u{2} \u{3}04red \u{1b}[31mansi",
+        server_time,
+        vec![],
+    );
+
+    assert_eq!(
+        format_match(
+            &message,
+            Output {
+                text_only: true,
+                ..Output::default()
+            }
+        ),
+        "[2026-06-16 16:01:17 UTC] <status> bold red ansi"
+    );
+}
+
+#[test]
+fn formats_match_timestamps_to_seconds() {
+    let server_time =
+        chrono::DateTime::parse_from_rfc3339("2026-06-16T16:01:17.068Z")
+            .expect("timestamp")
+            .with_timezone(&Utc);
+    let message = message_at("hello", server_time, vec![]);
+
+    assert_eq!(
+        format_match(&message, Output::default()),
+        "[2026-06-16 16:01:17 UTC] <status> hello"
+    );
+}
+
+#[test]
+fn formats_match_without_timestamp() {
+    let server_time =
+        chrono::DateTime::parse_from_rfc3339("2026-06-16T16:01:17.068Z")
+            .expect("timestamp")
+            .with_timezone(&Utc);
+    let message = message_at("hello", server_time, vec![]);
+
+    assert_eq!(
+        format_match(
+            &message,
+            Output {
+                no_timestamp: true,
+                ..Output::default()
+            }
+        ),
+        "<status> hello"
+    );
+}
+
+#[test]
+fn display_match_highlights_text_predicates() {
+    let message = message("hello world hello", vec![]);
+    let command = search("text=hello");
+    let display =
+        format_display_match(&message, Output::default(), Some(&command));
+
+    assert_eq!(display.text_highlights, vec![0..5, 12..17]);
+}
+
+#[test]
+fn display_match_highlights_case_insensitive_text_predicates() {
+    let message = message("Hello world", vec![]);
+    let command = search("itext=hello");
+    let display =
+        format_display_match(&message, Output::default(), Some(&command));
+
+    assert_eq!(display.text_highlights, vec![0..5]);
+}
+
+#[test]
+fn display_match_highlights_regex_text_predicates() {
+    let message = message("socket timeout", vec![]);
+    let command = search("regex=\"t[a-z]+out\"");
+    let display =
+        format_display_match(&message, Output::default(), Some(&command));
+
+    assert_eq!(display.text_highlights, vec![7..14]);
+}
+
+#[test]
+fn display_match_does_not_highlight_negated_text_predicates() {
+    let message = message("hello world", vec![]);
+    let command = search("NOT text=missing");
+    let display =
+        format_display_match(&message, Output::default(), Some(&command));
+
+    assert!(display.text_highlights.is_empty());
+}
+
+fn view(messages: &[message::Message]) -> history::View<'_> {
+    history::View {
+        total: messages.len(),
+        has_more_older_messages: false,
+        has_more_newer_messages: false,
+        old_messages: vec![],
+        new_messages: messages.iter().collect(),
+        cleared: false,
+    }
+}
+
+fn message(text: &str, reactions: Vec<Reaction>) -> message::Message {
+    message_at(text, Utc::now(), reactions)
+}
+
+fn message_at(
+    text: &str,
+    server_time: chrono::DateTime<Utc>,
+    reactions: Vec<Reaction>,
+) -> message::Message {
+    message_at_with_flags(
+        text,
+        server_time,
+        message::Direction::Received,
+        false,
+        reactions,
+    )
+}
+
+fn message_with_flags(
+    text: &str,
+    direction: message::Direction,
+    is_echo: bool,
+    reactions: Vec<Reaction>,
+) -> message::Message {
+    message_at_with_flags(text, Utc::now(), direction, is_echo, reactions)
+}
+
+fn message_at_with_flags(
+    text: &str,
+    server_time: chrono::DateTime<Utc>,
+    direction: message::Direction,
+    is_echo: bool,
+    reactions: Vec<Reaction>,
+) -> message::Message {
+    let received_at = Posix::now();
+    let content = message::plain(text.to_string());
+    let hash = message::Hash::new(&server_time, &content, &received_at);
+
+    message::Message {
+        received_at,
+        server_time,
+        direction,
+        target: message::Target::Server {
+            source: message::Source::Internal(
+                message::source::Internal::Status(
+                    message::source::Status::Success,
+                ),
+            ),
+        },
+        content,
+        id: None,
+        reply_to: None,
+        reply_preview: None,
+        hash,
+        hidden_urls: HashSet::default(),
+        is_echo,
+        received_with_server_time: false,
+        blocked: false,
+        condensed: None,
+        expanded: false,
+        command: None,
+        reactions,
+        rerouted_from: None,
+        deduplicate: false,
+        redaction: None,
+    }
+}
+
+fn user_message(text: &str, nick: Nick) -> message::Message {
+    let received_at = Posix::now();
+    let server_time = Utc::now();
+    let content = message::plain(text.to_string());
+    let hash = message::Hash::new(&server_time, &content, &received_at);
+
+    message::Message {
+        received_at,
+        server_time,
+        direction: message::Direction::Received,
+        target: message::Target::Server {
+            source: message::Source::User(crate::User::from(nick)),
+        },
+        content,
+        id: None,
+        reply_to: None,
+        reply_preview: None,
+        hash,
+        hidden_urls: HashSet::default(),
+        is_echo: false,
+        received_with_server_time: false,
+        blocked: false,
+        condensed: None,
+        expanded: false,
+        command: None,
+        reactions: vec![],
+        rerouted_from: None,
+        deduplicate: false,
+        redaction: None,
+    }
+}
+
+fn reaction(text: &str) -> Reaction {
+    Reaction {
+        sender: Nick::from_str("tester", crate::isupport::CaseMap::default()),
+        text: text.to_string(),
+        unreact: false,
+        id: None,
+        server_time: Utc::now(),
+    }
+}

--- a/data/src/command/search/token.rs
+++ b/data/src/command/search/token.rs
@@ -1,0 +1,128 @@
+use super::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Token {
+    Word(String),
+    Equal,
+    LeftParen,
+    RightParen,
+}
+
+/// Splits raw `/search` input into parser tokens.
+///
+/// Used by the search parser entry point. `raw` is the argument tail after the
+/// command name. Returns words, equals signs, and parentheses while preserving
+/// quoted text as a single word. Produces no output or side effects.
+pub(super) fn tokenize(raw: &str) -> Result<Vec<Token>, Error> {
+    let mut tokens = Vec::new();
+    let mut chars = raw.char_indices().peekable();
+
+    while let Some((_, ch)) = chars.peek().copied() {
+        match ch {
+            ch if ch.is_whitespace() => {
+                chars.next();
+            }
+            '=' => {
+                chars.next();
+                tokens.push(Token::Equal);
+            }
+            '(' => {
+                chars.next();
+                tokens.push(Token::LeftParen);
+            }
+            ')' => {
+                chars.next();
+                tokens.push(Token::RightParen);
+            }
+            _ => tokens.push(Token::Word(read_word(raw, &mut chars)?)),
+        }
+    }
+
+    Ok(tokens)
+}
+
+/// Reads one word token from the current lexer position.
+///
+/// Used by `tokenize`. `raw` is the full input and `chars` points at the first
+/// character of the word. Returns the raw word slice, including quotes when
+/// present. Advances `chars` to the next delimiter. Produces no output or
+/// external side effects.
+fn read_word(
+    raw: &str,
+    chars: &mut std::iter::Peekable<std::str::CharIndices<'_>>,
+) -> Result<String, Error> {
+    // Capture the starting byte index so quoted values preserve their original
+    // spelling until the parser decides whether to unquote or modify them.
+    let start = chars.peek().map(|(index, _)| *index).unwrap_or_default();
+    let mut in_quote = false;
+
+    while let Some((index, ch)) = chars.peek().copied() {
+        if in_quote && ch == '\\' {
+            chars.next();
+
+            if chars.peek().is_some() {
+                chars.next();
+            }
+        } else if ch == '"' {
+            in_quote = !in_quote;
+            chars.next();
+        } else if !in_quote
+            && (ch.is_whitespace() || matches!(ch, '=' | '(' | ')'))
+        {
+            return Ok(raw[start..index].to_string());
+        } else {
+            chars.next();
+        }
+    }
+
+    if in_quote {
+        return Err(Error::Syntax("unterminated quoted value"));
+    }
+
+    Ok(raw[start..].to_string())
+}
+
+/// Removes surrounding quotes from a parser word when present.
+///
+/// Used by selector and literal parsing. `value` is a raw word token. Returns
+/// the unquoted and unescaped value, or the original value when it is not
+/// quoted. Produces no output or side effects.
+pub(super) fn unquote(value: String) -> Result<String, Error> {
+    if value.starts_with('"') {
+        value
+            .strip_prefix('"')
+            .and_then(|value| value.strip_suffix('"'))
+            .map(unescape_quoted)
+            .ok_or(Error::Syntax("unterminated quoted value"))
+    } else {
+        Ok(value)
+    }
+}
+
+/// Applies the quoted-string escape rules for `/search`.
+///
+/// Used by `unquote` and modifier parsing. `value` is the inside of a quoted
+/// value. Returns text where `\"` becomes `"` and `\\` becomes `\`; unknown
+/// escapes are preserved. Produces no output or side effects.
+pub(super) fn unescape_quoted(value: &str) -> String {
+    let mut unescaped = String::with_capacity(value.len());
+    let mut chars = value.chars();
+
+    while let Some(ch) = chars.next() {
+        if ch == '\\'
+            && let Some(next) = chars.next()
+        {
+            match next {
+                '"' | '\\' => unescaped.push(next),
+                _ => {
+                    unescaped.push(ch);
+                    unescaped.push(next);
+                }
+            }
+        } else {
+            unescaped.push(ch);
+        }
+    }
+
+    unescaped
+}

--- a/data/src/config/keys.rs
+++ b/data/src/config/keys.rs
@@ -38,6 +38,8 @@ pub struct Keyboard {
     pub scroll_down_page: KeyBinds,
     pub scroll_to_top: KeyBinds,
     pub scroll_to_bottom: KeyBinds,
+    pub increase_font_size: KeyBinds,
+    pub decrease_font_size: KeyBinds,
     pub cycle_next_unread_buffer: KeyBinds,
     pub cycle_previous_unread_buffer: KeyBinds,
     pub mark_as_read: KeyBinds,
@@ -74,6 +76,12 @@ impl Default for Keyboard {
             scroll_down_page: KeyBind::scroll_down_page().into(),
             scroll_to_top: KeyBind::scroll_to_top().into(),
             scroll_to_bottom: KeyBind::scroll_to_bottom().into(),
+            increase_font_size: vec![
+                KeyBind::increase_font_size(),
+                KeyBind::increase_font_size_shifted(),
+            ]
+            .into(),
+            decrease_font_size: KeyBind::decrease_font_size().into(),
             cycle_next_unread_buffer: KeyBind::cycle_next_unread_buffer()
                 .into(),
             cycle_previous_unread_buffer:
@@ -114,6 +122,8 @@ impl Keyboard {
             (&self.scroll_down_page, ScrollDownPage),
             (&self.scroll_to_top, ScrollToTop),
             (&self.scroll_to_bottom, ScrollToBottom),
+            (&self.increase_font_size, IncreaseFontSize),
+            (&self.decrease_font_size, DecreaseFontSize),
             (&self.highlights, Highlights),
             (&self.cycle_next_unread_buffer, CycleNextUnreadBuffer),
             (

--- a/data/src/shortcut.rs
+++ b/data/src/shortcut.rs
@@ -43,6 +43,27 @@ impl From<KeyBind> for KeyBinds {
     }
 }
 
+impl From<Vec<KeyBind>> for KeyBinds {
+    fn from(values: Vec<KeyBind>) -> Self {
+        let mut unique = Vec::with_capacity(values.len());
+
+        // Default actions can intentionally provide multiple physical bindings
+        // for the same user-visible shortcut, such as Ctrl+= and Ctrl+Shift+=
+        // for "increase font size". Keep the same de-duplication and unbind
+        // filtering rules used by deserialized user configuration.
+        for key_bind in values {
+            if matches!(key_bind, KeyBind::Unbind) || unique.contains(&key_bind)
+            {
+                continue;
+            }
+
+            unique.push(key_bind);
+        }
+
+        Self(unique)
+    }
+}
+
 impl<'de> Deserialize<'de> for KeyBinds {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -105,6 +126,8 @@ pub enum Command {
     ScrollDownPage,
     ScrollToTop,
     ScrollToBottom,
+    IncreaseFontSize,
+    DecreaseFontSize,
     CycleNextUnreadBuffer,
     CyclePreviousUnreadBuffer,
     MarkAsRead,
@@ -347,6 +370,9 @@ impl KeyBind {
     // Don't use HOME / END since text input is always focused
     default!(scroll_to_top, ArrowUp, COMMAND);
     default!(scroll_to_bottom, ArrowDown, COMMAND);
+    default!(increase_font_size, "=", COMMAND);
+    default!(increase_font_size_shifted, "=", COMMAND | SHIFT);
+    default!(decrease_font_size, "-", COMMAND);
     default!(cycle_next_unread_buffer, "`", CTRL);
     default!(cycle_previous_unread_buffer, "`", CTRL | SHIFT);
     // Command + m is minimize in macOS

--- a/docs/configuration/keyboard.md
+++ b/docs/configuration/keyboard.md
@@ -38,6 +38,8 @@ Each shortcut accepts either a single keybind string or an array of keybind stri
 | `scroll_down_page`             | Scroll buffer down a page           | <kbd>Fn</kbd> + <kbd>↓</kbd>                        | <kbd>pagedown</kbd>                                 |
 | `scroll_to_top`                | Scroll to top of buffer             | <kbd>⌘</kbd> + <kbd>↑</kbd>                         | <kbd>ctrl</kbd> + <kbd>↑</kbd>                      |
 | `scroll_to_bottom`             | Scroll to bottom of buffer          | <kbd>⌘</kbd> + <kbd>↓</kbd>                         | <kbd>ctrl</kbd> + <kbd>↓</kbd>                      |
+| `increase_font_size`           | Increase runtime font size          | <kbd>⌘</kbd> + <kbd>+</kbd>                         | <kbd>ctrl</kbd> + <kbd>+</kbd>                      |
+| `decrease_font_size`           | Decrease runtime font size          | <kbd>⌘</kbd> + <kbd>-</kbd>                         | <kbd>ctrl</kbd> + <kbd>-</kbd>                      |
 | `leave_buffer`                 | Leave channel or close query        | <kbd>⌘</kbd> + <kbd>shift</kbd> + <kbd>w</kbd>      | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>w</kbd>   |
 | `mark_as_read`                 | Mark focused buffer as read         | <kbd>⌘</kbd> + <kbd>shift</kbd> + <kbd>m</kbd>      | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>m</kbd>   |
 | `toggle_nick_list`             | Toggle nick list                    | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>m</kbd>          | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>m</kbd>     |

--- a/docs/guides/search-common-feature-guide.md
+++ b/docs/guides/search-common-feature-guide.md
@@ -7,6 +7,10 @@ added in the Halloy feature branch. It is written as both user documentation
 and a portable design reference for possible future implementations in other
 IRC clients such as Konversation or Uplink.
 
+The branch also includes a buffer-close focus recovery fix: closing a channel
+or direct conversation returns focus to a useful related buffer instead of
+leaving the main pane on an empty "Select buffer" state.
+
 ## Security Model
 
 These commands are local inspection tools. They must not send IRC traffic by
@@ -253,6 +257,24 @@ Rules:
 - Shared channel names are sorted alphabetically.
 - Result rows are sorted by display nick.
 - No network refresh is performed.
+
+## Buffer Close Focus Recovery
+
+This branch also fixes a usability issue when closing buffers. Previously,
+closing a channel or direct conversation could leave Halloy showing an empty
+"Select buffer" pane even though useful nearby buffers were still available.
+
+The new focus-selection behavior chooses a replacement buffer locally:
+
+- prefer the parent/spawning buffer when that relationship is known;
+- otherwise prefer the most recent suitable buffer on the same network;
+- fall back to the same-network server buffer when appropriate;
+- avoid crossing networks while choosing a replacement;
+- use the empty selection state only when there is no suitable replacement.
+
+This is intentionally independent from `/search` and `/common`, but it supports
+the same workflow goal: commands or buffer actions that open or close panes
+should leave focus somewhere predictable and useful.
 
 ## Future `/common` Identity Enrichment
 

--- a/docs/guides/search-common-feature-guide.md
+++ b/docs/guides/search-common-feature-guide.md
@@ -323,3 +323,45 @@ For Konversation, Uplink, or another IRC client, keep the same major seams:
 The portable command grammar is more important than the Halloy-specific UI
 wiring. A different client can render results in a tab, pane, dialog, or inline
 buffer while retaining the same parser and security model.
+
+## Development Guidelines Used
+
+This branch was developed under a small set of explicit engineering guidelines:
+
+- Security first. New commands default to local-only behavior and must not send
+  IRC traffic unless a future option explicitly says it does.
+- Minimize upstream disruption. Existing Halloy files are touched mainly for
+  command registration, dispatch, buffer plumbing, and rendering hooks.
+- Keep feature logic localized. Parser, evaluator, formatter, and `/common`
+  scan logic live in added modules so reviewers can inspect the new behavior in
+  a small number of places.
+- Match Halloy style. Naming, module structure, parser patterns, and UI wiring
+  follow nearby Halloy conventions where practical.
+- Refactor only our added code aggressively. Upstream code is not reshaped just
+  to support this feature branch.
+- Keep files reviewable. Added production modules are split below the 500-line
+  refactoring-review trigger; the search test module is the remaining known
+  split candidate.
+- Prefer typed parsing and explicit errors. Command input is parsed into typed
+  selectors, modifiers, options, and expression trees instead of ad hoc string
+  handling during execution.
+- Use existing libraries where appropriate. Regex validation and escaping use
+  the existing regex crate support instead of custom metacharacter ladders.
+- Test parser and evaluator behavior directly. Unit tests cover selectors,
+  boolean grouping, modifiers, span parsing, escaping, output flags, filtering,
+  formatting, highlighting, and `/common` summary behavior.
+- Document non-obvious code. Added functions include comments describing their
+  purpose, callers, inputs, return values, and side effects or lack of side
+  effects.
+- Preserve privacy. Local config files and credentials are not committed, and
+  the staged diff is checked before publication.
+- Keep future network behavior explicit. Identity enrichment, saved searches,
+  result persistence, `view=tab`, and read-marker aware `/last` are documented
+  as separate slices rather than hidden inside this implementation.
+- Respect upstream process. This branch is presented as a draft/discussion
+  artifact, and any upstreamable patch should follow Halloy's contribution
+  rules at the time it is submitted.
+- Acknowledge AI assistance. This branch and document were produced with Codex
+  assistance under the guidelines above: security-first behavior, localized
+  changes, explicit tests, reviewable module boundaries, documented tradeoffs,
+  and human review before any upstream submission.

--- a/docs/guides/search-common-feature-guide.md
+++ b/docs/guides/search-common-feature-guide.md
@@ -1,0 +1,325 @@
+# Halloy Search And Common Channel Feature Guide
+
+Updated: 2026-06-16 EDT
+
+This document describes the local `/search`, `/last`, and `/common` features
+added in the Halloy feature branch. It is written as both user documentation
+and a portable design reference for possible future implementations in other
+IRC clients such as Konversation or Uplink.
+
+## Security Model
+
+These commands are local inspection tools. They must not send IRC traffic by
+default.
+
+- `/search` and `/last` inspect already-loaded local Halloy history only.
+- `/common` inspects already-known in-memory channel membership only.
+- `/common` does not issue `WHOIS`, `WHO`, `NAMES`, or other network refreshes.
+- Search result output is local status output or a local result pane.
+- Saved searches, filesystem scans, persistent result storage, and active
+  identity refresh are separate future features.
+
+Future network-enrichment modes, such as `/common --whois`, should be explicit,
+rate-limited, and documented as active network behavior.
+
+## `/search`
+
+`/search` searches the current buffer's loaded visible history.
+
+```text
+/search text=timeout
+/search itext=timeout
+/search regex="tim(e|ed) out"
+/search origin=alice text=deploy
+```
+
+Bare text is treated as a message-body search:
+
+```text
+/search timeout
+```
+
+Selector text inside quotes is literal body text:
+
+```text
+/search origin="alice"
+/search "origin=alice"
+```
+
+The first command filters by origin. The second command searches message text
+for the literal string `origin=alice`.
+
+## `/last`
+
+`/last` is retained as a convenience form of search for the current buffer.
+In the current implementation it searches the current buffer's loaded visible
+history. It is not yet anchored to a HexChat-style read marker.
+
+Planned future behavior: once read markers exist, `/last` should search from
+the last-viewed/read-marker boundary to the present by default.
+
+## Search Selectors
+
+| Selector | Aliases | Value |
+| --- | --- | --- |
+| `text` | `itext`, `regex`, `iregex`, `regexp`, `re`, `rx`, `exp` | string |
+| `origin` | `from`, `sender`, `nick`, `name` | nickname |
+| `target` | `to` | nickname or channel |
+| `type` | `kind` | message type |
+| `span` | `since` | duration |
+| `reaction` | `react` | reaction name |
+
+Examples:
+
+```text
+/search nick=alice
+/search react=love
+/search reaction=thumbsup
+/search type=action text=deploy
+```
+
+## Boolean Expressions
+
+Search expressions support explicit boolean operators and parentheses.
+
+```text
+/search text=deploy AND origin=alice
+/search text=deploy OR text=rollback
+/search text=deploy AND NOT origin=bob
+/search (text=deploy OR text=rollback) AND origin=alice
+```
+
+Adjacent predicates default to `AND`:
+
+```text
+/search origin=alice text=deploy
+```
+
+## String Modifiers
+
+Any string-valued selector can use compact modifiers before a quoted value:
+
+| Modifier | Meaning |
+| --- | --- |
+| `i` | case-insensitive |
+| `n` | negated |
+| `a` | comma-list values use AND |
+| `o` | comma-list values use OR |
+| `x` | regular expression |
+
+Examples:
+
+```text
+/search text=i"timeout"
+/search text=x"tim(e|ed) out"
+/search text=ix"tim(e|ed) out"
+/search text=n"noise"
+/search reaction=o"love,thumbsup"
+```
+
+The modifier form is intended to be portable across selectors:
+
+```text
+/search origin=i"alice"
+/search target=i"#rust"
+/search reaction=i"love"
+```
+
+## Quoting And Escapes
+
+Inside quoted values:
+
+- `\"` means a literal double quote.
+- `\\` means a literal backslash.
+- Unknown escape sequences preserve the backslash and following character.
+
+Examples:
+
+```text
+/search text="he said \"hello\""
+/search text="path C:\\tmp"
+```
+
+## Span
+
+`span=` accepts positive duration values with a required unit:
+
+| Example | Meaning |
+| --- | --- |
+| `span=3d` | last 3 days |
+| `span=2h` | last 2 hours |
+| `span=5m` | last 5 minutes |
+
+Examples:
+
+```text
+/search span=3d text=release
+/last span=2h itext=error
+```
+
+## Search Output Options
+
+| Option | Meaning |
+| --- | --- |
+| `--textonly` | strips IRC formatting controls and ANSI color/control sequences |
+| `--notimestamp` | omits timestamps from output |
+| `--other` | excludes messages uttered by the local user |
+| `context=<lines>` | includes loaded lines before and after each match |
+| `view=inline` | outputs local status lines in the current buffer |
+| `view=pane` | opens a transient local result pane |
+| `view=tab` | parsed but not implemented yet |
+
+Examples:
+
+```text
+/search --textonly itext=error
+/search --notimestamp text=deploy
+/search --other text=deploy
+/search context=2 text=panic
+/search view=pane itext=timeout
+```
+
+Timestamps are displayed to whole seconds:
+
+```text
+[2026-06-16 16:01:17 UTC] <alice> example
+```
+
+With `--notimestamp`:
+
+```text
+<alice> example
+```
+
+## Highlighting
+
+`view=pane` highlights positive message-body text predicate matches.
+
+Examples:
+
+```text
+/search view=pane text=timeout
+/search view=pane itext=timeout
+/search view=pane regex="tim(e|ed) out"
+```
+
+Current scope:
+
+- Highlights body text matches.
+- Highlights repeated matches.
+- Highlights multiple positive text predicates.
+- Does not yet highlight origin, target, type, or reaction fields.
+- Inline output is plain local status text.
+
+## `/common`
+
+`/common` lists users in the current channel who share other known channels with
+you. It uses Halloy's in-memory membership state only.
+
+```text
+/common
+/common scope=network
+/common scope=global
+```
+
+`scope=global` is the default.
+
+## `/common` Scope
+
+| Scope | Meaning | Display |
+| --- | --- | --- |
+| `scope=network` | current network only | `nick: #channel` |
+| `scope=global` | all connected networks | `network/nick: #channel` |
+
+Examples:
+
+```text
+/common scope=network
+alice: #rust, #linux
+```
+
+```text
+/common
+libera/alice: #rust
+oftc/alice: #debian
+```
+
+Rules:
+
+- `/common` works only from a channel buffer.
+- The local user's nick is excluded.
+- The current channel is excluded from the displayed overlap.
+- Users with no other shared known channels are omitted.
+- Shared channel names are sorted alphabetically.
+- Result rows are sorted by display nick.
+- No network refresh is performed.
+
+## Future `/common` Identity Enrichment
+
+The current `/common` implementation matches by nick across known membership
+state. A future enrichment slice can improve identity matching by using
+attributes Halloy already has in memory:
+
+- nick
+- username
+- hostname
+- account name
+
+An active `WHOIS` pass can provide stronger correlation on some networks, but
+it should be opt-in, explicit, and rate-limited:
+
+```text
+/common --whois
+```
+
+This future mode should clearly indicate that it sends IRC traffic.
+
+## Halloy Implementation Notes
+
+The current Halloy implementation keeps most feature logic in added modules:
+
+- `data/src/command/search/`
+- `data/src/command/common.rs`
+- `src/buffer/common.rs`
+- `src/buffer/search_results.rs`
+
+Existing Halloy files are used mainly for parser registration, command
+dispatch, buffer event plumbing, and pane rendering.
+
+The current implementation intentionally avoids:
+
+- persistent saved search storage;
+- active log/file scans;
+- active WHOIS fan-out;
+- first-class `view=tab` search-result buffers;
+- read-marker based `/last`.
+
+## Upstream Contribution Notes
+
+Halloy's current contribution guidance says significant new features should be
+discussed before submission and that patches are submitted through GitHub pull
+requests. If this work adds user-facing settings later, the related website
+Markdown documentation should be updated along with the code.
+
+Halloy's contribution page also currently says submitted AI-generated content
+is not allowed. This document is therefore a private design/support artifact for
+review, discussion, and possible porting. Any upstream submission should be
+human-owned, reviewed, and rewritten as needed to comply with the project's
+rules at the time of submission.
+
+Reference: <https://halloy.chat/contributing#patches-pull-requests>
+
+## Porting Notes
+
+For Konversation, Uplink, or another IRC client, keep the same major seams:
+
+- parse command syntax into typed selectors/options;
+- evaluate only local history or explicitly requested network data;
+- keep formatting/highlighting separate from evaluation;
+- make network-enriching modes opt-in;
+- keep default behavior local and side-effect free;
+- expose `scope=network|global` for common-channel matching.
+
+The portable command grammar is more important than the Halloy-specific UI
+wiring. A different client can render results in a tab, pane, dialog, or inline
+buffer while retaining the same parser and security model.

--- a/docs/guides/search-common-feature-guide.md
+++ b/docs/guides/search-common-feature-guide.md
@@ -5,7 +5,8 @@ Updated: 2026-06-16 EDT
 This document describes the local `/search`, `/last`, and `/common` features
 added in the Halloy feature branch. It is written as both user documentation
 and a portable design reference for possible future implementations in other
-IRC clients such as Konversation or Uplink.
+IRC clients such as Zoitechat, Konversation, and Uplink. The portable feature
+set is referred to below as **Rich Search Functionality** for IRC clients.
 
 The branch also includes a buffer-close focus recovery fix: closing a channel
 or direct conversation returns focus to a useful related buffer instead of
@@ -333,7 +334,8 @@ Reference: <https://halloy.chat/contributing#patches-pull-requests>
 
 ## Porting Notes
 
-For Konversation, Uplink, or another IRC client, keep the same major seams:
+For Zoitechat, Konversation, Uplink, or another IRC client, keep the same major
+seams:
 
 - parse command syntax into typed selectors/options;
 - evaluate only local history or explicitly requested network data;
@@ -345,6 +347,33 @@ For Konversation, Uplink, or another IRC client, keep the same major seams:
 The portable command grammar is more important than the Halloy-specific UI
 wiring. A different client can render results in a tab, pane, dialog, or inline
 buffer while retaining the same parser and security model.
+
+### Rich Search Functionality Port Targets
+
+The portable feature name for this work is **Rich Search Functionality**. The
+goal is to carry the command grammar, local-only security model, common-channel
+logic, and result rendering concepts across multiple IRC clients while adapting
+the data access and UI layers to each codebase.
+
+Likely implementation targets:
+
+| Client | Likely implementation language/style | Porting shape |
+| --- | --- | --- |
+| Zoitechat | likely C/GTK3 | Native plugin or client patch, depending on its extension API. |
+| Konversation | C++/KDE/Qt | Native C++ patch or script/plugin if its scripting API exposes enough message and channel state. |
+| Uplink | C++/Qt6 | Native C++/Qt6 implementation, ideally with a reusable parser/evaluator library. |
+
+The preferred architecture for each port is:
+
+- a small parser/evaluator core for the Rich Search Functionality grammar;
+- a client-specific message-history adapter;
+- a client-specific known-channel/user adapter for `/common`;
+- a result renderer that matches the client's native UI conventions;
+- an optional, explicit network-enrichment layer for `WHOIS`/`319` support.
+
+The default mode should remain local-only in every client. If a port adds
+active server queries, those should be exposed as explicit options rather than
+implicit behavior.
 
 ## Development Guidelines Used
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -18,6 +18,7 @@ pub use self::file_transfers::FileTransfers;
 pub use self::highlights::Highlights;
 pub use self::logs::Logs;
 pub use self::query::Query;
+pub use self::search_results::SearchResults;
 pub use self::server::Server;
 use crate::Theme;
 use crate::screen::dashboard::sidebar;
@@ -26,6 +27,7 @@ use crate::window::Window;
 
 pub mod channel;
 pub mod channel_discovery;
+mod common;
 pub mod context_menu;
 pub mod empty;
 pub mod file_transfers;
@@ -35,6 +37,7 @@ pub mod logs;
 mod message_view;
 pub mod query;
 mod scroll_view;
+pub mod search_results;
 pub mod server;
 pub mod typing;
 
@@ -48,6 +51,7 @@ pub enum Buffer {
     Logs(Logs),
     Highlights(Highlights),
     ChannelDiscovery(ChannelDiscovery),
+    SearchResults(SearchResults),
 }
 
 #[derive(Debug, Clone)]
@@ -65,6 +69,7 @@ pub enum Event {
     ContextMenu(context_menu::Event),
     OpenBuffers(data::Server, Vec<(Target, BufferAction)>),
     OpenInternalBuffer(buffer::Internal),
+    OpenSearchResults(SearchResults),
     OpenServer(String),
     Reconnect(data::Server),
     LeaveBuffers(Vec<Target>, Option<String>),
@@ -146,7 +151,8 @@ impl Buffer {
             | Buffer::FileTransfers(_)
             | Buffer::Logs(_)
             | Buffer::Highlights(_)
-            | Buffer::ChannelDiscovery(_) => None,
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::SearchResults(_) => None,
         }
     }
 
@@ -155,7 +161,8 @@ impl Buffer {
             Buffer::Empty
             | Buffer::Channel(_)
             | Buffer::Server(_)
-            | Buffer::Query(_) => None,
+            | Buffer::Query(_)
+            | Buffer::SearchResults(_) => None,
             Buffer::FileTransfers(_) => Some(buffer::Internal::FileTransfers),
             Buffer::Logs(_) => Some(buffer::Internal::Logs),
             Buffer::Highlights(_) => Some(buffer::Internal::Highlights),
@@ -189,6 +196,7 @@ impl Buffer {
             Buffer::ChannelDiscovery(state) => Some(data::Buffer::Internal(
                 buffer::Internal::ChannelDiscovery(state.server.clone()),
             )),
+            Buffer::SearchResults(_) => None,
         }
     }
 
@@ -201,7 +209,8 @@ impl Buffer {
             | Buffer::FileTransfers(_)
             | Buffer::Logs(_)
             | Buffer::Highlights(_)
-            | Buffer::ChannelDiscovery(_) => None,
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::SearchResults(_) => None,
         }
     }
 
@@ -216,7 +225,8 @@ impl Buffer {
             | Buffer::FileTransfers(_)
             | Buffer::Logs(_)
             | Buffer::Highlights(_)
-            | Buffer::ChannelDiscovery(_) => None,
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::SearchResults(_) => None,
         }
     }
 
@@ -246,7 +256,8 @@ impl Buffer {
             | Buffer::FileTransfers(_)
             | Buffer::Logs(_)
             | Buffer::Highlights(_)
-            | Buffer::ChannelDiscovery(_) => None,
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::SearchResults(_) => None,
         }
     }
 
@@ -278,6 +289,9 @@ impl Buffer {
                     }
                     channel::Event::OpenInternalBuffer(buffer) => {
                         Event::OpenInternalBuffer(buffer)
+                    }
+                    channel::Event::OpenSearchResults(results) => {
+                        Event::OpenSearchResults(results)
                     }
                     channel::Event::OpenServer(server) => {
                         Event::OpenServer(server)
@@ -350,6 +364,9 @@ impl Buffer {
                     server::Event::OpenInternalBuffer(buffer) => {
                         Event::OpenInternalBuffer(buffer)
                     }
+                    server::Event::OpenSearchResults(results) => {
+                        Event::OpenSearchResults(results)
+                    }
                     server::Event::OpenServer(server) => {
                         Event::OpenServer(server)
                     }
@@ -416,6 +433,9 @@ impl Buffer {
                     }
                     query::Event::OpenInternalBuffer(buffer) => {
                         Event::OpenInternalBuffer(buffer)
+                    }
+                    query::Event::OpenSearchResults(results) => {
+                        Event::OpenSearchResults(results)
                     }
                     query::Event::OpenServer(server) => {
                         Event::OpenServer(server)
@@ -631,6 +651,7 @@ impl Buffer {
                 channel_discovery::view(state, clients, config, theme)
                     .map(Message::ChannelList)
             }
+            Buffer::SearchResults(state) => search_results::view(state, theme),
         }
     }
 
@@ -643,7 +664,8 @@ impl Buffer {
             | Buffer::FileTransfers(_)
             | Buffer::Logs(_)
             | Buffer::Highlights(_)
-            | Buffer::ChannelDiscovery(_) => false,
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::SearchResults(_) => false,
         }
     }
 
@@ -677,7 +699,8 @@ impl Buffer {
             Buffer::Empty
             | Buffer::FileTransfers(_)
             | Buffer::Logs(_)
-            | Buffer::Highlights(_) => Task::none(),
+            | Buffer::Highlights(_)
+            | Buffer::SearchResults(_) => Task::none(),
             Buffer::Channel(channel) => channel.focus().map(Message::Channel),
             Buffer::Server(server) => server.focus().map(Message::Server),
             Buffer::Query(query) => query.focus().map(Message::Query),
@@ -693,7 +716,8 @@ impl Buffer {
             | Buffer::FileTransfers(_)
             | Buffer::Logs(_)
             | Buffer::Highlights(_)
-            | Buffer::ChannelDiscovery(_) => {}
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::SearchResults(_) => {}
             Buffer::Channel(channel) => channel.reset(),
             Buffer::Server(server) => server.reset(),
             Buffer::Query(query) => query.reset(),
@@ -711,7 +735,8 @@ impl Buffer {
             | Buffer::FileTransfers(_)
             | Buffer::Logs(_)
             | Buffer::Highlights(_)
-            | Buffer::ChannelDiscovery(_) => (),
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::SearchResults(_) => (),
             Buffer::Server(state) => state.input_view.insert_user(
                 nick,
                 state.buffer.clone(),
@@ -744,7 +769,8 @@ impl Buffer {
             | Buffer::FileTransfers(_)
             | Buffer::Logs(_)
             | Buffer::Highlights(_)
-            | Buffer::ChannelDiscovery(_) => (),
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::SearchResults(_) => (),
             Buffer::Server(state) => {
                 state.input_view.process_completion_and_notice(
                     &state.buffer,
@@ -776,7 +802,8 @@ impl Buffer {
         match self {
             Buffer::Empty
             | Buffer::FileTransfers(_)
-            | Buffer::ChannelDiscovery(_) => Task::none(),
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::SearchResults(_) => Task::none(),
             Buffer::Channel(channel) => {
                 channel.scroll_view.scroll_up_page().map(|message| {
                     Message::Channel(channel::Message::ScrollView(message))
@@ -811,7 +838,8 @@ impl Buffer {
         match self {
             Buffer::Empty
             | Buffer::FileTransfers(_)
-            | Buffer::ChannelDiscovery(_) => Task::none(),
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::SearchResults(_) => Task::none(),
             Buffer::Channel(channel) => {
                 channel.scroll_view.scroll_down_page().map(|message| {
                     Message::Channel(channel::Message::ScrollView(message))
@@ -846,7 +874,8 @@ impl Buffer {
         match self {
             Buffer::Empty
             | Buffer::FileTransfers(_)
-            | Buffer::ChannelDiscovery(_) => Task::none(),
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::SearchResults(_) => Task::none(),
             Buffer::Channel(channel) => {
                 channel.scroll_view.scroll_to_start(config).map(|message| {
                     Message::Channel(channel::Message::ScrollView(message))
@@ -882,7 +911,8 @@ impl Buffer {
         match self {
             Buffer::Empty
             | Buffer::FileTransfers(_)
-            | Buffer::ChannelDiscovery(_) => Task::none(),
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::SearchResults(_) => Task::none(),
             Buffer::Channel(channel) => {
                 channel.scroll_view.scroll_to_end(config).map(|message| {
                     Message::Channel(channel::Message::ScrollView(message))
@@ -922,7 +952,8 @@ impl Buffer {
         match self {
             Buffer::Empty
             | Buffer::FileTransfers(_)
-            | Buffer::ChannelDiscovery(_) => Task::none(),
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::SearchResults(_) => Task::none(),
             Buffer::Channel(state) => state
                 .scroll_view
                 .scroll_to_message(
@@ -991,7 +1022,8 @@ impl Buffer {
         match self {
             Buffer::Empty
             | Buffer::FileTransfers(_)
-            | Buffer::ChannelDiscovery(_) => Task::none(),
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::SearchResults(_) => Task::none(),
             Buffer::Channel(state) => state
                 .scroll_view
                 .scroll_to_backlog(
@@ -1047,7 +1079,8 @@ impl Buffer {
         match self {
             Buffer::Empty
             | Buffer::FileTransfers(_)
-            | Buffer::ChannelDiscovery(_) => false,
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::SearchResults(_) => false,
             Buffer::Channel(state) => state.scroll_view.has_pending_scroll_to(),
             Buffer::Server(state) => state.scroll_view.has_pending_scroll_to(),
             Buffer::Query(state) => state.scroll_view.has_pending_scroll_to(),
@@ -1066,7 +1099,8 @@ impl Buffer {
         match self {
             Buffer::Empty
             | Buffer::FileTransfers(_)
-            | Buffer::ChannelDiscovery(_) => Task::none(),
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::SearchResults(_) => Task::none(),
             Buffer::Channel(state) => state
                 .scroll_view
                 .prepare_for_pending_scroll_to(
@@ -1126,7 +1160,8 @@ impl Buffer {
         match self {
             Buffer::Empty
             | Buffer::FileTransfers(_)
-            | Buffer::ChannelDiscovery(_) => None,
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::SearchResults(_) => None,
             Buffer::Channel(channel) => {
                 Some(channel.scroll_view.is_scrolled_to_bottom())
             }
@@ -1149,7 +1184,8 @@ impl Buffer {
             | Buffer::FileTransfers(_)
             | Buffer::Logs(_)
             | Buffer::Highlights(_)
-            | Buffer::ChannelDiscovery(_) => false,
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::SearchResults(_) => false,
             Buffer::Server(state) => state.input_view.close_picker(),
             Buffer::Channel(state) => state.input_view.close_picker(),
             Buffer::Query(state) => state.input_view.close_picker(),
@@ -1166,7 +1202,8 @@ impl Buffer {
             | Buffer::FileTransfers(_)
             | Buffer::Logs(_)
             | Buffer::Highlights(_)
-            | Buffer::ChannelDiscovery(_) => false,
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::SearchResults(_) => false,
             Buffer::Server(state) => state.input_view.clear_draft_reply(
                 &state.buffer,
                 history,
@@ -1189,7 +1226,8 @@ impl Buffer {
         match self {
             Buffer::Empty
             | Buffer::FileTransfers(_)
-            | Buffer::ChannelDiscovery(_) => (),
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::SearchResults(_) => (),
             Buffer::Channel(channel) => {
                 channel.scroll_view.update_pane_size(pane_size, config);
             }
@@ -1214,7 +1252,8 @@ impl Buffer {
             | Buffer::FileTransfers(_)
             | Buffer::Logs(_)
             | Buffer::Highlights(_)
-            | Buffer::ChannelDiscovery(_) => None,
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::SearchResults(_) => None,
             Buffer::Server(state) => state.input_view.draft_reply(),
             Buffer::Channel(state) => state.input_view.draft_reply(),
             Buffer::Query(state) => state.input_view.draft_reply(),
@@ -1227,7 +1266,8 @@ impl Buffer {
             | Buffer::FileTransfers(_)
             | Buffer::Logs(_)
             | Buffer::Highlights(_)
-            | Buffer::ChannelDiscovery(_) => (),
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::SearchResults(_) => (),
             Buffer::Server(state) => {
                 state.input_view.set_reply_preview(reply_preview);
             }
@@ -1252,6 +1292,7 @@ impl fmt::Display for Buffer {
             Buffer::Logs(_) => write!(f, "Logs"),
             Buffer::Highlights(_) => write!(f, "Highlights"),
             Buffer::ChannelDiscovery(_) => write!(f, "Channel Discovery"),
+            Buffer::SearchResults(_) => write!(f, "Search Results"),
         }
     }
 }

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -31,6 +31,7 @@ pub enum Event {
     ContextMenu(context_menu::Event),
     OpenBuffers(Server, Vec<(Target, BufferAction)>),
     OpenInternalBuffer(buffer::Internal),
+    OpenSearchResults(super::SearchResults),
     OpenServer(String),
     Reconnect(Server),
     LeaveBuffers(Vec<Target>, Option<String>),
@@ -438,6 +439,9 @@ impl Channel {
                     }
                     Some(input_view::Event::OpenInternalBuffer(buffer)) => {
                         (command, Some(Event::OpenInternalBuffer(buffer)))
+                    }
+                    Some(input_view::Event::OpenSearchResults(results)) => {
+                        (command, Some(Event::OpenSearchResults(results)))
                     }
                     Some(input_view::Event::OpenServer(server)) => {
                         (command, Some(Event::OpenServer(server)))

--- a/src/buffer/common.rs
+++ b/src/buffer/common.rs
@@ -1,0 +1,157 @@
+use data::buffer::Upstream;
+use data::user::Nick;
+use data::{client, command};
+
+/// Builds display entries for `/common` from Halloy's live client state.
+///
+/// Used by the input view command dispatcher. `buffer` supplies the current
+/// context and must be a channel, `clients` supplies already-known in-memory
+/// membership state, and `command` supplies the selected scope. Returns sorted
+/// `/common` entries or a local error message. Produces no network traffic,
+/// filesystem access, or persistent output.
+pub fn entries(
+    buffer: &Upstream,
+    clients: &client::Map,
+    command: command::common::Command,
+) -> Result<Vec<command::common::Entry>, String> {
+    // `/common` is defined around a current channel. Server and query buffers
+    // do not provide the anchor channel needed to decide which users to check.
+    let Upstream::Channel(current_server, current_channel) = buffer else {
+        return Err("Common channels are available only in channel buffers."
+            .to_string());
+    };
+
+    // Candidate nicks are copied out of live channel state before any broader
+    // scan. This keeps the later network/global passes free of long borrows
+    // against the client map.
+    let nicks = candidate_nicks(buffer, clients);
+
+    // Scope selection is deliberately explicit. Global is the default command
+    // behavior, but network remains useful when the user wants current-server
+    // output without network prefixes.
+    let entries = match command.scope {
+        command::common::Scope::Network => {
+            network_entries(clients, current_server, current_channel, &nicks)
+        }
+        command::common::Scope::Global => {
+            global_entries(clients, current_server, current_channel, &nicks)
+        }
+    };
+
+    // The data command module owns sorting, deduplication, and omission of
+    // users with no remaining shared channels, so the UI layer cannot drift.
+    Ok(command::common::summarize(entries))
+}
+
+/// Extracts candidate nicks from the spawning channel.
+///
+/// Used by `entries`. `buffer` identifies the current channel and `clients`
+/// provides its in-memory user list. Returns owned nicks excluding the local
+/// user. Produces no output or side effects.
+fn candidate_nicks(buffer: &Upstream, clients: &client::Map) -> Vec<Nick> {
+    // The caller has already checked that the buffer is a channel. Matching
+    // here keeps this helper total and avoids panicking if it is reused later.
+    let Upstream::Channel(server, channel) = buffer else {
+        return Vec::new();
+    };
+
+    // If Halloy has no current user list for the channel, there is no safe
+    // local data to inspect. Returning an empty list keeps `/common` local-only.
+    let Some(users) = clients.get_channel_users(server, channel) else {
+        return Vec::new();
+    };
+
+    // The local user is excluded before any scope-specific scan, so both
+    // network and global modes share the same privacy behavior.
+    let own_nick = clients.nickname(server);
+
+    users
+        .iter()
+        .filter_map(|user| {
+            // Skip the local user's own nick. It would otherwise commonly
+            // appear in every joined channel and dominate the result list.
+            if own_nick.is_some_and(|own_nick| user.nickname() == own_nick) {
+                None
+            } else {
+                // Store an owned normalized nick so later lookups can use
+                // Halloy's server-aware nick comparison without borrowing the
+                // current channel user list.
+                Some(Nick::from(user.nickname()))
+            }
+        })
+        .collect()
+}
+
+/// Builds `/common scope=network` entries.
+///
+/// Used by `entries`. `clients` supplies local membership state,
+/// `current_server` and `current_channel` identify the anchor, and `nicks` are
+/// candidates from that channel. Returns unnormalized entries scoped to the
+/// current server. Produces no output or side effects.
+fn network_entries(
+    clients: &client::Map,
+    current_server: &data::Server,
+    current_channel: &data::target::Channel,
+    nicks: &[Nick],
+) -> Vec<command::common::Entry> {
+    nicks
+        .iter()
+        .map(|nick| {
+            // Network scope checks only the current server and omits the
+            // channel that spawned the command from the displayed overlap.
+            let channels = clients
+                .get_user_channels(current_server, nick.as_nickref())
+                .into_iter()
+                .filter(|shared| shared != current_channel)
+                .map(|shared| shared.to_string())
+                .collect();
+
+            command::common::Entry {
+                nick: nick.to_string(),
+                channels,
+            }
+        })
+        .collect()
+}
+
+/// Builds `/common scope=global` entries.
+///
+/// Used by `entries`. `clients` supplies all connected server state,
+/// `current_server` and `current_channel` identify the anchor to omit, and
+/// `nicks` are candidates from that channel. Returns unnormalized entries with
+/// `network/nick` labels. Produces no network traffic, output, or side effects.
+fn global_entries(
+    clients: &client::Map,
+    current_server: &data::Server,
+    current_channel: &data::target::Channel,
+    nicks: &[Nick],
+) -> Vec<command::common::Entry> {
+    let mut entries = Vec::new();
+
+    // Global scope still reads only Halloy's in-memory state. It walks the
+    // connected server set and never sends WHOIS, WHO, or any other IRC query.
+    for server in clients.connected_servers() {
+        // Each candidate nick from the spawning channel is checked on each
+        // connected network so output can show `network/nick` explicitly.
+        for nick in nicks {
+            let channels = clients
+                .get_user_channels(server, nick.as_nickref())
+                .into_iter()
+                .filter(|shared| {
+                    // The spawning channel is context, not a result. Other
+                    // channels with the same name on other networks remain
+                    // valid because their server differs.
+                    server != current_server || shared != current_channel
+                })
+                .map(|shared| shared.to_string())
+                .collect();
+
+            entries.push(command::common::Entry {
+                nick: format!("{server}/{nick}"),
+                channels,
+            });
+        }
+    }
+
+    entries
+}

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::convert;
 use std::time::{Duration, Instant};
 
@@ -14,6 +14,7 @@ use data::input::{self, CodeFence, RawInput};
 use data::rate_limit::TokenPriority;
 use data::server::Server;
 use data::target::Target;
+use data::time::Posix;
 use data::user::{ChannelUsers, Nick};
 use data::{Config, User, client, command, message, metadata, shortcut};
 use iced::advanced::widget::Tree;
@@ -30,6 +31,8 @@ use unicode_segmentation::UnicodeSegmentation;
 
 use self::completion::Completion;
 use self::exec::run as execute_shell_command;
+use super::common as common_results;
+use super::search_results::SearchResults;
 use crate::widget::key_press::is_numpad;
 use crate::widget::user_display::UserDisplay;
 use crate::widget::{
@@ -44,6 +47,213 @@ mod exec;
 
 const TYPING_REFRESH_INTERVAL: Duration = Duration::from_secs(4);
 
+fn search_results(
+    buffer: &Upstream,
+    matches: command::search::Matches<'_>,
+    search: &command::search::Command,
+) -> SearchResults {
+    // Search result panes are transient and local-only. The lines are owned
+    // strings so the pane does not borrow from mutable history state.
+    let summary = format!(
+        "Search matched {} visible messages{} in {}",
+        matches.total,
+        if matches.truncated {
+            "; showing first 50"
+        } else {
+            ""
+        },
+        buffer.key()
+    );
+    let lines = matches
+        .messages
+        .into_iter()
+        .map(|message| {
+            command::search::format_display_match(
+                message,
+                search.output,
+                Some(search),
+            )
+        })
+        .collect();
+
+    SearchResults::new("Search Results".to_string(), summary, lines)
+}
+
+fn search_result_messages(
+    buffer: &Upstream,
+    matches: command::search::Matches<'_>,
+    output: command::search::Output,
+) -> Vec<message::Message> {
+    // Inline results use the same local status-message shape as errors. That
+    // keeps the default view compact and guarantees search output never becomes
+    // an outbound IRC command.
+    let mut messages = Vec::new();
+
+    messages.push(search_status_message(
+        buffer,
+        format!(
+            "Search matched {} visible messages{}",
+            matches.total,
+            if matches.truncated {
+                "; showing first 50"
+            } else {
+                ""
+            }
+        ),
+        message::source::Status::Success,
+    ));
+
+    messages.extend(matches.messages.into_iter().map(|message| {
+        search_status_message(
+            buffer,
+            command::search::format_match(message, output),
+            message::source::Status::Success,
+        )
+    }));
+
+    messages
+}
+
+fn common_result_messages(
+    buffer: &Upstream,
+    entries: Vec<command::common::Entry>,
+) -> Vec<message::Message> {
+    let mut messages = Vec::new();
+
+    if entries.is_empty() {
+        messages.push(search_status_message(
+            buffer,
+            "No users in this channel share other known channels.".to_string(),
+            message::source::Status::Success,
+        ));
+    } else {
+        messages.push(search_status_message(
+            buffer,
+            "Common channels:".to_string(),
+            message::source::Status::Success,
+        ));
+
+        messages.extend(entries.into_iter().map(|entry| {
+            search_status_message(
+                buffer,
+                format!("{}: {}", entry.nick, entry.channels.join(", ")),
+                message::source::Status::Success,
+            )
+        }));
+    }
+
+    messages
+}
+
+fn common_error_messages(
+    buffer: &Upstream,
+    text: String,
+) -> Vec<message::Message> {
+    vec![search_status_message(
+        buffer,
+        text,
+        message::source::Status::Error,
+    )]
+}
+
+fn search_error_messages(
+    buffer: &Upstream,
+    error: command::search::Error,
+) -> Vec<message::Message> {
+    vec![search_status_message(
+        buffer,
+        error.to_string(),
+        message::source::Status::Error,
+    )]
+}
+
+fn unsupported_tab_view_messages(buffer: &Upstream) -> Vec<message::Message> {
+    vec![search_status_message(
+        buffer,
+        "Search view=tab is not implemented yet".to_string(),
+        message::source::Status::Error,
+    )]
+}
+
+fn search_no_history_messages(buffer: &Upstream) -> Vec<message::Message> {
+    vec![search_status_message(
+        buffer,
+        format!("Search has no loaded visible history for {}", buffer.key()),
+        message::source::Status::Error,
+    )]
+}
+
+fn search_status_message(
+    buffer: &Upstream,
+    text: String,
+    status: message::source::Status,
+) -> message::Message {
+    // Build the same internal status-message shape that Halloy already knows
+    // how to render for server/channel/query buffers. Keeping this local avoids
+    // pretending search output came from an IRC peer or from user input.
+    let received_at = Posix::now();
+    let server_time = Utc::now();
+    let content = message::plain(text);
+    let source =
+        message::Source::Internal(message::source::Internal::Status(status));
+    let target = match buffer {
+        Upstream::Server(_) => message::Target::Server { source },
+        Upstream::Channel(_, channel) => message::Target::Channel {
+            channel: channel.clone(),
+            source,
+        },
+        Upstream::Query(_, query) => message::Target::Query {
+            query: query.clone(),
+            source,
+        },
+    };
+    let hash = message::Hash::new(&server_time, &content, &received_at);
+
+    message::Message {
+        received_at,
+        server_time,
+        direction: message::Direction::Received,
+        target,
+        content,
+        id: None,
+        reply_to: None,
+        reply_preview: None,
+        hash,
+        hidden_urls: HashSet::default(),
+        is_echo: false,
+        received_with_server_time: false,
+        blocked: false,
+        condensed: None,
+        expanded: false,
+        command: None,
+        reactions: vec![],
+        rerouted_from: None,
+        deduplicate: false,
+        redaction: None,
+    }
+}
+
+fn record_search_messages(
+    messages: Vec<message::Message>,
+    buffer: &Upstream,
+    history: &mut history::Manager,
+    config: &Config,
+) -> Task<history::manager::Message> {
+    Task::batch(
+        messages
+            .into_iter()
+            .flat_map(|message| {
+                history.record_message(
+                    buffer.server(),
+                    message,
+                    None,
+                    &config.buffer,
+                )
+            })
+            .map(|task| Task::perform(task, convert::identity)),
+    )
+}
+
 pub enum Event {
     InputSent {
         history_task: Task<history::manager::Message>,
@@ -54,6 +264,7 @@ pub enum Event {
         targets: Vec<(Target, BufferAction)>,
     },
     OpenInternalBuffer(buffer::Internal),
+    OpenSearchResults(SearchResults),
     OpenServer(String),
     LeaveBuffers {
         targets: Vec<Target>,
@@ -2413,6 +2624,134 @@ impl State {
                     command::Internal::Delay(_) => {
                         return (Task::none(), None);
                     }
+                    command::Internal::Common(common) => {
+                        // `/common` is local state inspection only. Handle it
+                        // before IRC dispatch so the command never reaches the
+                        // server, even if invoked outside a channel.
+                        let entries =
+                            common_results::entries(buffer, clients, common);
+
+                        let messages = match entries {
+                            Ok(entries) => {
+                                common_result_messages(buffer, entries)
+                            }
+                            Err(error) => common_error_messages(buffer, error),
+                        };
+
+                        let history_task = record_search_messages(
+                            messages, buffer, history, config,
+                        );
+
+                        return (
+                            Task::none(),
+                            Some(Event::InputSent {
+                                history_task,
+                                open_buffers: vec![],
+                            }),
+                        );
+                    }
+                    command::Internal::Search(search) => {
+                        // Local search is intentionally handled before IRC
+                        // command dispatch. Results are recorded as local
+                        // status messages in the current buffer, so a malformed
+                        // or surprising query cannot send data to the network.
+                        let kind =
+                            history::Kind::from_input_buffer(buffer.clone());
+                        let Some(view) =
+                            history.get_messages(&kind, None, config)
+                        else {
+                            let history_task = record_search_messages(
+                                search_no_history_messages(buffer),
+                                buffer,
+                                history,
+                                config,
+                            );
+
+                            return (
+                                Task::none(),
+                                Some(Event::InputSent {
+                                    history_task,
+                                    open_buffers: vec![],
+                                }),
+                            );
+                        };
+
+                        let search_context =
+                            command::search::ExecutionContext {
+                                own_nick: clients.nickname(buffer.server()),
+                            };
+
+                        match command::search::find(
+                            &search,
+                            &view,
+                            search_context,
+                        ) {
+                            Ok(matches) => match search.output.view {
+                                command::search::View::Inline => {
+                                    let history_task = record_search_messages(
+                                        search_result_messages(
+                                            buffer,
+                                            matches,
+                                            search.output,
+                                        ),
+                                        buffer,
+                                        history,
+                                        config,
+                                    );
+
+                                    return (
+                                        Task::none(),
+                                        Some(Event::InputSent {
+                                            history_task,
+                                            open_buffers: vec![],
+                                        }),
+                                    );
+                                }
+                                command::search::View::Pane => {
+                                    return (
+                                        Task::none(),
+                                        Some(Event::OpenSearchResults(
+                                            search_results(
+                                                buffer, matches, &search,
+                                            ),
+                                        )),
+                                    );
+                                }
+                                command::search::View::Tab => {
+                                    let history_task = record_search_messages(
+                                        unsupported_tab_view_messages(buffer),
+                                        buffer,
+                                        history,
+                                        config,
+                                    );
+
+                                    return (
+                                        Task::none(),
+                                        Some(Event::InputSent {
+                                            history_task,
+                                            open_buffers: vec![],
+                                        }),
+                                    );
+                                }
+                            },
+                            Err(error) => {
+                                let history_task = record_search_messages(
+                                    search_error_messages(buffer, error),
+                                    buffer,
+                                    history,
+                                    config,
+                                );
+
+                                return (
+                                    Task::none(),
+                                    Some(Event::InputSent {
+                                        history_task,
+                                        open_buffers: vec![],
+                                    }),
+                                );
+                            }
+                        }
+                    }
                     command::Internal::ClearBuffer => {
                         let kind =
                             history::Kind::from_input_buffer(buffer.clone());
@@ -3069,6 +3408,8 @@ fn show_while_typing(error: &input::Error) -> bool {
             | command::Error::InvalidChathistoryTimestamp
             | command::Error::ChathistoryLimitTooLarge { .. }
             | command::Error::ExecDisabled
+            | command::Error::Common(_)
+            | command::Error::Search(_)
             | command::Error::CommandNotAvailable { .. }
             | command::Error::CommandNotEnabled { .. },
         ) => true,

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -1249,6 +1249,25 @@ fn connected_command_list<'a>(
                 subcommands: None,
             }
         },
+        // SEARCH
+        search_command("SEARCH"),
+        // LAST
+        search_command("LAST"),
+        // COMMON
+        {
+            Command {
+                title: "COMMON".into(),
+                args: vec![Argument {
+                    text: "scope=network|global".into(),
+                    kind: ArgumentKind::Optional { skipped: false },
+                    tooltip: Some(
+                        "scope=network limits matches to this network; scope=global searches all networks (default)"
+                            .to_string(),
+                    ),
+                }],
+                subcommands: None,
+            }
+        },
         // EXEC
         exec_command(),
         // CLEAR
@@ -1533,6 +1552,48 @@ fn exec_command() -> Command {
     }
 }
 
+fn search_command(title: &'static str) -> Command {
+    Command {
+        title: title.into(),
+        args: vec![Argument {
+            text: "query".into(),
+            kind: ArgumentKind::Optional { skipped: false },
+            tooltip: Some(search_tooltip()),
+        }],
+        subcommands: None,
+    }
+}
+
+fn search_tooltip() -> String {
+    let selectors = command::search::SELECTORS
+        .iter()
+        .map(|selector| {
+            if selector.aliases.is_empty() {
+                format!("{}=<{}>", selector.canonical, selector.value)
+            } else {
+                format!(
+                    "{}=<{}> aliases: {}",
+                    selector.canonical,
+                    selector.value,
+                    selector.aliases.join(", ")
+                )
+            }
+        })
+        .join("\n");
+
+    format!(
+        "{selectors}\
+       \n--textonly strips IRC control codes and ANSI colors from output\
+       \n--notimestamp omits timestamps from output\
+       \n--other excludes messages uttered by the local user\
+       \nview=inline|pane|tab controls where results are shown; default inline\
+       \ncontext=<lines> includes loaded lines before and after each match\
+       \nspan accepts Nd, Nh, or Nm, for example span=3d, span=2h, span=5m\
+       \noperators: AND, OR, NOT; parentheses group expressions\
+       \nstring modifiers before quoted values: i insensitive, n not, a AND, o OR, x regex"
+    )
+}
+
 fn commands_from_aliases(aliases: &[command::Alias]) -> Vec<Command> {
     aliases
         .iter()
@@ -1696,6 +1757,10 @@ impl Command {
             }
             "connect" => Cow::Borrowed("Connect to server"),
             "reconnect" => Cow::Owned(format!("Reconnect to {server}")),
+            "search" | "last" => Cow::Owned(search_tooltip()),
+            "common" => Cow::Borrowed(
+                "List users in the current channel who share other known channels",
+            ),
             "upload" => Cow::Borrowed("Upload a file to the server's filehost"),
             "invite" => Cow::Borrowed("Invite user to channel"),
             _ => config

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -28,6 +28,7 @@ pub enum Event {
     ContextMenu(context_menu::Event),
     OpenBuffers(Server, Vec<(Target, BufferAction)>),
     OpenInternalBuffer(buffer::Internal),
+    OpenSearchResults(super::SearchResults),
     OpenServer(String),
     Reconnect(Server),
     LeaveBuffers(Vec<Target>, Option<String>),
@@ -367,6 +368,9 @@ impl Query {
                     }
                     Some(input_view::Event::OpenInternalBuffer(buffer)) => {
                         (command, Some(Event::OpenInternalBuffer(buffer)))
+                    }
+                    Some(input_view::Event::OpenSearchResults(results)) => {
+                        (command, Some(Event::OpenSearchResults(results)))
                     }
                     Some(input_view::Event::OpenServer(server)) => {
                         (command, Some(Event::OpenServer(server)))

--- a/src/buffer/search_results.rs
+++ b/src/buffer/search_results.rs
@@ -1,0 +1,97 @@
+use data::command::search::DisplayMatch;
+use iced::widget::span;
+use iced::widget::{Scrollable, column, container, row};
+use iced::{Background, Length, padding};
+
+use crate::widget::{Element, selectable_rich_text, selectable_text};
+use crate::{Theme, font, theme};
+
+#[derive(Debug, Clone)]
+pub struct SearchResults {
+    pub title: String,
+    pub summary: String,
+    pub lines: Vec<DisplayMatch>,
+}
+
+impl SearchResults {
+    pub fn new(
+        title: String,
+        summary: String,
+        lines: Vec<DisplayMatch>,
+    ) -> Self {
+        Self {
+            title,
+            summary,
+            lines,
+        }
+    }
+}
+
+pub fn view<'a>(
+    state: &'a SearchResults,
+    theme: &'a Theme,
+) -> Element<'a, super::Message> {
+    // Search results are an ephemeral, local-only surface. They intentionally
+    // render owned strings instead of borrowing from history so closing or
+    // reloading buffers cannot invalidate the result view.
+    let mut rows = column![
+        selectable_text(&state.summary)
+            .font_maybe(theme::font_style::primary(theme).map(font::get))
+            .style(theme::selectable_text::default)
+    ]
+    .spacing(6);
+
+    if state.lines.is_empty() {
+        rows = rows.push(
+            selectable_text("No matching loaded messages")
+                .font_maybe(theme::font_style::primary(theme).map(font::get))
+                .style(theme::selectable_text::default),
+        );
+    } else {
+        for line in &state.lines {
+            rows = rows.push(
+                container(row![highlighted_line(line, theme)])
+                    .width(Length::Fill)
+                    .padding(padding::top(2)),
+            );
+        }
+    }
+
+    container(Scrollable::new(
+        container(rows).width(Length::Fill).padding(8),
+    ))
+    .width(Length::Fill)
+    .height(Length::Fill)
+    .into()
+}
+
+fn highlighted_line<'a>(
+    line: &'a DisplayMatch,
+    theme: &'a Theme,
+) -> Element<'a, super::Message> {
+    let mut spans = vec![span(line.prefix.as_str())];
+    let mut cursor = 0;
+
+    for range in &line.text_highlights {
+        if cursor < range.start {
+            spans.push(span(&line.text[cursor..range.start]));
+        }
+
+        spans
+            .push(span(&line.text[range.clone()]).background(
+                Background::Color(theme.styles().buffer.highlight),
+            ));
+
+        cursor = range.end;
+    }
+
+    if cursor < line.text.len() {
+        spans.push(span(&line.text[cursor..]));
+    }
+
+    selectable_rich_text::<_, (), (), _, _>(spans)
+        .width(Length::Fill)
+        .font_maybe(theme::font_style::primary(theme).map(font::get))
+        .style(theme::selectable_text::default)
+        .into()
+}

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -50,6 +50,7 @@ pub enum Event {
     ContextMenu(context_menu::Event),
     OpenBuffers(data::server::Server, Vec<(Target, BufferAction)>),
     OpenInternalBuffer(buffer::Internal),
+    OpenSearchResults(super::SearchResults),
     OpenServer(String),
     Reconnect(data::server::Server),
     LeaveBuffers(Vec<Target>, Option<String>),
@@ -462,6 +463,9 @@ impl Server {
                     }
                     Some(input_view::Event::OpenInternalBuffer(buffer)) => {
                         (command, Some(Event::OpenInternalBuffer(buffer)))
+                    }
+                    Some(input_view::Event::OpenSearchResults(results)) => {
+                        (command, Some(Event::OpenSearchResults(results)))
                     }
                     Some(input_view::Event::OpenServer(server)) => {
                         (command, Some(Event::OpenServer(server)))

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,9 @@ use self::notification::Notifications;
 use self::widget::Element;
 use self::window::Window;
 
+const MIN_RUNTIME_FONT_SIZE: u8 = 8;
+const MAX_RUNTIME_FONT_SIZE: u8 = 32;
+
 pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut args = env::args();
     args.next();
@@ -198,6 +201,21 @@ fn configure_runtime(runtime: Runtime) -> Task<Message> {
         vsync: runtime.vsync,
     })
     .map(Message::RuntimeConfigured)
+}
+
+// Applies keyboard font zoom to the live configuration only.
+//
+// Called by dashboard shortcut events for `increase_font_size` and
+// `decrease_font_size`. The input is a signed point-size delta, and the output
+// is the updated in-memory `config.font.size`. This deliberately does not write
+// `config.toml` or reload configuration, so accidental zoom changes remain
+// session-local and cannot rewrite user comments or formatting.
+fn adjust_runtime_font_size(config: &mut Config, delta: i8) {
+    let current = config.font.size.unwrap_or(theme::TEXT_SIZE as u8);
+    let adjusted = current.saturating_add_signed(delta);
+
+    config.font.size =
+        Some(adjusted.clamp(MIN_RUNTIME_FONT_SIZE, MAX_RUNTIME_FONT_SIZE));
 }
 
 fn handle_irc_error(e: anyhow::Error) {
@@ -570,6 +588,10 @@ impl Halloy {
                     Some(dashboard::Event::ToggleFullscreen) => {
                         self.main_window.toggle_fullscreen();
                         self.save_main_window_settings()
+                    }
+                    Some(dashboard::Event::AdjustFontSize(delta)) => {
+                        adjust_runtime_font_size(&mut self.config, delta);
+                        Task::none()
                     }
                     Some(dashboard::Event::ConfigReloaded(config)) => {
                         self.config_file_reloaded(config)

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -122,6 +122,7 @@ pub enum Event {
     OpenServer(String),
     ImagePreview(Image),
     ToggleFullscreen,
+    AdjustFontSize(i8),
     Remove(Server),
     PromptBeforeFileUpload {
         upload_url: String,
@@ -1225,6 +1226,12 @@ impl Dashboard {
                             window::toggle_fullscreen(),
                             Some(Event::ToggleFullscreen),
                         );
+                    }
+                    IncreaseFontSize => {
+                        return (Task::none(), Some(Event::AdjustFontSize(1)));
+                    }
+                    DecreaseFontSize => {
+                        return (Task::none(), Some(Event::AdjustFontSize(-1)));
                     }
                     QuitApplication => {
                         return (self.exit(clients, config), None);

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -32,6 +32,7 @@ use iced::{Length, Size, Task, Vector, advanced, clipboard, padding};
 use irc::proto;
 
 use self::command_bar::CommandBar;
+use self::focus::replacement_buffer_after_close;
 use self::modal::{reaction as reaction_modal, redaction as redaction_modal};
 use self::pane::Pane;
 use self::sidebar::Sidebar;
@@ -48,6 +49,7 @@ use crate::{
 };
 
 mod command_bar;
+mod focus;
 pub mod modal;
 pub mod pane;
 pub mod sidebar;
@@ -60,6 +62,7 @@ pub struct Dashboard {
     panes: Panes,
     focus: Focus,
     focus_history: VecDeque<pane_grid::Pane>,
+    buffer_parents: HashMap<data::Buffer, data::Buffer>,
     side_menu: Sidebar,
     history: history::Manager,
     last_changed: Option<Instant>,
@@ -149,6 +152,7 @@ impl Dashboard {
                 pane,
             },
             focus_history: VecDeque::new(),
+            buffer_parents: HashMap::new(),
             side_menu: sidebar,
             history: history::Manager::default(),
             last_changed: None,
@@ -1910,6 +1914,9 @@ impl Dashboard {
                     None,
                 );
             }
+            buffer::Event::OpenSearchResults(results) => {
+                return (self.open_search_results(results, config), None);
+            }
             buffer::Event::ContextMenu(event) => {
                 let mut tasks = if matches!(
                     event,
@@ -2957,8 +2964,10 @@ impl Dashboard {
     ) -> Task<Message> {
         // TODO(pounce) reduce clones
         let panes = self.panes.clone();
+        let parent = self.focused_buffer_data();
 
         self.last_changed = Some(Instant::now());
+        self.remember_buffer_parent(&buffer, parent);
 
         match buffer.upstream() {
             Some(buffer::Upstream::Channel(server, channel)) => {
@@ -3156,6 +3165,70 @@ impl Dashboard {
                 })
             }
         }
+    }
+
+    fn open_search_results(
+        &mut self,
+        results: buffer::SearchResults,
+        config: &Config,
+    ) -> Task<Message> {
+        self.last_changed = Some(Instant::now());
+
+        let search_buffer = Buffer::SearchResults(results);
+
+        // Search results are transient and should preserve the source buffer.
+        // Always open them in a split pane for this slice instead of replacing
+        // the current buffer or adding serialized sidebar state.
+        if self.panes.len() == 1 {
+            let panes = self.panes.clone();
+            for (id, pane) in panes.main.iter() {
+                if matches!(pane.buffer, Buffer::Empty) {
+                    self.panes.main.panes.entry(*id).and_modify(|pane| {
+                        pane.buffer = search_buffer.clone();
+                    });
+
+                    return self.focus_pane(self.main_window(), *id);
+                }
+            }
+        }
+
+        let Some((pane_to_split, pane_to_split_state)) = self
+            .panes
+            .main
+            .panes
+            .get(&self.focus.pane)
+            .map(|pane| (self.focus.pane, pane))
+        else {
+            log::error!("Didn't find focused pane for search results");
+            return Task::none();
+        };
+
+        let split_axis = match config.pane.split_axis {
+            config::pane::SplitAxis::Horizontal => pane_grid::Axis::Horizontal,
+            config::pane::SplitAxis::Vertical => pane_grid::Axis::Vertical,
+            config::pane::SplitAxis::Shorter
+            | config::pane::SplitAxis::LargestShorter => {
+                if pane_to_split_state.size.height
+                    < pane_to_split_state.size.width
+                {
+                    pane_grid::Axis::Vertical
+                } else {
+                    pane_grid::Axis::Horizontal
+                }
+            }
+        };
+
+        let result = self.panes.main.split(
+            split_axis,
+            pane_to_split,
+            Pane::new(search_buffer),
+        );
+
+        if let Some((pane, _)) = result {
+            return self.focus_pane(self.main_window(), pane);
+        }
+
+        Task::none()
     }
 
     pub fn leave_all_queries(
@@ -4028,6 +4101,16 @@ impl Dashboard {
         pane: pane_grid::Pane,
     ) -> Task<Message> {
         let mut tasks = vec![];
+        let closed_buffer = self
+            .panes
+            .get(window, pane)
+            .and_then(|state| state.buffer.data());
+        let replacement = self.replacement_buffer_after_close(
+            window,
+            pane,
+            closed_buffer.as_ref(),
+            clients,
+        );
 
         if let Some(state) = self.panes.get(window, pane) {
             mark_as_read_on_buffer_close(
@@ -4058,17 +4141,39 @@ impl Dashboard {
         }
 
         self.last_changed = Some(Instant::now());
+        if let Some(buffer) = closed_buffer.as_ref() {
+            self.forget_buffer_parent_refs(buffer);
+        }
 
         if window == self.main_window() {
             self.focus_history.retain(|p| *p != pane);
 
             if let Some((_, sibling)) = self.panes.main.close(pane) {
                 if (Focus { window, pane } == self.focus) {
-                    tasks.push(self.focus_pane(self.main_window(), sibling));
+                    let focus = replacement
+                        .as_ref()
+                        .and_then(|buffer| self.find_pane_with_buffer(buffer))
+                        .unwrap_or((self.main_window(), sibling));
+
+                    tasks.push(self.focus_pane(focus.0, focus.1));
                     return Task::batch(tasks);
                 }
             } else if let Some(pane) = self.panes.main.get_mut(pane) {
-                pane.buffer = Buffer::Empty;
+                let focus_replacement = replacement.is_some();
+                pane.buffer = replacement.map_or(Buffer::Empty, |buffer| {
+                    Buffer::from_data(
+                        buffer,
+                        clients,
+                        &self.history,
+                        pane.size,
+                        config,
+                    )
+                });
+
+                if focus_replacement {
+                    tasks.push(self.reset_pane(window, self.focus.pane));
+                    tasks.push(self.focus_pane(window, self.focus.pane));
+                }
             }
         } else if self.panes.popout.remove(&window).is_some() {
             if self.command_bar_window == Some(window) {
@@ -4083,6 +4188,64 @@ impl Dashboard {
         }
 
         Task::batch(tasks)
+    }
+
+    fn focused_buffer_data(&self) -> Option<data::Buffer> {
+        let Focus { window, pane } = self.focus;
+
+        self.panes
+            .get(window, pane)
+            .and_then(|state| state.buffer.data())
+    }
+
+    fn remember_buffer_parent(
+        &mut self,
+        child: &data::Buffer,
+        parent: Option<data::Buffer>,
+    ) {
+        if let Some(parent) = parent
+            && parent != *child
+        {
+            self.buffer_parents.insert(child.clone(), parent);
+        }
+    }
+
+    fn forget_buffer_parent_refs(&mut self, buffer: &data::Buffer) {
+        self.buffer_parents.remove(buffer);
+        self.buffer_parents.retain(|_, parent| parent != buffer);
+    }
+
+    fn find_pane_with_buffer(
+        &self,
+        buffer: &data::Buffer,
+    ) -> Option<(window::Id, pane_grid::Pane)> {
+        self.panes.iter().find_map(|(window, pane, state)| {
+            (state.buffer.data().as_ref() == Some(buffer))
+                .then_some((window, pane))
+        })
+    }
+
+    fn replacement_buffer_after_close(
+        &self,
+        window: window::Id,
+        closing_pane: pane_grid::Pane,
+        closed: Option<&data::Buffer>,
+        clients: &client::Map,
+    ) -> Option<data::Buffer> {
+        let parent = closed.and_then(|buffer| self.buffer_parents.get(buffer));
+        let previous = self.focus_history.iter().find_map(|pane| {
+            (*pane != closing_pane)
+                .then(|| self.panes.get(window, *pane))
+                .flatten()
+                .and_then(|state| state.buffer.data())
+        });
+
+        replacement_buffer_after_close(
+            closed,
+            parent,
+            previous.as_ref(),
+            all_upstream_buffers(clients, &self.history),
+        )
     }
 
     fn popout_pane(
@@ -4520,6 +4683,7 @@ impl Dashboard {
             panes,
             focus,
             focus_history: VecDeque::from([focus.pane]),
+            buffer_parents: HashMap::new(),
             side_menu: sidebar,
             history,
             last_changed: None,

--- a/src/screen/dashboard/focus.rs
+++ b/src/screen/dashboard/focus.rs
@@ -1,0 +1,155 @@
+use data::{Buffer, buffer};
+
+pub(super) fn replacement_buffer_after_close(
+    closed: Option<&Buffer>,
+    parent: Option<&Buffer>,
+    previous: Option<&Buffer>,
+    available: Vec<buffer::Upstream>,
+) -> Option<Buffer> {
+    // Preserve explicit user intent first. Network fallbacks only apply when no
+    // recorded parent or previous focused buffer can take over.
+    parent
+        .filter(|parent| Some(*parent) != closed)
+        .or_else(|| previous.filter(|previous| Some(*previous) != closed))
+        .cloned()
+        .or_else(|| same_network_fallback(closed, available))
+}
+
+fn same_network_fallback(
+    closed: Option<&Buffer>,
+    available: Vec<buffer::Upstream>,
+) -> Option<Buffer> {
+    let closed_upstream = closed.and_then(Buffer::upstream)?;
+    let server = closed_upstream.server();
+
+    available
+        .iter()
+        .filter(|candidate| *candidate != closed_upstream)
+        .find(|candidate| {
+            candidate.server() == server
+                && !matches!(candidate, buffer::Upstream::Server(_))
+        })
+        .or_else(|| {
+            available.iter().find(|candidate| {
+                matches!(candidate, buffer::Upstream::Server(candidate_server) if candidate_server == server)
+            })
+        })
+        .cloned()
+        .map(Buffer::Upstream)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use data::{Server, isupport, target};
+
+    use super::*;
+
+    fn server(name: &str) -> Server {
+        Server {
+            name: Arc::from(name),
+            network: None,
+        }
+    }
+
+    fn channel(name: &str) -> target::Channel {
+        target::Channel::from_str(name, &['#'], isupport::CaseMap::default())
+    }
+
+    fn query(name: &str) -> target::Query {
+        target::Query::parse(name, &['#'], &[], isupport::CaseMap::default())
+            .expect("valid query")
+    }
+
+    fn upstream_channel(server: &Server, name: &str) -> buffer::Upstream {
+        buffer::Upstream::Channel(server.clone(), channel(name))
+    }
+
+    fn upstream_query(server: &Server, name: &str) -> buffer::Upstream {
+        buffer::Upstream::Query(server.clone(), query(name))
+    }
+
+    #[test]
+    fn replacement_prefers_parent_buffer() {
+        let server = server("libera");
+        let closed = Buffer::Upstream(upstream_query(&server, "alice"));
+        let parent = Buffer::Upstream(upstream_channel(&server, "#rust"));
+        let previous = Buffer::Upstream(upstream_channel(&server, "#halloy"));
+
+        let replacement = replacement_buffer_after_close(
+            Some(&closed),
+            Some(&parent),
+            Some(&previous),
+            vec![upstream_channel(&server, "#linux")],
+        );
+
+        assert_eq!(replacement, Some(parent));
+    }
+
+    #[test]
+    fn replacement_uses_previous_when_parent_is_closed_buffer() {
+        let server = server("libera");
+        let closed = Buffer::Upstream(upstream_query(&server, "alice"));
+        let previous = Buffer::Upstream(upstream_channel(&server, "#halloy"));
+
+        let replacement = replacement_buffer_after_close(
+            Some(&closed),
+            Some(&closed),
+            Some(&previous),
+            vec![upstream_channel(&server, "#linux")],
+        );
+
+        assert_eq!(replacement, Some(previous));
+    }
+
+    #[test]
+    fn replacement_falls_back_to_same_network_buffer_before_server() {
+        let server = server("libera");
+        let closed = Buffer::Upstream(upstream_query(&server, "alice"));
+        let fallback = upstream_channel(&server, "#rust");
+
+        let replacement = replacement_buffer_after_close(
+            Some(&closed),
+            None,
+            None,
+            vec![buffer::Upstream::Server(server.clone()), fallback.clone()],
+        );
+
+        assert_eq!(replacement, Some(Buffer::Upstream(fallback)));
+    }
+
+    #[test]
+    fn replacement_falls_back_to_same_network_server() {
+        let server = server("libera");
+        let closed = Buffer::Upstream(upstream_query(&server, "alice"));
+
+        let replacement = replacement_buffer_after_close(
+            Some(&closed),
+            None,
+            None,
+            vec![buffer::Upstream::Server(server.clone())],
+        );
+
+        assert_eq!(
+            replacement,
+            Some(Buffer::Upstream(buffer::Upstream::Server(server)))
+        );
+    }
+
+    #[test]
+    fn replacement_does_not_cross_networks() {
+        let libera = server("libera");
+        let oftc = server("oftc");
+        let closed = Buffer::Upstream(upstream_query(&libera, "alice"));
+
+        let replacement = replacement_buffer_after_close(
+            Some(&closed),
+            None,
+            None,
+            vec![upstream_channel(&oftc, "#debian")],
+        );
+
+        assert_eq!(replacement, None);
+    }
+}

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -163,6 +163,10 @@ impl Pane {
                 .wrapping(Wrapping::None)
                 .ellipsis(text::Ellipsis::End)
                 .into(),
+            Buffer::SearchResults(state) => text(&state.title)
+                .wrapping(Wrapping::None)
+                .ellipsis(text::Ellipsis::End)
+                .into(),
         };
 
         let title_bar = self.title_bar.view(
@@ -256,7 +260,9 @@ impl Pane {
             }),
             Buffer::Logs(_) => Some(history::Resource::logs()),
             Buffer::Highlights(_) => Some(history::Resource::highlights()),
-            Buffer::ChannelDiscovery(_) | Buffer::FileTransfers(_) => None,
+            Buffer::ChannelDiscovery(_)
+            | Buffer::FileTransfers(_)
+            | Buffer::SearchResults(_) => None,
         }
     }
 
@@ -271,7 +277,8 @@ impl Pane {
             | Buffer::FileTransfers(_)
             | Buffer::Logs(_)
             | Buffer::Highlights(_)
-            | Buffer::ChannelDiscovery(_) => vec![],
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::SearchResults(_) => vec![],
         }
     }
 }
@@ -703,6 +710,7 @@ impl From<Pane> for data::Pane {
             Buffer::ChannelDiscovery(state) => data::Buffer::Internal(
                 buffer::Internal::ChannelDiscovery(state.server.clone()),
             ),
+            Buffer::SearchResults(_) => return data::Pane::Empty,
         };
 
         data::Pane::Buffer { buffer }


### PR DESCRIPTION
Draft/discussion PR for local-only IRC history search and common-channel inspection. The portable feature set is framed in the documentation as **Rich Search Functionality** for IRC clients, with notes for possible native ports to Zoitechat, Konversation, and Uplink.

This branch is also published as a readable fork landing page:

- Fork/README: https://github.com/roeyk/halloy
- Feature guide in this branch: https://github.com/roeyk/halloy/blob/roey/last-common-buffer-slices/docs/guides/search-common-feature-guide.md

## This Branch Adds

- `/search` and `/last` parsing, completion metadata, local loaded-history evaluation, inline output, pane output, text highlighting, context lines, span filters, `--other`, `--textonly`, and `--notimestamp`.
- `/common` with `scope=global|network`, using Halloy's already-known in-memory channel membership only.
- Buffer-close focus recovery so closing a channel or direct conversation returns focus to a useful related buffer instead of leaving the main pane on an empty "Select buffer" state.
- A feature guide at `docs/guides/search-common-feature-guide.md` covering syntax, security boundaries, examples, implementation notes, development guidelines, Codex assistance disclosure, and Rich Search Functionality porting notes.

## Portability Notes

- Zoitechat is treated as a likely C/GTK3 target.
- Konversation is treated as a C++/KDE/Qt target.
- Uplink is treated as a C++/Qt6 target.
- The intended portable split is parser/evaluator core, message-history adapter, known-channel/user adapter, native result renderer, and optional explicit `WHOIS`/`319` enrichment.

## Security/Behavior Notes

- Default behavior is local-only.
- `/search` and `/last` inspect already-loaded local history only.
- `/common` does not issue `WHOIS`, `WHO`, `NAMES`, or other IRC traffic.
- `view=tab` is parsed but intentionally not implemented yet.

## Validation Run Locally

- `cargo fmt --all --check`
- `cargo check`
- `cargo test -p data command::`
- `cargo test`

## Contribution-Policy Note

Halloy's current contribution page says significant features should be discussed before submission and that submitted AI-generated content is not allowed. This is opened as a draft discussion branch so maintainers can evaluate the design and decide whether any human-owned rewrite or different process is needed before it could become an upstreamable patch.
