### PR TITLE
docs: add privacy and code signing policies

### DIFF
--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -1,0 +1,5 @@
+# Code signing policy
+
+Windows release builds of Halloy are code-signed, including the Windows installer itself and the Halloy application binary packaged inside the installer.
+
+Free code signing provided by [SignPath.io](https://signpath.io/), certificate by [SignPath Foundation](https://signpath.org/?utm_source=foundation&utm_medium=github&utm_campaign=gitextension).

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,7 @@
+# Privacy policy
+
+Halloy does not include telemetry and does not transfer information to other networked systems unless specifically requested by the user or the person installing or operating it.
+
+As an IRC client, Halloy connects to IRC servers explicitly configured by the user. When connecting to such servers, information required for IRC communication, such as server address, nickname, username, messages, channel joins and related IRC protocol data, is transferred to the selected IRC network.
+
+Halloy does not control the privacy practices of IRC networks selected by the user.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ See the [contributing guide](https://halloy.chat/contributing) to get started.
 
 Halloy is released under the GPL-3.0 License. For more details, see the [LICENSE](LICENSE) file.
 
+## Code signing policy
+
+Read our [code signing policy](./CODE_SIGNING_POLICY.md).
+
+Free code signing provided by [SignPath.io](https://signpath.io/), certificate by [SignPath Foundation](https://signpath.org/?utm_source=foundation&utm_medium=github&utm_campaign=gitextension).
+
 ## Contact
 
 For any questions, suggestions, or issues, please open an issue on the [GitHub repository](https://github.com/squidowl/halloy/issues).


### PR DESCRIPTION
This adds a code signing policy according to the SignPath Foundation requirements.