### PR TITLE
Minor Contributing Update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,0 @@
-# Contributing to Halloy
-
-Thanks for your interest in contributing to Halloy. See the [contributing guide](https://halloy.chat/contributing) to get started.


### PR DESCRIPTION
Allow GitHub to render the contributing page directly, rather than linking to the page on https://halloy.chat.