### PR TITLE
Only-Contract Setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Changed:
 - Renamed `actions.buffer.local` → `actions.buffer.open_internal` to match naming convention used elsewhere
 - Renamed `actions.buffer.click_username` to `actions.buffer.click_nickname` for more consistent terminology
 - Moved functionality from `buffer.nickname.click` → `actions.buffer.click_nickname` and `buffer.channel.nicklist.click` → `actions.nicklist.click_nickname`
+- Clicking on a message expanded out of a condensed message will always contract it (configurable via `actions.only_contract_expanded_message`)
 - Windows release artifacts are signed using SignPath
 - Set window icon also on Linux for X11
 

--- a/data/src/config/actions.rs
+++ b/data/src/config/actions.rs
@@ -11,7 +11,7 @@ pub struct Actions {
     pub notification: Notification,
 }
 
-#[derive(Debug, Default, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct Buffer {
     pub click_channel_name: ChannelClickAction,
@@ -24,6 +24,23 @@ pub struct Buffer {
     pub open_internal: BufferAction,
     pub message_channel: BufferAction,
     pub message_user: BufferAction,
+    pub only_contract_expanded_message: bool,
+}
+
+impl Default for Buffer {
+    fn default() -> Self {
+        Self {
+            click_channel_name: ChannelClickAction::default(),
+            click_highlight: ChannelClickAction::default(),
+            click_channel_discovery: ChannelClickAction::default(),
+            click_username: NicknameClickAction::default(),
+            join_channel: BufferAction::default(),
+            open_internal: BufferAction::default(),
+            message_channel: BufferAction::default(),
+            message_user: BufferAction::default(),
+            only_contract_expanded_message: true,
+        }
+    }
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -4078,8 +4078,40 @@ pub enum Link {
     Url(String),
     User(Server, User),
     GoToMessage(Server, target::Channel, Hash, Option<BufferAction>),
-    ExpandMessage(DateTime<Utc>, Hash),
-    ContractMessage(DateTime<Utc>, Hash),
+    ExpandMessage(DateTime<Utc>, Hash, Option<LinkContext>),
+    ContractMessage(DateTime<Utc>, Hash, Option<LinkContext>),
+}
+
+#[derive(Debug, Clone)]
+pub enum LinkContext {
+    User(User),
+    Url(String),
+    Channel(Server, target::Channel),
+}
+
+impl Link {
+    pub fn set_context(&mut self, other: &Link) {
+        match self {
+            Link::ExpandMessage(_, _, link_context)
+            | Link::ContractMessage(_, _, link_context) => {
+                *link_context = match other {
+                    Link::Channel(server, channel, _)
+                    | Link::GoToMessage(server, channel, _, _) => Some(
+                        LinkContext::Channel(server.clone(), channel.clone()),
+                    ),
+                    Link::Url(url) => Some(LinkContext::Url(url.clone())),
+                    Link::User(_, user) => {
+                        Some(LinkContext::User(user.clone()))
+                    }
+                    Link::ExpandMessage(..) | Link::ContractMessage(..) => None,
+                };
+            }
+            Link::Channel(..)
+            | Link::Url(..)
+            | Link::User(..)
+            | Link::GoToMessage(..) => (),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]

--- a/docs/configuration/actions.md
+++ b/docs/configuration/actions.md
@@ -122,6 +122,19 @@ Action when joining a channel via `/join` command. `"new-pane"` opens a new pane
 join_channel = "replace-pane"
 ```
 
+### `only_contract_expanded_message`
+
+All actions on an expanded message will be disabled in favor of closing the message.  In other words, if set to `true` then clicking anywhere on an expanded message will contract it.
+
+```toml
+# Type: bool
+# Values: true, false
+# Default: true
+
+[actions.buffer]
+only_contract_expanded_message = false
+```
+
 ## `nicklist`
 
 How nicklist actions should be enacted.

--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -131,29 +131,36 @@ pub fn view<'a>(
             theme::selectable_text::topic,
             theme::font_style::topic,
             Option::<fn(Color) -> Color>::None,
-            move |link| match link {
-                message::Link::User(_, user) => {
-                    let user_in_channel =
-                        users.and_then(|users| users.resolve(user));
+            move |link| {
+                context_menu::Entry::link_list(
+                    link,
+                    Some(|user| {
+                        let user_in_channel =
+                            users.and_then(|users| users.resolve(user));
 
-                    context_menu::Entry::user_list(
-                        true,
-                        user_in_channel,
-                        our_user,
-                        config.file_transfer.enabled,
-                        context_menu::has_user_metadata(user, registry, config),
-                    )
-                }
-                message::Link::Url(_) => context_menu::Entry::url_list(
-                    false, None, None, false, false, false
-                ),
-                message::Link::Channel(server, channel, _) => {
-                    context_menu::Entry::channel_list(
-                        channel_is_open(server, channel),
-                        channel_is_focused(server, channel),
-                    )
-                }
-                _ => vec![],
+                        context_menu::Entry::user_list(
+                            true,
+                            user_in_channel,
+                            our_user,
+                            config.file_transfer.enabled,
+                            context_menu::has_user_metadata(
+                                user, registry, config,
+                            ),
+                            false,
+                        )
+                    }),
+                    Some(|_| {
+                        context_menu::Entry::url_list(
+                            false, None, None, false, false, false,
+                        )
+                    }),
+                    Some(|server, channel| {
+                        context_menu::Entry::channel_list(
+                            channel_is_open(server, channel),
+                            channel_is_focused(server, channel),
+                        )
+                    }),
+                )
             },
             move |link, entry, length| {
                 let context = Context::link(

--- a/src/buffer/channel_discovery.rs
+++ b/src/buffer/channel_discovery.rs
@@ -274,14 +274,18 @@ fn channel_list_view<'a>(
             ])
             .on_link(Message::Link)
             .context_menu(
-                move |link| match link {
-                    message::Link::Channel(server, channel, _) => {
-                        context_menu::Entry::channel_list(
-                            channel_is_open(server, channel),
-                            channel_is_focused(server, channel),
-                        )
-                    }
-                    _ => vec![],
+                move |link| {
+                    context_menu::Entry::link_list(
+                        link,
+                        Option::<fn(&User) -> Vec<context_menu::Entry>>::None,
+                        Option::<fn(&str) -> Vec<context_menu::Entry>>::None,
+                        Some(|server, channel| {
+                            context_menu::Entry::channel_list(
+                                channel_is_open(server, channel),
+                                channel_is_focused(server, channel),
+                            )
+                        }),
+                    )
                 },
                 move |link, entry, length| {
                     entry
@@ -324,17 +328,22 @@ fn channel_list_view<'a>(
                     theme::selectable_text::topic,
                     theme::font_style::topic,
                     Option::<fn(Color) -> Color>::None,
-                    move |link| match link {
-                        message::Link::Url(_) => context_menu::Entry::url_list(
-                            false, None, None, false, false, false,
-                        ),
-                        message::Link::Channel(server, channel, _) => {
-                            context_menu::Entry::channel_list(
-                                channel_is_open(server, channel),
-                                channel_is_focused(server, channel),
-                            )
-                        }
-                        _ => vec![],
+                    move |link| {
+                        context_menu::Entry::link_list(
+                            link,
+                            Option::<fn(&User) -> Vec<context_menu::Entry>>::None,
+                            Some(|_| {
+                                context_menu::Entry::url_list(
+                                    false, None, None, false, false, false,
+                                )
+                            }),
+                            Some(|server, channel| {
+                                context_menu::Entry::channel_list(
+                                    channel_is_open(server, channel),
+                                    channel_is_focused(server, channel),
+                                )
+                            }),
+                        )
                     },
                     move |link, entry, length| {
                         entry

--- a/src/buffer/context_menu.rs
+++ b/src/buffer/context_menu.rs
@@ -67,19 +67,45 @@ impl<'a> Context<'a> {
         >,
     ) -> Option<Context<'a>> {
         match link {
-            message::Link::User(_, user) => {
-                into_user_context.map(|into_user_context| {
-                    Context::User(into_user_context(user))
-                })
-            }
-            message::Link::Url(url) => into_url_context
+            message::Link::User(_, user)
+            | message::Link::ExpandMessage(
+                _,
+                _,
+                Some(message::LinkContext::User(user)),
+            )
+            | message::Link::ContractMessage(
+                _,
+                _,
+                Some(message::LinkContext::User(user)),
+            ) => into_user_context.map(|into_user_context| {
+                Context::User(into_user_context(user))
+            }),
+            message::Link::Url(url)
+            | message::Link::ExpandMessage(
+                _,
+                _,
+                Some(message::LinkContext::Url(url)),
+            )
+            | message::Link::ContractMessage(
+                _,
+                _,
+                Some(message::LinkContext::Url(url)),
+            ) => into_url_context
                 .map(|into_url_context| Context::Url(into_url_context(url))),
             message::Link::Channel(server, channel, _)
-            | message::Link::GoToMessage(server, channel, _, _) => {
-                into_channel_context.map(|into_channel_context| {
-                    Context::Channel(into_channel_context(server, channel))
-                })
-            }
+            | message::Link::GoToMessage(server, channel, _, _)
+            | message::Link::ExpandMessage(
+                _,
+                _,
+                Some(message::LinkContext::Channel(server, channel)),
+            )
+            | message::Link::ContractMessage(
+                _,
+                _,
+                Some(message::LinkContext::Channel(server, channel)),
+            ) => into_channel_context.map(|into_channel_context| {
+                Context::Channel(into_channel_context(server, channel))
+            }),
             message::Link::ExpandMessage(..)
             | message::Link::ContractMessage(..) => None,
         }
@@ -132,6 +158,59 @@ pub enum UserAvatar<'a> {
 }
 
 impl Entry {
+    pub fn link_list<'a>(
+        link: &'a message::Link,
+        into_user_list: Option<impl Fn(&'a User) -> Vec<Self>>,
+        into_url_list: Option<impl Fn(&'a str) -> Vec<Self>>,
+        into_channel_list: Option<
+            impl Fn(&'a Server, &'a target::Channel) -> Vec<Self>,
+        >,
+    ) -> Vec<Self> {
+        match link {
+            message::Link::User(_, user)
+            | message::Link::ExpandMessage(
+                _,
+                _,
+                Some(message::LinkContext::User(user)),
+            )
+            | message::Link::ContractMessage(
+                _,
+                _,
+                Some(message::LinkContext::User(user)),
+            ) => into_user_list
+                .map_or(vec![], |into_user_list| into_user_list(user)),
+            message::Link::Url(url)
+            | message::Link::ExpandMessage(
+                _,
+                _,
+                Some(message::LinkContext::Url(url)),
+            )
+            | message::Link::ContractMessage(
+                _,
+                _,
+                Some(message::LinkContext::Url(url)),
+            ) => {
+                into_url_list.map_or(vec![], |into_url_list| into_url_list(url))
+            }
+            message::Link::Channel(server, channel, _)
+            | message::Link::GoToMessage(server, channel, _, _)
+            | message::Link::ExpandMessage(
+                _,
+                _,
+                Some(message::LinkContext::Channel(server, channel)),
+            )
+            | message::Link::ContractMessage(
+                _,
+                _,
+                Some(message::LinkContext::Channel(server, channel)),
+            ) => into_channel_list.map_or(vec![], |into_channel_list| {
+                into_channel_list(server, channel)
+            }),
+            message::Link::ExpandMessage(..)
+            | message::Link::ContractMessage(..) => vec![],
+        }
+    }
+
     pub fn not_sent_message_list(can_resend: bool) -> Vec<Self> {
         if can_resend {
             vec![Entry::DeleteMessage, Entry::ResendMessage]
@@ -264,6 +343,7 @@ impl Entry {
         our_user: Option<&User>,
         file_transfer_enabled: bool,
         has_metadata: bool,
+        message_is_rerouted: bool,
     ) -> Vec<Self> {
         let mut user_info_entries = vec![Entry::UserInfo];
 
@@ -275,7 +355,15 @@ impl Entry {
         if is_channel {
             if user_in_channel.is_none() {
                 let mut list = user_info_entries;
-                list.extend([Entry::HorizontalRule, Entry::Whowas]);
+
+                list.push(Entry::HorizontalRule);
+
+                if message_is_rerouted {
+                    list.push(Entry::Whois);
+                } else {
+                    list.push(Entry::Whowas);
+                }
+
                 list
             } else if our_user.is_some_and(|u| {
                 u.has_access_level(data::user::AccessLevel::Oper)
@@ -1123,6 +1211,7 @@ pub fn user<'a>(
         our_user,
         config.file_transfer.enabled,
         has_user_metadata(user, registry, config),
+        false,
     );
 
     user_with_entries(
@@ -1141,7 +1230,7 @@ pub fn user<'a>(
     )
 }
 
-pub fn rerouted_private_user<'a>(
+pub fn rerouted_message_user<'a>(
     content: impl Into<Element<'a, Message>>,
     server: &'a Server,
     prefix: &'a [isupport::PrefixMap],

--- a/src/buffer/highlights.rs
+++ b/src/buffer/highlights.rs
@@ -107,14 +107,22 @@ pub fn view<'a>(
                 ])
                 .on_link(scroll_view::Message::Link)
                 .context_menu(
-                    move |link| match link {
-                        message::Link::GoToMessage(server, channel, _, _) => {
-                            context_menu::Entry::channel_list(
-                                channel_is_open(server, channel),
-                                channel_is_focused(server, channel),
-                            )
-                        }
-                        _ => vec![],
+                    move |link| {
+                        context_menu::Entry::link_list(
+                                    link,
+                                    Option::<
+                                        fn(&User) -> Vec<context_menu::Entry>,
+                                    >::None,
+                                    Option::<
+                                        fn(&str) -> Vec<context_menu::Entry>,
+                                    >::None,
+                                    Some(|server, channel| {
+                                        context_menu::Entry::channel_list(
+                                            channel_is_open(server, channel),
+                                            channel_is_focused(server, channel),
+                                        )
+                                    }),
+                                )
                     },
                     move |link, entry, length| {
                         entry
@@ -211,30 +219,35 @@ pub fn view<'a>(
                     theme::selectable_text::default,
                     theme::font_style::primary,
                     Option::<fn(Color) -> Color>::None,
-                    move |link| match link {
-                        message::Link::User(_, _) => {
-                            context_menu::Entry::user_list(
-                                true,
-                                current_user,
-                                None,
-                                config.file_transfer.enabled,
-                                context_menu::has_user_metadata(
-                                    user,
-                                    clients.get_registry(server),
-                                    config,
-                                ),
-                            )
-                        }
-                        message::Link::Url(_) => context_menu::Entry::url_list(
-                            false, None, None, false, false, false,
-                        ),
-                        message::Link::Channel(server, channel, _) => {
-                            context_menu::Entry::channel_list(
-                                channel_is_open(server, channel),
-                                channel_is_focused(server, channel),
-                            )
-                        }
-                        _ => vec![],
+                    move |link| {
+                        context_menu::Entry::link_list(
+                            link,
+                            Some(|user| {
+                                context_menu::Entry::user_list(
+                                    true,
+                                    current_user,
+                                    None,
+                                    config.file_transfer.enabled,
+                                    context_menu::has_user_metadata(
+                                        user,
+                                        clients.get_registry(server),
+                                        config,
+                                    ),
+                                    true,
+                                )
+                            }),
+                            Some(|_| {
+                                context_menu::Entry::url_list(
+                                    false, None, None, false, false, false,
+                                )
+                            }),
+                            Some(|server, channel| {
+                                context_menu::Entry::channel_list(
+                                    channel_is_open(server, channel),
+                                    channel_is_focused(server, channel),
+                                )
+                            }),
+                        )
                     },
                     move |link, entry, length| {
                         let context = Context::link(

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -860,7 +860,12 @@ impl<'a> ChannelQueryLayout<'a> {
             formatter.casemapping,
             self.theme,
             Message::Link,
-            link,
+            link.map(|link| {
+                (
+                    link,
+                    self.config.actions.buffer.only_contract_expanded_message,
+                )
+            }),
             message_style,
             message_font_style,
             Some(|color: Color| -> Color {
@@ -1018,7 +1023,7 @@ impl<'a> ChannelQueryLayout<'a> {
             formatter.casemapping,
             self.theme,
             move |_| Message::Link(moved_link.clone()),
-            Some(link),
+            Some((link, true)),
             message_style,
             message_font_style,
             Some(|color: Color| -> Color {

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -146,36 +146,6 @@ impl<'a> ChannelQueryLayout<'a> {
         Some(message.hidden_urls.contains(&parsed))
     }
 
-    fn url_entries(
-        &self,
-        message: &data::Message,
-        link: &message::Link,
-    ) -> Vec<context_menu::Entry> {
-        let can_send_replies = self.can_send_replies && message.id.is_some();
-        match link {
-            message::Link::Url(url) => context_menu::Entry::url_list(
-                message.redaction.is_some(),
-                message.redaction_expanded(&self.config.buffer.redaction),
-                self.preview_hidden_for_url(message, url),
-                self.can_send_reactions,
-                self.can_redact_message(message),
-                can_send_replies,
-            ),
-            _ => {
-                let mut entries = vec![];
-                if can_send_replies || self.can_send_reactions {
-                    if can_send_replies {
-                        entries.push(context_menu::Entry::Reply);
-                    }
-                    if self.can_send_reactions {
-                        entries.push(context_menu::Entry::AddReaction);
-                    }
-                }
-                entries
-            }
-        }
-    }
-
     fn can_redact_message(&self, message: &data::Message) -> bool {
         // Gate on message-redaction capability first.
         if !self.can_redact {
@@ -567,13 +537,13 @@ impl<'a> ChannelQueryLayout<'a> {
 
         let user_in_channel =
             self.target.users().and_then(|users| users.resolve(user));
-        let rerouted_private = message.is_rerouted();
+        let rerouted_message = message.is_rerouted();
         let is_user_away = match self.config.buffer.nickname.shown_status {
             ShownStatus::Current => user_in_channel.unwrap_or(user),
             ShownStatus::Historical => user,
         }
         .is_away();
-        let is_user_offline = if rerouted_private {
+        let is_user_offline = if rerouted_message {
             false
         } else {
             match self.config.buffer.nickname.shown_status {
@@ -583,10 +553,6 @@ impl<'a> ChannelQueryLayout<'a> {
                 ShownStatus::Historical => false,
             }
         };
-        let is_ourself = self
-            .target
-            .our_user()
-            .is_some_and(|our_user| our_user.nickname() == user.nickname());
 
         let user_display = UserDisplay::new(
             user,
@@ -630,8 +596,8 @@ impl<'a> ChannelQueryLayout<'a> {
                     .into();
             }
 
-            if rerouted_private && user_in_channel.is_none() {
-                context_menu::rerouted_private_user(
+            if rerouted_message && user_in_channel.is_none() {
+                context_menu::rerouted_message_user(
                     nick_text,
                     self.server,
                     self.prefix,
@@ -666,7 +632,7 @@ impl<'a> ChannelQueryLayout<'a> {
 
         let message_style = move |message_theme: &Theme| {
             theme::selectable_text::dimmed(
-                if rerouted_private {
+                if rerouted_message {
                     theme::selectable_text::tertiary(message_theme)
                 } else {
                     theme::selectable_text::default(message_theme)
@@ -707,6 +673,7 @@ impl<'a> ChannelQueryLayout<'a> {
                     .on_press(Message::Link(message::Link::ExpandMessage(
                         message.server_time,
                         message.hash,
+                        None,
                     )))
                     .into(),
                     vec![],
@@ -727,40 +694,13 @@ impl<'a> ChannelQueryLayout<'a> {
                             message_style,
                             theme::font_style::primary,
                             color_transformation,
-                            move |link| match link {
-                                message::Link::User(_, _) => {
-                                    if rerouted_private
-                                        && !is_ourself
-                                        && user_in_channel.is_none()
-                                    {
-                                        vec![context_menu::Entry::Whois]
-                                    } else {
-                                        context_menu::Entry::user_list(
-                                            formatter.target.is_channel(),
-                                            user_in_channel,
-                                            formatter.target.our_user(),
-                                            formatter
-                                                .config
-                                                .file_transfer
-                                                .enabled,
-                                            context_menu::has_user_metadata(
-                                                user,
-                                                formatter.registry,
-                                                formatter.config,
-                                            ),
-                                        )
-                                    }
-                                }
-                                message::Link::Url(_) => {
-                                    formatter.url_entries(message, link)
-                                }
-                                message::Link::Channel(server, channel, _) => {
-                                    context_menu::Entry::channel_list(
-                                        channel_is_open(server, channel),
-                                        channel_is_focused(server, channel),
-                                    )
-                                }
-                                _ => vec![],
+                            move |link| {
+                                formatter.link_entries(
+                                    message,
+                                    link,
+                                    channel_is_focused,
+                                    channel_is_open,
+                                )
                             },
                             move |link, entry, length| {
                                 entry
@@ -830,6 +770,7 @@ impl<'a> ChannelQueryLayout<'a> {
         let link = message.expanded.then_some(message::Link::ContractMessage(
             message.server_time,
             message.hash,
+            None,
         ));
 
         let marker_style = move |message_theme: &Theme| {
@@ -878,31 +819,13 @@ impl<'a> ChannelQueryLayout<'a> {
                     color
                 }
             }),
-            move |link| match link {
-                message::Link::User(_, user) => {
-                    let user_in_channel =
-                        formatter.target.users().and_then(|u| u.resolve(user));
-
-                    context_menu::Entry::user_list(
-                        formatter.target.is_channel(),
-                        user_in_channel,
-                        formatter.target.our_user(),
-                        formatter.config.file_transfer.enabled,
-                        context_menu::has_user_metadata(
-                            user,
-                            formatter.registry,
-                            formatter.config,
-                        ),
-                    )
-                }
-                message::Link::Url(_) => formatter.url_entries(message, link),
-                message::Link::Channel(server, channel, _) => {
-                    context_menu::Entry::channel_list(
-                        channel_is_open(server, channel),
-                        channel_is_focused(server, channel),
-                    )
-                }
-                _ => vec![],
+            move |link| {
+                formatter.link_entries(
+                    message,
+                    link,
+                    channel_is_focused,
+                    channel_is_open,
+                )
             },
             move |link, entry, length| {
                 entry
@@ -954,8 +877,11 @@ impl<'a> ChannelQueryLayout<'a> {
             theme::font_style::server(message_theme, None)
         };
 
-        let link =
-            message::Link::ExpandMessage(message.server_time, message.hash);
+        let link = message::Link::ExpandMessage(
+            message.server_time,
+            message.hash,
+            None,
+        );
         let moved_link = link.clone();
 
         let range_end_timestamp = if let message::Source::Internal(
@@ -1036,31 +962,13 @@ impl<'a> ChannelQueryLayout<'a> {
                     color
                 }
             }),
-            move |link| match link {
-                message::Link::User(_, user) => {
-                    let user_in_channel =
-                        formatter.target.users().and_then(|u| u.resolve(user));
-
-                    context_menu::Entry::user_list(
-                        formatter.target.is_channel(),
-                        user_in_channel,
-                        formatter.target.our_user(),
-                        formatter.config.file_transfer.enabled,
-                        context_menu::has_user_metadata(
-                            user,
-                            formatter.registry,
-                            formatter.config,
-                        ),
-                    )
-                }
-                message::Link::Url(_) => formatter.url_entries(message, link),
-                message::Link::Channel(server, channel, _) => {
-                    context_menu::Entry::channel_list(
-                        channel_is_open(server, channel),
-                        channel_is_focused(server, channel),
-                    )
-                }
-                _ => vec![],
+            move |link| {
+                formatter.link_entries(
+                    message,
+                    link,
+                    channel_is_focused,
+                    channel_is_open,
+                )
             },
             move |link, entry, length| {
                 entry
@@ -1088,6 +996,54 @@ impl<'a> ChannelQueryLayout<'a> {
                 self.config.buffer.nickname.alignment,
             ),
             (Source::User(_), Alignment::Top)
+        )
+    }
+
+    fn link_entries<'b>(
+        &'b self,
+        message: &'b data::Message,
+        link: &'b message::Link,
+        channel_is_focused: impl Fn(&Server, &target::Channel) -> bool + Copy + 'b,
+        channel_is_open: impl Fn(&Server, &target::Channel) -> bool + Copy + 'b,
+    ) -> Vec<context_menu::Entry> {
+        context_menu::Entry::link_list(
+            link,
+            Some(|user| {
+                let user_in_channel =
+                    self.target.users().and_then(|users| users.resolve(user));
+
+                context_menu::Entry::user_list(
+                    self.target.is_channel(),
+                    user_in_channel,
+                    self.target.our_user(),
+                    self.config.file_transfer.enabled,
+                    context_menu::has_user_metadata(
+                        user,
+                        self.registry,
+                        self.config,
+                    ),
+                    message.is_rerouted(),
+                )
+            }),
+            Some(|url| {
+                let can_send_replies =
+                    self.can_send_replies && message.id.is_some();
+
+                context_menu::Entry::url_list(
+                    message.redaction.is_some(),
+                    message.redaction_expanded(&self.config.buffer.redaction),
+                    self.preview_hidden_for_url(message, url),
+                    self.can_send_reactions,
+                    self.can_redact_message(message),
+                    can_send_replies,
+                )
+            }),
+            Some(|server, channel| {
+                context_menu::Entry::channel_list(
+                    channel_is_open(server, channel),
+                    channel_is_focused(server, channel),
+                )
+            }),
         )
     }
 
@@ -1337,35 +1293,13 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
                     message_style,
                     theme::font_style::action,
                     color_transformation,
-                    move |link| match link {
-                        message::Link::User(_, user) => {
-                            let user_in_channel = formatter
-                                .target
-                                .users()
-                                .and_then(|u| u.resolve(user));
-
-                            context_menu::Entry::user_list(
-                                formatter.target.is_channel(),
-                                user_in_channel,
-                                formatter.target.our_user(),
-                                formatter.config.file_transfer.enabled,
-                                context_menu::has_user_metadata(
-                                    user,
-                                    formatter.registry,
-                                    formatter.config,
-                                ),
-                            )
-                        }
-                        message::Link::Url(_) => {
-                            formatter.url_entries(message, link)
-                        }
-                        message::Link::Channel(server, channel, _) => {
-                            context_menu::Entry::channel_list(
-                                channel_is_open(server, channel),
-                                channel_is_focused(server, channel),
-                            )
-                        }
-                        _ => vec![],
+                    move |link| {
+                        formatter.link_entries(
+                            message,
+                            link,
+                            channel_is_focused,
+                            channel_is_open,
+                        )
                     },
                     move |link, entry, length| {
                         entry

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -1185,7 +1185,11 @@ impl State {
                     );
                 }
             }
-            Message::Link(message::Link::ExpandMessage(server_time, hash)) => {
+            Message::Link(message::Link::ExpandMessage(
+                server_time,
+                hash,
+                _,
+            )) => {
                 return (
                     Task::none(),
                     Some(Event::ExpandMessage(server_time, hash)),
@@ -1194,6 +1198,7 @@ impl State {
             Message::Link(message::Link::ContractMessage(
                 server_time,
                 hash,
+                _,
             )) => {
                 return (
                     Task::none(),

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -253,7 +253,7 @@ pub fn view<'a>(
                             .map(scroll_view::Message::ContextMenu)
                         };
 
-                        let rerouted_private = message.is_rerouted();
+                        let rerouted_message = message.is_rerouted();
 
                         let content = message_content(
                             &message.content,
@@ -266,7 +266,7 @@ pub fn view<'a>(
                             scroll_view::Message::Link,
                             None,
                             move |theme| {
-                                if rerouted_private {
+                                if rerouted_message {
                                     theme::selectable_text::tertiary(theme)
                                 } else {
                                     theme::selectable_text::default(theme)

--- a/src/widget/message_content.rs
+++ b/src/widget/message_content.rs
@@ -374,7 +374,13 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a + std::clone::Clone>(
                                 &default_link
                                 && (span.link.is_none() || *overwrite_link)
                             {
-                                span.link(default_link.clone())
+                                let mut link = default_link.clone();
+
+                                if let Some(span_link) = span.link.as_ref() {
+                                    link.set_context(span_link);
+                                }
+
+                                span.link(link)
                             } else {
                                 span
                             },

--- a/src/widget/message_content.rs
+++ b/src/widget/message_content.rs
@@ -19,7 +19,7 @@ pub fn message_content<'a, M: 'a + std::clone::Clone>(
     casemapping: isupport::CaseMap,
     theme: &'a Theme,
     on_link: impl Fn(message::Link) -> M + 'a,
-    default_link: Option<message::Link>,
+    default_link: Option<(message::Link, bool)>,
     style: impl Fn(&Theme) -> selectable_text::Style + 'a,
     font_style: impl Fn(&Theme) -> Option<FontStyle>,
     color_transformation: Option<impl Fn(Color) -> Color>,
@@ -54,7 +54,7 @@ pub fn with_context<'a, T: Copy + 'a, M: 'a + std::clone::Clone>(
     casemapping: isupport::CaseMap,
     theme: &'a Theme,
     on_link: impl Fn(message::Link) -> M + 'a,
-    default_link: Option<message::Link>,
+    default_link: Option<(message::Link, bool)>,
     style: impl Fn(&Theme) -> selectable_text::Style + 'a,
     font_style: impl Fn(&Theme) -> Option<FontStyle>,
     color_transformation: Option<impl Fn(Color) -> Color>,
@@ -92,7 +92,7 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a + std::clone::Clone>(
     casemapping: isupport::CaseMap,
     theme: &'a Theme,
     on_link: impl Fn(message::Link) -> M + 'a,
-    default_link: Option<message::Link>,
+    default_link: Option<(message::Link, bool)>,
     style: impl Fn(&Theme) -> selectable_text::Style + 'a,
     font_style: impl Fn(&Theme) -> Option<FontStyle>,
     color_transformation: Option<impl Fn(Color) -> Color>,
@@ -148,7 +148,7 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a + std::clone::Clone>(
                     .style(style)
             };
 
-            if let Some(default_link) = default_link {
+            if let Some((default_link, _)) = default_link {
                 button(selectable_text)
                     .style(theme::button::bare)
                     .padding(0)
@@ -370,8 +370,9 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a + std::clone::Clone>(
                         };
 
                         Some(
-                            if span.link.is_none()
-                                && let Some(default_link) = &default_link
+                            if let Some((default_link, overwrite_link)) =
+                                &default_link
+                                && (span.link.is_none() || *overwrite_link)
                             {
                                 span.link(default_link.clone())
                             } else {


### PR DESCRIPTION
Adds setting, on by default, to only contract an expanded message when clicking anywhere on the message (previously, clicking on any link/nickname in the message trigger the corresponding action instead).

Also changes it so the context menu for the underlying link is displayed when right-clicking on a message where link/nickname behavior is being overridden with an expand/contract action.