### PR TITLE
Restructure Indicator Settings

### DIFF
--- a/.config/lychee-internal.toml
+++ b/.config/lychee-internal.toml
@@ -9,5 +9,6 @@ include_fragments = true
 exclude_all_private = true
 exclude = [ '^http://.*', '^https://.*', '^irc://.*', '^ircs://.*',
 						'/configuration/servers.md#sasl-plain',   # Incorrectly flagged as invalid
-						'/configuration/servers.md#sasl-external' # Incorrectly flagged as invalid
+						'/configuration/servers.md#sasl-external', # Incorrectly flagged as invalid
+						'/configuration/sidebar.md#highlight-indicator' # Incorrectly flagged as invalid
 					]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ Added:
 - Explicit portable mode
 - Theme editor can be closed via Escape
 - `actions.buffer.click_channel_discovery` to configure click behavior for channel names in the channel discovery pane (default: `"new-pane"`)
-- `sidebar.unread_indicator.exclude` no longer suppresses highlight indicators
-- New `sidebar.unread_indicator.highlight_exclude` / `sidebar.unread_indicator.highlight_include` settings for independent highlight control
+- `sidebar.unread_indicator.exclude` & `sidebar.unread_indicator.include` no longer controls highlight indicators
+- New `sidebar.highlight_indicator.title`, `sidebar.highlight_indicator.show_on_open_buffers`, `sidebar.highlight_indicator.exclude`, and `sidebar.highlight_indicator.include` settings for independent highlight control
 
 Fixed:
 
@@ -43,6 +43,7 @@ Changed:
 
 - `change_mode` server messages are categorized as `actions` (i.e. `actions_dimmed` controls whether they are dimmed by default)
 - Renamed `sidebar.server_icon` → `sidebar.primary_icon` and `sidebar.server_font_size` → `sidebar.primary_font_size` since the settings now apply to both servers and internal buffers
+- Renamed `sidebar.unread_indicator.highlight_icon` → `sidebar.highlight_indicator.icon` and `sidebar.unread_indicator.highlight_icon_size` → `sidebar.highlight_indicator.icon_size`
 - Renamed `sidebar.font_size` → `sidebar.secondary_font_size` to reflect its relationship to `sidebar.primary_font_size`
 - Renamed `actions.buffer.local` → `actions.buffer.open_internal` to match naming convention used elsewhere
 - Renamed `actions.buffer.click_username` to `actions.buffer.click_nickname` for more consistent terminology

--- a/data/src/config/sidebar.rs
+++ b/data/src/config/sidebar.rs
@@ -17,6 +17,8 @@ pub struct Sidebar {
     pub max_width: Option<u16>,
     #[serde(deserialize_with = "deserialize_unread_indicator")]
     pub unread_indicator: UnreadIndicator,
+    #[serde(deserialize_with = "deserialize_highlight_indicator")]
+    pub highlight_indicator: HighlightIndicator,
     pub position: Position,
     pub order_by: OrderBy,
     pub scrollbar: Scrollbar,
@@ -148,15 +150,10 @@ pub struct UnreadIndicator {
     pub icon: Icon,
     #[serde(deserialize_with = "deserialize_u32_positive_integer")]
     pub icon_size: u32,
-    pub highlight_icon: Icon,
-    #[serde(deserialize_with = "deserialize_u32_positive_integer")]
-    pub highlight_icon_size: u32,
     pub show_on_open_buffers: bool,
     pub query_as_highlight: bool,
     pub exclude: Option<Inclusivities>,
     pub include: Option<Inclusivities>,
-    pub highlight_exclude: Option<Inclusivities>,
-    pub highlight_include: Option<Inclusivities>,
 }
 
 impl Default for UnreadIndicator {
@@ -165,28 +162,20 @@ impl Default for UnreadIndicator {
             title: false,
             icon: Icon::Dot,
             icon_size: 6,
-            highlight_icon: Icon::CircleEmpty,
-            highlight_icon_size: 6,
             show_on_open_buffers: true,
             query_as_highlight: false,
             exclude: None,
             include: None,
-            highlight_exclude: None,
-            highlight_include: None,
         }
     }
 }
 
 impl UnreadIndicator {
-    pub fn has_unread_icon(&self) -> bool {
+    pub fn has_icon(&self) -> bool {
         !matches!(self.icon, Icon::None)
     }
 
-    pub fn has_unread_highlight_icon(&self) -> bool {
-        !matches!(self.highlight_icon, Icon::None)
-    }
-
-    pub fn should_indicate_unread(
+    pub fn should_indicate(
         &self,
         target: Option<&Target>,
         server: &Server,
@@ -205,30 +194,6 @@ impl UnreadIndicator {
             is_server_included(
                 self.include.as_ref(),
                 self.exclude.as_ref(),
-                server,
-            )
-        }
-    }
-
-    pub fn should_indicate_highlight(
-        &self,
-        target: Option<&Target>,
-        server: &Server,
-        casemapping: isupport::CaseMap,
-    ) -> bool {
-        if let Some(target) = target {
-            is_target_included(
-                self.highlight_include.as_ref(),
-                self.highlight_exclude.as_ref(),
-                None,
-                target.as_target_ref(),
-                server,
-                casemapping,
-            )
-        } else {
-            is_server_included(
-                self.highlight_include.as_ref(),
-                self.highlight_exclude.as_ref(),
                 server,
             )
         }
@@ -247,20 +212,105 @@ where
             "title" => Ok(UnreadIndicator {
                 title: true,
                 icon: Icon::None,
-                highlight_icon: Icon::None,
                 ..UnreadIndicator::default()
             }),
             "none" => Ok(UnreadIndicator {
                 title: false,
                 icon: Icon::None,
-                highlight_icon: Icon::None,
                 ..UnreadIndicator::default()
             }),
             "dot" => Ok(UnreadIndicator {
                 title: false,
                 icon: Icon::Dot,
-                highlight_icon: Icon::Dot,
                 ..UnreadIndicator::default()
+            }),
+            _ => Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(string),
+                &"one of: \"dot\", \"title\", or \"none\"",
+            )),
+        })
+        .map(|map| map.deserialize())
+        .deserialize(deserializer)
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct HighlightIndicator {
+    pub title: bool,
+    pub icon: Icon,
+    #[serde(deserialize_with = "deserialize_u32_positive_integer")]
+    pub icon_size: u32,
+    pub show_on_open_buffers: bool,
+    pub exclude: Option<Inclusivities>,
+    pub include: Option<Inclusivities>,
+}
+
+impl Default for HighlightIndicator {
+    fn default() -> Self {
+        HighlightIndicator {
+            title: false,
+            icon: Icon::CircleEmpty,
+            icon_size: 6,
+            show_on_open_buffers: true,
+            exclude: None,
+            include: None,
+        }
+    }
+}
+
+impl HighlightIndicator {
+    pub fn has_icon(&self) -> bool {
+        !matches!(self.icon, Icon::None)
+    }
+
+    pub fn should_indicate(
+        &self,
+        target: Option<&Target>,
+        server: &Server,
+        casemapping: isupport::CaseMap,
+    ) -> bool {
+        if let Some(target) = target {
+            is_target_included(
+                self.include.as_ref(),
+                self.exclude.as_ref(),
+                None,
+                target.as_target_ref(),
+                server,
+                casemapping,
+            )
+        } else {
+            is_server_included(
+                self.include.as_ref(),
+                self.exclude.as_ref(),
+                server,
+            )
+        }
+    }
+}
+
+pub fn deserialize_highlight_indicator<'de, D>(
+    deserializer: D,
+) -> Result<HighlightIndicator, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[allow(clippy::redundant_closure_for_method_calls)]
+    UntaggedEnumVisitor::new()
+        .string(|string| match string {
+            "title" => Ok(HighlightIndicator {
+                title: true,
+                icon: Icon::None,
+                ..HighlightIndicator::default()
+            }),
+            "none" => Ok(HighlightIndicator {
+                title: false,
+                icon: Icon::None,
+                ..HighlightIndicator::default()
+            }),
+            "dot" => Ok(HighlightIndicator {
+                title: false,
+                icon: Icon::Dot,
+                ..HighlightIndicator::default()
             }),
             _ => Err(serde::de::Error::invalid_value(
                 serde::de::Unexpected::Str(string),

--- a/docs/configuration/sidebar.md
+++ b/docs/configuration/sidebar.md
@@ -212,7 +212,7 @@ scroller_width = 5
 
 ## `unread_indicator`
 
-Unread buffer indicator style.
+Unread message in buffer indicator style.
 
 ### `title`
 
@@ -240,24 +240,9 @@ Changes the icon which appears when unread messages are present. To disable use 
 icon = "dot"
 ```
 
-### `highlight_icon`
-
-Changes the icon which appears when unread highlight messages are present. To disable use `"none"`.
-
-```toml
-# Type: string
-# Values: "dot", "circle-empty", "dot-circled", "certificate", "asterisk", "speaker", "lightbulb", "star", "none"
-# Default: "circle-empty"
-
-[sidebar.unread_indicator]
-highlight_icon = "circle-empty"
-```
-
 ### `icon_size`
 
-Changes the unread icon size.
-
-Note: If set larger than the line height of the specified [font](/configuration/font) then the icon will not render.
+Changes the unread message icon size.
 
 ```toml
 # Type: integer
@@ -268,24 +253,9 @@ Note: If set larger than the line height of the specified [font](/configuration/
 icon_size = 6
 ```
 
-### `highlight_icon_size`
-
-Changes the highlight unread icon size.
-
-Note: If set larger than the line height of the specified [font](/configuration/font) then the icon will not render.
-
-```toml
-# Type: integer
-# Values: any positive integer"
-# Default: 6
-
-[sidebar.unread_indicator]
-highlight_icon_size = 6
-```
-
 ### `show_on_open_buffers`
 
-Show unread/highlight indicators on buffers that have an open pane.
+Show unread message indicators on buffers that have an open pane.
 
 ```toml
 # Type: boolean
@@ -299,9 +269,9 @@ show_on_open_buffers = false
 
 ### `query_as_highlight`
 
-Treat unread query (direct message) buffers as highlights for sidebar styling.
-When enabled, unread query buffers styled as highlights follow
-`highlight_exclude` / `highlight_include`, not `exclude` / `include`.
+Treat unread messages in query (direct message) buffers as highlights for
+sidebar styling. When enabled, the resulting indicator for messages will be
+controlled by [`sidebar.highlight_indicator`](#highlight-indicator) settings.
 
 ```toml
 # Type: boolean
@@ -317,10 +287,11 @@ query_as_highlight = true
 [Exclusion conditions](/configuration/conditions.md) for which unread indicators
 won't be shown. Inclusion conditions will take precedence over exclusion
 conditions. You can also exclude all conditions by setting to `"all"` or `"*"`.
-Unlike earlier versions, `exclude` does not suppress highlight indicators.
-Highlight indicators still appear for excluded buffers unless `highlight_exclude`
-is also set. To hide both unread and highlight indicators for the same buffers,
-set the same conditions on `exclude` and `highlight_exclude`.
+Does not suppress unread highlight indicators; use
+[`highlight_indicator.exclude`](#exclude-1) to suppress unread highlight
+indicators. To hide both unread message and highlight indicators for the same
+buffers, set the same conditions on `unread_indicator.exclude` and
+`highlight_indicator.exclude`.
 
 ```toml
 # Type: inclusion/exclusion conditions
@@ -348,37 +319,96 @@ exclude = "*"
 include = { channels = ["#halloy"] }
 ```
 
-### `highlight_exclude`
+## `highlight_indicator`
 
-[Exclusion conditions](/configuration/conditions.md) for which highlight
-indicators won't be shown. Inclusion conditions will take precedence over
-exclusion conditions. You can also exclude all conditions by setting to `"all"`
-or `"*"`.
+Unread highlight in buffer indicator style.
+
+### `title`
+
+Changes buffer title color when unread highlights are present
 
 ```toml
-# Type: inclusion/exclusion conditions
-# Values: channel, user, & server inclusion/exclusion conditions
-# Default: not set
+# Type: boolean
+# Values: true, false
+# Default: false
 
-[sidebar.unread_indicator]
-highlight_exclude = { channels = ["#noisy-channel"] }
+[sidebar.highlight_indicator]
+title = false
 ```
 
-### `highlight_include`
+### `icon`
 
-[Inclusion conditions](/configuration/conditions.md) for which highlight
-indicators will be shown. Highlight indicators are enabled in all conditions
-unless explicitly excluded, so this setting is only relevant when combined with
-the `highlight_exclude` setting.
+Changes the icon which appears when unread highlights are present. To disable use `"none"`.
+
+```toml
+# Type: string
+# Values: "dot", "circle-empty", "dot-circled", "certificate", "asterisk", "speaker", "lightbulb", "star", "none"
+# Default: "dot"
+
+[sidebar.highlight_indicator]
+icon = "dot"
+```
+
+### `icon_size`
+
+Changes the unread highlight icon size.
+
+```toml
+# Type: integer
+# Values: any positive integer"
+# Default: 6
+
+[sidebar.highlight_indicator]
+icon_size = 6
+```
+
+### `show_on_open_buffers`
+
+Show unread/highlight indicators on buffers that have an open pane.
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: true
+
+[sidebar.highlight_indicator]
+show_on_open_buffers = false
+```
+
+### `exclude`
+
+[Exclusion conditions](/configuration/conditions.md) for which unread indicators
+won't be shown. Inclusion conditions will take precedence over exclusion
+conditions. You can also exclude all conditions by setting to `"all"` or `"*"`.
+Does not suppress unread message indicators; use
+[`unread_indicator.exclude`](#exclude) to suppress unread message indicators. To
+hide both unread message and highlight indicators for the same buffers, set the
+same conditions on `unread_indicator.exclude` and `highlight_indicator.exclude`.
 
 ```toml
 # Type: inclusion/exclusion conditions
 # Values: channel, user, & server inclusion/exclusion conditions
 # Default: not set
 
-[sidebar.unread_indicator]
-highlight_exclude = "*"
-highlight_include = { channels = ["#halloy"] }
+[sidebar.highlight_indicator]
+exclude = { channels = ["#noisy-channel"] }
+```
+
+### `include`
+
+[Inclusion conditions](/configuration/conditions.md) for which unread indicators
+will be shown. Unread indicators are enabled in all conditions unless explicitly
+excluded, so this setting is only relevant when combined with the `exclude`
+setting.
+
+```toml
+# Type: inclusion/exclusion conditions
+# Values: channel, user, & server inclusion/exclusion conditions
+# Default: not set
+
+[sidebar.highlight_indicator]
+exclude = "*"
+include = { channels = ["#halloy"] }
 ```
 
 ## `user_menu`

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -961,13 +961,14 @@ fn upstream_buffer_button<'a>(
         false
     };
 
-    let has_highlight = if config.sidebar.unread_indicator.show_on_open_buffers
-        || !is_visible
-    {
-        history.has_highlight(&kind)
-    } else {
-        false
-    };
+    let has_highlight =
+        if config.sidebar.highlight_indicator.show_on_open_buffers
+            || !is_visible
+        {
+            history.has_highlight(&kind)
+        } else {
+            false
+        };
 
     let is_focused = panes.iter().find_map(|(window_id, pane, state)| {
         (Focus {
@@ -979,13 +980,13 @@ fn upstream_buffer_button<'a>(
     });
 
     let should_indicate_unread =
-        config.sidebar.unread_indicator.should_indicate_unread(
+        config.sidebar.unread_indicator.should_indicate(
             buffer.target().as_ref(),
             buffer.server(),
             casemapping,
         );
     let should_indicate_highlight =
-        config.sidebar.unread_indicator.should_indicate_highlight(
+        config.sidebar.highlight_indicator.should_indicate(
             buffer.target().as_ref(),
             buffer.server(),
             casemapping,
@@ -997,19 +998,19 @@ fn upstream_buffer_button<'a>(
             && config.sidebar.unread_indicator.query_as_highlight);
 
     let show_highlight_icon = has_highlight
-        && config.sidebar.unread_indicator.has_unread_highlight_icon()
+        && config.sidebar.highlight_indicator.has_icon()
         && should_indicate_highlight;
     let show_unread_icon = has_unread
-        && config.sidebar.unread_indicator.has_unread_icon()
+        && config.sidebar.unread_indicator.has_icon()
         && should_indicate_unread;
     let show_unread_title = has_unread
         && config.sidebar.unread_indicator.title
         && should_indicate_unread;
-    let show_highlight_unread_title = has_highlight
-        && config.sidebar.unread_indicator.title
+    let show_highlight_title = has_highlight
+        && config.sidebar.highlight_indicator.title
         && should_indicate_highlight;
 
-    let buffer_title_style = if show_highlight_unread_title {
+    let buffer_title_style = if show_highlight_title {
         theme::text::highlight_indicator
     } else if show_unread_title {
         theme::text::unread_indicator
@@ -1057,7 +1058,7 @@ fn upstream_buffer_button<'a>(
         ))
     } else if show_highlight_icon
         && let Some(highlight_icon) =
-            icon::from_icon(config.sidebar.unread_indicator.highlight_icon)
+            icon::from_icon(config.sidebar.highlight_indicator.icon)
     {
         Some((
             highlight_icon.style(theme::text::highlight_indicator),
@@ -1437,7 +1438,7 @@ fn internal_buffer_button<'a>(
 
     let (has_unread, can_mark_as_read) = match buffer {
         buffer::Internal::Highlights
-            if (config.sidebar.unread_indicator.show_on_open_buffers
+            if (config.sidebar.highlight_indicator.show_on_open_buffers
                 || open.is_none()) =>
         {
             (
@@ -1473,9 +1474,9 @@ fn internal_buffer_button<'a>(
         }
         buffer::Internal::Highlights => {
             let badge = if has_unread
-                && let Some(highlight_icon) = icon::from_icon(
-                    config.sidebar.unread_indicator.highlight_icon,
-                ) {
+                && let Some(highlight_icon) =
+                    icon::from_icon(config.sidebar.highlight_indicator.icon)
+            {
                 Some((
                     highlight_icon.style(theme::text::highlight_indicator),
                     dimensions.highlight_indicator_size,
@@ -1807,19 +1808,18 @@ impl From<&config::sidebar::Sidebar> for Dimensions {
                 config::sidebar::PrimaryIcon::Hidden => (0, 0, 0),
             };
 
-        let unread_indicator_size = if config.unread_indicator.has_unread_icon()
-        {
+        let unread_indicator_size = if config.unread_indicator.has_icon() {
             config.unread_indicator.icon_size
         } else {
             0
         };
 
-        let highlight_indicator_size =
-            if config.unread_indicator.has_unread_highlight_icon() {
-                config.unread_indicator.highlight_icon_size
-            } else {
-                0
-            };
+        let highlight_indicator_size = if config.highlight_indicator.has_icon()
+        {
+            config.highlight_indicator.icon_size
+        } else {
+            0
+        };
 
         Self {
             icon_size,


### PR DESCRIPTION
Restructure indicator settings to avoid populating `sidebar.unread_indicator` with too many `highlight_*` settings.

Also adds independent `title` and `show_on_open_buffers` settings for highlights.