### PR TITLE
feat: show topic changes as a diff against the previous topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Added:
 - `actions.buffer.click_channel_name` and `actions.buffer.click_highlight` can be set to no action (`"no-action"` or `"noop"`) to not open the channel when clicking on the channel name
 - Explicit portable mode
 - Theme editor can be closed via Escape
+- `buffer.server_messages.change_topic.show_previous` setting to show the previous topic in topic change messages
 
 Fixed:
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -2397,6 +2397,20 @@ impl Client {
                         casemapping,
                     )))
                 {
+                    if let Some(previous_topic) = channel
+                        .topic
+                        .content
+                        .as_ref()
+                        .map(|content| content.text().into_owned())
+                    {
+                        // Prefix ':' to ensure it cannot match any valid
+                        // message tag
+                        message.tags.insert(
+                            ":previous_topic".to_string(),
+                            previous_topic,
+                        );
+                    }
+
                     if let Some(text) = topic
                         && !text.is_empty()
                     {
@@ -6452,5 +6466,141 @@ mod tests {
         );
 
         assert_eq!(channel_user_is_away(&client, "tester"), Some(false));
+    }
+
+    #[test]
+    fn topic_change_stamps_previous_topic_before_updating_channel_topic() {
+        let mut client = test_client("tester");
+        let config = config::Config::default();
+
+        let self_source = proto::Source::User(proto::User {
+            nickname: "tester".to_string(),
+            username: Some("tester".to_string()),
+            hostname: Some("example.test".to_string()),
+        });
+        let alice_source = proto::Source::User(proto::User {
+            nickname: "alice".to_string(),
+            username: Some("alice".to_string()),
+            hostname: Some("example.test".to_string()),
+        });
+
+        deliver(
+            &mut client,
+            &config,
+            self_source,
+            Command::JOIN("#test".to_string(), None),
+        );
+
+        let events = client
+            .handle(
+                message::Encoded(proto::Message {
+                    tags: BTreeMap::default(),
+                    source: Some(alice_source.clone()),
+                    command: Command::TOPIC(
+                        "#test".to_string(),
+                        Some("old topic".to_string()),
+                    ),
+                }),
+                None,
+                &config,
+            )
+            .unwrap();
+
+        let [Event::Single { message, .. }] = events.as_slice() else {
+            panic!("expected single topic event");
+        };
+        assert_eq!(message.previous_topic(), None);
+
+        let events = client
+            .handle(
+                message::Encoded(proto::Message {
+                    tags: BTreeMap::default(),
+                    source: Some(alice_source.clone()),
+                    command: Command::TOPIC(
+                        "#test".to_string(),
+                        Some("new topic".to_string()),
+                    ),
+                }),
+                None,
+                &config,
+            )
+            .unwrap();
+
+        let [Event::Single { message, .. }] = events.as_slice() else {
+            panic!("expected single topic event");
+        };
+        assert_eq!(message.previous_topic(), Some("old topic"));
+
+        let channel = client.chanmap.values().next().unwrap();
+        assert_eq!(
+            channel
+                .topic
+                .content
+                .as_ref()
+                .map(|content| content.text().into_owned()),
+            Some("new topic".to_string())
+        );
+
+        let events = client
+            .handle(
+                message::Encoded(proto::Message {
+                    tags: BTreeMap::default(),
+                    source: Some(alice_source.clone()),
+                    command: Command::TOPIC(
+                        "#test".to_string(),
+                        Some(String::new()),
+                    ),
+                }),
+                None,
+                &config,
+            )
+            .unwrap();
+
+        let [Event::Single { message, .. }] = events.as_slice() else {
+            panic!("expected single topic event");
+        };
+        assert_eq!(message.previous_topic(), Some("new topic"));
+
+        let channel = client.chanmap.values().next().unwrap();
+        assert!(channel.topic.content.is_none());
+        assert!(channel.topic.who.is_none());
+        assert!(channel.topic.time.is_none());
+
+        client
+            .handle(
+                message::Encoded(proto::Message {
+                    tags: BTreeMap::default(),
+                    source: Some(alice_source.clone()),
+                    command: Command::TOPIC(
+                        "#test".to_string(),
+                        Some("restored topic".to_string()),
+                    ),
+                }),
+                None,
+                &config,
+            )
+            .unwrap();
+
+        let events = client
+            .handle(
+                message::Encoded(proto::Message {
+                    tags: BTreeMap::default(),
+                    source: Some(alice_source),
+                    command: Command::TOPIC("#test".to_string(), None),
+                }),
+                None,
+                &config,
+            )
+            .unwrap();
+
+        let [Event::Single { message, .. }] = events.as_slice() else {
+            panic!("expected single topic event");
+        };
+        assert_eq!(message.previous_topic(), Some("restored topic"));
+
+        let channel = client.chanmap.values().next().unwrap();
+        assert!(channel.topic.content.is_none());
+        assert!(channel.topic.who.is_none());
+        assert!(channel.topic.time.is_none());
     }
 }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -2388,6 +2388,7 @@ impl Client {
             }
             Command::TOPIC(channel, topic) => {
                 let casemapping = self.casemapping();
+                let topic = topic.clone();
 
                 if let Some(channel) =
                     self.chanmap.get_mut(&context!(target::Channel::parse(
@@ -2415,7 +2416,7 @@ impl Client {
                         && !text.is_empty()
                     {
                         channel.topic.content =
-                            Some(message::parse_fragments(text.clone()));
+                            Some(message::parse_fragments(text));
                         channel.topic.who = message.user(casemapping);
                         channel.topic.time =
                             Some(message.server_time_or_now().0);

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -617,6 +617,11 @@ impl ServerMessages {
             .or(self.default.smart)
     }
 
+    pub fn show_previous(&self, kind: source::server::Kind) -> bool {
+        matches!(kind, source::server::Kind::ChangeTopic)
+            && self.get(kind).show_previous.unwrap_or_default()
+    }
+
     pub fn username_format(
         &self,
         kind: Option<source::server::Kind>,
@@ -730,6 +735,7 @@ pub enum CondensationIcon {
 pub struct ServerMessage {
     pub enabled: Option<ServerMessageEnabled>,
     pub smart: Option<i64>,
+    pub show_previous: Option<bool>,
     pub username_format: Option<UsernameFormat>,
     pub exclude: Option<Inclusivities>,
     pub include: Option<Inclusivities>,
@@ -1097,4 +1103,49 @@ where
             alpha: Some(dim),
         },
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Buffer;
+    use crate::message::source;
+
+    #[test]
+    fn server_messages_change_topic_deserializes_show_previous() {
+        #[derive(serde::Deserialize)]
+        struct Root {
+            buffer: Buffer,
+        }
+
+        let config: Root = toml::from_str(
+            r#"
+            [buffer.server_messages.change_topic]
+            show_previous = true
+            "#,
+        )
+        .expect("valid change_topic show_previous setting");
+
+        assert_eq!(
+            config.buffer.server_messages.change_topic.show_previous,
+            Some(true)
+        );
+        assert!(
+            config
+                .buffer
+                .server_messages
+                .show_previous(source::server::Kind::ChangeTopic)
+        );
+    }
+
+    #[test]
+    fn server_messages_show_previous_defaults_disabled() {
+        let buffer = Buffer::default();
+
+        assert_eq!(buffer.server_messages.change_topic.show_previous, None);
+        assert!(
+            !buffer
+                .server_messages
+                .show_previous(source::server::Kind::ChangeTopic)
+        );
+    }
 }

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -1580,7 +1580,13 @@ fn has_matching_content(
     other: &Message,
     use_echo_cmp: bool,
 ) -> bool {
-    if message.target == other.target {
+    if let Some(matches) = matching_change_topic(message, other) {
+        return matches;
+    }
+
+    if message.target == other.target
+        || matching_change_topic_actor(message, other)
+    {
         if let message::Source::Server(Some(source)) = message.target.source() {
             match source.kind() {
                 message::source::server::Kind::Join
@@ -1612,6 +1618,54 @@ fn has_matching_content(
     } else {
         false
     }
+}
+
+fn matching_change_topic(message: &Message, other: &Message) -> Option<bool> {
+    if !matching_change_topic_actor(message, other) {
+        return None;
+    }
+
+    match (change_topic(&message.target), change_topic(&other.target)) {
+        (Some(topic), Some(other_topic)) => Some(topic == other_topic),
+        _ => None,
+    }
+}
+
+fn matching_change_topic_actor(message: &Message, other: &Message) -> bool {
+    let Some((channel, source)) = change_topic_source(&message.target) else {
+        return false;
+    };
+    let Some((other_channel, other_source)) =
+        change_topic_source(&other.target)
+    else {
+        return false;
+    };
+
+    channel == other_channel && source.nick() == other_source.nick()
+}
+
+fn change_topic<'a>(target: &'a message::Target) -> Option<&'a str> {
+    let (_, source) = change_topic_source(target)?;
+
+    match source.change() {
+        Some(message::source::server::Change::Topic(topic)) => Some(topic),
+        _ => None,
+    }
+}
+
+fn change_topic_source<'a>(
+    target: &'a message::Target,
+) -> Option<(&'a target::Channel, &'a message::source::server::Server)> {
+    let message::Target::Channel {
+        channel,
+        source: message::Source::Server(Some(source)),
+    } = target
+    else {
+        return None;
+    };
+
+    matches!(source.kind(), message::source::server::Kind::ChangeTopic)
+        .then_some((channel, source))
 }
 
 pub fn insert_reaction(
@@ -1750,4 +1804,73 @@ pub enum Error {
     Io(#[from] io::Error),
     #[error(transparent)]
     SerdeJson(#[from] serde_json::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use irc::proto;
+
+    use super::*;
+    use crate::User;
+    use crate::config::Config;
+    use crate::history::reroute::RerouteRules;
+
+    fn topic_message(topic: &str, previous_topic: Option<&str>) -> Message {
+        let isupport = HashMap::<isupport::Kind, isupport::Parameter>::new();
+        let casemapping = isupport::get_casemapping_or_default(&isupport);
+        let our_nick = Nick::from_str("our_nick", casemapping);
+        let server = Server {
+            name: "Test Server".into(),
+            network: None,
+        };
+        let mut config = Config::default();
+        config.buffer.server_messages.change_topic.show_previous = Some(true);
+
+        let mut encoded = proto::parse::message(&format!(
+            ":alice!u@h TOPIC #chan :{topic}\r\n"
+        ))
+        .unwrap();
+        if let Some(previous_topic) = previous_topic {
+            encoded
+                .tags
+                .insert(":previous_topic".to_string(), previous_topic.into());
+        }
+
+        Message::received(
+            message::Encoded::from(encoded),
+            our_nick,
+            true,
+            &config,
+            &RerouteRules::default(),
+            |_: &User, _: &target::Channel| None,
+            |_channel: &target::Channel| None,
+            &server,
+            isupport::get_chantypes_or_default(&isupport),
+            isupport::get_statusmsg_or_default(&isupport),
+            casemapping,
+            isupport::get_prefix_or_default(&isupport),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn change_topic_matches_replay_without_previous_topic_tag() {
+        let live = topic_message("new topic", Some("old topic"));
+        let replay = topic_message("new topic", None);
+
+        assert_ne!(live.content, replay.content);
+        assert_eq!(change_topic(&live.target), Some("new topic"));
+        assert_eq!(change_topic(&replay.target), Some("new topic"));
+        assert!(has_matching_content(&live, &replay, false));
+    }
+
+    #[test]
+    fn change_topic_dedupe_compares_new_topic() {
+        let live = topic_message("new topic", Some("old topic"));
+        let replay = topic_message("different topic", None);
+
+        assert!(!has_matching_content(&live, &replay, false));
+    }
 }

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -1644,7 +1644,7 @@ fn matching_change_topic_actor(message: &Message, other: &Message) -> bool {
     channel == other_channel && source.nick() == other_source.nick()
 }
 
-fn change_topic<'a>(target: &'a message::Target) -> Option<&'a str> {
+fn change_topic(target: &message::Target) -> Option<&str> {
     let (_, source) = change_topic_source(target)?;
 
     match source.change() {
@@ -1653,9 +1653,9 @@ fn change_topic<'a>(target: &'a message::Target) -> Option<&'a str> {
     }
 }
 
-fn change_topic_source<'a>(
-    target: &'a message::Target,
-) -> Option<(&'a target::Channel, &'a message::source::server::Server)> {
+fn change_topic_source(
+    target: &message::Target,
+) -> Option<(&target::Channel, &message::source::server::Server)> {
     let message::Target::Channel {
         channel,
         source: message::Source::Server(Some(source)),

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -181,6 +181,10 @@ impl Encoded {
         self.tags.contains_key(":join_topic")
     }
 
+    pub fn previous_topic(&self) -> Option<&str> {
+        self.tags.get(":previous_topic").map(String::as_str)
+    }
+
     pub fn channel_context(
         &self,
         chantypes: &[char],
@@ -3095,11 +3099,37 @@ fn content<'a>(
             .unwrap_or(raw_user);
 
             let topic = topic.as_ref()?;
+            let previous_topic = if config
+                .buffer
+                .server_messages
+                .show_previous(source::server::Kind::ChangeTopic)
+            {
+                message.previous_topic()
+            } else {
+                None
+            };
 
             if topic.is_empty() {
+                let text = if let Some(previous_topic) = previous_topic {
+                    format!(
+                        "{} cleared the topic\n- {previous_topic}",
+                        user.nickname()
+                    )
+                } else {
+                    format!("{} cleared the topic", user.nickname())
+                };
+
+                Some((
+                    parse_fragments_with_user(text, &user, casemapping),
+                    None,
+                ))
+            } else if let Some(previous_topic) = previous_topic {
                 Some((
                     parse_fragments_with_user(
-                        format!("{} cleared the topic", user.nickname()),
+                        format!(
+                            "{} changed the topic\n- {previous_topic}\n+ {topic}",
+                            user.nickname()
+                        ),
                         &user,
                         casemapping,
                     ),
@@ -4952,6 +4982,115 @@ pub mod tests {
             || panic!("failed to create Message from {encoded:?}"),
             |(msg, highlight, _)| (msg, highlight),
         )
+    }
+
+    fn topic_message_content(
+        irc_message: &str,
+        previous_topic: Option<&str>,
+        show_previous: bool,
+    ) -> Content {
+        use std::collections::HashMap;
+
+        use irc::proto;
+
+        use crate::config::Config;
+        use crate::history::reroute::RerouteRules;
+
+        let isupport = HashMap::<isupport::Kind, isupport::Parameter>::new();
+        let casemapping = isupport::get_casemapping_or_default(&isupport);
+        let our_nick = Nick::from_str("our_nick", casemapping);
+        let server = Server {
+            name: "Test Server".into(),
+            network: None,
+        };
+        let mut config = Config::default();
+        config.buffer.server_messages.change_topic.show_previous =
+            show_previous.then_some(true);
+
+        let mut encoded = proto::parse::message(irc_message).unwrap();
+        if let Some(previous_topic) = previous_topic {
+            encoded
+                .tags
+                .insert(":previous_topic".to_string(), previous_topic.into());
+        }
+
+        Message::received(
+            message::Encoded::from(encoded.clone()),
+            our_nick,
+            false,
+            &config,
+            &RerouteRules::default(),
+            |_: &User, _: &target::Channel| None,
+            |_channel: &target::Channel| None,
+            &server,
+            isupport::get_chantypes_or_default(&isupport),
+            isupport::get_statusmsg_or_default(&isupport),
+            casemapping,
+            isupport::get_prefix_or_default(&isupport),
+        )
+        .map_or_else(
+            || panic!("failed to create Message from {encoded:?}"),
+            |message| message.content,
+        )
+    }
+
+    #[test]
+    fn topic_change_shows_previous_topic_when_enabled() {
+        let content = topic_message_content(
+            ":alice!u@h TOPIC #chan :new topic\r\n",
+            Some("old topic"),
+            true,
+        );
+
+        assert_eq!(
+            content.text(),
+            "alice changed the topic\n- old topic\n+ new topic"
+        );
+    }
+
+    #[test]
+    fn topic_change_uses_existing_text_without_previous_topic_diff() {
+        let tests = [
+            (
+                Some("old topic"),
+                false,
+                "alice changed the topic to new topic",
+            ),
+            (None, true, "alice changed the topic to new topic"),
+            (None, false, "alice changed the topic to new topic"),
+        ];
+
+        for (previous_topic, show_previous, expected) in tests {
+            let content = topic_message_content(
+                ":alice!u@h TOPIC #chan :new topic\r\n",
+                previous_topic,
+                show_previous,
+            );
+
+            assert_eq!(content.text(), expected);
+        }
+    }
+
+    #[test]
+    fn topic_clear_shows_previous_topic_when_enabled() {
+        let content = topic_message_content(
+            ":alice!u@h TOPIC #chan :\r\n",
+            Some("old topic"),
+            true,
+        );
+
+        assert_eq!(content.text(), "alice cleared the topic\n- old topic");
+    }
+
+    #[test]
+    fn topic_clear_uses_existing_text_without_previous_topic_diff() {
+        let content = topic_message_content(
+            ":alice!u@h TOPIC #chan :\r\n",
+            Some("old topic"),
+            false,
+        );
+
+        assert_eq!(content.text(), "alice cleared the topic");
     }
 
     #[test]

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -1830,6 +1830,16 @@ fn condense_associated_fragments(
                         })
                         .collect()
                     }
+                    Some(Change::Topic(_)) => {
+                        let nick = user.nickname().to_string();
+
+                        nick_fragments
+                            .chain(vec![
+                                Fragment::User(user, nick),
+                                Fragment::Text(String::from("  ")),
+                            ])
+                            .collect()
+                    }
                     None => {
                         let nick = user.nickname().to_string();
 
@@ -2510,7 +2520,7 @@ fn target(
                 ))
             }
         }
-        Command::TOPIC(channel, _) => {
+        Command::TOPIC(channel, topic) => {
             let channel = target::Channel::parse(
                 channel,
                 chantypes,
@@ -2525,7 +2535,7 @@ fn target(
                     source: Source::Server(Some(source::Server::new(
                         Kind::ChangeTopic,
                         Some(user?.nickname().to_owned()),
-                        None,
+                        topic.clone().map(Change::Topic),
                     ))),
                 },
                 None,

--- a/data/src/message/source.rs
+++ b/data/src/message/source.rs
@@ -195,6 +195,7 @@ pub mod server {
     pub enum Change {
         Nick(Nick),
         Host(String, String),
+        Topic(String),
     }
 
     #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/docs/configuration/buffer.md
+++ b/docs/configuration/buffer.md
@@ -989,6 +989,20 @@ enabled = true
 smart = 180
 ```
 
+#### `show_previous`
+
+Show the previous topic in `change_topic` server messages when Halloy already
+knows it. This only applies to `change_topic` messages.
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: false
+
+[buffer.server_messages.change_topic]
+show_previous = true
+```
+
 #### `exclude`
 
 [Exclusion conditions](/configuration/conditions.md) in which the server message


### PR DESCRIPTION
## Summary
Topic changes can now render as a diff against the previous topic. A new `buffer.server-messages.topic` option `show-previous` shows what changed instead of only the new topic, so long topics where one word changed are readable at a glance.

## Why this matters
Issue #2089 asks for exactly this, and the maintainer responded "Fun feature." Channels with long informational topics (schedules, link lists) change one segment at a time; without the diff you re-read the whole topic to find the change. The previous topic is tracked per channel from live `TOPIC` events, rendering strips/marks the changed segments, and history replay dedupe compares the underlying new-topic content so replayed topic changes never duplicate live ones (covered by tests).

## Testing
`cargo test --workspace` passes, including new cases for the diff rendering, the config option default (off), and history dedupe with and without the previous-topic tag. Docs (`docs/configuration/buffer.md`) and CHANGELOG updated.

Fixes #2089
