### PR TITLE
No Terminal Window for `/exec` on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Fixed:
 - Allow sound files to be symbolic links
 - Queries specified in configuration correctly added to the sidebar
 - Do not reconnect automatically when the server closes the connection in response to a requested quit
+- Don't show a transient terminal window when running `/exec` on Windows
 
 Changed:
 
@@ -63,7 +64,7 @@ Changed:
 Thanks:
 
 - Contributions: @englut, @luca020400, @classabbyamp, @KaiKorla, @TheDcoder, @City-busz, @rtmongold, @Gelbpunkt, @zsigisti
-- Bug reports: @luca020400, agent314, flooferland, @englut
+- Bug reports: @luca020400, agent314, @FlooferLand, @englut
 
 # 2026.7.2 (2026-06-08)
 

--- a/src/buffer/input_view/exec.rs
+++ b/src/buffer/input_view/exec.rs
@@ -4,6 +4,10 @@ use std::time::Duration;
 use tokio::process::Command;
 use tokio::time;
 
+// https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
+#[cfg(target_os = "windows")]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
 pub async fn run(
     command: String,
     timeout_secs: u64,
@@ -12,6 +16,8 @@ pub async fn run(
     let output = time::timeout(Duration::from_secs(timeout_secs), async move {
         let mut process = if cfg!(target_os = "windows") {
             let mut process = Command::new("cmd");
+            #[cfg(target_os = "windows")]
+            process.creation_flags(CREATE_NO_WINDOW);
             process.arg("/C").arg(command);
             process
         } else {


### PR DESCRIPTION
Do not create a terminal window when running `/exec` on Windows.