### PR TITLE
Notification Action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Added:
 - Support displaying a larger version of the card images in-app
 - IRCv3 `no-implicit-names` support
 - Keyboard shortcuts validation (e.g no duplicate key binds)
-- `actions.buffer.notification` setting to control how interacting with notifications is handled
+- `actions.buffer.notifications` settings to control how interacting with notifications is handled
 - `actions.buffer.click_nickname` and `actions.nicklist.click_nickname` can be used to specify whether a nickname will: open query and how the query is opened, insert nickname in the input box, or no action (`"no-action"` or `"noop"`); takes over functionality from `buffer.nickname.click` and `buffer.channel.nicklist.click` and adds the ability to perform no action
 - `actions.buffer.click_channel_name` and `actions.buffer.click_highlight` can be set to no action (`"no-action"` or `"noop"`) to not open the channel when clicking on the channel name
 - Explicit portable mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Added:
 - Support displaying a larger version of the card images in-app
 - IRCv3 `no-implicit-names` support
 - Keyboard shortcuts validation (e.g no duplicate key binds)
+- `actions.buffer.notification` setting to control how interacting with notifications is handled
 - `actions.buffer.click_nickname` and `actions.nicklist.click_nickname` can be used to specify whether a nickname will: open query and how the query is opened, insert nickname in the input box, or no action (`"no-action"` or `"noop"`); takes over functionality from `buffer.nickname.click` and `buffer.channel.nicklist.click` and adds the ability to perform no action
 - `actions.buffer.click_channel_name` and `actions.buffer.click_highlight` can be set to no action (`"no-action"` or `"noop"`) to not open the channel when clicking on the channel name
 - Explicit portable mode
@@ -18,6 +19,7 @@ Fixed:
 - Nick highlight improvements
   - Handle nick possessives `<nick>'s` (`<nick>` should be parsed)
   - Skip parsing nicks inside abbreviations (`e.g.` shouldn't have highlights)
+- Notifications no longer immediately dismissed in some Wayland DE(s)
 - Do not send duplicate `JOIN` message when using `/join`
 - Do not send `MARKREAD` for non-`PRIVMSG`/`NOTICE` messages when the server does not support echoes
 - Do not show unread/highlight indicators for ignored messages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
 dependencies = [
  "async-io",
  "async-lock",
@@ -4415,6 +4415,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
 dependencies = [
  "futures-lite",
+ "image",
+ "lazy_static",
  "log",
  "mac-notification-sys",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ ipc = { version = "0.1.0", path = "ipc" }
 irc = { version = "0.1.0", path = "irc" }
 
 signal-hook = "0.3.18"
-notify-rust = "4.11"
+notify-rust = { version = "4.18", features = [ "images" ] }
 fern = "0.7.1"
 unicode-segmentation = "1.6"
 open = "5.0.1"

--- a/data/src/config/actions.rs
+++ b/data/src/config/actions.rs
@@ -8,7 +8,7 @@ pub struct Actions {
     pub sidebar: Sidebar,
     pub buffer: Buffer,
     pub nicklist: Nicklist,
-    pub notification: NotificationAction,
+    pub notification: Notification,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -138,43 +138,17 @@ impl<'de> Deserialize<'de> for ChannelClickAction {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default)]
-pub enum NotificationAction {
-    OpenBuffer(BufferAction),
-    #[default]
-    Noop,
+#[derive(Debug, Copy, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct Notification {
+    pub default: NotificationAction,
+    pub open_buffer: BufferAction,
 }
 
-impl<'de> Deserialize<'de> for NotificationAction {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        #[serde(rename_all = "kebab-case")]
-        enum ClickAction {
-            OpenBuffer(BufferAction),
-            #[serde(alias = "no-action")]
-            Noop,
-        }
-
-        #[derive(Deserialize)]
-        #[serde(untagged)]
-        enum Action {
-            ClickAction(ClickAction),
-            BufferAction(BufferAction),
-        }
-
-        match Action::deserialize(deserializer)? {
-            Action::ClickAction(click_action) => match click_action {
-                ClickAction::OpenBuffer(buffer_action) => {
-                    Ok(NotificationAction::OpenBuffer(buffer_action))
-                }
-                ClickAction::Noop => Ok(NotificationAction::Noop),
-            },
-            Action::BufferAction(buffer_action) => {
-                Ok(NotificationAction::OpenBuffer(buffer_action))
-            }
-        }
-    }
+#[derive(Debug, Copy, Clone, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum NotificationAction {
+    OpenBuffer,
+    #[default]
+    ActivateApplication,
 }

--- a/data/src/config/actions.rs
+++ b/data/src/config/actions.rs
@@ -8,6 +8,7 @@ pub struct Actions {
     pub sidebar: Sidebar,
     pub buffer: Buffer,
     pub nicklist: Nicklist,
+    pub notification: NotificationAction,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -132,6 +133,47 @@ impl<'de> Deserialize<'de> for ChannelClickAction {
             },
             Action::BufferAction(buffer_action) => {
                 Ok(ChannelClickAction::OpenChannel(buffer_action))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Default)]
+pub enum NotificationAction {
+    OpenBuffer(BufferAction),
+    #[default]
+    Noop,
+}
+
+impl<'de> Deserialize<'de> for NotificationAction {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "kebab-case")]
+        enum ClickAction {
+            OpenBuffer(BufferAction),
+            #[serde(alias = "no-action")]
+            Noop,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Action {
+            ClickAction(ClickAction),
+            BufferAction(BufferAction),
+        }
+
+        match Action::deserialize(deserializer)? {
+            Action::ClickAction(click_action) => match click_action {
+                ClickAction::OpenBuffer(buffer_action) => {
+                    Ok(NotificationAction::OpenBuffer(buffer_action))
+                }
+                ClickAction::Noop => Ok(NotificationAction::Noop),
+            },
+            Action::BufferAction(buffer_action) => {
+                Ok(NotificationAction::OpenBuffer(buffer_action))
             }
         }
     }

--- a/docs/configuration/actions.md
+++ b/docs/configuration/actions.md
@@ -4,7 +4,7 @@ Application-wide actions; how user actions should be enacted.
 
 ## `buffer`
 
-How buffer actions should be enacted
+How buffer actions should be enacted.
 
 ```toml
 # Replace pane when clicking on channel/user names in a pane
@@ -111,7 +111,7 @@ join_channel = "replace-pane"
 
 ## `nicklist`
 
-How nicklist actions should be enacted
+How nicklist actions should be enacted.
 
 ```toml
 # Replace pane when clicking on a nickname in the nicklist
@@ -139,15 +139,40 @@ click_nickname = { "open-query" = "replace-pane" }
 
 ## `notification`
 
-Action when clicking on a notification with a buffer context (e.g. when clicking a notification for a highlight in a channel, the context is the channel buffer). `"new-pane"` opens a new pane each time. `"replace-pane"` replaces the focused pane with the buffer context. `"new-window"` opens a new window each time. `"no-action"` or `"noop"` will perform no action on clicks aside from the default application activation behavior.
+How notification actions should be enacted.
+
+```toml
+# Open buffer in a new window when clicking on a notification
+
+[actions.notification]
+default = "open-buffer"
+open_buffer = "new-window"
+```
+
+### `default`
+
+Default action when clicking on a notification.  When set to `"activate-application"` or when there is no buffer context for the notification (e.g. when clicking a notification for a monitored user going offline), then the default application activation behavior for notification will be enacted.  When there is a buffer context (e.g. when clicking a notification for a highlight in a channel, the context is the channel buffer) and set to `"open-buffer"`, then the buffer context will be opened.  If there is a buffer context and `"activate-application"` is set, then `"open-buffer"` will be provided as a secondary action (if supported by the notification system).  When opening a buffer, [`actions.notification.open_buffer`](#open_buffer) determines how it will be opened.
 
 ```toml
 # Type: string
-# Values: "new-pane", "replace-pane", "new-window", "no-action", "noop"
-# Default: "noop"
+# Values: "activate-application", "open-buffer"
+# Default: "activate-application"
 
-[actions]
-notification = "new-pane"
+[actions.notification]
+default = "open-buffer"
+```
+
+### `open_buffer`
+
+When opening a buffer from a notification, how it will be opened. `"new-pane"` opens a new pane each time. `"replace-pane"` replaces the focused pane with the buffer. `"new-window"` opens a new window each time.
+
+```toml
+# Type: string
+# Values: "new-pane", "replace-pane", "new-window"
+# Default: "new-pane"
+
+[actions.notification]
+open_buffer = "replace-pane"
 ```
 
 ## `sidebar`

--- a/docs/configuration/actions.md
+++ b/docs/configuration/actions.md
@@ -137,6 +137,19 @@ Click action for when interaction with nicknames.  If not set, then the behavior
 click_nickname = { "open-query" = "replace-pane" }
 ```
 
+## `notification`
+
+Action when clicking on a notification with a buffer context (e.g. when clicking a notification for a highlight in a channel, the context is the channel buffer). `"new-pane"` opens a new pane each time. `"replace-pane"` replaces the focused pane with the buffer context. `"new-window"` opens a new window each time. `"no-action"` or `"noop"` will perform no action on clicks aside from the default application activation behavior.
+
+```toml
+# Type: string
+# Values: "new-pane", "replace-pane", "new-window", "no-action", "noop"
+# Default: "noop"
+
+[actions]
+notification = "new-pane"
+```
+
 ## `sidebar`
 
 How sidebar actions should be enacted.

--- a/src/main.rs
+++ b/src/main.rs
@@ -248,7 +248,7 @@ impl Halloy {
             }
         };
 
-        let (screen, servers, config, command) = match config_load {
+        let (screen, servers, config, commands) = match config_load {
             Ok(config) => {
                 let mut servers: server::Map = config.servers.clone().into();
                 servers.set_order(config.sidebar.order_by);
@@ -280,7 +280,11 @@ impl Halloy {
             ),
         };
 
-        let notifications = Notifications::new(&config);
+        let (notifications, stream) = Notifications::new(&config);
+
+        let commands =
+            Task::batch(vec![stream.map(Message::Notification), commands]);
+
         (
             Halloy {
                 version: Version::new(),
@@ -297,7 +301,7 @@ impl Halloy {
                 pending_logs: vec![],
                 notifications,
             },
-            command,
+            commands,
         )
     }
 }
@@ -333,6 +337,7 @@ pub enum Message {
     ConfigReloaded(Result<Config, config::Error>),
     RuntimeConfigured(Result<(), iced::backend::Error>),
     SystemInformation(iced::system::Information),
+    Notification(notification::Event),
 }
 
 impl Halloy {
@@ -692,42 +697,42 @@ impl Halloy {
                         let statusmsg = self
                             .clients
                             .get_server_statusmsg_or_default(&server);
-                        if let Some(our_nick) = self.clients.nickname(&server) {
-                            Task::batch(
-                                events
-                                    .into_iter()
-                                    .filter_map(|event| match event {
-                                        EchoEvent::Reaction(reaction) => {
-                                            handle_reaction_to_echo(
-                                                &self.config,
-                                                &server,
-                                                casemapping,
-                                                chantypes,
-                                                statusmsg,
-                                                dashboard,
-                                                &self.main_window,
-                                                reaction,
-                                                &mut self.notifications,
-                                                our_nick.to_owned(),
-                                            )
-                                        }
-                                        EchoEvent::Reply(reply) => {
-                                            handle_reply_to_echo(
-                                                &self.config,
-                                                &server,
-                                                casemapping,
-                                                dashboard,
-                                                &self.main_window,
-                                                reply,
-                                                &mut self.notifications,
-                                            )
-                                        }
-                                    })
-                                    .collect::<Vec<_>>(),
-                            )
-                        } else {
-                            Task::none()
+                        if let Some(our_nick) = self.clients.nickname(&server)
+                            && let Screen::Dashboard(dashboard) =
+                                &mut self.screen
+                        {
+                            for event in events.into_iter() {
+                                match event {
+                                    EchoEvent::Reaction(reaction) => {
+                                        handle_reaction_to_echo(
+                                            &self.config,
+                                            &server,
+                                            casemapping,
+                                            chantypes,
+                                            statusmsg,
+                                            dashboard,
+                                            &self.main_window,
+                                            reaction,
+                                            &mut self.notifications,
+                                            our_nick.to_owned(),
+                                        );
+                                    }
+                                    EchoEvent::Reply(reply) => {
+                                        handle_reply_to_echo(
+                                            &self.config,
+                                            &server,
+                                            casemapping,
+                                            dashboard,
+                                            &self.main_window,
+                                            reply,
+                                            &mut self.notifications,
+                                        );
+                                    }
+                                }
+                            }
                         }
+
+                        Task::none()
                     }
                     None => Task::none(),
                 };
@@ -794,20 +799,15 @@ impl Halloy {
                     if is_initial {
                         Task::none()
                     } else {
-                        let request_attention = if !self.main_window.focused {
+                        if !self.main_window.focused {
                             self.notifications.notify(
-                                &self.config.notifications,
+                                &self.config,
                                 &Notification::Disconnected,
                                 &server,
-                                dashboard
-                                    .find_window_with_server(&server)
-                                    .unwrap_or(self.main_window.id),
-                            )
-                        } else {
-                            None
-                        };
+                            );
+                        }
 
-                        let mut tasks = vec![
+                        Task::batch(vec![
                             dashboard
                                 .broadcast(
                                     &server,
@@ -821,13 +821,7 @@ impl Halloy {
                                     Broadcast::Disconnected { error },
                                 )
                                 .map(Message::Dashboard),
-                        ];
-
-                        if let Some(request_attention) = request_attention {
-                            tasks.push(request_attention);
-                        }
-
-                        Task::batch(tasks)
+                        ])
                     }
                 }
                 stream::Update::Connecting { server, sent_time } => {
@@ -872,17 +866,12 @@ impl Halloy {
                         (Notification::Reconnected, Broadcast::Reconnected)
                     };
 
-                    let request_attention = if !self.main_window.focused {
+                    if !self.main_window.focused {
                         self.notifications.notify(
-                            &self.config.notifications,
+                            &self.config,
                             &notification,
                             &server,
-                            dashboard
-                                .find_window_with_server(&server)
-                                .unwrap_or(self.main_window.id),
-                        )
-                    } else {
-                        None
+                        );
                     };
 
                     let broadcast = dashboard
@@ -900,13 +889,7 @@ impl Halloy {
                     let refocus_pane =
                         dashboard.refocus_pane().map(Message::Dashboard);
 
-                    let mut tasks = vec![broadcast, refocus_pane];
-
-                    if let Some(request_attention) = request_attention {
-                        tasks.push(request_attention);
-                    }
-
-                    Task::batch(tasks)
+                    Task::batch(vec![broadcast, refocus_pane])
                 }
                 stream::Update::ConnectionFailed {
                     server,
@@ -1376,6 +1359,19 @@ impl Halloy {
                 }
                 _ => Task::none(),
             },
+            Message::Notification(event) => {
+                if let Screen::Dashboard(dashboard) = &mut self.screen {
+                    dashboard
+                        .handle_notification_event(
+                            event,
+                            &mut self.clients,
+                            &self.config,
+                        )
+                        .map(Message::Dashboard)
+                } else {
+                    Task::none()
+                }
+            }
         }
     }
 
@@ -1571,7 +1567,7 @@ impl Halloy {
                     .into();
 
                 // Load new notification sounds.
-                self.notifications = Notifications::new(&updated);
+                self.notifications.update(&updated);
 
                 self.config = updated;
 
@@ -1794,6 +1790,7 @@ fn handle_client_events(
                     casemapping,
                     request,
                     config,
+                    notifications,
                 ) {
                     commands.push(command.map(Message::Dashboard));
                 }
@@ -1870,7 +1867,6 @@ fn handle_client_events(
                     our_nick,
                     user,
                     dashboard,
-                    &mut commands,
                     clients,
                     config,
                     notifications,
@@ -1882,16 +1878,11 @@ fn handle_client_events(
                 let message_window = dashboard.find_window_with_history(&kind);
 
                 if message_window.is_none() || !main_window.focused {
-                    let request_attention = notifications.notify(
-                        &config.notifications,
+                    notifications.notify(
+                        config,
                         &Notification::MonitoredOnline(users),
                         server,
-                        message_window.unwrap_or(main_window.id),
                     );
-
-                    if let Some(request_attention) = request_attention {
-                        commands.push(request_attention);
-                    }
                 }
             }
             Event::MonitoredOffline(users) => {
@@ -1899,16 +1890,11 @@ fn handle_client_events(
                 let message_window = dashboard.find_window_with_history(&kind);
 
                 if message_window.is_none() || !main_window.focused {
-                    let request_attention = notifications.notify(
-                        &config.notifications,
+                    notifications.notify(
+                        config,
                         &Notification::MonitoredOffline(users),
                         server,
-                        message_window.unwrap_or(main_window.id),
                     );
-
-                    if let Some(request_attention) = request_attention {
-                        commands.push(request_attention);
-                    }
                 }
             }
             Event::OnConnect(on_connect) => {
@@ -2237,7 +2223,6 @@ fn handle_priv_or_notice(
             notification_enabled,
             window,
             casemapping,
-            commands,
             config,
             notifications,
             main_window,
@@ -2256,8 +2241,8 @@ fn handle_priv_or_notice(
             ..
         } = &msg.target
     {
-        let request_attention = notifications.notify(
-            &config.notifications,
+        notifications.notify(
+            config,
             &Notification::Reply {
                 user: user.clone(),
                 channel: channel.clone(),
@@ -2265,11 +2250,7 @@ fn handle_priv_or_notice(
                 message: msg.text().to_string(),
             },
             server,
-            window.unwrap_or(main_window.id),
         );
-        if let Some(req) = request_attention {
-            commands.push(req);
-        }
     }
 
     commands.push(
@@ -2323,8 +2304,8 @@ fn handle_highlight(
             }
         };
 
-        let request_attention = notifications.notify(
-            &config.notifications,
+        notifications.notify(
+            config,
             &Notification::Highlight {
                 user: highlight_user,
                 channel: highlight_channel,
@@ -2334,12 +2315,7 @@ fn handle_highlight(
                 sound,
             },
             server,
-            message_window.unwrap_or(main_window.id),
         );
-
-        if let Some(request_attention) = request_attention {
-            commands.push(request_attention);
-        }
     }
 
     commands.push(
@@ -2355,7 +2331,6 @@ fn maybe_notify_channel_message(
     notification_enabled: bool,
     message_window: Option<window::Id>,
     casemapping: data::isupport::CaseMap,
-    commands: &mut Vec<Task<Message>>,
     config: &Config,
     notifications: &mut Notifications,
     main_window: &Window,
@@ -2381,8 +2356,8 @@ fn maybe_notify_channel_message(
         _ => return,
     };
 
-    let request_attention = notifications.notify(
-        &config.notifications,
+    notifications.notify(
+        config,
         &Notification::Channel {
             user,
             channel,
@@ -2390,12 +2365,7 @@ fn maybe_notify_channel_message(
             message: msg.text().to_string(),
         },
         server,
-        message_window.unwrap_or(main_window.id),
     );
-
-    if let Some(request_attention) = request_attention {
-        commands.push(request_attention);
-    }
 }
 
 fn handle_broadcast(
@@ -2514,7 +2484,7 @@ fn handle_reaction_to_echo(
     reaction_to_echo: ReactionToEcho,
     notifications: &mut Notifications,
     our_nick: Nick,
-) -> Option<Task<Message>> {
+) {
     let sender_nick = reaction_to_echo.reaction.inner.sender.clone();
     let self_reaction = our_nick == sender_nick;
     let sender = User::from(sender_nick);
@@ -2555,21 +2525,16 @@ fn handle_reaction_to_echo(
         && !reaction_to_echo.reaction.inner.unreact
         && (message_window.is_none() || !main_window.focused)
     {
-        let request_attention = notifications.notify(
-            &config.notifications,
+        notifications.notify(
+            config,
             &Notification::Reaction {
                 casemapping,
                 reaction: reaction_to_echo.reaction,
                 message_text: reaction_to_echo.message_text,
             },
             server,
-            message_window.unwrap_or(main_window.id),
         );
-
-        return request_attention;
     }
-
-    None
 }
 
 fn handle_reply_to_echo(
@@ -2580,7 +2545,7 @@ fn handle_reply_to_echo(
     main_window: &Window,
     reply_to_echo: ReplyToEcho,
     notifications: &mut Notifications,
-) -> Option<Task<Message>> {
+) {
     let data::message::Target::Channel {
         channel,
         source:
@@ -2589,7 +2554,7 @@ fn handle_reply_to_echo(
         ..
     } = &reply_to_echo.message.target
     else {
-        return None;
+        return;
     };
 
     let kind = history::Kind::Channel(server.to_owned(), channel.to_owned());
@@ -2602,8 +2567,8 @@ fn handle_reply_to_echo(
     );
 
     if !blocked && (message_window.is_none() || !main_window.focused) {
-        return notifications.notify(
-            &config.notifications,
+        notifications.notify(
+            config,
             &Notification::Reply {
                 user: user.clone(),
                 channel: channel.clone(),
@@ -2611,11 +2576,8 @@ fn handle_reply_to_echo(
                 message: reply_to_echo.message.text().to_string(),
             },
             server,
-            message_window.unwrap_or(main_window.id),
         );
     }
-
-    None
 }
 
 fn handle_direct_message(
@@ -2624,7 +2586,6 @@ fn handle_direct_message(
     our_nick: data::user::Nick,
     user: User,
     dashboard: &mut screen::Dashboard,
-    commands: &mut Vec<Task<Message>>,
     clients: &data::client::Map,
     config: &Config,
     notifications: &mut Notifications,
@@ -2661,20 +2622,15 @@ fn handle_direct_message(
     let message_window = dashboard.find_window_with_history(&kind);
 
     if !blocked && (message_window.is_none() || !main_window.focused) {
-        let request_attention = notifications.notify(
-            &config.notifications,
+        notifications.notify(
+            config,
             &Notification::DirectMessage {
                 user,
                 casemapping,
                 message: msg.text().to_string(),
             },
             server,
-            message_window.unwrap_or(main_window.id),
         );
-
-        if let Some(request_attention) = request_attention {
-            commands.push(request_attention);
-        }
     }
 }
 

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -516,7 +516,7 @@ impl Notifications {
 
         self.execute(
             notification_config,
-            config.actions.notification,
+            config.actions.notification.default,
             notification,
             &title,
             subtitle.as_deref(),

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -2,16 +2,32 @@ use std::collections::HashMap;
 
 use chrono::{DateTime, TimeDelta, Utc};
 use data::audio::Sound;
-use data::config::{self, notification};
+use data::buffer::{self, Buffer};
+use data::config::actions::NotificationAction;
+use data::config::notification;
 use data::target::join_targets;
 use data::user::Nick;
 use data::{Config, Notification, Server, User};
 use iced::Task;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
 
+use self::toast::Toast;
 pub use self::toast::prepare;
-use crate::{audio, window};
+use crate::audio;
 
-mod toast;
+pub mod toast;
+
+#[derive(Debug)]
+pub enum Event {
+    RequestAttention {
+        buffer: Option<Buffer>,
+    },
+    NotificationResponse {
+        action: toast::Action,
+        buffer: Option<Buffer>,
+    },
+}
 
 #[derive(PartialEq, Eq, Hash, Clone)]
 enum NotificationDelayKey {
@@ -71,412 +87,455 @@ impl From<&Notification> for NotificationDelayKey {
 pub struct Notifications {
     recent_notifications: HashMap<NotificationDelayKey, DateTime<Utc>>,
     sounds: HashMap<String, Sound>,
+    sender: mpsc::Sender<Event>,
 }
 
 impl Notifications {
-    pub fn new(config: &Config) -> Self {
-        // Load sounds from different sources.
-        let sounds =
-            config.notifications.load_sounds(
-                config.highlights.matches.iter().filter_map(
-                    |highlight_match| highlight_match.sound.as_deref(),
-                ),
-            );
+    pub fn new(config: &Config) -> (Self, Task<Event>) {
+        let sounds = Notifications::load_sounds(config);
 
-        Self {
-            recent_notifications: HashMap::new(),
-            sounds,
-        }
+        let (sender, receiver) = mpsc::channel(50);
+
+        (
+            Self {
+                recent_notifications: HashMap::new(),
+                sounds,
+                sender,
+            },
+            Task::stream(ReceiverStream::new(receiver)),
+        )
     }
 
-    pub fn notify<Message: 'static + Send>(
+    pub fn update(&mut self, config: &Config) {
+        // Load sounds from different sources.
+        self.sounds = Notifications::load_sounds(config);
+    }
+
+    fn load_sounds(config: &Config) -> HashMap<String, Sound> {
+        // Load sounds from different sources.
+        config.notifications.load_sounds(
+            config
+                .highlights
+                .matches
+                .iter()
+                .filter_map(|highlight_match| highlight_match.sound.as_deref()),
+        )
+    }
+
+    pub fn notify(
         &mut self,
-        config: &config::Notifications,
+        config: &Config,
         notification: &Notification,
         server: &Server,
-        window_id: window::Id,
-    ) -> Option<Task<Message>> {
-        let request_attention = match notification {
-            Notification::Connected => {
-                self.execute(
-                    &config.connected,
-                    notification,
-                    "Connected",
+    ) {
+        let (notification_config, title, subtitle, body, sound_name, buffer) =
+            match notification {
+                Notification::Connected => (
+                    &config.notifications.connected,
+                    "Connected".to_string(),
                     None,
-                    &server.to_string(),
+                    server.to_string(),
                     None,
-                );
-
-                config.connected.request_attention
-            }
-            Notification::Disconnected => {
-                self.execute(
-                    &config.disconnected,
-                    notification,
-                    "Disconnected",
                     None,
-                    &server.to_string(),
+                ),
+                Notification::Disconnected => (
+                    &config.notifications.disconnected,
+                    "Disconnected".to_string(),
                     None,
-                );
-
-                config.disconnected.request_attention
-            }
-            Notification::Reconnected => {
-                self.execute(
-                    &config.reconnected,
-                    notification,
-                    "Reconnected",
+                    server.to_string(),
                     None,
-                    &server.to_string(),
                     None,
-                );
-
-                config.reconnected.request_attention
-            }
-            Notification::MonitoredOnline(targets) => {
-                self.execute(
-                    &config.monitored_online,
-                    notification,
+                ),
+                Notification::Reconnected => (
+                    &config.notifications.reconnected,
+                    "Reconnected".to_string(),
+                    None,
+                    server.to_string(),
+                    None,
+                    None,
+                ),
+                Notification::MonitoredOnline(targets) => (
+                    &config.notifications.monitored_online,
                     if targets.len() == 1 {
                         "Monitored user is online"
                     } else {
                         "Monitored users are online"
-                    },
+                    }
+                    .to_string(),
                     None,
-                    &join_targets(targets.iter().map(User::as_str).collect()),
+                    join_targets(targets.iter().map(User::as_str).collect()),
                     None,
-                );
-
-                config.monitored_online.request_attention
-            }
-            Notification::MonitoredOffline(targets) => {
-                self.execute(
-                    &config.monitored_offline,
-                    notification,
+                    None,
+                ),
+                Notification::MonitoredOffline(targets) => (
+                    &config.notifications.monitored_offline,
                     if targets.len() == 1 {
                         "Monitored user is offline"
                     } else {
                         "Monitored users are offline"
-                    },
-                    None,
-                    &join_targets(targets.iter().map(Nick::as_str).collect()),
-                    None,
-                );
-
-                config.monitored_offline.request_attention
-            }
-            Notification::FileTransferRequest {
-                nick,
-                casemapping,
-                filename,
-            } => {
-                if config.file_transfer_request.should_notify(
-                    &User::from(nick.clone()),
-                    None,
-                    server,
-                    *casemapping,
-                ) {
-                    let (title, subtitle, body): (
-                        String,
-                        Option<String>,
-                        String,
-                    ) = if config.file_transfer_request.show_content {
-                        (
-                            nick.as_str().to_owned(),
-                            Some(format!("{server}")),
-                            format!("Sent you a file: {filename}"),
-                        )
-                    } else {
-                        (
-                            format!("File transfer from {nick}"),
-                            None,
-                            format!("Sent you a file on {server}"),
-                        )
-                    };
-
-                    self.execute(
-                        &config.file_transfer_request,
-                        notification,
-                        title.as_str(),
-                        subtitle.as_deref(),
-                        body.as_str(),
-                        None,
-                    );
-
-                    config.file_transfer_request.request_attention
-                } else {
-                    false
-                }
-            }
-            Notification::DirectMessage {
-                user,
-                casemapping,
-                message,
-            } => {
-                if config.direct_message.should_notify(
-                    user,
-                    None,
-                    server,
-                    *casemapping,
-                ) {
-                    let (title, subtitle, body): (
-                        String,
-                        Option<String>,
-                        String,
-                    ) = if config.direct_message.show_content {
-                        (
-                            user.nickname().as_str().to_owned(),
-                            Some(format!("{server}")),
-                            message.to_owned(),
-                        )
-                    } else {
-                        (
-                            user.nickname().as_str().to_owned(),
-                            None,
-                            format!("Sent you a direct message on {server}"),
-                        )
-                    };
-
-                    self.execute(
-                        &config.direct_message,
-                        notification,
-                        title.as_str(),
-                        subtitle.as_deref(),
-                        body.as_str(),
-                        None,
-                    );
-
-                    config.direct_message.request_attention
-                } else {
-                    false
-                }
-            }
-            Notification::Highlight {
-                user,
-                channel,
-                casemapping,
-                message,
-                description,
-                sound,
-            } => {
-                if config.highlight.should_notify(
-                    user,
-                    Some(channel),
-                    server,
-                    *casemapping,
-                ) {
-                    // Description is expected to be expanded by the calling
-                    // routine when show_content is true
-                    if config.highlight.show_content {
-                        self.execute(
-                            &config.highlight,
-                            notification,
-                            &format!("{} {description}", user.nickname()),
-                            Some(if cfg!(target_os = "macos") {
-                                format!("{channel} ({server})")
-                            } else {
-                                format!("{channel}, {server}")
-                            })
-                            .as_deref(),
-                            message,
-                            sound.as_deref(),
-                        );
-
-                        config.highlight.request_attention
-                    } else {
-                        self.execute(
-                            &config.highlight,
-                            notification,
-                            user.nickname().as_str(),
-                            None,
-                            &format!("{description} in {channel} ({server})"),
-                            sound.as_deref(),
-                        );
-
-                        config.highlight.request_attention
                     }
-                } else {
-                    false
+                    .to_string(),
+                    None,
+                    join_targets(targets.iter().map(Nick::as_str).collect()),
+                    None,
+                    None,
+                ),
+                Notification::FileTransferRequest {
+                    nick,
+                    casemapping,
+                    filename,
+                } => {
+                    if config.notifications.file_transfer_request.should_notify(
+                        &User::from(nick.clone()),
+                        None,
+                        server,
+                        *casemapping,
+                    ) {
+                        let (title, subtitle, body): (
+                            String,
+                            Option<String>,
+                            String,
+                        ) = if config
+                            .notifications
+                            .file_transfer_request
+                            .show_content
+                        {
+                            (
+                                nick.as_str().to_owned(),
+                                Some(format!("{server}")),
+                                format!("Sent you a file: {filename}"),
+                            )
+                        } else {
+                            (
+                                format!("File transfer from {nick}"),
+                                None,
+                                format!("Sent you a file on {server}"),
+                            )
+                        };
+
+                        (
+                            &config.notifications.file_transfer_request,
+                            title,
+                            subtitle,
+                            body,
+                            None,
+                            Some(Buffer::Internal(
+                                buffer::Internal::FileTransfers,
+                            )),
+                        )
+                    } else {
+                        return;
+                    }
                 }
-            }
-            Notification::Channel {
-                user,
-                channel,
-                casemapping,
-                message,
-            } => {
-                if let Some(notification_config) =
-                    config.channels.get(channel.as_str())
-                    && notification_config.should_notify(
+                Notification::DirectMessage {
+                    user,
+                    casemapping,
+                    message,
+                } => {
+                    if config.notifications.direct_message.should_notify(
                         user,
                         None,
                         server,
                         *casemapping,
-                    )
-                {
-                    if notification_config.show_content {
-                        self.execute(
-                            notification_config,
-                            notification,
-                            user.nickname().as_str(),
-                            Some(if cfg!(target_os = "macos") {
-                                format!("{channel} ({server})")
-                            } else {
-                                format!("{channel}, {server}")
-                            })
-                            .as_deref(),
-                            message,
-                            None,
-                        );
+                    ) {
+                        let (title, subtitle, body): (
+                            String,
+                            Option<String>,
+                            String,
+                        ) = if config.notifications.direct_message.show_content
+                        {
+                            (
+                                user.nickname().as_str().to_owned(),
+                                Some(format!("{server}")),
+                                message.to_owned(),
+                            )
+                        } else {
+                            (
+                                user.nickname().as_str().to_owned(),
+                                None,
+                                format!(
+                                    "Sent you a direct message on {server}"
+                                ),
+                            )
+                        };
 
-                        notification_config.request_attention
+                        (
+                            &config.notifications.direct_message,
+                            title,
+                            subtitle,
+                            body,
+                            None,
+                            Some(Buffer::Upstream(buffer::Upstream::Query(
+                                server.clone(),
+                                user.into(),
+                            ))),
+                        )
                     } else {
-                        self.execute(
-                            notification_config,
-                            notification,
-                            user.nickname().as_str(),
-                            None,
-                            &format!("Sent a message in {channel} ({server})"),
-                            None,
-                        );
-
-                        notification_config.request_attention
+                        return;
                     }
-                } else {
-                    false
                 }
-            }
-            Notification::Reaction {
-                casemapping,
-                reaction,
-                message_text,
-            } => {
-                let channel_option = reaction.target.clone().to_channel();
-                let channel = channel_option.as_ref();
-                if config.reaction.should_notify(
-                    &User::from(reaction.inner.sender.clone()),
-                    channel,
-                    server,
-                    *casemapping,
-                ) {
-                    let react_sent_in = match channel {
-                        Some(channel) => {
-                            if cfg!(target_os = "macos")
-                                || !config.reaction.show_content
-                            {
-                                format!("{channel} ({server})")
-                            } else {
-                                format!("{channel}, {server}")
-                            }
-                        }
-                        None => {
-                            if cfg!(target_os = "macos")
-                                || !config.reaction.show_content
-                            {
-                                format!("query ({server})")
-                            } else {
-                                format!("query, {server}")
-                            }
-                        }
-                    };
-
-                    let (title, subtitle, body): (
-                        String,
-                        Option<String>,
-                        String,
-                    ) = if config.reaction.show_content {
-                        (
-                            reaction.inner.sender.to_string(),
-                            Some(react_sent_in.to_string()),
-                            format!(
-                                "Reacted {} to your message: {message_text}",
-                                reaction.inner.text
-                            ),
-                        )
-                    } else {
-                        (
-                            reaction.inner.sender.to_string(),
-                            Some(react_sent_in.to_string()),
-                            "Reacted to your message".to_string(),
-                        )
-                    };
-
-                    self.execute(
-                        &config.reaction,
-                        notification,
-                        title.as_str(),
-                        subtitle.as_deref(),
-                        body.as_str(),
-                        None,
-                    );
-
-                    config.reaction.request_attention
-                } else {
-                    false
-                }
-            }
-            Notification::Reply {
-                user,
-                channel,
-                casemapping,
-                message,
-            } => {
-                if config.highlight.should_notify(
+                Notification::Highlight {
                     user,
-                    Some(channel),
-                    server,
-                    *casemapping,
-                ) {
-                    if config.highlight.show_content {
-                        self.execute(
-                            &config.highlight,
-                            notification,
-                            &format!("{} replied to you", user.nickname()),
-                            Some(if cfg!(target_os = "macos") {
-                                format!("{channel} ({server})")
-                            } else {
-                                format!("{channel}, {server}")
-                            })
-                            .as_deref(),
-                            message,
-                            None,
-                        );
+                    channel,
+                    casemapping,
+                    message,
+                    description,
+                    sound,
+                } => {
+                    if config.notifications.highlight.should_notify(
+                        user,
+                        Some(channel),
+                        server,
+                        *casemapping,
+                    ) {
+                        let buffer =
+                            Buffer::Upstream(buffer::Upstream::Channel(
+                                server.clone(),
+                                channel.clone(),
+                            ));
+
+                        // Description is expected to be expanded by the calling
+                        // routine when show_content is true
+                        if config.notifications.highlight.show_content {
+                            (
+                                &config.notifications.highlight,
+                                format!("{} {description}", user.nickname()),
+                                Some(if cfg!(target_os = "macos") {
+                                    format!("{channel} ({server})")
+                                } else {
+                                    format!("{channel}, {server}")
+                                }),
+                                message.to_owned(),
+                                sound.to_owned(),
+                                Some(buffer),
+                            )
+                        } else {
+                            (
+                                &config.notifications.highlight,
+                                user.nickname().to_string(),
+                                None,
+                                format!(
+                                    "{description} in {channel} ({server})"
+                                ),
+                                sound.to_owned(),
+                                Some(buffer),
+                            )
+                        }
                     } else {
-                        self.execute(
-                            &config.highlight,
-                            notification,
-                            user.nickname().as_str(),
-                            None,
-                            &format!("replied to you in {channel} ({server})"),
-                            None,
-                        );
+                        return;
                     }
-
-                    config.highlight.request_attention
-                } else {
-                    false
                 }
-            }
-        };
+                Notification::Channel {
+                    user,
+                    channel,
+                    casemapping,
+                    message,
+                } => {
+                    let buffer = Buffer::Upstream(buffer::Upstream::Channel(
+                        server.clone(),
+                        channel.clone(),
+                    ));
 
-        if request_attention {
-            Some(iced::window::request_user_attention(
-                window_id,
-                Some(iced::window::UserAttention::Informational),
-            ))
-        } else {
-            None
+                    if let Some(channel_notifications_config) =
+                        config.notifications.channels.get(channel.as_str())
+                        && channel_notifications_config.should_notify(
+                            user,
+                            None,
+                            server,
+                            *casemapping,
+                        )
+                    {
+                        if channel_notifications_config.show_content {
+                            (
+                                channel_notifications_config,
+                                user.nickname().to_string(),
+                                Some(if cfg!(target_os = "macos") {
+                                    format!("{channel} ({server})")
+                                } else {
+                                    format!("{channel}, {server}")
+                                }),
+                                message.to_owned(),
+                                None,
+                                Some(buffer),
+                            )
+                        } else {
+                            (
+                                channel_notifications_config,
+                                user.nickname().to_string(),
+                                None,
+                                format!(
+                                    "Sent a message in {channel} ({server})"
+                                ),
+                                None,
+                                Some(buffer),
+                            )
+                        }
+                    } else {
+                        return;
+                    }
+                }
+                Notification::Reaction {
+                    casemapping,
+                    reaction,
+                    message_text,
+                } => {
+                    let channel_option = reaction.target.clone().to_channel();
+                    let channel = channel_option.as_ref();
+                    let user = User::from(reaction.inner.sender.clone());
+                    if config.notifications.reaction.should_notify(
+                        &user,
+                        channel,
+                        server,
+                        *casemapping,
+                    ) {
+                        let (react_sent_in, buffer) = match channel {
+                            Some(channel) => (
+                                if cfg!(target_os = "macos")
+                                    || !config
+                                        .notifications
+                                        .reaction
+                                        .show_content
+                                {
+                                    format!("{channel} ({server})")
+                                } else {
+                                    format!("{channel}, {server}")
+                                },
+                                Buffer::Upstream(buffer::Upstream::Channel(
+                                    server.clone(),
+                                    channel.clone(),
+                                )),
+                            ),
+                            None => (
+                                if cfg!(target_os = "macos")
+                                    || !config
+                                        .notifications
+                                        .reaction
+                                        .show_content
+                                {
+                                    format!("query ({server})")
+                                } else {
+                                    format!("query, {server}")
+                                },
+                                Buffer::Upstream(buffer::Upstream::Query(
+                                    server.clone(),
+                                    (&user).into(),
+                                )),
+                            ),
+                        };
+
+                        let (title, subtitle, body): (
+                            String,
+                            Option<String>,
+                            String,
+                        ) = if config.notifications.reaction.show_content {
+                            (
+                                user.nickname().to_string(),
+                                Some(react_sent_in.to_string()),
+                                format!(
+                                    "Reacted {} to your message: {message_text}",
+                                    reaction.inner.text
+                                ),
+                            )
+                        } else {
+                            (
+                                user.nickname().to_string(),
+                                Some(react_sent_in.to_string()),
+                                "Reacted to your message".to_string(),
+                            )
+                        };
+
+                        (
+                            &config.notifications.reaction,
+                            title,
+                            subtitle,
+                            body,
+                            None,
+                            Some(buffer),
+                        )
+                    } else {
+                        return;
+                    }
+                }
+                Notification::Reply {
+                    user,
+                    channel,
+                    casemapping,
+                    message,
+                } => {
+                    if config.notifications.highlight.should_notify(
+                        user,
+                        Some(channel),
+                        server,
+                        *casemapping,
+                    ) {
+                        let buffer =
+                            Buffer::Upstream(buffer::Upstream::Channel(
+                                server.clone(),
+                                channel.clone(),
+                            ));
+
+                        if config.notifications.highlight.show_content {
+                            (
+                                &config.notifications.highlight,
+                                format!("{} replied to you", user.nickname()),
+                                Some(if cfg!(target_os = "macos") {
+                                    format!("{channel} ({server})")
+                                } else {
+                                    format!("{channel}, {server}")
+                                }),
+                                message.to_owned(),
+                                None,
+                                Some(buffer),
+                            )
+                        } else {
+                            (
+                                &config.notifications.highlight,
+                                user.nickname().to_string(),
+                                None,
+                                format!(
+                                    "replied to you in {channel} ({server})"
+                                ),
+                                None,
+                                Some(buffer),
+                            )
+                        }
+                    } else {
+                        return;
+                    }
+                }
+            };
+
+        if notification_config.request_attention {
+            let sender = self.sender.clone();
+            let buffer = buffer.clone();
+
+            tokio::task::spawn(async move {
+                let _ = sender.send(Event::RequestAttention { buffer }).await;
+            });
         }
+
+        self.execute(
+            notification_config,
+            config.actions.notification,
+            notification,
+            &title,
+            subtitle.as_deref(),
+            &body,
+            sound_name.as_deref(),
+            buffer,
+        );
     }
 
     fn execute(
         &mut self,
         config: &notification::Notification,
+        notification_action: NotificationAction,
         notification: &Notification,
         title: &str,
         subtitle: Option<&str>,
         body: &str,
         sound_name: Option<&str>,
+        buffer: Option<Buffer>,
     ) {
         let now = Utc::now();
         let delay_key = notification.into();
@@ -495,7 +554,23 @@ impl Notifications {
         self.recent_notifications.insert(delay_key, now);
 
         if config.show_toast {
-            toast::show(title, subtitle, body);
+            let toast = Toast::new(
+                title,
+                subtitle,
+                body,
+                buffer.is_some(),
+                notification_action,
+            );
+
+            let sender = self.sender.clone();
+
+            tokio::task::spawn(async move {
+                if let Some(action) = toast.show_and_wait_for_response().await {
+                    let _ = sender
+                        .send(Event::NotificationResponse { action, buffer })
+                        .await;
+                }
+            });
         }
 
         if let Some(sound) = sound_name

--- a/src/notification/toast.rs
+++ b/src/notification/toast.rs
@@ -75,11 +75,17 @@ impl Toast {
             notification.app_id(data::environment::APPLICATION_ID);
         }
 
-        if has_buffer_context
-            && !matches!(notification_action, NotificationAction::Noop)
-        {
-            notification.action("default", "Open Buffer");
-            notification.action("open_or_focus_buffer", "Open Buffer");
+        match notification_action {
+            NotificationAction::ActivateApplication => {
+                if has_buffer_context {
+                    notification.action("open_or_focus_buffer", "Open Buffer");
+                }
+            }
+            NotificationAction::OpenBuffer => {
+                if has_buffer_context {
+                    notification.action("default", "Open Buffer");
+                }
+            }
         }
 
         Self(notification.finalize())

--- a/src/notification/toast.rs
+++ b/src/notification/toast.rs
@@ -1,3 +1,8 @@
+use data::config::actions::NotificationAction;
+#[cfg(target_os = "linux")]
+use image::EncodableLayout;
+use notify_rust::{Notification, NotificationResponse};
+
 #[cfg(target_os = "macos")]
 pub fn prepare() {
     match notify_rust::set_application(data::environment::APPLICATION_ID) {
@@ -11,32 +16,140 @@ pub fn prepare() {
 #[cfg(not(target_os = "macos"))]
 pub fn prepare() {}
 
-pub fn show(title: &str, subtitle: Option<&str>, body: &str) {
-    let mut notification = notify_rust::Notification::new();
+pub struct Toast(Notification);
 
-    notification.body(body);
+impl Toast {
+    pub fn new(
+        title: &str,
+        subtitle: Option<&str>,
+        body: &str,
+        has_buffer_context: bool,
+        notification_action: NotificationAction,
+    ) -> Self {
+        let mut notification = notify_rust::Notification::new();
 
-    #[cfg(target_os = "macos")]
-    {
-        notification.summary(title);
-        if let Some(subtitle) = subtitle {
-            notification.subtitle(subtitle);
-        }
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        if let Some(subtitle) = subtitle {
-            notification.summary(&format!("{title} ({subtitle})"));
-        } else {
+        notification.body(body);
+
+        #[cfg(target_os = "macos")]
+        {
             notification.summary(title);
+            if let Some(subtitle) = subtitle {
+                notification.subtitle(subtitle);
+            }
         }
-        notification.appname("Halloy");
-        notification.icon(data::environment::APPLICATION_ID);
-    }
-    #[cfg(target_os = "windows")]
-    {
-        notification.app_id(data::environment::APPLICATION_ID);
+        #[cfg(not(target_os = "macos"))]
+        {
+            if let Some(subtitle) = subtitle {
+                notification.summary(&format!("{title} ({subtitle})"));
+            } else {
+                notification.summary(title);
+            }
+            notification.appname("Halloy");
+            notification.icon(data::environment::APPLICATION_ID);
+        }
+        #[cfg(target_os = "linux")]
+        {
+            // For GNOME 46+ setting the icon is not sufficient to show the icon
+            // in the body area of the notification; setting image_data or
+            // image_path is needed.
+            if let Some(logo) = image::load_from_memory_with_format(
+                include_bytes!("../../assets/logo.png"),
+                image::ImageFormat::Png,
+            )
+            .ok()
+            .and_then(|image| {
+                image.as_rgba8().and_then(|image| {
+                    notify_rust::Image::from_rgba(
+                        image.width().try_into().unwrap_or_default(),
+                        image.height().try_into().unwrap_or_default(),
+                        image.as_bytes().to_vec(),
+                    )
+                    .ok()
+                })
+            }) {
+                notification.image_data(logo);
+            }
+        }
+        #[cfg(target_os = "windows")]
+        {
+            notification.app_id(data::environment::APPLICATION_ID);
+        }
+
+        if has_buffer_context
+            && !matches!(notification_action, NotificationAction::Noop)
+        {
+            notification.action("default", "Open Buffer");
+            notification.action("open_or_focus_buffer", "Open Buffer");
+        }
+
+        Self(notification.finalize())
     }
 
-    let _ = notification.show();
+    #[cfg(target_os = "linux")]
+    pub async fn show_and_wait_for_response(self) -> Option<Action> {
+        // When image_data is set, Notification::show/Notification::show_async
+        // will attempt to start a tokio runtime and panic.  This is a
+        // workaround for that behavior.
+        let mut action = None;
+
+        if let Ok(handle) = tokio::task::spawn_blocking(move || {
+            futures::executor::block_on(async { self.0.show_async().await })
+        })
+        .await
+        .ok()?
+        {
+            handle
+                .wait_for_action_async(|response: &NotificationResponse| {
+                    Toast::handle_response(response, &mut action);
+                })
+                .await;
+        }
+
+        action
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub async fn show_and_wait_for_response(self) -> Option<Action> {
+        let mut action = None;
+
+        // Notification::show_async and
+        // NotificationHandle::wait_for_action_async are not available on
+        // macOS/Windows.
+        self.0
+            .show()
+            .ok()?
+            .wait_for_response(|response: &NotificationResponse| {
+                Toast::handle_response(response, &mut action);
+            })
+            .ok()?;
+
+        action
+    }
+
+    fn handle_response(
+        response: &NotificationResponse,
+        action: &mut Option<Action>,
+    ) {
+        match response {
+            NotificationResponse::Default => {
+                *action = Some(Action::OpenOrFocusBuffer);
+            }
+            NotificationResponse::Action(response_action)
+                if response_action == "open_or_focus_buffer" =>
+            {
+                *action = Some(Action::OpenOrFocusBuffer);
+            }
+            NotificationResponse::Action(_)
+            | NotificationResponse::Reply(_)
+            | NotificationResponse::Closed(_) => {
+                *action = Some(Action::Dismiss);
+            }
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum Action {
+    OpenOrFocusBuffer,
+    Dismiss,
 }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -9,7 +9,6 @@ use chrono::{DateTime, Utc};
 use data::capabilities::{
     LabeledResponseContext, MultilineBatchKind, multiline_concat_lines,
 };
-use data::config::actions::NotificationAction;
 use data::config::buffer::{ScrollPosition, UsernameFormat};
 use data::dashboard::{self, BufferAction};
 use data::environment::{RELEASE_WEBSITE, WIKI_WEBSITE};
@@ -4637,10 +4636,7 @@ impl Dashboard {
                 match action {
                     toast::Action::Dismiss => Task::none(),
                     toast::Action::OpenOrFocusBuffer => {
-                        if let Some(buffer) = buffer
-                            && let NotificationAction::OpenBuffer(buffer_action) =
-                                config.actions.notification
-                        {
+                        if let Some(buffer) = buffer {
                             // When an notification action is performed in Wayland
                             // the application is not automatically brought forward.
                             // Request attention in order to do so.
@@ -4661,7 +4657,7 @@ impl Dashboard {
                             .chain(
                                 self.open_or_focus_buffer(
                                     buffer,
-                                    buffer_action,
+                                    config.actions.notification.open_buffer,
                                     clients,
                                     config,
                                 ),

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -9,6 +9,7 @@ use chrono::{DateTime, Utc};
 use data::capabilities::{
     LabeledResponseContext, MultilineBatchKind, multiline_concat_lines,
 };
+use data::config::actions::NotificationAction;
 use data::config::buffer::{ScrollPosition, UsernameFormat};
 use data::dashboard::{self, BufferAction};
 use data::environment::{RELEASE_WEBSITE, WIKI_WEBSITE};
@@ -37,14 +38,14 @@ use self::pane::Pane;
 use self::sidebar::Sidebar;
 use self::theme_editor::ThemeEditor;
 use crate::buffer::{self, Buffer};
+use crate::notification::{self, Notifications, toast};
 use crate::widget::{
     Column, Element, Row, anchored_overlay, context_menu, selectable_text,
     shortcut,
 };
 use crate::window::Window;
 use crate::{
-    Theme, event, filehost, notification, open_url, platform_specific, theme,
-    window,
+    Theme, event, filehost, open_url, platform_specific, theme, window,
 };
 
 mod command_bar;
@@ -67,7 +68,6 @@ pub struct Dashboard {
     command_bar_window: Option<window::Id>,
     file_transfers: file_transfer::Manager,
     theme_editor: Option<ThemeEditor>,
-    notifications: notification::Notifications,
     previews: preview::Collection,
     previews_cache: Arc<cache::FileCache>,
     server_icons: server_icon::Manager,
@@ -156,7 +156,6 @@ impl Dashboard {
             command_bar_window: None,
             file_transfers: file_transfer::Manager::default(),
             theme_editor: None,
-            notifications: notification::Notifications::new(config),
             previews: preview::Collection::default(),
             previews_cache: Arc::new(preview_cache(&config.preview)),
             server_icons: server_icon::Manager::default(),
@@ -3171,6 +3170,20 @@ impl Dashboard {
         }
     }
 
+    fn open_or_focus_buffer(
+        &mut self,
+        buffer: data::Buffer,
+        buffer_action: BufferAction,
+        clients: &mut data::client::Map,
+        config: &Config,
+    ) -> Task<Message> {
+        if let Some((window, pane, _)) = self.panes.get_by_buffer(&buffer) {
+            self.focus_pane(window, pane)
+        } else {
+            self.open_buffer(buffer, buffer_action, clients, config)
+        }
+    }
+
     pub fn leave_all_queries(
         &mut self,
         clients: &mut data::client::Map,
@@ -4353,6 +4366,7 @@ impl Dashboard {
         casemapping: isupport::CaseMap,
         request: file_transfer::ReceiveRequest,
         config: &Config,
+        notifications: &mut Notifications,
     ) -> Option<Task<Message>> {
         if !config.file_transfer.enabled {
             log::info!(
@@ -4365,12 +4379,8 @@ impl Dashboard {
 
         let event = self.file_transfers.receive(request.clone(), config)?;
 
-        let request_attention_window = self
-            .find_window_with_file_transfers()
-            .unwrap_or(self.main_window());
-
-        let request_attention = self.notifications.notify(
-            &config.notifications,
+        notifications.notify(
+            config,
             &Notification::FileTransferRequest {
                 nick: request.from.nickname().to_owned(),
                 casemapping,
@@ -4382,7 +4392,6 @@ impl Dashboard {
                 },
             },
             server,
-            request_attention_window,
         );
 
         let query = target::Query::from(request.from);
@@ -4394,11 +4403,7 @@ impl Dashboard {
             &config.buffer,
         );
 
-        if let Some(request_attention) = request_attention {
-            Some(Task::batch(vec![task, request_attention]))
-        } else {
-            Some(task)
-        }
+        Some(task)
     }
 
     pub fn handle_file_transfer_event(
@@ -4540,7 +4545,6 @@ impl Dashboard {
             command_bar_window: None,
             file_transfers: file_transfer::Manager::default(),
             theme_editor: None,
-            notifications: notification::Notifications::new(config),
             previews: preview::Collection::default(),
             previews_cache: Arc::new(preview_cache(&config.preview)),
             server_icons: server_icon::Manager::default(),
@@ -4620,6 +4624,70 @@ impl Dashboard {
 
     pub fn get_reroute_rules_mut(&mut self) -> &mut RerouteRules {
         self.history.get_reroute_rules_mut()
+    }
+
+    pub fn handle_notification_event(
+        &mut self,
+        event: notification::Event,
+        clients: &mut data::client::Map,
+        config: &Config,
+    ) -> Task<Message> {
+        match event {
+            notification::Event::NotificationResponse { action, buffer } => {
+                match action {
+                    toast::Action::Dismiss => Task::none(),
+                    toast::Action::OpenOrFocusBuffer => {
+                        if let Some(buffer) = buffer
+                            && let NotificationAction::OpenBuffer(buffer_action) =
+                                config.actions.notification
+                        {
+                            // When an notification action is performed in Wayland
+                            // the application is not automatically brought forward.
+                            // Request attention in order to do so.
+                            let window_id = if let Some((window, _, _)) =
+                                self.panes.get_by_buffer(&buffer)
+                            {
+                                window
+                            } else {
+                                self.focus.window
+                            };
+
+                            iced::window::request_user_attention(
+                                window_id,
+                                Some(
+                                    iced::window::UserAttention::Informational,
+                                ),
+                            )
+                            .chain(
+                                self.open_or_focus_buffer(
+                                    buffer,
+                                    buffer_action,
+                                    clients,
+                                    config,
+                                ),
+                            )
+                        } else {
+                            Task::none()
+                        }
+                    }
+                }
+            }
+            notification::Event::RequestAttention { buffer } => {
+                let window_id = if let Some(buffer) = buffer
+                    && let Some((window, _, _)) =
+                        self.panes.get_by_buffer(&buffer)
+                {
+                    window
+                } else {
+                    self.focus.window
+                };
+
+                iced::window::request_user_attention(
+                    window_id,
+                    Some(iced::window::UserAttention::Informational),
+                )
+            }
+        }
     }
 
     pub fn handle_window_event(
@@ -5077,6 +5145,15 @@ impl Panes {
                 .get_mut(&window)
                 .and_then(|panes| panes.get_mut(pane))
         }
+    }
+
+    fn get_by_buffer(
+        &mut self,
+        buffer: &data::Buffer,
+    ) -> Option<(window::Id, pane_grid::Pane, &Pane)> {
+        self.iter().find(|(_, _, state)| {
+            state.buffer.data().is_some_and(|b| b == *buffer)
+        })
     }
 
     fn get_mut_by_buffer(


### PR DESCRIPTION
Add notification action setting, to allow the associated buffer to be opened when clicking on a notification.

Fixes an issue where notifications would be immediately dismissed in some Wayland DE(s) due to the D-Bus connection being dropped.  Also fixes an issue where the icon would be relegated to the title section of the notification in some Wayland DE(s).