### PR TITLE
add/highlight_indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Added:
 - Explicit portable mode
 - Theme editor can be closed via Escape
 - `actions.buffer.click_channel_discovery` to configure click behavior for channel names in the channel discovery pane (default: `"new-pane"`)
+- `sidebar.unread_indicator.exclude` no longer suppresses highlight indicators
+- New `sidebar.unread_indicator.highlight_exclude` / `sidebar.unread_indicator.highlight_include` settings for independent highlight control
 
 Fixed:
 

--- a/data/src/config/sidebar.rs
+++ b/data/src/config/sidebar.rs
@@ -155,6 +155,8 @@ pub struct UnreadIndicator {
     pub query_as_highlight: bool,
     pub exclude: Option<Inclusivities>,
     pub include: Option<Inclusivities>,
+    pub highlight_exclude: Option<Inclusivities>,
+    pub highlight_include: Option<Inclusivities>,
 }
 
 impl Default for UnreadIndicator {
@@ -169,6 +171,8 @@ impl Default for UnreadIndicator {
             query_as_highlight: false,
             exclude: None,
             include: None,
+            highlight_exclude: None,
+            highlight_include: None,
         }
     }
 }
@@ -201,6 +205,30 @@ impl UnreadIndicator {
             is_server_included(
                 self.include.as_ref(),
                 self.exclude.as_ref(),
+                server,
+            )
+        }
+    }
+
+    pub fn should_indicate_highlight(
+        &self,
+        target: Option<&Target>,
+        server: &Server,
+        casemapping: isupport::CaseMap,
+    ) -> bool {
+        if let Some(target) = target {
+            is_target_included(
+                self.highlight_include.as_ref(),
+                self.highlight_exclude.as_ref(),
+                None,
+                target.as_target_ref(),
+                server,
+                casemapping,
+            )
+        } else {
+            is_server_included(
+                self.highlight_include.as_ref(),
+                self.highlight_exclude.as_ref(),
                 server,
             )
         }

--- a/docs/configuration/conditions.md
+++ b/docs/configuration/conditions.md
@@ -47,6 +47,23 @@ criteria = [{ channel = "#halloy", user = "GH-Bot" },
             { channel = "#halloy", user = "ChanServ" }]
 ```
 
+This example mutes unread indicators in a noisy channel while still showing
+highlight indicators when you are mentioned. See
+[sidebar unread indicators](/configuration/sidebar#exclude).
+
+```toml
+[sidebar.unread_indicator]
+exclude = { channels = ["#noisy-channel"] }
+```
+
+To hide highlight indicators as well, set the same conditions on `highlight_exclude`:
+
+```toml
+[sidebar.unread_indicator]
+exclude = { channels = ["#noisy-channel"] }
+highlight_exclude = { channels = ["#noisy-channel"] }
+```
+
 This example excludes messages in `#halloy` on the `libera` server only.
 
 ```toml

--- a/docs/configuration/sidebar.md
+++ b/docs/configuration/sidebar.md
@@ -300,6 +300,8 @@ show_on_open_buffers = false
 ### `query_as_highlight`
 
 Treat unread query (direct message) buffers as highlights for sidebar styling.
+When enabled, unread query buffers styled as highlights follow
+`highlight_exclude` / `highlight_include`, not `exclude` / `include`.
 
 ```toml
 # Type: boolean
@@ -315,6 +317,10 @@ query_as_highlight = true
 [Exclusion conditions](/configuration/conditions.md) for which unread indicators
 won't be shown. Inclusion conditions will take precedence over exclusion
 conditions. You can also exclude all conditions by setting to `"all"` or `"*"`.
+Unlike earlier versions, `exclude` does not suppress highlight indicators.
+Highlight indicators still appear for excluded buffers unless `highlight_exclude`
+is also set. To hide both unread and highlight indicators for the same buffers,
+set the same conditions on `exclude` and `highlight_exclude`.
 
 ```toml
 # Type: inclusion/exclusion conditions
@@ -340,6 +346,39 @@ setting.
 [sidebar.unread_indicator]
 exclude = "*"
 include = { channels = ["#halloy"] }
+```
+
+### `highlight_exclude`
+
+[Exclusion conditions](/configuration/conditions.md) for which highlight
+indicators won't be shown. Inclusion conditions will take precedence over
+exclusion conditions. You can also exclude all conditions by setting to `"all"`
+or `"*"`.
+
+```toml
+# Type: inclusion/exclusion conditions
+# Values: channel, user, & server inclusion/exclusion conditions
+# Default: not set
+
+[sidebar.unread_indicator]
+highlight_exclude = { channels = ["#noisy-channel"] }
+```
+
+### `highlight_include`
+
+[Inclusion conditions](/configuration/conditions.md) for which highlight
+indicators will be shown. Highlight indicators are enabled in all conditions
+unless explicitly excluded, so this setting is only relevant when combined with
+the `highlight_exclude` setting.
+
+```toml
+# Type: inclusion/exclusion conditions
+# Values: channel, user, & server inclusion/exclusion conditions
+# Default: not set
+
+[sidebar.unread_indicator]
+highlight_exclude = "*"
+highlight_include = { channels = ["#halloy"] }
 ```
 
 ## `user_menu`

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -984,6 +984,12 @@ fn upstream_buffer_button<'a>(
             buffer.server(),
             casemapping,
         );
+    let should_indicate_highlight =
+        config.sidebar.unread_indicator.should_indicate_highlight(
+            buffer.target().as_ref(),
+            buffer.server(),
+            casemapping,
+        );
     let is_unread_query =
         matches!(buffer, buffer::Upstream::Query(_, _)) && has_unread;
     let has_highlight = has_highlight
@@ -992,7 +998,7 @@ fn upstream_buffer_button<'a>(
 
     let show_highlight_icon = has_highlight
         && config.sidebar.unread_indicator.has_unread_highlight_icon()
-        && should_indicate_unread;
+        && should_indicate_highlight;
     let show_unread_icon = has_unread
         && config.sidebar.unread_indicator.has_unread_icon()
         && should_indicate_unread;
@@ -1001,7 +1007,7 @@ fn upstream_buffer_button<'a>(
         && should_indicate_unread;
     let show_highlight_unread_title = has_highlight
         && config.sidebar.unread_indicator.title
-        && should_indicate_unread;
+        && should_indicate_highlight;
 
     let buffer_title_style = if show_highlight_unread_title {
         theme::text::highlight_indicator


### PR DESCRIPTION
Closes #1445
Decouple sidebar highlight indicators from unread exclude.  First PR here, I think I found everything that I needed to update.