### PR TITLE
Minor IRCv3 Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Added:
 - New `sidebar.highlight_indicator.title`, `sidebar.highlight_indicator.show_on_open_buffers`, `sidebar.highlight_indicator.exclude`, and `sidebar.highlight_indicator.include` settings for independent highlight control
 - Context menu on channel links
 - Shortcuts displayed in pane button tooltips (where available/configured)
+- `servers.<name>.do_not_request` can be specified to prevent IRCv3 capability requests (e.g. `servers.<name>.do_not_request = [ "labeled-response" ]` will prevent [labeled-response](https://ircv3.net/specs/extensions/labeled-response) from being requested from the server)
 
 Fixed:
 
@@ -54,6 +55,7 @@ Changed:
 - Renamed `sidebar.font_size` → `sidebar.secondary_font_size` to reflect its relationship to `sidebar.primary_font_size`
 - Renamed `actions.buffer.local` → `actions.buffer.open_internal` to match naming convention used elsewhere
 - Renamed `actions.buffer.click_username` to `actions.buffer.click_nickname` for more consistent terminology
+- Renamed `servers.<name>.chathistory` to `servers.<name>.automated_chathistory`, and it now controls whether chathistory requests are made automatically instead of controlling whether the chathistory capability is requested (see `servers.<name>.do_not_request` for controlling whether the capability is requested)
 - Moved functionality from `buffer.nickname.click` → `actions.buffer.click_nickname` and `buffer.channel.nicklist.click` → `actions.nicklist.click_nickname`
 - Clicking on a message expanded out of a condensed message will always contract it (configurable via `actions.only_contract_expanded_message`)
 - Windows release artifacts are signed using SignPath

--- a/data/src/capabilities.rs
+++ b/data/src/capabilities.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::string::ToString;
@@ -5,6 +6,7 @@ use std::sync::LazyLock;
 
 use chrono::{DateTime, TimeDelta, Utc};
 use irc::proto::{self, Tags, command, format};
+use serde::Deserialize;
 
 use crate::message::formatting::{Modifier, update_formatting_with_modifier};
 use crate::{Target, User, config, message};
@@ -16,7 +18,8 @@ pub static DEFAULT: LazyLock<Capabilities> =
 // Halloy will request when available.  When adding new IRCv3 capabilities to
 // Halloy they should be added to this enum (Capability), Capability::from_str,
 // and Capabilities::create_requested.
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum Capability {
     AccountNotify,
     AwayNotify,
@@ -279,7 +282,11 @@ pub struct Capabilities {
 impl Capabilities {
     pub fn acknowledge(&mut self, caps: impl Iterator<Item = String>) {
         for cap in caps {
-            if let Ok(cap) = Capability::from_str(cap.as_str()) {
+            if let Some(cap) = cap.as_str().strip_prefix('-') {
+                if let Ok(cap) = Capability::from_str(cap) {
+                    self.acknowledged.remove(&cap);
+                }
+            } else if let Ok(cap) = Capability::from_str(cap.as_str()) {
                 self.acknowledged.insert(cap);
             }
         }
@@ -289,175 +296,279 @@ impl Capabilities {
         self.acknowledged.contains(&cap)
     }
 
-    pub fn create_requested(
-        &mut self,
+    fn create_request(
+        &self,
+        capability_str: &'static str,
+        requirements: &[&'static str],
+        available: &HashMap<String, String>,
         config: &config::Server,
-    ) -> Vec<&'static str> {
+    ) -> Option<Cow<'static, str>> {
+        let capability_enum = Capability::from_str(capability_str).ok()?;
+
+        if available.contains_key(capability_str)
+            && requirements.iter().all(|requirement_str| {
+                if let Ok(requirement_enum) =
+                    Capability::from_str(requirement_str)
+                {
+                    (available.contains_key(*requirement_str)
+                        || self.acknowledged(requirement_enum))
+                        && !config.do_not_request.contains(&requirement_enum)
+                } else {
+                    false
+                }
+            })
+        {
+            match capability_enum {
+                Capability::Multiline => {
+                    if available.get(capability_str).is_none_or(|multiline| {
+                        MultilineLimits::from_str(multiline).is_err()
+                    }) {
+                        return None;
+                    }
+                }
+                Capability::AccountNotify
+                | Capability::AwayNotify
+                | Capability::Batch
+                | Capability::BouncerNetworks
+                | Capability::Chathistory
+                | Capability::Chghost
+                | Capability::EchoMessage
+                | Capability::EventPlayback
+                | Capability::ExtendedJoin
+                | Capability::ExtendedMonitor
+                | Capability::InviteNotify
+                | Capability::LabeledResponse
+                | Capability::MessageTags
+                | Capability::MessageRedaction
+                | Capability::MultiPrefix
+                | Capability::Metadata
+                | Capability::NoImplicitNames
+                | Capability::ReadMarker
+                | Capability::Sasl
+                | Capability::ServerTime
+                | Capability::Setname
+                | Capability::UserhostInNames
+                | Capability::Whoami => (),
+            }
+
+            if !config.do_not_request.contains(&capability_enum)
+                && !self.acknowledged(capability_enum)
+            {
+                return Some(capability_str.into());
+            } else if config.do_not_request.contains(&capability_enum)
+                && self.acknowledged(capability_enum)
+            {
+                return Some(format!("-{capability_str}").into());
+            }
+        }
+
+        None
+    }
+
+    fn create_requested(
+        &self,
+        available: &HashMap<String, String>,
+        config: &config::Server,
+    ) -> Vec<Cow<'static, str>> {
         let mut requested = vec![];
 
-        if self.pending.contains_key("invite-notify")
-            && !self.acknowledged(Capability::InviteNotify)
+        if let Some(request) =
+            self.create_request("invite-notify", &[], available, config)
         {
-            requested.push("invite-notify");
+            requested.push(request);
         }
 
-        if self.pending.contains_key("userhost-in-names")
-            && !self.acknowledged(Capability::UserhostInNames)
+        if let Some(request) =
+            self.create_request("userhost-in-names", &[], available, config)
         {
-            requested.push("userhost-in-names");
+            requested.push(request);
         }
 
-        if self.pending.contains_key("away-notify")
-            && !self.acknowledged(Capability::AwayNotify)
+        if let Some(request) =
+            self.create_request("away-notify", &[], available, config)
         {
-            requested.push("away-notify");
+            requested.push(request);
         }
 
-        if self.pending.contains_key("message-tags")
-            && !self.acknowledged(Capability::MessageTags)
+        if let Some(request) =
+            self.create_request("message-tags", &[], available, config)
         {
-            requested.push("message-tags");
+            requested.push(request);
         }
 
-        if self.pending.contains_key("draft/message-redaction")
-            && !self.acknowledged(Capability::MessageRedaction)
-        {
-            requested.push("draft/message-redaction");
+        if let Some(request) = self.create_request(
+            "draft/message-redaction",
+            &[],
+            available,
+            config,
+        ) {
+            requested.push(request);
         }
 
-        if self.pending.contains_key("server-time")
-            && !self.acknowledged(Capability::ServerTime)
+        if let Some(request) =
+            self.create_request("server-time", &[], available, config)
         {
-            requested.push("server-time");
+            requested.push(request);
         }
 
-        if self.pending.contains_key("chghost")
-            && !self.acknowledged(Capability::Chghost)
+        if let Some(request) =
+            self.create_request("chghost", &[], available, config)
         {
-            requested.push("chghost");
+            requested.push(request);
         }
 
-        if self.pending.contains_key("extended-monitor")
-            && !self.acknowledged(Capability::ExtendedMonitor)
+        if let Some(request) =
+            self.create_request("extended-monitor", &[], available, config)
         {
-            requested.push("extended-monitor");
+            requested.push(request);
         }
 
-        if self.pending.contains_key("account-notify")
-            || self.acknowledged(Capability::AccountNotify)
-        {
-            if !self.acknowledged(Capability::AccountNotify) {
-                requested.push("account-notify");
-            }
-
-            if self.pending.contains_key("extended-join")
-                && !self.acknowledged(Capability::ExtendedJoin)
-            {
-                requested.push("extended-join");
-            }
+        if let Some(request) = self.create_request(
+            "draft/message-redaction",
+            &[],
+            available,
+            config,
+        ) {
+            requested.push(request);
         }
 
-        if self.pending.contains_key("batch")
-            || self.acknowledged(Capability::Batch)
+        if let Some(request) =
+            self.create_request("account-notify", &[], available, config)
         {
-            if !self.acknowledged(Capability::Batch) {
-                requested.push("batch");
-            }
-
-            // We require batch for chathistory support
-            if (self.pending.contains_key("draft/chathistory")
-                && config.chathistory)
-                || self.acknowledged(Capability::Chathistory)
-            {
-                if !self.acknowledged(Capability::Chathistory) {
-                    requested.push("draft/chathistory");
-                }
-
-                if self.pending.contains_key("draft/event-playback")
-                    && !self.acknowledged(Capability::EventPlayback)
-                {
-                    requested.push("draft/event-playback");
-                }
-            }
+            requested.push(request);
         }
 
-        if self.pending.contains_key("labeled-response")
-            && !self.acknowledged(Capability::LabeledResponse)
-        {
-            requested.push("labeled-response");
+        if let Some(request) = self.create_request(
+            "extended-join",
+            &["account-notify"],
+            available,
+            config,
+        ) {
+            requested.push(request);
         }
 
-        if self.pending.contains_key("echo-message")
-            && !self.acknowledged(Capability::EchoMessage)
+        if let Some(request) =
+            self.create_request("batch", &[], available, config)
         {
-            requested.push("echo-message");
+            requested.push(request);
         }
 
-        if self.pending.contains_key("multi-prefix")
-            && !self.acknowledged(Capability::MultiPrefix)
-        {
-            requested.push("multi-prefix");
+        if let Some(request) = self.create_request(
+            "draft/chathistory",
+            &["batch"],
+            available,
+            config,
+        ) {
+            requested.push(request);
         }
 
-        if self.pending.contains_key("draft/read-marker")
-            && !self.acknowledged(Capability::ReadMarker)
-        {
-            requested.push("draft/read-marker");
+        if let Some(request) = self.create_request(
+            "draft/event-playback",
+            &["batch", "draft/chathistory"],
+            available,
+            config,
+        ) {
+            requested.push(request);
         }
 
-        if self.pending.contains_key("setname")
-            && !self.acknowledged(Capability::Setname)
+        if let Some(request) =
+            self.create_request("labeled-response", &[], available, config)
         {
-            requested.push("setname");
+            requested.push(request);
         }
 
-        if self.pending.contains_key("soju.im/bouncer-networks")
-            && !self.acknowledged(Capability::BouncerNetworks)
+        if let Some(request) =
+            self.create_request("echo-message", &[], available, config)
         {
-            requested.push("soju.im/bouncer-networks");
+            requested.push(request);
         }
 
-        if self.pending.iter().any(|(cap, _)| cap.starts_with("sasl"))
-            && !self.acknowledged(Capability::Sasl)
+        if let Some(request) =
+            self.create_request("multi-prefix", &[], available, config)
         {
-            requested.push("sasl");
+            requested.push(request);
         }
 
-        if let Some(multiline) = self.pending.get("draft/multiline")
-            && !self.acknowledged(Capability::Multiline)
-            && MultilineLimits::from_str(multiline).is_ok()
+        if let Some(request) =
+            self.create_request("draft/read-marker", &[], available, config)
         {
-            requested.push("draft/multiline");
+            requested.push(request);
+        }
+
+        if let Some(request) =
+            self.create_request("setname", &[], available, config)
+        {
+            requested.push(request);
+        }
+
+        if let Some(request) = self.create_request(
+            "soju.im/bouncer-networks",
+            &[],
+            available,
+            config,
+        ) {
+            requested.push(request);
+        }
+
+        if let Some(request) =
+            self.create_request("sasl", &[], available, config)
+        {
+            requested.push(request);
+        }
+
+        if let Some(request) =
+            self.create_request("draft/multiline", &[], available, config)
+        {
+            requested.push(request);
         }
 
         // TODO(quaff): remove `draft/no-implicit-names` support when ergo & soju have both been upgraded
-        if self.pending.contains_key("no-implicit-names")
-            && !self.acknowledged(Capability::NoImplicitNames)
+        if let Some(request) =
+            self.create_request("no-implicit-names", &[], available, config)
         {
-            requested.push("no-implicit-names");
-        } else if self.pending.contains_key("draft/no-implicit-names")
-            && !self.acknowledged(Capability::NoImplicitNames)
-        {
-            requested.push("draft/no-implicit-names");
+            requested.push(request);
+        } else if let Some(request) = self.create_request(
+            "draft/no-implicit-names",
+            &[],
+            available,
+            config,
+        ) {
+            requested.push(request);
         }
 
-        if self.pending.contains_key("draft/metadata-2")
-            && !self.acknowledged(Capability::Metadata)
+        if let Some(request) =
+            self.create_request("draft/metadata-2", &[], available, config)
         {
-            requested.push("draft/metadata-2");
+            requested.push(request);
         }
 
-        if self.pending.contains_key("draft/whoami")
-            && !self.acknowledged(Capability::Whoami)
+        if let Some(request) =
+            self.create_request("draft/whoami", &[], available, config)
         {
-            requested.push("draft/whoami");
+            requested.push(request);
         }
+
+        requested
+    }
+
+    pub fn create_new_requested(
+        &mut self,
+        config: &config::Server,
+    ) -> Vec<Cow<'static, str>> {
+        let requested = self.create_requested(&self.pending, config);
 
         for (cap, val) in self.pending.drain() {
             self.listed.insert(cap, val);
         }
 
         requested
+    }
+
+    pub fn create_update_requested(
+        &self,
+        config: &config::Server,
+    ) -> Vec<Cow<'static, str>> {
+        self.create_requested(&self.listed, config)
     }
 
     pub fn delete(&mut self, caps: impl Iterator<Item = String>) {

--- a/data/src/capabilities.rs
+++ b/data/src/capabilities.rs
@@ -41,6 +41,7 @@ pub enum Capability {
     ServerTime,
     Setname,
     UserhostInNames,
+    Whoami,
 }
 
 impl FromStr for Capability {
@@ -56,6 +57,7 @@ impl FromStr for Capability {
             "draft/event-playback" => Ok(Self::EventPlayback),
             "draft/multiline" => Ok(Self::Multiline),
             "draft/read-marker" => Ok(Self::ReadMarker),
+            "draft/whoami" => Ok(Self::Whoami),
             "echo-message" => Ok(Self::EchoMessage),
             "extended-join" => Ok(Self::ExtendedJoin),
             "extended-monitor" => Ok(Self::ExtendedMonitor),
@@ -443,6 +445,12 @@ impl Capabilities {
             && !self.acknowledged(Capability::Metadata)
         {
             requested.push("draft/metadata-2");
+        }
+
+        if self.pending.contains_key("draft/whoami")
+            && !self.acknowledged(Capability::Whoami)
+        {
+            requested.push("draft/whoami");
         }
 
         for (cap, val) in self.pending.drain() {

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1073,6 +1073,9 @@ impl Client {
                                     ))
                                 })
                             }
+                            Some("labeled-response") => {
+                                Some(BatchKind::LabeledResponse)
+                            }
                             _ => None,
                         };
 
@@ -1201,6 +1204,7 @@ impl Client {
                                         _,
                                     ))
                                     | Some(BatchKind::ZncPlayback(_))
+                                    | Some(BatchKind::LabeledResponse)
                                     | None => (),
                                 };
 
@@ -1233,9 +1237,9 @@ impl Client {
                             self.handle_multiline(message, batch_tag);
                             vec![]
                         }
-                        Some(BatchKind::ChathistoryTargets) | None => {
-                            self.handle(message, context, config)?
-                        }
+                        Some(BatchKind::ChathistoryTargets)
+                        | Some(BatchKind::LabeledResponse)
+                        | None => self.handle(message, context, config)?,
                         Some(BatchKind::ZncPlayback(batch_target)) => self
                             .handle_znc_playback(message, batch_target.clone()),
                     };
@@ -5554,7 +5558,9 @@ impl Context {
                 )
             }
             Command::BATCH(_, params)
-                if params.iter().any(|param| param == "draft/multiline") =>
+                if params.iter().any(|param| {
+                    param == "draft/multiline" || param == "labeled-response"
+                }) =>
             {
                 Self::PrivOrNotice(
                     buffer,
@@ -5607,6 +5613,7 @@ pub enum BatchKind {
         String,
     ),
     ZncPlayback(Target),
+    LabeledResponse,
 }
 
 impl BatchKind {
@@ -5615,7 +5622,7 @@ impl BatchKind {
             Self::ChathistoryTarget(batch_target)
             | Self::Multiline(_, _, batch_target, _, _)
             | Self::ZncPlayback(batch_target) => Some(batch_target.clone()),
-            Self::ChathistoryTargets => None,
+            Self::ChathistoryTargets | Self::LabeledResponse => None,
         }
     }
 }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::binary_heap::PeekMut;
 use std::collections::{BTreeMap, BinaryHeap, HashMap, HashSet};
@@ -350,8 +351,23 @@ impl Client {
         from_modal: bool,
     ) -> Vec<Event> {
         if self.registration_step == RegistrationStep::Complete {
+            let requested =
+                if config.do_not_request != self.config.do_not_request {
+                    self.capabilities.create_update_requested(&config)
+                } else {
+                    vec![]
+                };
+
+            if !requested.is_empty() {
+                for message in group_capability_requests(&requested) {
+                    let _ = self.handle.try_send(message);
+                }
+            }
+
             // TODO: allow from_modal when modal matching to bouncer networks is added.
-            if !self.capabilities.acknowledged(Capability::BouncerNetworks) {
+            if !self.capabilities.acknowledged(Capability::BouncerNetworks)
+                || config.do_not_request.contains(&Capability::BouncerNetworks)
+            {
                 self.join(
                     &config
                         .channels
@@ -453,10 +469,12 @@ impl Client {
                 }
             }
 
-            if (!config.metadata.is_empty() || !self.config.metadata.is_empty())
-                && config.metadata != self.config.metadata
-            {
-                if self.capabilities.acknowledged(Capability::Metadata) {
+            if config.metadata != self.config.metadata {
+                if self.capabilities.acknowledged(Capability::Metadata)
+                    && !config
+                        .do_not_request
+                        .contains(&Capability::BouncerNetworks)
+                {
                     self.send(
                         None,
                         command!(
@@ -1345,7 +1363,7 @@ impl Client {
                 // Finished
                 if asterisk.is_none() {
                     let requested =
-                        self.capabilities.create_requested(&self.config);
+                        self.capabilities.create_new_requested(&self.config);
 
                     if !requested.is_empty() {
                         // Request
@@ -1422,7 +1440,7 @@ impl Client {
                 self.capabilities.extend_list(caps.split(' '));
 
                 let requested =
-                    self.capabilities.create_requested(&self.config);
+                    self.capabilities.create_new_requested(&self.config);
 
                 if !requested.is_empty() {
                     for message in group_capability_requests(&requested) {
@@ -3711,7 +3729,10 @@ impl Client {
         subcommand: ChatHistorySubcommand,
         priority: TokenPriority,
     ) {
-        if self.capabilities.acknowledged(Capability::Chathistory) {
+        if self.capabilities.acknowledged(Capability::Chathistory)
+            && (matches!(priority, TokenPriority::User)
+                || self.config.automated_chathistory)
+        {
             if let Some(target) = subcommand.target() {
                 if self.pending_chathistory_requests.contains_key(target) {
                     return;
@@ -5797,7 +5818,7 @@ impl PartialEq for MetadataSync {
 impl Eq for MetadataSync {}
 
 fn group_capability_requests<'a>(
-    capabilities: &'a [&'a str],
+    capabilities: &'a [Cow<'static, str>],
 ) -> impl Iterator<Item = proto::Message> + 'a {
     const MAX_LEN: usize = proto::format::BYTE_LIMIT - b"CAP REQ :\r\n".len();
 

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -10,6 +10,7 @@ use tokio::process::Command;
 
 use self::filehost::Filehost;
 use self::icon::Icon;
+use crate::capabilities::Capability;
 use crate::config::inclusivities::{
     Inclusivities, is_target_channel_included, is_target_query_included,
 };
@@ -133,18 +134,25 @@ pub struct Server {
     pub who_poll_interval: Duration,
     /// A list of nicknames to monitor (if MONITOR is supported by the server).
     pub monitor: Vec<String>,
-    pub chathistory: bool,
+    /// Whether to automatically make chathistory requests on the user's behalf
+    #[serde(alias = "chathistory")]
+    pub automated_chathistory: bool,
+    /// Flood protection settings, to help the user avoid sending too many messages too quickly.
     #[serde(deserialize_with = "deserialize_anti_flood")]
     pub anti_flood: Duration,
     #[serde(skip)]
     pub order: u16,
     pub proxy: Option<config::Proxy>,
     pub confirm_message_delivery: ConfirmMessageDelivery,
+    /// Whether to automatically connect to the server on launch.
     pub autoconnect: bool,
     pub typing: OptionalTyping,
     pub filehost: Filehost,
+    /// The key-value pairs for the user's metadata.
     pub metadata: HashMap<metadata::Key, String>,
     pub icon: Icon,
+    /// A list of capabilities not to request from the server (even if present).
+    pub do_not_request: Vec<Capability>,
 }
 
 impl Server {
@@ -268,7 +276,7 @@ impl Default for Server {
             who_poll_enabled: true,
             who_poll_interval: Duration::from_secs(2),
             monitor: Vec::default(),
-            chathistory: true,
+            automated_chathistory: true,
             anti_flood: Duration::from_millis(2000),
             order: 0,
             proxy: None,
@@ -278,6 +286,7 @@ impl Default for Server {
             filehost: Filehost::default(),
             metadata: HashMap::default(),
             icon: Icon::default(),
+            do_not_request: vec![],
         }
     }
 }

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -1501,13 +1501,10 @@ pub fn insert_message(
         if let Some(index) = messages[start_index..end_index]
             .iter()
             .enumerate()
-            .find_map(|(slice_index, message)| {
-                message
-                    .id
-                    .as_ref()
-                    .is_some_and(|id| {
-                        *id == labeled_response_context.label_as_id
-                    })
+            .find_map(|(slice_index, stored)| {
+                (stored.id.as_ref().is_some_and(|id| {
+                    *id == labeled_response_context.label_as_id
+                }) && stored.target == message.target)
                     .then_some(start_index + slice_index)
             })
         {

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -517,9 +517,9 @@ Read more about [monitoring users](../guides/monitor-users.md).
 monitor = ["Foo", "Bar"]
 ```
 
-## `chathistory`
+## `automated_chathistory`
 
-Whether or not to enable [IRCv3 Chat History](https://ircv3.net/specs/extensions/chathistory) (if it is supported by the server).
+Whether or not to enable automated [IRCv3 Chat History](https://ircv3.net/specs/extensions/chathistory) requests (if it is supported by the server).  For example, automatically requesting history when joining a channel since the last received message in the channel.
 
 ```toml
 # Type: boolean
@@ -527,7 +527,7 @@ Whether or not to enable [IRCv3 Chat History](https://ircv3.net/specs/extensions
 # Default: true
 
 [servers.<name>]
-chathistory = true
+automated_chathistory = true
 ```
 
 ## `proxy`
@@ -1069,6 +1069,19 @@ Override the server icon URL advertised by the server via ISUPPORT.
 
 [servers.<name>.icon]
 override_url = "https://libera.chat/static/img/libera-color.svg"
+```
+
+## `do_not_request`
+
+[IRCv3 capabilities](https://ircv3.net/irc/) to **not** request from the server.  All [supported IRCv3 capabilities](/index.md#ircv3-capabilities) that are available are requested by default.
+
+```toml
+# Type: array of strings
+# Values: "account-notify", "away-notify", "batch", "bouncer-networks", "chathistory", "chghost", "echo-message", "event-playback", "extended-join", "extended-monitor", "invite-notify", "labeled-response", "message-tags", "message-redaction", "multiline", "multi-prefix", "metadata", "no-implicit-names", "read-marker", "sasl", "server-time", "setname", "userhost-in-names", "whoami"
+# Default: not set
+
+[servers.<name>]
+do_not_request = [ "labeled-response" ]
 ```
 
 [^1]: Windows path strings should usually be specified as literal strings (e.g. `'C:\Users\Default\'`), otherwise directory separators will need to be escaped (e.g. `"C:\\Users\\Default\\"`).


### PR DESCRIPTION
Minor improvements to IRCv3 handling:
- Request draft/whoami if the server supports it (existing message handling should provide the needed capabilities)
- Add explicit handling of labeled-response batches (was previously only expected labeled-response on draft/multiline batches)
- Add `servers.<name>.do_not_request` setting to control which capabilities are requested from a server (closes #662)