### PR TITLE
Harden against three remote-DoS issues (reported via private advisory)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Fixed:
 - Disabled menu entries now block clicks from passing through
 - Preserve own away state when leaving and rejoining a channel
 - Do not panic when previewing an SVG with a very large filter
+- Reject overlong lines from the server connection instead of buffering them without bound
+- Do not panic when a server-supplied METADATA retry-after value would overflow the retry timer
+- Stop busy-looping on CPU when a DCC file-transfer peer closes its connection early
 
 Changed:
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -3387,7 +3387,11 @@ impl Client {
                         .and_then(|secs| secs.parse::<u64>().ok())
                         .map_or(Duration::ZERO, Duration::from_secs);
 
-                    let ready_at = Instant::now() + retry_after;
+                    // `Instant + Duration` panics on overflow, so a huge server-supplied RetryAfter
+                    // would crash the client. Clamp via checked_add.
+                    let ready_at = Instant::now()
+                        .checked_add(retry_after)
+                        .unwrap_or_else(|| Instant::now() + Duration::from_secs(60));
 
                     log::debug!(
                         "[{}] Metadata sync postponed for [{target}], retrying in {retry_after:?}",

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -3389,9 +3389,10 @@ impl Client {
 
                     // `Instant + Duration` panics on overflow, so a huge server-supplied RetryAfter
                     // would crash the client. Clamp via checked_add.
-                    let ready_at = Instant::now()
-                        .checked_add(retry_after)
-                        .unwrap_or_else(|| Instant::now() + Duration::from_secs(60));
+                    let ready_at =
+                        Instant::now().checked_add(retry_after).unwrap_or_else(
+                            || Instant::now() + Duration::from_secs(60),
+                        );
 
                     log::debug!(
                         "[{}] Metadata sync postponed for [{target}], retrying in {retry_after:?}",

--- a/data/src/file_transfer/task.rs
+++ b/data/src/file_transfer/task.rs
@@ -341,6 +341,10 @@ async fn receive(
                     .await;
                 last_progress = Instant::now();
             }
+        } else {
+            // Peer closed before the full size arrived. Without this, a closed stream yields
+            // Ready(None) on every poll and this loop hot-spins at 100% CPU forever.
+            return Err(Error::TruncatedTransfer);
         }
     }
 
@@ -551,4 +555,6 @@ enum Error {
     TimeoutConnection,
     #[error("timed out waiting for remote to confirm passive request")]
     TimeoutPassive,
+    #[error("connection closed before the transfer completed")]
+    TruncatedTransfer,
 }

--- a/irc/src/codec.rs
+++ b/irc/src/codec.rs
@@ -8,6 +8,10 @@ pub type ParseResult<T = Message, E = parse::Error> = std::result::Result<T, E>;
 
 pub struct Codec;
 
+/// Maximum bytes buffered for a single IRC line before it is rejected. Generous headroom over the
+/// IRCv3 message-tags limit (8191) plus the 512-byte message.
+const MAX_LINE_LENGTH: usize = 16 * 1024;
+
 impl Decoder for Codec {
     type Item = ParseResult;
     type Error = Error;
@@ -17,6 +21,11 @@ impl Decoder for Codec {
         src: &mut BytesMut,
     ) -> Result<Option<Self::Item>, Self::Error> {
         let Some(pos) = src.windows(2).position(|b| b == [b'\r', b'\n']) else {
+            // Guard against a peer that never sends CRLF: without a cap the framed stream would
+            // buffer the "line" without bound, exhausting memory from a single connection.
+            if src.len() > MAX_LINE_LENGTH {
+                return Err(Error::LineTooLong);
+            }
             return Ok(None);
         };
 
@@ -44,4 +53,6 @@ impl Encoder<Message> for Codec {
 pub enum Error {
     #[error(transparent)]
     Io(#[from] io::Error),
+    #[error("IRC line exceeded the maximum buffered length")]
+    LineTooLong,
 }


### PR DESCRIPTION
Three small, independent robustness fixes for remote-DoS issues I reported privately in a GitHub Security Advisory on this repo. One commit each:
1. fix(irc): cap maximum buffered line length in the codec — Codec::decode had no max-length check, so a peer that never sends CRLF buffers the line without bound (memory exhaustion). Rejects lines over 16 KiB.
2. fix(data): avoid panic on RPL_METADATASYNCLATER retry overflow — a server-supplied RetryAfter reaches Instant::now() + retry_after, which panics on overflow; now uses checked_add.
3. fix(data): terminate DCC receive loop on early peer close — a closed stream yields Ready(None) on every poll, hot-spinning the receive loop at 100% CPU; now returns an error.

cargo check -p irc -p data passes. Happy to split into separate PRs if you prefer. The SSRF findings from the advisory I'll handle via the advisory's private fork.