### PR TITLE
iced Update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3139,7 +3139,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=81579e865efad8aca9ab2489f282487b536217e7#81579e865efad8aca9ab2489f282487b536217e7"
+source = "git+https://github.com/squidowl/iced?rev=f1ae74c3d07585dae2a4c5d6951d71db59c815a1#f1ae74c3d07585dae2a4c5d6951d71db59c815a1"
 dependencies = [
  "iced_core",
  "iced_debug",
@@ -3157,7 +3157,7 @@ dependencies = [
 [[package]]
 name = "iced_beacon"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=81579e865efad8aca9ab2489f282487b536217e7#81579e865efad8aca9ab2489f282487b536217e7"
+source = "git+https://github.com/squidowl/iced?rev=f1ae74c3d07585dae2a4c5d6951d71db59c815a1#f1ae74c3d07585dae2a4c5d6951d71db59c815a1"
 dependencies = [
  "bincode 1.3.3",
  "futures",
@@ -3172,7 +3172,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=81579e865efad8aca9ab2489f282487b536217e7#81579e865efad8aca9ab2489f282487b536217e7"
+source = "git+https://github.com/squidowl/iced?rev=f1ae74c3d07585dae2a4c5d6951d71db59c815a1#f1ae74c3d07585dae2a4c5d6951d71db59c815a1"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
@@ -3191,7 +3191,7 @@ dependencies = [
 [[package]]
 name = "iced_debug"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=81579e865efad8aca9ab2489f282487b536217e7#81579e865efad8aca9ab2489f282487b536217e7"
+source = "git+https://github.com/squidowl/iced?rev=f1ae74c3d07585dae2a4c5d6951d71db59c815a1#f1ae74c3d07585dae2a4c5d6951d71db59c815a1"
 dependencies = [
  "iced_beacon",
  "iced_core",
@@ -3202,7 +3202,7 @@ dependencies = [
 [[package]]
 name = "iced_devtools"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=81579e865efad8aca9ab2489f282487b536217e7#81579e865efad8aca9ab2489f282487b536217e7"
+source = "git+https://github.com/squidowl/iced?rev=f1ae74c3d07585dae2a4c5d6951d71db59c815a1#f1ae74c3d07585dae2a4c5d6951d71db59c815a1"
 dependencies = [
  "iced_debug",
  "iced_program",
@@ -3213,7 +3213,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=81579e865efad8aca9ab2489f282487b536217e7#81579e865efad8aca9ab2489f282487b536217e7"
+source = "git+https://github.com/squidowl/iced?rev=f1ae74c3d07585dae2a4c5d6951d71db59c815a1#f1ae74c3d07585dae2a4c5d6951d71db59c815a1"
 dependencies = [
  "futures",
  "iced_core",
@@ -3227,7 +3227,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=81579e865efad8aca9ab2489f282487b536217e7#81579e865efad8aca9ab2489f282487b536217e7"
+source = "git+https://github.com/squidowl/iced?rev=f1ae74c3d07585dae2a4c5d6951d71db59c815a1#f1ae74c3d07585dae2a4c5d6951d71db59c815a1"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
@@ -3247,7 +3247,7 @@ dependencies = [
 [[package]]
 name = "iced_highlighter"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=81579e865efad8aca9ab2489f282487b536217e7#81579e865efad8aca9ab2489f282487b536217e7"
+source = "git+https://github.com/squidowl/iced?rev=f1ae74c3d07585dae2a4c5d6951d71db59c815a1#f1ae74c3d07585dae2a4c5d6951d71db59c815a1"
 dependencies = [
  "iced_core",
  "two-face",
@@ -3256,7 +3256,7 @@ dependencies = [
 [[package]]
 name = "iced_program"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=81579e865efad8aca9ab2489f282487b536217e7#81579e865efad8aca9ab2489f282487b536217e7"
+source = "git+https://github.com/squidowl/iced?rev=f1ae74c3d07585dae2a4c5d6951d71db59c815a1#f1ae74c3d07585dae2a4c5d6951d71db59c815a1"
 dependencies = [
  "iced_graphics",
  "iced_runtime",
@@ -3265,7 +3265,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=81579e865efad8aca9ab2489f282487b536217e7#81579e865efad8aca9ab2489f282487b536217e7"
+source = "git+https://github.com/squidowl/iced?rev=f1ae74c3d07585dae2a4c5d6951d71db59c815a1#f1ae74c3d07585dae2a4c5d6951d71db59c815a1"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -3277,7 +3277,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=81579e865efad8aca9ab2489f282487b536217e7#81579e865efad8aca9ab2489f282487b536217e7"
+source = "git+https://github.com/squidowl/iced?rev=f1ae74c3d07585dae2a4c5d6951d71db59c815a1#f1ae74c3d07585dae2a4c5d6951d71db59c815a1"
 dependencies = [
  "bytes",
  "iced_core",
@@ -3288,7 +3288,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=81579e865efad8aca9ab2489f282487b536217e7#81579e865efad8aca9ab2489f282487b536217e7"
+source = "git+https://github.com/squidowl/iced?rev=f1ae74c3d07585dae2a4c5d6951d71db59c815a1#f1ae74c3d07585dae2a4c5d6951d71db59c815a1"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -3305,7 +3305,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=81579e865efad8aca9ab2489f282487b536217e7#81579e865efad8aca9ab2489f282487b536217e7"
+source = "git+https://github.com/squidowl/iced?rev=f1ae74c3d07585dae2a4c5d6951d71db59c815a1#f1ae74c3d07585dae2a4c5d6951d71db59c815a1"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
@@ -3324,7 +3324,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=81579e865efad8aca9ab2489f282487b536217e7#81579e865efad8aca9ab2489f282487b536217e7"
+source = "git+https://github.com/squidowl/iced?rev=f1ae74c3d07585dae2a4c5d6951d71db59c815a1#f1ae74c3d07585dae2a4c5d6951d71db59c815a1"
 dependencies = [
  "iced_highlighter",
  "iced_renderer",
@@ -3340,7 +3340,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=81579e865efad8aca9ab2489f282487b536217e7#81579e865efad8aca9ab2489f282487b536217e7"
+source = "git+https://github.com/squidowl/iced?rev=f1ae74c3d07585dae2a4c5d6951d71db59c815a1#f1ae74c3d07585dae2a4c5d6951d71db59c815a1"
 dependencies = [
  "arboard",
  "iced_debug",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,9 +167,9 @@ embed-resource = "3.0.2"
 windows_exe_info = "0.4"
 
 [patch.crates-io]
-iced = { git = "https://github.com/squidowl/iced", rev = "81579e865efad8aca9ab2489f282487b536217e7" }
-iced_core = { git = "https://github.com/squidowl/iced", rev = "81579e865efad8aca9ab2489f282487b536217e7" }
-iced_wgpu = { git = "https://github.com/squidowl/iced", rev = "81579e865efad8aca9ab2489f282487b536217e7" }
+iced = { git = "https://github.com/squidowl/iced", rev = "f1ae74c3d07585dae2a4c5d6951d71db59c815a1" }
+iced_core = { git = "https://github.com/squidowl/iced", rev = "f1ae74c3d07585dae2a4c5d6951d71db59c815a1" }
+iced_wgpu = { git = "https://github.com/squidowl/iced", rev = "f1ae74c3d07585dae2a4c5d6951d71db59c815a1" }
 
 [profile.packaging]
 inherits = "release"


### PR DESCRIPTION
Pulls in a missing commit from the previous `arboard-full-patch` branch (fixes a regression in input selection).  (Also re-orders the patch branch commits a bit to group commits by feature).