### PR TITLE
Include `actions.buffer.join_channel` in single pane guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Changed:
 - Renamed `sidebar.server_icon` → `sidebar.primary_icon` and `sidebar.server_font_size` → `sidebar.primary_font_size` since the settings now apply to both servers and internal buffers
 - Renamed `sidebar.font_size` → `sidebar.secondary_font_size` to reflect its relationship to `sidebar.primary_font_size`
 - Renamed `actions.buffer.local` → `actions.buffer.open_internal` to match naming convention used elsewhere
-- Renamed `actions.buffer.click_username` to `action_buffer.click_nickname` for more consistent terminology
+- Renamed `actions.buffer.click_username` to `actions.buffer.click_nickname` for more consistent terminology
 - Moved functionality from `buffer.nickname.click` → `actions.buffer.click_nickname` and `buffer.channel.nicklist.click` → `actions.nicklist.click_nickname`
 
 Thanks:

--- a/docs/guides/single-pane.md
+++ b/docs/guides/single-pane.md
@@ -7,6 +7,7 @@ The settings below will configure Halloy to have a single pane (or fixed number 
 click_channel_name = "replace-pane"
 click_highlight = "replace-pane"
 click_username = "replace-pane"
+join_channel = "replace-pane"
 local = "replace-pane"
 message_channel = "replace-pane"
 message_user = "replace-pane"


### PR DESCRIPTION
Updated single pane guide to include `join_channel` in the `actions.buffer` section.