### PR TITLE
Do not reconnect when the server closes the connection after a requested quit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Fixed:
 - Only play one sound at a time (if two sounds would overlap, then the second sound is skipped)
 - Allow sound files to be symbolic links
 - Queries specified in configuration correctly added to the sidebar
+- Do not reconnect automatically when the server closes the connection in response to a requested quit
 
 Changed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ Changed:
 
 Thanks:
 
-- Contributions: @englut, @luca020400, @classabbyamp, @KaiKorla, @TheDcoder, @City-busz, @rtmongold, @Gelbpunkt
+- Contributions: @englut, @luca020400, @classabbyamp, @KaiKorla, @TheDcoder, @City-busz, @rtmongold, @Gelbpunkt, @zsigisti
 - Bug reports: @luca020400, agent314, flooferland, @englut
 
 # 2026.7.2 (2026-06-08)

--- a/data/src/stream.rs
+++ b/data/src/stream.rs
@@ -351,42 +351,20 @@ async fn _run(
                         log::warn!("message decoding failed: {e}");
                     }
                     Input::IrcMessage(Err(e)) => {
-                        if quit_requested.is_some() {
-                            let _ =
-                                sender.unbounded_send(Update::Disconnected {
-                                    server: server.clone(),
-                                    is_initial,
-                                    error: None,
-                                    sent_time: Utc::now(),
-                                });
-
-                            // If QUIT was requested, then the server closing
-                            // the connection is a valid acknowledgement as
-                            // well, so don't reconnect
-                            state = State::Disconnected {
-                                autoconnect: false,
-                                retry: time::interval_at(
-                                    Instant::now() + config.reconnect_delay,
-                                    config.reconnect_delay,
-                                ),
-                            };
-                        } else {
-                            log::info!("[{server}] disconnected: {e}");
-                            let _ =
-                                sender.unbounded_send(Update::Disconnected {
-                                    server: server.clone(),
-                                    is_initial,
-                                    error: Some(e.to_string()),
-                                    sent_time: Utc::now(),
-                                });
-                            state = State::Disconnected {
-                                autoconnect: true,
-                                retry: time::interval_at(
-                                    Instant::now() + config.reconnect_delay,
-                                    config.reconnect_delay,
-                                ),
-                            };
-                        }
+                        log::info!("[{server}] disconnected: {e}");
+                        let _ = sender.unbounded_send(Update::Disconnected {
+                            server: server.clone(),
+                            is_initial,
+                            error: Some(e.to_string()),
+                            sent_time: Utc::now(),
+                        });
+                        state = State::Disconnected {
+                            autoconnect: quit_requested.is_none(),
+                            retry: time::interval_at(
+                                Instant::now() + config.reconnect_delay,
+                                config.reconnect_delay,
+                            ),
+                        };
                     }
                     Input::Batch(messages) => {
                         let _ = sender.unbounded_send(
@@ -430,7 +408,7 @@ async fn _run(
                             sent_time: Utc::now(),
                         });
                         state = State::Disconnected {
-                            autoconnect: true,
+                            autoconnect: quit_requested.is_none(),
                             retry: time::interval_at(
                                 Instant::now() + config.reconnect_delay,
                                 config.reconnect_delay,

--- a/data/src/stream.rs
+++ b/data/src/stream.rs
@@ -351,20 +351,42 @@ async fn _run(
                         log::warn!("message decoding failed: {e}");
                     }
                     Input::IrcMessage(Err(e)) => {
-                        log::info!("[{server}] disconnected: {e}");
-                        let _ = sender.unbounded_send(Update::Disconnected {
-                            server: server.clone(),
-                            is_initial,
-                            error: Some(e.to_string()),
-                            sent_time: Utc::now(),
-                        });
-                        state = State::Disconnected {
-                            autoconnect: true,
-                            retry: time::interval_at(
-                                Instant::now() + config.reconnect_delay,
-                                config.reconnect_delay,
-                            ),
-                        };
+                        if quit_requested.is_some() {
+                            let _ =
+                                sender.unbounded_send(Update::Disconnected {
+                                    server: server.clone(),
+                                    is_initial,
+                                    error: None,
+                                    sent_time: Utc::now(),
+                                });
+
+                            // If QUIT was requested, then the server closing
+                            // the connection is a valid acknowledgement as
+                            // well, so don't reconnect
+                            state = State::Disconnected {
+                                autoconnect: false,
+                                retry: time::interval_at(
+                                    Instant::now() + config.reconnect_delay,
+                                    config.reconnect_delay,
+                                ),
+                            };
+                        } else {
+                            log::info!("[{server}] disconnected: {e}");
+                            let _ =
+                                sender.unbounded_send(Update::Disconnected {
+                                    server: server.clone(),
+                                    is_initial,
+                                    error: Some(e.to_string()),
+                                    sent_time: Utc::now(),
+                                });
+                            state = State::Disconnected {
+                                autoconnect: true,
+                                retry: time::interval_at(
+                                    Instant::now() + config.reconnect_delay,
+                                    config.reconnect_delay,
+                                ),
+                            };
+                        }
                     }
                     Input::Batch(messages) => {
                         let _ = sender.unbounded_send(


### PR DESCRIPTION
When a quit is requested, Halloy waits for the server to acknowledge it. An `ERROR` reply is already handled (`quit_requested` is checked and autoconnect is disabled), but many servers just close the connection after `QUIT`, or the close beats the `ERROR` reply. That path went through the generic connection-error arm, which unconditionally re-enabled autoconnect — so a manual quit showed a "connection lost" error and then reconnected a few seconds later.

The connection-error arm now checks `quit_requested` the same way the `ERROR` arm does: treat the close as a valid acknowledgement, report a clean disconnect, and don't reconnect.

A clean EOF without an error was already covered by the quit-request timeout, so this only changes the case where the closing connection surfaces as an error (connection reset and the like).

Closes #2126

Note: this touches the same match arm as #2181 refactors (which keeps `autoconnect = true` there), so whichever lands second will need a trivial rebase.