### PR TITLE
Minor Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Fixed:
 - Stop busy-looping on CPU when a DCC file-transfer peer closes its connection early
 - Only play one sound at a time (if two sounds would overlap, then the second sound is skipped)
 - Allow sound files to be symbolic links
+- Queries specified in configuration correctly added to the sidebar
 
 Changed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ Changed:
 Thanks:
 
 - Contributions: @englut, @luca020400, @classabbyamp, @KaiKorla, @TheDcoder, @City-busz, @rtmongold, @Gelbpunkt
-- Bug reports: @luca020400, agent314
+- Bug reports: @luca020400, agent314, flooferland
 
 # 2026.7.2 (2026-06-08)
 

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -255,14 +255,9 @@ pub async fn overwrite(
         .await;
     }
 
-    let latest = &messages[messages.len().saturating_sub(MAX_MESSAGES)..];
+    let messages = write_messages(kind, messages).await?;
 
-    let path = path(kind).await?;
-    let compressed = compression::compress(&latest)?;
-
-    fs::write(path, &compressed).await?;
-
-    metadata::save(kind, latest, read_marker, chathistory_references).await?;
+    metadata::save(kind, messages, read_marker, chathistory_references).await?;
 
     Ok(())
 }
@@ -272,6 +267,8 @@ pub async fn append(
     seed: Option<Seed>,
     pending_messages: Vec<(Message, Option<LabeledResponseContext>)>,
     read_marker: Option<ReadMarker>,
+    max_triggers_unread: Option<DateTime<Utc>>,
+    max_triggers_highlight: Option<DateTime<Utc>>,
     chathistory_references: Option<MessageReferences>,
     pending_reactions: HashMap<message::Id, reaction::Pending>,
     pending_redactions: HashMap<message::Id, redaction::Pending>,
@@ -356,9 +353,37 @@ pub async fn append(
         },
     );
 
-    overwrite(kind, &all_messages, read_marker, chathistory_references)
-        .await
-        .map(|()| echo_events)
+    let _ = write_messages(kind, &all_messages).await?;
+
+    // Update metadata directly, without referencing all messages, since all
+    // messages have not been processed (and so do not have their blocked state
+    // set → blocked messages may incorrectly update metadata).
+
+    metadata::update(
+        kind,
+        read_marker,
+        max_triggers_unread,
+        max_triggers_highlight,
+        chathistory_references,
+    )
+    .await?;
+
+    Ok(echo_events)
+}
+
+async fn write_messages<'a>(
+    kind: &Kind,
+    messages: &'a [Message],
+) -> Result<&'a [Message], Error> {
+    let latest_messages =
+        &messages[messages.len().saturating_sub(MAX_MESSAGES)..];
+
+    let path = path(kind).await?;
+    let compressed = compression::compress(&latest_messages)?;
+
+    fs::write(path, &compressed).await?;
+
+    Ok(latest_messages)
 }
 
 pub async fn delete(kind: &Kind) -> Result<(), Error> {
@@ -793,6 +818,8 @@ impl History {
                 pending_messages,
                 last_updated_at,
                 read_marker,
+                max_triggers_unread,
+                max_triggers_highlight,
                 chathistory_references,
                 pending_reactions,
                 pending_redactions,
@@ -814,6 +841,8 @@ impl History {
                     let pending_messages = std::mem::take(pending_messages);
                     *flushing_messages = pending_messages.clone();
                     let read_marker = *read_marker;
+                    let max_triggers_unread = *max_triggers_unread;
+                    let max_triggers_highlight = *max_triggers_highlight;
                     let chathistory_references = chathistory_references.clone();
                     let pending_reactions = std::mem::take(pending_reactions);
                     *flushing_reactions = pending_reactions.clone();
@@ -829,6 +858,8 @@ impl History {
                                 seed,
                                 pending_messages,
                                 read_marker,
+                                max_triggers_unread,
+                                max_triggers_highlight,
                                 chathistory_references,
                                 pending_reactions,
                                 pending_redactions,
@@ -957,6 +988,8 @@ impl History {
                 kind,
                 pending_messages,
                 read_marker,
+                max_triggers_unread,
+                max_triggers_highlight,
                 chathistory_references,
                 pending_reactions,
                 pending_redactions,
@@ -966,6 +999,8 @@ impl History {
                 seed,
                 pending_messages,
                 read_marker,
+                max_triggers_unread,
+                max_triggers_highlight,
                 chathistory_references,
                 pending_reactions,
                 pending_redactions,

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -319,10 +319,20 @@ impl Manager {
     }
 
     pub fn open(&mut self, kind: history::Kind) {
-        self.data
+        let history = self
+            .data
             .map
             .entry(kind.clone())
             .or_insert(History::partial(kind.clone()));
+
+        match history {
+            History::Full { .. } => (),
+            History::Partial {
+                show_in_sidebar, ..
+            } => {
+                *show_in_sidebar = true;
+            }
+        }
     }
 
     pub fn exit(

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -173,10 +173,16 @@ impl Manager {
         match message {
             Message::LoadFull(kind, Ok(loaded)) => {
                 let len = loaded.messages.len();
-                self.data.load_full(kind.clone(), loaded);
-                log::debug!("loaded history for {kind}: {len} messages");
 
-                self.process_messages(kind.clone(), clients, buffer_config);
+                self.data.load_full(
+                    kind.clone(),
+                    loaded,
+                    FilterChain::borrow(&self.filters),
+                    clients,
+                    buffer_config,
+                );
+
+                log::debug!("loaded history for {kind}: {len} messages");
 
                 return Some(Event::Loaded(kind));
             }
@@ -1108,9 +1114,32 @@ impl Manager {
     }
 
     // Block, condense, and populate reply-previews for history's messages
-    pub fn process_messages(
+    pub fn process_history(
         &mut self,
         kind: history::Kind,
+        clients: &client::Map,
+        buffer_config: &config::Buffer,
+    ) {
+        if let Some(History::Full { messages, .. }) =
+            self.data.map.get_mut(&kind)
+        {
+            Manager::process_messages(
+                &kind,
+                messages,
+                FilterChain::borrow(&self.filters),
+                clients,
+                buffer_config,
+            );
+        }
+
+        log::debug!("processed messages in {kind}");
+    }
+
+    // Block, condense, and populate reply-previews for history's messages
+    fn process_messages(
+        kind: &history::Kind,
+        messages: &mut [message::Message],
+        filter_chain: FilterChain,
         clients: &client::Map,
         buffer_config: &config::Buffer,
     ) {
@@ -1119,202 +1148,182 @@ impl Manager {
             Condensable(NaiveDate),
             Singular,
         }
+        let mut last_seen = HashMap::<Nick, DateTime<Utc>>::new();
+        let mut last_away = HashMap::<Nick, DateTime<Utc>>::new();
 
-        if let Some(History::Full { messages, .. }) =
-            self.data.map.get_mut(&kind)
-        {
-            let mut last_seen = HashMap::<Nick, DateTime<Utc>>::new();
-            let mut last_away = HashMap::<Nick, DateTime<Utc>>::new();
+        messages.iter_mut().for_each(|message| {
+            message.blocked = false;
 
-            messages.iter_mut().for_each(|message| {
-                message.blocked = false;
+            if message.redaction.is_some()
+                && !buffer_config.redaction.display.is_visible()
+            {
+                message.blocked = true;
+            } else {
+                match message.target.source() {
+                    message::Source::Server(source) => {
+                        let server = if let Some(server) = kind.server() {
+                            Some(server)
+                        } else if let message::Target::Highlights {
+                            server,
+                            ..
+                        } = &message.target
+                        {
+                            Some(server)
+                        } else {
+                            None
+                        };
 
-                if message.redaction.is_some()
-                    && !buffer_config.redaction.display.is_visible()
-                {
-                    message.blocked = true;
-                } else {
-                    match message.target.source() {
-                        message::Source::Server(source) => {
-                            let server = if let Some(server) = kind.server() {
-                                Some(server)
-                            } else if let message::Target::Highlights {
-                                server,
-                                ..
-                            } = &message.target
-                            {
-                                Some(server)
-                            } else {
-                                None
-                            };
+                        let casemapping = clients
+                            .get_maybe_server_casemapping_or_default(server);
 
-                            let casemapping = clients
-                                .get_maybe_server_casemapping_or_default(
+                        // Check if target is included/excluded.
+                        let target_ref = match &message.target {
+                            message::Target::Channel { channel, .. }
+                            | message::Target::Highlights { channel, .. } => {
+                                Some(channel.as_target_ref())
+                            }
+
+                            message::Target::Query { query, .. } => {
+                                Some(query.as_target_ref())
+                            }
+                            message::Target::Server { .. }
+                            | message::Target::Logs { .. } => None,
+                        };
+
+                        let source_kind = source
+                            .as_ref()
+                            .map(message::source::server::Server::kind);
+
+                        if let Some(target_ref) = target_ref
+                            && let Some(server) = server
+                            && !buffer_config
+                                .server_messages
+                                .should_send_message(
+                                    source.as_ref(),
+                                    target_ref,
                                     server,
-                                );
-
-                            // Check if target is included/excluded.
-                            let target_ref = match &message.target {
-                                message::Target::Channel {
-                                    channel, ..
-                                }
-                                | message::Target::Highlights {
-                                    channel, ..
-                                } => Some(channel.as_target_ref()),
-
-                                message::Target::Query { query, .. } => {
-                                    Some(query.as_target_ref())
-                                }
-                                message::Target::Server { .. }
-                                | message::Target::Logs { .. } => None,
+                                    casemapping,
+                                )
+                        {
+                            message.blocked = true;
+                        } else if let Some(seconds) =
+                            buffer_config.server_messages.smart(source_kind)
+                        {
+                            let nick = match source
+                                .as_ref()
+                                .and_then(|source| source.nick())
+                            {
+                                Some(nick) => Some(nick.clone()),
+                                None => message.plain().and_then(|s| {
+                                    s.split(' ').nth(1).map(|nick| {
+                                        Nick::from_str(nick, casemapping)
+                                    })
+                                }),
                             };
 
-                            let source_kind = source
-                                .as_ref()
-                                .map(message::source::server::Server::kind);
+                            if let Some(nick) = nick {
+                                match source_kind {
+                                    Some(message::Kind::Away) => {
+                                        message.blocked = smart_filter_repeat(
+                                            message,
+                                            &seconds,
+                                            last_away.get(&nick),
+                                        );
 
-                            if let Some(target_ref) = target_ref
-                                && let Some(server) = server
-                                && !buffer_config
-                                    .server_messages
-                                    .should_send_message(
-                                        source.as_ref(),
-                                        target_ref,
-                                        server,
-                                        casemapping,
-                                    )
-                            {
-                                message.blocked = true;
-                            } else if let Some(seconds) =
-                                buffer_config.server_messages.smart(source_kind)
-                            {
-                                let nick = match source
-                                    .as_ref()
-                                    .and_then(|source| source.nick())
-                                {
-                                    Some(nick) => Some(nick.clone()),
-                                    None => message.plain().and_then(|s| {
-                                        s.split(' ').nth(1).map(|nick| {
-                                            Nick::from_str(nick, casemapping)
-                                        })
-                                    }),
-                                };
-
-                                if let Some(nick) = nick {
-                                    match source_kind {
-                                        Some(message::Kind::Away) => {
-                                            message.blocked =
-                                                smart_filter_repeat(
-                                                    message,
-                                                    &seconds,
-                                                    last_away.get(&nick),
-                                                );
-
-                                            if !message.blocked {
-                                                last_away.insert(
-                                                    nick.clone(),
-                                                    message.server_time,
-                                                );
-                                            }
+                                        if !message.blocked {
+                                            last_away.insert(
+                                                nick.clone(),
+                                                message.server_time,
+                                            );
                                         }
-                                        _ => {
-                                            message.blocked =
-                                                smart_filter_message(
-                                                    message,
-                                                    &seconds,
-                                                    last_seen.get(&nick),
-                                                );
-                                        }
+                                    }
+                                    _ => {
+                                        message.blocked = smart_filter_message(
+                                            message,
+                                            &seconds,
+                                            last_seen.get(&nick),
+                                        );
                                     }
                                 }
                             }
                         }
-                        crate::message::Source::User(message_user) => {
-                            last_seen.insert(
-                                message_user.nickname().to_owned(),
-                                message.server_time,
+                    }
+                    crate::message::Source::User(message_user) => {
+                        last_seen.insert(
+                            message_user.nickname().to_owned(),
+                            message.server_time,
+                        );
+                    }
+                    message::Source::Internal(
+                        message::source::Internal::Status(status),
+                    ) => {
+                        if !buffer_config.internal_messages.enabled(status) {
+                            message.blocked = true;
+                        } else if let Some(seconds) =
+                            buffer_config.internal_messages.smart(status)
+                        {
+                            message.blocked = smart_filter_internal_message(
+                                message, &seconds,
                             );
                         }
-                        message::Source::Internal(
-                            message::source::Internal::Status(status),
-                        ) => {
-                            if !buffer_config.internal_messages.enabled(status)
-                            {
-                                message.blocked = true;
-                            } else if let Some(seconds) =
-                                buffer_config.internal_messages.smart(status)
-                            {
-                                message.blocked = smart_filter_internal_message(
-                                    message, &seconds,
-                                );
-                            }
-                        }
-                        _ => (),
                     }
+                    _ => (),
                 }
-            });
+            }
+        });
 
-            let chain = FilterChain::borrow(&self.filters);
+        messages.iter_mut().for_each(|message| {
+            if message.blocked {
+                return;
+            }
 
-            messages.iter_mut().for_each(|message| {
-                if message.blocked {
-                    return;
+            filter_chain.filter_message_of_kind(message, kind);
+        });
+
+        messages
+            .iter_mut()
+            .filter(|message| !message.blocked)
+            .chunk_by(|message| {
+                if message.can_condense(&buffer_config.server_messages.condense)
+                {
+                    CondensationKey::Condensable(
+                        message.server_time.with_timezone(&Local).date_naive(),
+                    )
+                } else {
+                    CondensationKey::Singular
                 }
+            })
+            .into_iter()
+            .for_each(|(key, chunk)| match key {
+                CondensationKey::Condensable(_) => {
+                    let mut condensable_messages =
+                        chunk.collect::<Vec<&mut message::Message>>();
 
-                chain.filter_message_of_kind(message, &kind);
-            });
+                    let condensed_message = message::condense(
+                        &condensable_messages
+                            .iter()
+                            .map(|message| &**message)
+                            .collect::<Vec<&message::Message>>(),
+                        &buffer_config.server_messages.condense,
+                    );
 
-            messages
-                .iter_mut()
-                .filter(|message| !message.blocked)
-                .chunk_by(|message| {
-                    if message
-                        .can_condense(&buffer_config.server_messages.condense)
-                    {
-                        CondensationKey::Condensable(
-                            message
-                                .server_time
-                                .with_timezone(&Local)
-                                .date_naive(),
-                        )
-                    } else {
-                        CondensationKey::Singular
-                    }
-                })
-                .into_iter()
-                .for_each(|(key, chunk)| match key {
-                    CondensationKey::Condensable(_) => {
-                        let mut condensable_messages =
-                            chunk.collect::<Vec<&mut message::Message>>();
-
-                        let condensed_message = message::condense(
-                            &condensable_messages
-                                .iter()
-                                .map(|message| &**message)
-                                .collect::<Vec<&message::Message>>(),
-                            &buffer_config.server_messages.condense,
-                        );
-
-                        condensable_messages
-                            .iter_mut()
-                            .for_each(|message| message.condensed = None);
-
-                        if let Some(first_message) =
-                            condensable_messages.first_mut()
-                        {
-                            first_message.condensed = condensed_message;
-                        }
-                    }
-                    CondensationKey::Singular => chunk
-                        .collect::<Vec<&mut message::Message>>()
+                    condensable_messages
                         .iter_mut()
-                        .for_each(|message| message.condensed = None),
-                });
+                        .for_each(|message| message.condensed = None);
 
-            populate_reply_previews(messages);
-        }
+                    if let Some(first_message) =
+                        condensable_messages.first_mut()
+                    {
+                        first_message.condensed = condensed_message;
+                    }
+                }
+                CondensationKey::Singular => chunk
+                    .collect::<Vec<&mut message::Message>>()
+                    .iter_mut()
+                    .for_each(|message| message.condensed = None),
+            });
 
-        log::debug!("processed messages in {kind}");
+        populate_reply_previews(messages);
     }
 
     pub fn renormalize_messages(
@@ -1367,13 +1376,28 @@ struct Data {
 }
 
 impl Data {
-    fn load_full(&mut self, kind: history::Kind, data: history::Loaded) {
+    fn load_full(
+        &mut self,
+        kind: history::Kind,
+        data: history::Loaded,
+        filter_chain: FilterChain,
+        clients: &client::Map,
+        buffer_config: &config::Buffer,
+    ) {
         use std::collections::hash_map;
 
         let history::Loaded {
             mut messages,
             metadata,
         } = data;
+
+        Manager::process_messages(
+            &kind,
+            &mut messages,
+            filter_chain,
+            clients,
+            buffer_config,
+        );
 
         match self.map.entry(kind.clone()) {
             hash_map::Entry::Occupied(mut entry) => match entry.get_mut() {

--- a/data/src/history/metadata.rs
+++ b/data/src/history/metadata.rs
@@ -144,6 +144,27 @@ pub async fn save(
     Ok(())
 }
 
+pub async fn update(
+    kind: &Kind,
+    read_marker: Option<ReadMarker>,
+    max_triggers_unread: Option<DateTime<Utc>>,
+    max_triggers_highlight: Option<DateTime<Utc>>,
+    chathistory_references: Option<MessageReferences>,
+) -> Result<(), Error> {
+    let bytes = serde_json::to_vec(&Metadata {
+        read_marker,
+        last_triggers_unread: max_triggers_unread,
+        last_triggers_highlight: max_triggers_highlight,
+        chathistory_references,
+    })?;
+
+    let path = path(kind).await?;
+
+    fs::write(path, &bytes).await?;
+
+    Ok(())
+}
+
 pub async fn update_chathistory_references(
     kind: &Kind,
     chathistory_references: &MessageReferences,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -10,6 +10,8 @@ use data::user::Nick;
 use data::{
     Config, Image, buffer, file_transfer, history, input, message, preview,
 };
+use iced::advanced::widget;
+use iced::advanced::widget::operation::focusable;
 use iced::{Size, Task};
 
 pub use self::channel::Channel;
@@ -753,7 +755,7 @@ impl Buffer {
             | Buffer::FileTransfers(_)
             | Buffer::Logs(_)
             | Buffer::Highlights(_)
-            | Buffer::ConfigEditor(_) => Task::none(),
+            | Buffer::ConfigEditor(_) => widget::operate(focusable::unfocus()),
             Buffer::Channel(channel) => channel.focus().map(Message::Channel),
             Buffer::Server(server) => server.focus().map(Message::Server),
             Buffer::Query(query) => query.focus().map(Message::Query),

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -289,8 +289,11 @@ impl Dashboard {
             .collect();
 
         open_pane_kinds.into_iter().for_each(|kind| {
-            self.history.process_messages(kind, clients, buffer_config);
+            self.history.process_history(kind, clients, buffer_config);
         });
+
+        // TODO: Reprocess unloaded history to determine/update metadata?
+        // Re-visit after history storage is transitioned to SQL.
     }
 
     pub fn renormalize_history(


### PR DESCRIPTION
A couple minor fixes:
- Fix regression where queries specified in configuration were not added to the sidebar
- Fix in focus handling, ensuring that focus is not left with the previous pane when a new pane is opened
- Skip blocked messages when updating history metadata on close (prevent unread indicator appearing for blocked messages after closing then re-opening Halloy)