### PR TITLE
Sidebar typing indicator for queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Added:
   - New `buffer.focus` theme color for the focused message border
 - Server context menu action to open Channel Discovery with that server selected
 - Animated GIFs support
+- Sidebar typing indicators for queries
 
 Fixed:
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -5635,6 +5635,21 @@ impl Map {
         self.client(server).map(|client| &client.handle)
     }
 
+    pub fn has_any_query_typing(&self) -> bool {
+        self.0
+            .values()
+            .filter_map(|state| match state {
+                State::Ready(client) => Some(client),
+                _ => None,
+            })
+            .any(|client| {
+                client
+                    .querymap
+                    .iter()
+                    .any(|(query, _)| client.has_query_typing_users(query))
+            })
+    }
+
     pub fn connected_servers(&self) -> impl Iterator<Item = &Server> {
         self.0.iter().filter_map(|(server, state)| {
             if let State::Ready(_) = state {

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -763,6 +763,14 @@ impl Config {
 
         let _ = create_owned_file(config_path.as_path(), config_bytes);
     }
+
+    pub fn can_show_any_typing(&self) -> bool {
+        self.buffer.typing.show
+            || self
+                .servers
+                .iter()
+                .any(|(_, server)| server.typing.show.is_some_and(|show| show))
+    }
 }
 
 #[cfg(unix)]

--- a/data/src/config/sidebar.rs
+++ b/data/src/config/sidebar.rs
@@ -19,6 +19,7 @@ pub struct Sidebar {
     pub unread_indicator: UnreadIndicator,
     #[serde(deserialize_with = "deserialize_highlight_indicator")]
     pub highlight_indicator: HighlightIndicator,
+    pub query_typing_indicator: QueryTypingIndicator,
     pub position: Position,
     pub order_by: OrderBy,
     pub scrollbar: Scrollbar,
@@ -40,6 +41,13 @@ pub struct Sidebar {
     pub order_channels_by: OrderChannelsBy,
     pub channel_name_casing: Option<ChannelNameCasing>,
     pub internal_buffers: InternalBuffers,
+}
+
+impl Sidebar {
+    pub fn can_show_typing(&self) -> bool {
+        self.query_typing_indicator
+            .can_show(self.position.is_horizontal())
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -357,6 +365,53 @@ where
         })
         .map(|map| map.deserialize())
         .deserialize(deserializer)
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(default)]
+pub struct QueryTypingIndicator {
+    pub show: QueryTypingIndicatorShow,
+    pub scale_factor: ScaleFactor,
+}
+
+impl QueryTypingIndicator {
+    pub fn can_show(&self, is_horizontal: bool) -> bool {
+        match self.show {
+            QueryTypingIndicatorShow::All => true,
+            QueryTypingIndicatorShow::Vertical => !is_horizontal,
+            QueryTypingIndicatorShow::None => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum QueryTypingIndicatorShow {
+    All,
+    #[default]
+    Vertical,
+    None,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+pub struct ScaleFactor(f32);
+
+impl Default for ScaleFactor {
+    fn default() -> Self {
+        Self(0.75)
+    }
+}
+
+impl From<f32> for ScaleFactor {
+    fn from(value: f32) -> Self {
+        ScaleFactor(value.clamp(0.01, 1.0))
+    }
+}
+
+impl From<ScaleFactor> for f32 {
+    fn from(value: ScaleFactor) -> Self {
+        value.0
+    }
 }
 
 #[derive(Debug, Copy, Clone, Deserialize, Default)]

--- a/docs/configuration/sidebar.md
+++ b/docs/configuration/sidebar.md
@@ -4,7 +4,7 @@ Sidebar settings for Halloy.
 
 ## `primary_font_size`
 
-Configure the font size used for server and internal buffer titles.  If not set, then [`sidebar.secondary_font_size`](./sidebar#secondary_font_size) will be used.
+Configure the font size used for server and internal buffer titles. If not set, then [`sidebar.secondary_font_size`](./sidebar#secondary_font_size) will be used.
 
 ```toml
 # Type: integer
@@ -37,7 +37,7 @@ primary_icon = "hidden"
 
 ## `secondary_font_size`
 
-Configure the font size used for buffers in the sidebar.  If not set, then [`font.size`](./font#size) will be used.
+Configure the font size used for buffers in the sidebar. If not set, then [`font.size`](./font#size) will be used.
 
 ```toml
 # Type: integer
@@ -294,7 +294,6 @@ Show unread message indicators on buffers that have an open pane.
 show_on_open_buffers = false
 ```
 
-
 ### `query_as_highlight`
 
 Treat unread messages in query (direct message) buffers as highlights for
@@ -439,6 +438,39 @@ exclude = "*"
 include = { channels = ["#halloy"] }
 ```
 
+## `query_typing_indicator`
+
+Show typing indicator for query buffers (direct messages) in sidebars.
+Requires typing indicators to be enabled, either [globally](/configuration/buffer#show-1) or at the [server level](/configuration/servers#show).
+
+### `show`
+
+Change which sidebar rotation to display the typing indicators for. To disable the sidebar indicator use `"none"`.
+
+Due to space constraints, by default, the indicator is only enabled for vertical sidebars. Use `"all"` to display the indicator for horizontal sidebars.
+
+```toml
+# Type: string
+# Values: "all", "vertical", "none"
+# Default: "vertical"
+
+[sidebar.query_typing_indicator]
+show = "all"
+```
+
+### `scale_factor`
+
+Change the size of the query typing indicator. Multiplies the [typing indicator font size](/configuration/buffer#font_size) by `scale_factor`.
+
+```toml
+# Type: float
+# Values: 0.01 .. 1.0
+# Default: 0.75
+
+[sidebar.query_typing_indicator]
+scale_factor = 0.5
+```
+
 ## `user_menu`
 
 User menu in sidebar settings.
@@ -463,7 +495,7 @@ Adjust padding for sidebar
 ### `buffer`
 
 Controls padding for buffer buttons (server, channels, queries) in the sidebar
-The value is an array where the first value is vertical padding and the second is horizontal padding. 
+The value is an array where the first value is vertical padding and the second is horizontal padding.
 
 ```toml
 # Type: array

--- a/src/buffer/typing.rs
+++ b/src/buffer/typing.rs
@@ -129,7 +129,7 @@ pub fn view<'a, Message: 'a>(
     typing
 }
 
-fn animate<'a, Message: 'a>(
+pub fn animate<'a, Message: 'a>(
     animation: Option<&Animation>,
     font_size: f32,
     animation_config: &data::config::buffer::Animation,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1081,7 +1081,7 @@ impl Halloy {
             Message::AnimationTick(now) => {
                 if let Screen::Dashboard(dashboard) = &mut self.screen {
                     dashboard
-                        .animation_tick(now, &self.clients)
+                        .animation_tick(now, &self.clients, &self.config)
                         .map(Message::Dashboard)
                 } else {
                     Task::none()
@@ -1590,11 +1590,13 @@ impl Halloy {
         ];
 
         if self.config.buffer.typing.animation.enabled
-            && matches!(
+            && (matches!(
                 &self.screen,
                 Screen::Dashboard(dashboard)
             if dashboard.has_typing_activity_in_focused_window(&self.clients, self.focused_window)
-            )
+            ) || (self.config.can_show_any_typing()
+                && self.config.sidebar.can_show_typing()
+                && self.clients.has_any_query_typing()))
         {
             subscriptions.push(
                 iced::time::every(Duration::from_millis(50))

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1887,6 +1887,7 @@ impl Dashboard {
                 version,
                 theme,
                 self.buffer_settings.show_muted,
+                self.typing_animation.as_ref(),
             )
             .map(|e| e.map(Message::Sidebar));
 
@@ -4571,7 +4572,7 @@ impl Dashboard {
         clients: &data::client::Map,
         config: &Config,
     ) -> Task<Message> {
-        if !self.has_typing_activity(clients) {
+        if !self.has_typing_activity(clients, config) {
             self.typing_animation = None;
         }
 
@@ -4624,8 +4625,9 @@ impl Dashboard {
         &mut self,
         now: Instant,
         clients: &data::client::Map,
+        config: &Config,
     ) -> Task<Message> {
-        if self.has_typing_activity(clients) {
+        if self.has_typing_activity(clients, config) {
             buffer::typing::advance(&mut self.typing_animation, now);
         } else {
             self.typing_animation = None;
@@ -5225,10 +5227,17 @@ impl Dashboard {
         })
     }
 
-    pub fn has_typing_activity(&self, clients: &client::Map) -> bool {
+    pub fn has_typing_activity(
+        &self,
+        clients: &client::Map,
+        config: &Config,
+    ) -> bool {
         self.panes
             .iter()
             .any(|(_, _, pane)| pane.buffer.has_typing_activity(clients))
+            || (config.can_show_any_typing()
+                && config.sidebar.can_show_typing()
+                && clients.has_any_query_typing())
     }
 
     pub fn has_typing_activity_in_focused_window(

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -21,6 +21,7 @@ use iced::{
 use itertools::Either;
 
 use super::{Focus, Panes, Server};
+use crate::buffer::typing;
 use crate::widget::text_color_svg::TextColorSvg;
 use crate::widget::{
     Element, Text, TextExt, context_menu, double_pass, image, text,
@@ -555,10 +556,10 @@ impl Sidebar {
 
         let base = button(
             sidebar_icon(
-                Some(Icon::Internal(icon)),
+                config,
+                Some(BufferIcon::Icon(Icon::Internal(icon))),
                 badge,
                 dimensions,
-                config.sidebar.position.is_horizontal(),
             )
             .into_iter()
             .next(),
@@ -804,7 +805,7 @@ impl Sidebar {
     pub fn view<'a>(
         &'a self,
         servers: &server::Map,
-        clients: &data::client::Map,
+        clients: &'a data::client::Map,
         history: &'a history::Manager,
         panes: &'a Panes,
         focus: Focus,
@@ -814,6 +815,7 @@ impl Sidebar {
         version: &'a Version,
         theme: &'a Theme,
         show_muted_buffers: bool,
+        typing_animation: Option<&'a typing::Animation>,
     ) -> Option<Element<'a, Message>> {
         if self.hidden {
             return None;
@@ -898,6 +900,7 @@ impl Sidebar {
                                     has_collapsible_buffers,
                                 server_has_unread,
                                 supports_detach,
+                                clients,
                                 casemapping,
                                 server_icon_enabled,
                                 server_sidebar_visibility,
@@ -905,6 +908,7 @@ impl Sidebar {
                                 width,
                                 theme,
                                 collapse: &self.collapse,
+                                typing_animation,
                             };
 
                             buffers.push(upstream_buffer_button(context));
@@ -1408,6 +1412,7 @@ struct UpstreamButtonContext<'a> {
     server_has_collapsible_buffers: bool,
     server_has_unread: bool,
     supports_detach: bool,
+    clients: &'a data::client::Map,
     casemapping: isupport::CaseMap,
     server_icon_enabled: bool,
     server_sidebar_visibility: SidebarVisibility,
@@ -1415,6 +1420,7 @@ struct UpstreamButtonContext<'a> {
     width: Length,
     theme: &'a Theme,
     collapse: &'a collapse::State,
+    typing_animation: Option<&'a typing::Animation>,
 }
 
 fn upstream_buffer_title<'a>(
@@ -1517,6 +1523,11 @@ fn upstream_buffer_title<'a>(
     }
 }
 
+enum BufferIcon<'a> {
+    Icon(Icon<'a>),
+    Element(Element<'a, Message>),
+}
+
 fn upstream_buffer_button<'a>(
     context: UpstreamButtonContext<'a>,
 ) -> Element<'a, Message> {
@@ -1530,6 +1541,7 @@ fn upstream_buffer_button<'a>(
         indicators,
         connection_status,
         server_has_collapsible_buffers,
+        clients,
         casemapping,
         server_icon_enabled,
         server_sidebar_visibility,
@@ -1537,6 +1549,7 @@ fn upstream_buffer_button<'a>(
         width,
         theme,
         collapse,
+        typing_animation,
         ..
     } = &context;
 
@@ -1568,6 +1581,15 @@ fn upstream_buffer_button<'a>(
     let show_highlight_title =
         indicators.highlight && config.sidebar.highlight_indicator.title;
 
+    let is_query_with_typing = if config.sidebar.can_show_typing()
+        && let buffer::Upstream::Query(server, query) = &buffer
+    {
+        clients.get_server_show_typing(server)
+            && clients.has_query_typing_users(server, query)
+    } else {
+        false
+    };
+
     let buffer_title_style = if show_highlight_title {
         theme::text::highlight_indicator
     } else if show_unread_title {
@@ -1595,14 +1617,30 @@ fn upstream_buffer_button<'a>(
         if *server_icon_enabled
             && let Some(server_icon) = server_icons.get(server)
         {
-            Some(Icon::Upstream(server_icon))
+            Some(BufferIcon::Icon(Icon::Upstream(server_icon)))
         } else {
-            Some(Icon::Internal(if server.is_bouncer_network() {
-                icon::link()
-            } else {
-                icon::connected()
-            }))
+            Some(BufferIcon::Icon(Icon::Internal(
+                if server.is_bouncer_network() {
+                    icon::link()
+                } else {
+                    icon::connected()
+                },
+            )))
         }
+    } else if is_query_with_typing {
+        typing::animate::<_>(
+            *typing_animation,
+            config
+                .buffer
+                .typing
+                .font_size
+                .or(config.sidebar.secondary_font_size)
+                .map_or(theme::TEXT_SIZE, f32::from)
+                * f32::from(config.sidebar.query_typing_indicator.scale_factor),
+            &config.buffer.typing.animation,
+            theme.styles().text.secondary.color,
+        )
+        .map(BufferIcon::Element)
     } else {
         None
     };
@@ -1633,6 +1671,8 @@ fn upstream_buffer_button<'a>(
             icon::connecting().style(theme::text::success),
             dimensions.icon_badge_size,
         ))
+    } else if is_query_with_typing {
+        None
     } else if show_highlight_icon
         && let Some(highlight_icon) =
             icon::from_icon(config.sidebar.highlight_indicator.icon)
@@ -1663,12 +1703,7 @@ fn upstream_buffer_button<'a>(
 
     let mut content = row![].align_y(iced::Alignment::Center);
 
-    content = content.extend(sidebar_icon(
-        icon,
-        indicator,
-        dimensions,
-        config.sidebar.position.is_horizontal(),
-    ));
+    content = content.extend(sidebar_icon(config, icon, indicator, dimensions));
 
     content = content.extend(upstream_buffer_title(
         config,
@@ -2125,10 +2160,10 @@ fn internal_buffer_button<'a>(
     let mut content = row![].align_y(iced::Alignment::Center);
 
     content = content.extend(sidebar_icon(
-        icon.map(Icon::Internal),
+        config,
+        icon.map(|icon| BufferIcon::Icon(Icon::Internal(icon))),
         badge,
         dimensions,
-        config.sidebar.position.is_horizontal(),
     ));
 
     content = content.push(
@@ -2297,25 +2332,34 @@ enum Icon<'a> {
 }
 
 fn sidebar_icon<'a>(
-    icon: Option<Icon<'a>>,
+    config: &'a Config,
+    icon: Option<BufferIcon<'a>>,
     indicator: Option<(TextColorSvg<'a, Theme>, u32)>,
     dimensions: Dimensions,
-    sidebar_is_horizontal: bool,
 ) -> impl IntoIterator<Item = Element<'a, Message>> {
     let (icon, icon_height, icon_left_spacing): (
         Option<Element<'a, Message>>,
         u32,
         f32,
     ) = if let Some(icon) = icon {
-        let icon: Element<'a, Message> = container(match icon {
-            Icon::Upstream(server_icon) => {
-                image::from_data(server_icon, true, ContentFit::Contain)
-            }
-            Icon::Internal(icon) => icon.into(),
-        })
-        .width(dimensions.icon_size)
-        .height(dimensions.icon_size)
-        .into();
+        let icon: Element<'a, Message> = match icon {
+            BufferIcon::Icon(Icon::Upstream(server_icon)) => container(
+                image::from_data(server_icon, true, ContentFit::Contain),
+            )
+            .width(dimensions.icon_size)
+            .height(dimensions.icon_size)
+            .into(),
+            BufferIcon::Icon(Icon::Internal(icon)) => container(icon)
+                .width(dimensions.icon_size)
+                .height(dimensions.icon_size)
+                .into(),
+            BufferIcon::Element(element) => container(element)
+                .width(dimensions.icon_size)
+                .height(dimensions.icon_size)
+                .align_x(iced::alignment::Horizontal::Center)
+                .align_y(iced::alignment::Vertical::Center)
+                .into(),
+        };
 
         let badge: Option<Element<'a, Message>> =
             indicator.map(move |(indicator, _)| {
@@ -2371,20 +2415,21 @@ fn sidebar_icon<'a>(
                         .content_fit(ContentFit::Contain),
                 )
                 .width(indicator_size)
-                .height(indicator_size)
+                .height(sidebar_icon_size(config, indicator_size))
+                .align_y(iced::alignment::Vertical::Center)
                 .into(),
             ),
-            indicator_size,
+            sidebar_icon_size(config, indicator_size),
             dimensions
                 .max_indicator_size()
                 .saturating_sub(indicator_size) as f32
                 / 2.0,
         )
     } else {
-        (None, 1, 0.0)
+        (None, sidebar_icon_size(config, 1), 0.0)
     };
 
-    if sidebar_is_horizontal {
+    if config.sidebar.position.is_horizontal() {
         if let Some(icon) = icon {
             Either::Left(vec![icon, Space::new().width(8).into()].into_iter())
         } else {
@@ -2407,6 +2452,16 @@ fn sidebar_icon<'a>(
             ]
             .into_iter(),
         )
+    }
+}
+
+fn sidebar_icon_size(config: &Config, icon_size: u32) -> u32 {
+    let dimensions = Dimensions::from(&config.sidebar);
+    if config.can_show_any_typing() && config.sidebar.can_show_typing() {
+        // use max_icon_size if query typing is enabled for uniform height
+        dimensions.max_icon_size()
+    } else {
+        icon_size
     }
 }
 


### PR DESCRIPTION
Sidebar typing indicator for query buffers. Requires either `buffer.typing.show = true` or `server.<server>.typing.show = true`.

By default, this is enabled only for vertical sidebars;

Here's a screencap:

[Screencast_20260704_185038.webm](https://github.com/user-attachments/assets/065d441a-0d84-4309-9665-db3bd31dc675)

## new config options

### `sidebar.query_typing_indicator.show`

Show typing indicator for sidebar queries.

Because of space constraints in horizontal sidebars, I've defaulted this option to `"vertical"`.

Set to `"all"` if you want to display typing indicators in horizontal sidebars.

```toml
# Type: boolean
# Values: "all", "vertical", "none"
# Default: "vertical"

[sidebar.query_typing_indicator]
show = "all"
```

### `sidebar.query_typing_indicator.scale_factor`

Change the size of the query typing indicator. Mulitplies `buffer.typing.font_size` by `scale_factor`.

```toml
# Type: float
# Values: 0.01 .. 1.0
# Default: 0.75

[sidebar.query_typing_indicator]
scale_factor = 0.5
```