### PR TITLE
Sound Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Fixed:
 - Reject overlong lines from the server connection instead of buffering them without bound
 - Do not panic when a server-supplied METADATA retry-after value would overflow the retry timer
 - Stop busy-looping on CPU when a DCC file-transfer peer closes its connection early
+- Only play one sound at a time (if two sounds would overlap, then the second sound is skipped)
+- Allow sound files to be symbolic links
 
 Changed:
 

--- a/data/src/audio.rs
+++ b/data/src/audio.rs
@@ -95,14 +95,16 @@ impl TryFrom<&str> for Internal {
 fn find_external_sound(sound: &str) -> Result<PathBuf, LoadError> {
     let sounds_dir = Config::sounds_dir();
 
-    for e in walkdir::WalkDir::new(sounds_dir.clone())
+    for dir_entry in walkdir::WalkDir::new(sounds_dir.clone())
+        .follow_links(true)
+        .max_depth(32)
         .into_iter()
         .filter_map(Result::ok)
     {
-        if e.metadata().is_ok_and(|data| data.is_file())
-            && e.file_name() == sound
+        if dir_entry.metadata().is_ok_and(|data| data.is_file())
+            && dir_entry.file_name() == sound
         {
-            return Ok(e.path().to_path_buf());
+            return Ok(dir_entry.path().to_path_buf());
         }
     }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,20 +1,23 @@
 # Configuration
 
-Halloy uses a TOML file for configuration called `config.toml`.  
-A default file is created when you launch Halloy for the first time. The location depends on your system:
+Halloy uses a TOML file for configuration called `config.toml`.  The specification for the configuration file format ([TOML](https://toml.io/)) can be found at [https://toml.io/](https://toml.io/).
 
-* Windows: `%AppData%\halloy`
-* Mac: `~/Library/Application Support/halloy` or `$HOME/.config/halloy`
-* Linux: `$XDG_CONFIG_HOME/halloy`, `$HOME/.config/halloy` or `$HOME/.var/app/org.squidowl.halloy/config` (Flatpak)
+A default file is created in the [configuration directory](#directory) when you launch Halloy for the first time.
 
 ::: tip
 Most configuration changes can be applied by reloading the configuration file from the sidebar menu, [keyboard shortcut](./configuration/keyboard.md), or the command bar
 :::
-
-The specification for the configuration file format ([TOML](https://toml.io/)) can be found at [https://toml.io/](https://toml.io/).
 
 See the following guides for example configurations:
 - [Example Server Configurations](./guides/example-server-configurations.md)
 - [Multiple Servers](./guides/multiple-servers.md)
 - [Connect with soju](./guides/connect-with-soju.md)
 - [Connect with ZNC](./guides/connect-with-znc.md)
+
+## Directory
+
+The location of the configuration directory depends on your system:
+
+* Windows: `%AppData%\halloy`
+* Mac: `~/Library/Application Support/halloy` or `$HOME/.config/halloy`
+* Linux: `$XDG_CONFIG_HOME/halloy`, `$HOME/.config/halloy` or `$HOME/.var/app/org.squidowl.halloy/config` (Flatpak)

--- a/docs/configuration/highlights.md
+++ b/docs/configuration/highlights.md
@@ -119,7 +119,7 @@ include = { channels = ["#halloy"] }
 Sound to play when notifying for a highlight. If not specified then the sound
 specified for highlight notifications will be used. Supports both built-in
 sounds, and external sound files (`mp3`, `ogg`, `flac` or `wav` placed inside
-the `sounds` folder within the configuration directory). See
+the `sounds` folder within the [configuration directory](/configuration#directory)). See
 [notifications](/configuration/notifications#sound) for a list of all built-in
 sounds.
 

--- a/docs/configuration/notifications.md
+++ b/docs/configuration/notifications.md
@@ -61,7 +61,7 @@ The following table shows all available built-in sounds
 
 Notification sound. Supports both built-in sounds, and external sound files
 (`mp3`, `ogg`, `flac` or `wav` placed inside the `sounds` folder within the
-configuration directory).
+[configuration directory](/configuration#directory)).
 
 ```toml
 # Type: string

--- a/docs/configuration/themes.md
+++ b/docs/configuration/themes.md
@@ -8,7 +8,7 @@ Theme settings for Halloy.
 `theme` is a root key, so it must be placed before every section.
 :::
 
-Specify the theme name(s) to use. The theme must correspond to a file in the `themes` folder of your Halloy configuration directory. For more details, see the [configuration overview](../configuration.md). The default theme in Halloy is [Ferra](https://github.com/casperstorm/ferra/).
+Specify the theme name(s) to use. The theme must correspond to a file in the `themes` folder of your Halloy [configuration directory](/configuration#directory). The default theme in Halloy is [Ferra](https://github.com/casperstorm/ferra/).
 
 When multiple themes are specified, Halloy will randomly select one each time the application starts. When a dynamic theme is used, Halloy will match the appearance of the OS.
 

--- a/docs/guides/custom-themes.md
+++ b/docs/guides/custom-themes.md
@@ -1,6 +1,6 @@
 # Custom themes
 
-To create a custom theme for Halloy, simply place a theme file (with a `.toml` extension) inside the `themes` folder within the configuration directory.
+To create a custom theme for Halloy, simply place a theme file (with a `.toml` extension) inside the `themes` folder within the [configuration directory](/configuration#directory).
 
 ```toml
 # Consider we have a theme called "foobar.toml" inside the themes folder.

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -5,12 +5,12 @@ use std::thread;
 use data::audio::Sound;
 use rodio::{Decoder, DeviceSinkBuilder, Player};
 
-pub fn play(sound: Sound) {
+pub fn play(sound: Sound) -> thread::JoinHandle<()> {
     thread::spawn(move || {
         if let Err(e) = _play(sound) {
             log::error!("Failed to play sound: {e}");
         }
-    });
+    })
 }
 
 fn _play(sound: Sound) -> Result<(), PlayError> {

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::thread;
 
 use chrono::{DateTime, TimeDelta, Utc};
 use data::audio::Sound;
@@ -88,6 +89,7 @@ pub struct Notifications {
     recent_notifications: HashMap<NotificationDelayKey, DateTime<Utc>>,
     sounds: HashMap<String, Sound>,
     sender: mpsc::Sender<Event>,
+    audio: Option<thread::JoinHandle<()>>,
 }
 
 impl Notifications {
@@ -101,6 +103,7 @@ impl Notifications {
                 recent_notifications: HashMap::new(),
                 sounds,
                 sender,
+                audio: None,
             },
             Task::stream(ReceiverStream::new(receiver)),
         )
@@ -576,8 +579,12 @@ impl Notifications {
         if let Some(sound) = sound_name
             .or(config.sound.as_deref())
             .and_then(|sound_name| self.sounds.get(sound_name))
+            && self
+                .audio
+                .as_ref()
+                .is_none_or(thread::JoinHandle::is_finished)
         {
-            audio::play(sound.clone());
+            self.audio = Some(audio::play(sound.clone()));
         }
     }
 }


### PR DESCRIPTION
Two small fixes for playing sounds:
- Allow sound files to be symbolic links (the maximum folder depth is capped to prevent searching the sound folder from taking too long)
- Prevent sound playback from overlapping;  skips any sound that would start while another is playing