### PR TITLE
add click_channel_discovery action config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Added:
 - `actions.buffer.click_channel_name` and `actions.buffer.click_highlight` can be set to no action (`"no-action"` or `"noop"`) to not open the channel when clicking on the channel name
 - Explicit portable mode
 - Theme editor can be closed via Escape
+- `actions.buffer.click_channel_discovery` to configure click behavior for channel names in the channel discovery pane (default: `"new-pane"`)
 
 Fixed:
 
@@ -49,7 +50,7 @@ Changed:
 
 Thanks:
 
-- Contributions: @englut, @luca020400, @classabbyamp, @KaiKorla, @TheDcoder, @City-busz
+- Contributions: @englut, @luca020400, @classabbyamp, @KaiKorla, @TheDcoder, @City-busz @rtmongold
 - Bug reports: @luca020400, agent314
 
 # 2026.7.2 (2026-06-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ Changed:
 
 Thanks:
 
-- Contributions: @englut, @luca020400, @classabbyamp, @KaiKorla, @TheDcoder, @City-busz @rtmongold
+- Contributions: @englut, @luca020400, @classabbyamp, @KaiKorla, @TheDcoder, @City-busz, @rtmongold
 - Bug reports: @luca020400, agent314
 
 # 2026.7.2 (2026-06-08)

--- a/data/src/config/actions.rs
+++ b/data/src/config/actions.rs
@@ -16,6 +16,7 @@ pub struct Actions {
 pub struct Buffer {
     pub click_channel_name: ChannelClickAction,
     pub click_highlight: ChannelClickAction,
+    pub click_channel_discovery: ChannelClickAction,
     #[serde(alias = "click_nickname")]
     pub click_username: NicknameClickAction,
     pub join_channel: BufferAction,

--- a/docs/configuration/actions.md
+++ b/docs/configuration/actions.md
@@ -40,6 +40,19 @@ Action when clicking on the channel name of a highlight in the highlights buffer
 click_highlight = "new-pane"
 ```
 
+### `click_channel_discovery`
+
+Action when clicking on a channel name in the channel discovery pane. `"new-pane"` opens a new pane each time. `"replace-pane"` replaces the focused pane with the clicked channel. `"new-window"` opens a new window each time. `"no-action"` or `"noop"` will ignore clicks on the channel names in the channel discovery pane.
+
+```toml
+# Type: string
+# Values: "new-pane", "replace-pane", "new-window", "no-action", "noop"
+# Default: "new-pane"
+
+[actions.buffer]
+click_channel_discovery = "new-pane"
+```
+
 ### `click_nickname`
 
 Click action for when interaction with nicknames.

--- a/src/buffer/channel_discovery.rs
+++ b/src/buffer/channel_discovery.rs
@@ -234,40 +234,44 @@ fn channel_list_view<'a>(
                 .enumerate()
                 .map(|(idx, (channel, topic_content, user_count))| {
                     let channel_text =
-                        selectable_rich_text::<_, message::Link, (), _, _>(
-                            vec![
-                        span(channel.as_str())
-                            .font_maybe(
-                                theme
-                                    .styles()
-                                    .buffer
-                                    .url
-                                    .font_style
-                                    .map(font::get),
-                            )
-                            .color(theme.styles().buffer.url.color)
-                            .link(message::Link::Channel(
-                                server.clone(),
-                                target::Channel::from_str(
-                                    channel.as_str(),
-                                    clients.get_server_chantypes_or_default(
-                                        server,
-                                    ),
-                                    clients.get_server_casemapping_or_default(
-                                        server,
-                                    ),
+                        selectable_rich_text::<_, message::Link, (), _, _>(vec![
+                            span(channel.as_str())
+                                .font_maybe(
+                                    theme
+                                        .styles()
+                                        .buffer
+                                        .url
+                                        .font_style
+                                        .map(font::get),
+                                )
+                                .color(theme.styles().buffer.url.color)
+                                .link_maybe(
+                                    match config
+                                        .actions
+                                        .buffer
+                                        .click_channel_discovery
+                                    {
+                                        ChannelClickAction::OpenChannel(
+                                            buffer_action,
+                                        ) => Some(message::Link::Channel(
+                                            server.clone(),
+                                            target::Channel::from_str(
+                                                channel.as_str(),
+                                                clients
+                                                    .get_server_chantypes_or_default(
+                                                        server,
+                                                    ),
+                                                clients
+                                                    .get_server_casemapping_or_default(
+                                                        server,
+                                                    ),
+                                            ),
+                                            buffer_action,
+                                        )),
+                                        ChannelClickAction::Noop => None,
+                                    },
                                 ),
-                                match config.actions.buffer.click_channel_name {
-                                    ChannelClickAction::OpenChannel(
-                                        buffer_action,
-                                    ) => buffer_action,
-                                    ChannelClickAction::Noop => {
-                                        config.actions.buffer.join_channel
-                                    }
-                                },
-                            )),
-                    ],
-                        )
+                        ])
                         .on_link(Message::Link);
                     let user_count_text =
                         selectable_text(format!("{user_count} users"))


### PR DESCRIPTION
Closes #1548
Change channel discovery to use click_channel_discovery. Default click_channel_discovery to new-pane so /list stays open.