### PR TITLE
No-Action Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Added:
 - Support displaying a larger version of the card images in-app
 - IRCv3 `no-implicit-names` support
 - Keyboard shortcuts validation (e.g no duplicate key binds)
+- `actions.buffer.click_nickname` and `actions.nicklist.click_nickname` can be used to specify whether a nickname will: open query and how the query is opened, insert nickname in the input box, or no action (`"no-action"` or `"noop"`); takes over functionality from `buffer.nickname.click` and `buffer.channel.nicklist.click` and adds the ability to perform no action
+- `actions.buffer.click_channel_name` and `actions.buffer.click_highlight` can be set to no action (`"no-action"` or `"noop"`) to not open the channel when clicking on the channel name
 
 Fixed:
 
@@ -27,7 +29,9 @@ Changed:
 - `change_mode` server messages are categorized as `actions` (i.e. `actions_dimmed` controls whether they are dimmed by default)
 - Renamed `sidebar.server_icon` → `sidebar.primary_icon` and `sidebar.server_font_size` → `sidebar.primary_font_size` since the settings now apply to both servers and internal buffers
 - Renamed `sidebar.font_size` → `sidebar.secondary_font_size` to reflect its relationship to `sidebar.primary_font_size`
-- Removed unnecessary AWS-LC dependency
+- Renamed `actions.buffer.local` → `actions.buffer.open_internal` to match naming convention used elsewhere
+- Renamed `actions.buffer.click_username` to `action_buffer.click_nickname` for more consistent terminology
+- Moved functionality from `buffer.nickname.click` → `actions.buffer.click_nickname` and `buffer.channel.nicklist.click` → `actions.nicklist.click_nickname`
 
 Thanks:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Fixed:
 - Do not copy empty selections to the primary clipboard (i.e. do not clear the primary clipboard when a non-selection action is performed, such as moving the cursor or focusing the text input on some systems)
 - Prevent anti-flood rate limiting from refilling the token bucket beyond its configured capacity
 - Show unread indicators for panes hidden by maximize
+- Allow commands (e.g. `/join`) to be used in the input box of not-joined channels
 
 Changed:
 

--- a/data/src/config/actions.rs
+++ b/data/src/config/actions.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 
 use crate::dashboard::{BufferAction, BufferFocusedAction};
 
@@ -7,16 +7,19 @@ use crate::dashboard::{BufferAction, BufferFocusedAction};
 pub struct Actions {
     pub sidebar: Sidebar,
     pub buffer: Buffer,
+    pub nicklist: Nicklist,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default)]
 pub struct Buffer {
-    pub click_channel_name: BufferAction,
-    pub click_highlight: BufferAction,
-    pub click_username: BufferAction,
-    pub join_channel: Option<BufferAction>,
-    pub local: BufferAction,
+    pub click_channel_name: ChannelClickAction,
+    pub click_highlight: ChannelClickAction,
+    #[serde(alias = "click_nickname")]
+    pub click_username: NicknameClickAction,
+    pub join_channel: BufferAction,
+    #[serde(alias = "local")]
+    pub open_internal: BufferAction,
     pub message_channel: BufferAction,
     pub message_user: BufferAction,
 }
@@ -28,4 +31,108 @@ pub struct Sidebar {
     pub channel: Option<BufferAction>,
     pub query: Option<BufferAction>,
     pub focused_buffer: Option<BufferFocusedAction>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default)]
+pub struct Nicklist {
+    #[serde(alias = "click_nickname")]
+    pub click_username: Option<NicknameClickAction>,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum NicknameClickAction {
+    OpenQuery(BufferAction),
+    InsertNickname,
+    Noop,
+}
+
+impl Default for NicknameClickAction {
+    fn default() -> Self {
+        Self::OpenQuery(BufferAction::default())
+    }
+}
+
+impl<'de> Deserialize<'de> for NicknameClickAction {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "kebab-case")]
+        enum ClickAction {
+            OpenQuery(BufferAction),
+            InsertNickname,
+            #[serde(alias = "no-action")]
+            Noop,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Action {
+            ClickAction(ClickAction),
+            BufferAction(BufferAction),
+        }
+
+        match Action::deserialize(deserializer)? {
+            Action::ClickAction(click_action) => match click_action {
+                ClickAction::OpenQuery(buffer_action) => {
+                    Ok(NicknameClickAction::OpenQuery(buffer_action))
+                }
+                ClickAction::InsertNickname => {
+                    Ok(NicknameClickAction::InsertNickname)
+                }
+                ClickAction::Noop => Ok(NicknameClickAction::Noop),
+            },
+            Action::BufferAction(buffer_action) => {
+                Ok(NicknameClickAction::OpenQuery(buffer_action))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum ChannelClickAction {
+    OpenChannel(BufferAction),
+    Noop,
+}
+
+impl Default for ChannelClickAction {
+    fn default() -> Self {
+        Self::OpenChannel(BufferAction::default())
+    }
+}
+
+impl<'de> Deserialize<'de> for ChannelClickAction {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "kebab-case")]
+        enum ClickAction {
+            OpenChannel(BufferAction),
+            #[serde(alias = "no-action")]
+            Noop,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Action {
+            ClickAction(ClickAction),
+            BufferAction(BufferAction),
+        }
+
+        match Action::deserialize(deserializer)? {
+            Action::ClickAction(click_action) => match click_action {
+                ClickAction::OpenChannel(buffer_action) => {
+                    Ok(ChannelClickAction::OpenChannel(buffer_action))
+                }
+                ClickAction::Noop => Ok(ChannelClickAction::Noop),
+            },
+            Action::BufferAction(buffer_action) => {
+                Ok(ChannelClickAction::OpenChannel(buffer_action))
+            }
+        }
+    }
 }

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -121,14 +121,6 @@ impl Default for ReplyTooltip {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
-pub enum NicknameClickAction {
-    #[default]
-    OpenQuery,
-    InsertNickname,
-}
-
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct Emojis {

--- a/data/src/config/buffer/channel.rs
+++ b/data/src/config/buffer/channel.rs
@@ -1,6 +1,5 @@
 use serde::Deserialize;
 
-use super::NicknameClickAction;
 use crate::channel::Position;
 use crate::config::buffer::AccessLevelFormat;
 use crate::isupport;
@@ -60,7 +59,6 @@ pub struct Nicklist {
     pub show_access_levels: AccessLevelFormat,
     pub show_bot_icon: bool,
     pub truncate: Option<u16>,
-    pub click: NicknameClickAction,
 }
 
 impl Default for Nicklist {
@@ -73,7 +71,6 @@ impl Default for Nicklist {
             show_access_levels: AccessLevelFormat::default(),
             show_bot_icon: true,
             truncate: None,
-            click: NicknameClickAction::default(),
         }
     }
 }

--- a/data/src/config/buffer/nickname.rs
+++ b/data/src/config/buffer/nickname.rs
@@ -1,9 +1,7 @@
 use serde::Deserialize;
 
 use crate::buffer::{Alignment, Brackets, Color};
-use crate::config::buffer::{
-    AccessLevelFormat, Away, HideConsecutive, NicknameClickAction,
-};
+use crate::config::buffer::{AccessLevelFormat, Away, HideConsecutive};
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
@@ -15,7 +13,6 @@ pub struct Nickname {
     pub alignment: Alignment,
     pub show_access_levels: AccessLevelFormat,
     pub show_bot_icon: bool,
-    pub click: NicknameClickAction,
     pub shown_status: ShownStatus,
     pub truncate: Option<u16>,
     pub hide_consecutive: HideConsecutive,
@@ -31,7 +28,6 @@ impl Default for Nickname {
             alignment: Alignment::default(),
             show_access_levels: AccessLevelFormat::default(),
             show_bot_icon: true,
-            click: NicknameClickAction::default(),
             shown_status: ShownStatus::default(),
             truncate: None,
             hide_consecutive: HideConsecutive::default(),

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -556,7 +556,7 @@ impl History {
             ..
         } = self
             && (matches!(message.direction, message::Direction::Sent)
-                || (((message.triggers_unread() && !message.blocked)
+                || ((message.triggers_unread()
                     || (message.is_echo && !message.deduplicate))
                     && Some(message.server_time) > *max_triggers_unread))
         {
@@ -564,7 +564,6 @@ impl History {
         }
 
         if message.triggers_unread()
-            && !message.blocked
             && let History::Partial {
                 max_triggers_unread,
                 ..

--- a/data/src/input.rs
+++ b/data/src/input.rs
@@ -134,6 +134,8 @@ pub fn parse(
         }
     };
 
+    let is_command = matches!(content, Content::Command(..));
+
     let parsed = Parsed::Input(Input { buffer, content });
 
     if let Some(multiline_limits) = capabilities.multiline_limits()
@@ -171,7 +173,7 @@ pub fn parse(
 
     if !is_connected {
         return Err(Error::Command(command::Error::Disconnected));
-    } else if in_channel.is_some_and(|in_channel| !in_channel) {
+    } else if in_channel.is_some_and(|in_channel| !in_channel && !is_command) {
         return Err(Error::Command(command::Error::NotInChannel));
     }
 

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -23,6 +23,7 @@ use crate::capabilities::LabeledResponseContext;
 use crate::client::Destination;
 use crate::config::buffer::{CondensationFormat, UsernameFormat};
 use crate::config::{self, Highlights};
+use crate::dashboard::BufferAction;
 use crate::history::reroute::RerouteRules;
 use crate::log::Level;
 use crate::reaction::Reaction;
@@ -4073,10 +4074,10 @@ pub fn quit_text(
 
 #[derive(Debug, Clone)]
 pub enum Link {
-    Channel(Server, target::Channel),
+    Channel(Server, target::Channel, BufferAction),
     Url(String),
     User(Server, User),
-    GoToMessage(Server, target::Channel, Hash),
+    GoToMessage(Server, target::Channel, Hash, BufferAction),
     ExpandMessage(DateTime<Utc>, Hash),
     ContractMessage(DateTime<Utc>, Hash),
 }

--- a/docs/configuration/actions.md
+++ b/docs/configuration/actions.md
@@ -7,20 +7,20 @@ Application-wide actions; how user actions should be enacted.
 How buffer actions should be enacted
 
 ```toml
-# Replace pane when clicking on channel/user names in a pane,
+# Replace pane when clicking on channel/user names in a pane
 
 [actions.buffer]
 click_channel_name = "replace-pane"
-click_username = "replace-pane"
+click_nickname = "replace-pane"
 ```
 
 ### `click_channel_name`
 
-Action when clicking on a channel name in a pane. `"new-pane"` opens a new pane each time. `"replace-pane"` replaces the focused pane with the clicked channel. `"new-window"` opens a new window each time.
+Action when clicking on a channel name in a pane. `"new-pane"` opens a new pane each time. `"replace-pane"` replaces the focused pane with the clicked channel. `"new-window"` opens a new window each time. `"no-action"` or `"noop"` will ignore clicks on channel names.
 
 ```toml
 # Type: string
-# Values: "new-pane", "replace-pane", "new-window"
+# Values: "new-pane", "replace-pane", "new-window", "no-action", "noop"
 # Default: "new-pane"
 
 [actions.buffer]
@@ -29,33 +29,37 @@ click_channel_name = "new-pane"
 
 ### `click_highlight`
 
-Action when clicking on a highlight in the highlights buffer. `"new-pane"` opens a new pane each time. `"replace-pane"` replaces the focused pane with the buffer that contains the highlight. `"new-window"` opens a new window each time.
+Action when clicking on the channel name of a highlight in the highlights buffer. `"new-pane"` opens a new pane each time. `"replace-pane"` replaces the focused pane with the buffer that contains the highlight. `"new-window"` opens a new window each time. `"no-action"` or `"noop"` will ignore clicks on the channel name of highlights.
 
 ```toml
 # Type: string
-# Values: "new-pane", "replace-pane", "new-window"
+# Values: "new-pane", "replace-pane", "new-window", "no-action", "noop"
 # Default: "new-pane"
 
 [actions.buffer]
 click_highlight = "new-pane"
 ```
 
-### `click_username`
+### `click_nickname`
 
-Action when clicking on a user name in a pane (if `buffer.channel.nicklist` or `buffer.nickname` is set to `"open-query"`). `"new-pane"` opens a new pane each time. `"replace-pane"` replaces the focused pane with a query for clicked user. `"new-window"` opens a new window each time.
+Click action for when interaction with nicknames.
+
+- `"open-query" = "buffer-action"`: Open a query with the user with the prescribed buffer action (`"new-pane"`, `"replace-pane"`, or `"new-window"`). `"new-pane"` opens a new pane each time. `"replace-pane"` replaces the focused pane with a query for clicked user. `"new-window"` opens a new window each time.
+- `"insert-nickname"`: Inserts the nickname into the buffer's input box.
+- `"no-action"` or `"noop"`: No action is performed
 
 ```toml
 # Type: string
-# Values: "new-pane", "replace-pane", "new-window"
-# Default: "new-pane"
+# Values: "open-query" = "new-pane", "open-query" = "replace-pane", "open-query" = "new-window", "insert-nickname", "no-action", "noop"
+# Default: "open-query" = "new-pane"
 
 [actions.buffer]
-click_username = "new-pane"
+click_nickname = { "open-query" = "replace-pane" }
 ```
 
-### `local`
+### `open_internal`
 
-Action when opening a local buffer (the highlights or logs buffer). `"new-pane"` opens a new pane each time. `"replace-pane"` replaces the focused pane with the local buffer. `"new-window"` opens a new window each time.
+Action when opening an internal buffer (e.g. highlights, logs, or channel discovery buffers) via keyboard shortcut, command bar, user menu, or slash-command (e.g. `/list`). `"new-pane"` opens a new pane each time. `"replace-pane"` replaces the focused pane with the internal buffer. `"new-window"` opens a new window each time.
 
 ```toml
 # Type: string
@@ -63,7 +67,7 @@ Action when opening a local buffer (the highlights or logs buffer). `"new-pane"`
 # Default: "new-pane"
 
 [actions.buffer]
-local = "new-pane"
+open_internal = "new-pane"
 ```
 
 ### `message_channel`
@@ -94,7 +98,7 @@ message_user = "replace-pane"
 
 ### `join_channel`
 
-Action when sending joining a channel via `/join` command. `"new-pane"` opens a new pane each time. `"replace-pane"` replaces the focused pane with the channel. `"new-window"` opens a new window each time.
+Action when joining a channel via `/join` command. `"new-pane"` opens a new pane each time. `"replace-pane"` replaces the focused pane with the channel. `"new-window"` opens a new window each time.
 
 ```toml
 # Type: string
@@ -103,6 +107,34 @@ Action when sending joining a channel via `/join` command. `"new-pane"` opens a 
 
 [actions.buffer]
 join_channel = "replace-pane"
+```
+
+## `nicklist`
+
+How nicklist actions should be enacted
+
+```toml
+# Replace pane when clicking on a nickname in the nicklist
+
+[actions.buffer]
+click_nickname = "replace-pane"
+```
+
+### `click_nickname`
+
+Click action for when interaction with nicknames.  If not set, then the behavior specified by [`actions.buffer.click_nickname`](#click_nickname) will be used.
+
+- `"open-query" = "buffer-action"`: Open a query with the user with the prescribed buffer action (`"new-pane"`, `"replace-pane"`, or `"new-window"`). `"new-pane"` opens a new pane each time. `"replace-pane"` replaces the focused pane with a query for clicked user. `"new-window"` opens a new window each time.
+- `"insert-nickname"`: Inserts the nickname into the buffer's input box.
+- `"no-action"` or `"noop"`: No action is performed
+
+```toml
+# Type: string
+# Values: "open-query" = "new-pane", "open-query" = "replace-pane", "open-query" = "new-window", "insert-nickname", "no-action", "noop", not set
+# Default: not set
+
+[actions.nicklist]
+click_nickname = { "open-query" = "replace-pane" }
 ```
 
 ## `sidebar`

--- a/docs/configuration/buffer.md
+++ b/docs/configuration/buffer.md
@@ -215,23 +215,6 @@ Overwrite nicklist width in pixels.
 width = 150
 ```
 
-#### `click`
-
-Click action for when interaction with nicknames.
-
-- `"open-query"`: Open a query with the User
-- `"insert-nickname"`: Inserts the nickname into text input
-
-```toml
-# Type: string
-# Values: "open-query", "insert-nickname"
-# Default: "open-query"
-
-[buffer.channel.nicklist]
-click = "open-query"
-```
-
-
 ### `topic_banner`
 
 Topic banner settings within a channel buffer.
@@ -881,22 +864,6 @@ What status should be indicated (by either `away` or `offline` settings), the us
 # Default: "current"
 [buffer.nickname]
 shown_status = "current"
-```
-
-### `click`
-
-Click action for when interaction with nicknames.
-
-- `"open-query"`: Open a query with the User
-- `"insert-nickname"`: Inserts the nickname into text input
-
-```toml
-# Type: string
-# Values: "open-query", "insert-nickname"
-# Default: "open-query"
-
-[buffer.nickname]
-click = "open-query"
 ```
 
 ### `truncate`

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -69,7 +69,7 @@ pub enum Event {
     Reconnect(data::Server),
     LeaveBuffers(Vec<Target>, Option<String>),
     SelectedServer(data::Server),
-    GoToMessage(data::Server, target::Channel, message::Hash),
+    GoToMessage(data::Server, target::Channel, message::Hash, BufferAction),
     History(Task<history::manager::Message>),
     RequestOlderChatHistory,
     PreviewChanged,
@@ -307,8 +307,13 @@ impl Buffer {
                     channel::Event::ContractMessage(server_time, hash) => {
                         Event::ContractMessage(server_time, hash)
                     }
-                    channel::Event::GoToMessage(server, channel, hash) => {
-                        Event::GoToMessage(server, channel, hash)
+                    channel::Event::GoToMessage(
+                        server,
+                        channel,
+                        hash,
+                        buffer_action,
+                    ) => {
+                        Event::GoToMessage(server, channel, hash, buffer_action)
                     }
                     channel::Event::InputSent {
                         history_task,
@@ -491,12 +496,10 @@ impl Buffer {
                     channel_discovery::Event::OpenChannelForServer(
                         server,
                         channel,
+                        buffer_action,
                     ) => Event::OpenBuffers(
                         server,
-                        vec![(
-                            Target::Channel(channel),
-                            config.actions.buffer.click_channel_name,
-                        )],
+                        vec![(Target::Channel(channel), buffer_action)],
                     ),
                     channel_discovery::Event::ContextMenu(event) => {
                         Event::ContextMenu(event)
@@ -551,7 +554,13 @@ impl Buffer {
                         server,
                         channel,
                         message,
-                    ) => Event::GoToMessage(server, channel, message),
+                        buffer_action,
+                    ) => Event::GoToMessage(
+                        server,
+                        channel,
+                        message,
+                        buffer_action,
+                    ),
                     highlights::Event::History(task) => Event::History(task),
                     highlights::Event::MarkAsRead => {
                         Event::MarkAsRead(history::Kind::Highlights)

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -43,7 +43,7 @@ pub enum Event {
     ImagePreview(Image),
     ExpandMessage(DateTime<Utc>, message::Hash),
     ContractMessage(DateTime<Utc>, message::Hash),
-    GoToMessage(Server, target::Channel, message::Hash),
+    GoToMessage(Server, target::Channel, message::Hash, BufferAction),
     InputSent {
         history_task: Task<history::manager::Message>,
         open_buffers: Vec<(Target, BufferAction)>,
@@ -360,9 +360,17 @@ impl Channel {
                         server,
                         vec![(target, buffer_action)],
                     )),
-                    scroll_view::Event::GoToMessage(server, channel, hash) => {
-                        Some(Event::GoToMessage(server, channel, hash))
-                    }
+                    scroll_view::Event::GoToMessage(
+                        server,
+                        channel,
+                        hash,
+                        buffer_action,
+                    ) => Some(Event::GoToMessage(
+                        server,
+                        channel,
+                        hash,
+                        buffer_action,
+                    )),
                     scroll_view::Event::RequestOlderChatHistory => {
                         Some(Event::RequestOlderChatHistory)
                     }
@@ -514,15 +522,14 @@ impl Channel {
                     topic::Event::ContextMenu(event) => {
                         Event::ContextMenu(event)
                     }
-                    topic::Event::OpenChannel(server, channel) => {
-                        Event::OpenBuffers(
-                            server,
-                            vec![(
-                                Target::Channel(channel),
-                                config.actions.buffer.click_channel_name,
-                            )],
-                        )
-                    }
+                    topic::Event::OpenChannel(
+                        server,
+                        channel,
+                        buffer_action,
+                    ) => Event::OpenBuffers(
+                        server,
+                        vec![(Target::Channel(channel), buffer_action)],
+                    ),
                     topic::Event::OpenUrl(url) => Event::OpenUrl(url),
                 }),
             ),
@@ -701,7 +708,12 @@ mod nick_list {
                 our_user,
                 config,
                 theme,
-                &config.buffer.channel.nicklist.click,
+                config
+                    .actions
+                    .nicklist
+                    .click_username
+                    .as_ref()
+                    .unwrap_or(&config.actions.buffer.click_username),
             )
         });
 

--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Local, Utc};
+use data::dashboard::BufferAction;
 use data::user::ChannelUsers;
 use data::{Config, Server, User, isupport, message, target};
 use iced::widget::{Scrollable, column, container, row, rule, scrollable};
@@ -12,7 +13,7 @@ use crate::{Theme, font, theme};
 #[derive(Debug, Clone)]
 pub enum Event {
     ContextMenu(context_menu::Event),
-    OpenChannel(Server, target::Channel),
+    OpenChannel(Server, target::Channel, BufferAction),
     OpenUrl(String),
 }
 
@@ -27,9 +28,11 @@ pub fn update(message: Message) -> Option<Event> {
         Message::ContextMenu(message) => {
             context_menu::update(message).map(Event::ContextMenu)
         }
-        Message::Link(message::Link::Channel(server, channel)) => {
-            Some(Event::OpenChannel(server, channel))
-        }
+        Message::Link(message::Link::Channel(
+            server,
+            channel,
+            buffer_action,
+        )) => Some(Event::OpenChannel(server, channel, buffer_action)),
         Message::Link(message::Link::Url(url)) => Some(Event::OpenUrl(url)),
         Message::Link(message::Link::User(_, user)) => {
             Some(Event::ContextMenu(context_menu::Event::InsertNickname(
@@ -90,7 +93,7 @@ pub fn view<'a>(
             our_user,
             config,
             theme,
-            &config.buffer.nickname.click,
+            &config.actions.buffer.click_username,
         );
 
         Some(

--- a/src/buffer/channel_discovery.rs
+++ b/src/buffer/channel_discovery.rs
@@ -1,3 +1,5 @@
+use data::config::actions::ChannelClickAction;
+use data::dashboard::BufferAction;
 use data::{Config, Server, channel_discovery, message, metadata, target};
 use iced::widget::{
     self, button, center, column, container, operation, pick_list, row, rule,
@@ -24,7 +26,7 @@ pub enum Message {
 pub enum Event {
     SelectedServer(Server),
     OpenUrl(String),
-    OpenChannelForServer(data::Server, target::Channel),
+    OpenChannelForServer(data::Server, target::Channel, BufferAction),
     ContextMenu(context_menu::Event),
     SendUnsafeList(Server),
 }
@@ -65,9 +67,13 @@ impl ChannelDiscovery {
                 message::Link::Url(url) => {
                     (Task::none(), Some(Event::OpenUrl(url)))
                 }
-                message::Link::Channel(server, channel) => (
+                message::Link::Channel(server, channel, buffer_action) => (
                     Task::none(),
-                    Some(Event::OpenChannelForServer(server, channel)),
+                    Some(Event::OpenChannelForServer(
+                        server,
+                        channel,
+                        buffer_action,
+                    )),
                 ),
                 _ => (Task::none(), None),
             },
@@ -251,6 +257,14 @@ fn channel_list_view<'a>(
                                         server,
                                     ),
                                 ),
+                                match config.actions.buffer.click_channel_name {
+                                    ChannelClickAction::OpenChannel(
+                                        buffer_action,
+                                    ) => buffer_action,
+                                    ChannelClickAction::Noop => {
+                                        config.actions.buffer.join_channel
+                                    }
+                                },
                             )),
                     ],
                         )

--- a/src/buffer/context_menu.rs
+++ b/src/buffer/context_menu.rs
@@ -2,11 +2,11 @@ use std::str::FromStr;
 use std::string::ToString;
 
 use chrono::{DateTime, Utc};
+use data::config::actions::NicknameClickAction;
 use data::dashboard::BufferAction;
 use data::user::Nick;
 use data::{
-    Config, Server, User, config, ctcp, isupport, message, metadata, preview,
-    target,
+    Config, Server, User, ctcp, isupport, message, metadata, preview, target,
 };
 use iced::widget::{Space, button, center, column, container, row, rule, span};
 use iced::{
@@ -963,7 +963,7 @@ pub fn user<'a>(
     our_user: Option<&'a User>,
     config: &'a Config,
     theme: &'a Theme,
-    click: &'a config::buffer::NicknameClickAction,
+    click: &'a NicknameClickAction,
 ) -> Element<'a, Message> {
     let entries = Entry::user_list(
         channel.is_some(),
@@ -998,7 +998,7 @@ pub fn rerouted_private_user<'a>(
     user: &'a User,
     config: &'a Config,
     theme: &'a Theme,
-    click: &'a config::buffer::NicknameClickAction,
+    click: &'a NicknameClickAction,
 ) -> Element<'a, Message> {
     user_with_entries(
         content,
@@ -1027,21 +1027,26 @@ fn user_with_entries<'a>(
     current_user: Option<&'a User>,
     config: &'a Config,
     theme: &'a Theme,
-    click: &'a config::buffer::NicknameClickAction,
+    click: &'a NicknameClickAction,
     entries: Vec<Entry>,
 ) -> Element<'a, Message> {
     let message = match click {
-        data::config::buffer::NicknameClickAction::OpenQuery => Message::Query(
+        NicknameClickAction::OpenQuery(buffer_action) => Some(Message::Query(
             server.clone(),
             target::Query::from(user),
-            config.actions.buffer.click_username,
-        ),
-        data::config::buffer::NicknameClickAction::InsertNickname => {
-            Message::InsertNickname(user.nickname().to_owned())
+            *buffer_action,
+        )),
+        NicknameClickAction::InsertNickname => {
+            Some(Message::InsertNickname(user.nickname().to_owned()))
         }
+        NicknameClickAction::Noop => None,
     };
 
-    let base = widget::button::transparent_button(content, message);
+    let base = if let Some(message) = message {
+        widget::button::transparent_button(content, message)
+    } else {
+        content.into()
+    };
     let avatar = user_avatar(user, registry, previews);
     let on_open = config
         .context_menu

--- a/src/buffer/highlights.rs
+++ b/src/buffer/highlights.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use data::config::actions::ChannelClickAction;
 use data::config::buffer::nickname::ShownStatus;
 use data::dashboard::BufferAction;
 use data::target::{self, Target};
@@ -24,7 +25,7 @@ pub enum Message {
 pub enum Event {
     ContextMenu(context_menu::Event),
     OpenBuffer(Server, Target, BufferAction),
-    GoToMessage(Server, target::Channel, message::Hash),
+    GoToMessage(Server, target::Channel, message::Hash, BufferAction),
     History(Task<history::manager::Message>),
     OpenUrl(String),
     MarkAsRead,
@@ -90,11 +91,20 @@ pub fn view<'a>(
                                         .map(font::get),
                                 )
                                 .color(theme.styles().buffer.url.color)
-                                .link(message::Link::GoToMessage(
-                                    server.clone(),
-                                    channel.clone(),
-                                    message.hash,
-                                )),
+                                .link_maybe(
+                                    match config.actions.buffer.click_highlight
+                                    {
+                                        ChannelClickAction::OpenChannel(
+                                            buffer_action,
+                                        ) => Some(message::Link::GoToMessage(
+                                            server.clone(),
+                                            channel.clone(),
+                                            message.hash,
+                                            buffer_action,
+                                        )),
+                                        ChannelClickAction::Noop => None,
+                                    },
+                                ),
                             span(" "),
                         ])
                         .on_link(scroll_view::Message::Link);
@@ -159,7 +169,7 @@ pub fn view<'a>(
                         None,
                         config,
                         theme,
-                        &config.buffer.nickname.click,
+                        &config.actions.buffer.click_username,
                     )
                     .map(scroll_view::Message::ContextMenu);
 
@@ -261,11 +271,20 @@ pub fn view<'a>(
                         selectable_rich_text::<_, _, (), _, _>(vec![
                             span(channel.as_str())
                                 .color(theme.styles().buffer.url.color)
-                                .link(message::Link::GoToMessage(
-                                    server.clone(),
-                                    channel.clone(),
-                                    message.hash,
-                                )),
+                                .link_maybe(
+                                    match config.actions.buffer.click_highlight
+                                    {
+                                        ChannelClickAction::OpenChannel(
+                                            buffer_action,
+                                        ) => Some(message::Link::GoToMessage(
+                                            server.clone(),
+                                            channel.clone(),
+                                            message.hash,
+                                            buffer_action,
+                                        )),
+                                        ChannelClickAction::Noop => None,
+                                    },
+                                ),
                             span(" "),
                         ])
                         .on_link(scroll_view::Message::Link);
@@ -361,7 +380,10 @@ impl Highlights {
                         server,
                         channel,
                         message,
-                    ) => Some(Event::GoToMessage(server, channel, message)),
+                        action,
+                    ) => Some(Event::GoToMessage(
+                        server, channel, message, action,
+                    )),
                     scroll_view::Event::RequestOlderChatHistory => None,
                     scroll_view::Event::PreviewChanged => None,
                     scroll_view::Event::HidePreview(..) => None,

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -2637,7 +2637,6 @@ impl State {
 
         let open_buffers = if let Some(command::Irc::Join(targets, _)) =
             input.command()
-            && let Some(buffer_action) = config.actions.buffer.join_channel
         {
             let chantypes =
                 clients.get_server_chantypes_or_default(buffer.server());
@@ -2657,7 +2656,7 @@ impl State {
                     );
 
                     matches!(target, Target::Channel(_))
-                        .then_some((target, buffer_action))
+                        .then_some((target, config.actions.buffer.join_channel))
                 })
                 .collect()
         } else {

--- a/src/buffer/logs.rs
+++ b/src/buffer/logs.rs
@@ -150,7 +150,7 @@ impl Logs {
                         Some(Event::ContextMenu(event))
                     }
                     scroll_view::Event::OpenBuffer(_, _, _) => None,
-                    scroll_view::Event::GoToMessage(_, _, _) => None,
+                    scroll_view::Event::GoToMessage(..) => None,
                     scroll_view::Event::RequestOlderChatHistory => None,
                     scroll_view::Event::PreviewChanged => None,
                     scroll_view::Event::HidePreview(..) => None,

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -5,6 +5,7 @@ use data::buffer::RightAlignmentWidths;
 use data::config::buffer::nickname::ShownStatus;
 use data::config::buffer::{CondensationIcon, Dimmed};
 use data::config::preview::HideUrlCondition;
+use data::dashboard::BufferAction;
 use data::isupport::{CaseMap, PrefixMap};
 use data::preview::{self, Previews};
 use data::redaction::Redaction;
@@ -636,7 +637,7 @@ impl<'a> ChannelQueryLayout<'a> {
                     user,
                     self.config,
                     self.theme,
-                    &self.config.buffer.nickname.click,
+                    &self.config.actions.buffer.click_username,
                 )
                 .map(Message::ContextMenu)
             } else {
@@ -652,7 +653,7 @@ impl<'a> ChannelQueryLayout<'a> {
                     self.target.our_user(),
                     self.config,
                     self.theme,
-                    &self.config.buffer.nickname.click,
+                    &self.config.actions.buffer.click_username,
                 )
                 .map(Message::ContextMenu)
             }
@@ -1725,7 +1726,10 @@ impl<'a> ChannelQueryLayout<'a> {
                     .style(theme::button::reply_preview)
                     .padding(0)
                     .on_press(Message::Link(message::Link::GoToMessage(
-                        server, channel, hash,
+                        server,
+                        channel,
+                        hash,
+                        BufferAction::default(), // Currently unimportant, since the buffer will always be already open
                     )))
                     .into()
             } else {

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -291,7 +291,7 @@ impl Query {
                         server,
                         vec![(target, buffer_action)],
                     )),
-                    scroll_view::Event::GoToMessage(_, _, _) => None,
+                    scroll_view::Event::GoToMessage(..) => None,
                     scroll_view::Event::RequestOlderChatHistory => {
                         Some(Event::RequestOlderChatHistory)
                     }

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use chrono::{DateTime, Local, NaiveDate, Utc};
 use data::buffer::RightAlignmentWidths;
 use data::command::Irc;
+use data::config::actions::NicknameClickAction;
 use data::config::buffer::{CondensationIcon, HideConsecutiveEnabled};
 use data::dashboard::BufferAction;
 use data::isupport::ChatHistoryState;
@@ -89,7 +90,7 @@ impl From<context_menu::Message> for Message {
 pub enum Event {
     ContextMenu(context_menu::Event),
     OpenBuffer(Server, Target, BufferAction),
-    GoToMessage(Server, target::Channel, message::Hash),
+    GoToMessage(Server, target::Channel, message::Hash, BufferAction),
     RequestOlderChatHistory,
     PreviewChanged,
     HidePreview(history::Kind, message::Hash, url::Url),
@@ -1043,13 +1044,17 @@ impl State {
                     context_menu::update(message).map(Event::ContextMenu),
                 );
             }
-            Message::Link(message::Link::Channel(server, channel)) => {
+            Message::Link(message::Link::Channel(
+                server,
+                channel,
+                buffer_action,
+            )) => {
                 return (
                     Task::none(),
                     Some(Event::OpenBuffer(
                         server,
                         Target::Channel(channel),
-                        config.actions.buffer.click_channel_name,
+                        buffer_action,
                     )),
                 );
             }
@@ -1057,33 +1062,42 @@ impl State {
                 return (Task::none(), Some(Event::OpenUrl(url)));
             }
             Message::Link(message::Link::User(server, user)) => {
-                let event = match config.buffer.nickname.click {
-                    data::config::buffer::NicknameClickAction::OpenQuery => {
+                let event = match config.actions.buffer.click_username {
+                    NicknameClickAction::OpenQuery(buffer_action) => {
                         let query = target::Query::from(user);
 
-                        Event::OpenBuffer(
+                        Some(Event::OpenBuffer(
                             server,
                             Target::Query(query),
-                            config.actions.buffer.click_username,
-                        )
-                    }
-                    data::config::buffer::NicknameClickAction::InsertNickname => {
-                        Event::ContextMenu(context_menu::Event::InsertNickname(
-                            user.nickname().to_owned(),
+                            buffer_action,
                         ))
                     }
+                    NicknameClickAction::InsertNickname => {
+                        Some(Event::ContextMenu(
+                            context_menu::Event::InsertNickname(
+                                user.nickname().to_owned(),
+                            ),
+                        ))
+                    }
+                    NicknameClickAction::Noop => None,
                 };
 
-                return (Task::none(), Some(event));
+                return (Task::none(), event);
             }
             Message::Link(message::Link::GoToMessage(
                 server,
                 channel,
                 message,
+                buffer_action,
             )) => {
                 return (
                     Task::none(),
-                    Some(Event::GoToMessage(server, channel, message)),
+                    Some(Event::GoToMessage(
+                        server,
+                        channel,
+                        message,
+                        buffer_action,
+                    )),
                 );
             }
             Message::ScrollTo(keyed::Hit {

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -246,7 +246,7 @@ pub fn view<'a>(
                                 None,
                                 config,
                                 theme,
-                                &config.buffer.nickname.click,
+                                &config.actions.buffer.click_username,
                             )
                             .map(scroll_view::Message::ContextMenu)
                         };
@@ -396,7 +396,7 @@ impl Server {
                         server,
                         vec![(target, buffer_action)],
                     )),
-                    scroll_view::Event::GoToMessage(_, _, _) => None,
+                    scroll_view::Event::GoToMessage(..) => None,
                     scroll_view::Event::RequestOlderChatHistory => None,
                     scroll_view::Event::PreviewChanged => None,
                     scroll_view::Event::HidePreview(..) => None,

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1903,7 +1903,7 @@ impl Dashboard {
                 return (
                     self.open_buffer(
                         data::Buffer::Internal(buffer),
-                        config.actions.buffer.click_channel_name,
+                        config.actions.buffer.open_internal,
                         clients,
                         config,
                     ),
@@ -2340,7 +2340,12 @@ impl Dashboard {
             buffer::Event::History(history_task) => {
                 return (history_task.map(Message::History), None);
             }
-            buffer::Event::GoToMessage(server, channel, message) => {
+            buffer::Event::GoToMessage(
+                server,
+                channel,
+                message,
+                buffer_action,
+            ) => {
                 let buffer = data::Buffer::Upstream(buffer::Upstream::Channel(
                     server, channel,
                 ));
@@ -2350,7 +2355,7 @@ impl Dashboard {
                 if self.panes.get_mut_by_buffer(&buffer).is_none() {
                     tasks.push(self.open_buffer(
                         buffer.clone(),
-                        config.actions.buffer.click_highlight,
+                        buffer_action,
                         clients,
                         config,
                     ));
@@ -2899,7 +2904,7 @@ impl Dashboard {
         } else {
             self.open_buffer(
                 buffer.into(),
-                config.actions.buffer.local,
+                config.actions.buffer.open_internal,
                 clients,
                 config,
             )

--- a/src/widget/message_content.rs
+++ b/src/widget/message_content.rs
@@ -1,4 +1,5 @@
 use data::appearance::theme::{FontStyle, nickname_color};
+use data::config::actions::ChannelClickAction;
 use data::config::display::nickname::Metadata;
 use data::target::Query;
 use data::{Config, Server, User, isupport, message, metadata, target};
@@ -212,14 +213,26 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a + std::clone::Clone>(
                                     .color(transform_color(
                                         theme.styles().buffer.url.color,
                                     ))
-                                    .link(message::Link::Channel(
-                                        server.clone(),
-                                        target::Channel::from_str(
-                                            s.as_str(),
-                                            chantypes,
-                                            casemapping,
-                                        ),
-                                    ))
+                                    .link_maybe(
+                                        match config
+                                            .actions
+                                            .buffer
+                                            .click_channel_name
+                                        {
+                                            ChannelClickAction::OpenChannel(
+                                                buffer_action,
+                                            ) => Some(message::Link::Channel(
+                                                server.clone(),
+                                                target::Channel::from_str(
+                                                    s.as_str(),
+                                                    chantypes,
+                                                    casemapping,
+                                                ),
+                                                buffer_action,
+                                            )),
+                                            ChannelClickAction::Noop => None,
+                                        },
+                                    )
                             }
                             data::message::Fragment::User(user, text) => {
                                 let color = color_from_user(user);


### PR DESCRIPTION
Allows some actions to be set to `"no-action"` or `"noop"`, preventing any action being taken.  Specifically:
- Consolidates settings from `buffer.nickname.click` and `buffer.channel.nicklist.click` into `actions.buffer.click_nickname` and `actions.nicklist.click_nickname`.
- Renames actions settings to match terminology used elsewhere (e.g. `actions.buffer.click_username` → `actions.buffer.click_nickname` and `actions.buffer.local` → `actions.buffer.open_internal`).
- Allows `actions.buffer.click_nickname`, `actions.buffer.click_channel_name`, `actions.buffer.click_highlight`, and `actions.nicklist.click_nickname` to have no associated action.

Also fixes a tangentially related bug where slash-commands (e.g. `/join`) cannot be used in input boxes for channels that are not joined.