### PR TITLE
Specify Accept Header when Requesting Previews/Icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Thanks:
 
 - Contributions: @englut, @luca020400, @classabbyamp, @KaiKorla, @TheDcoder, @City-busz, @rtmongold, @Gelbpunkt, @zsigisti
 - Bug reports: @luca020400, agent314, @FlooferLand, @englut
+- Feature requests: @FlooferLand
 
 # 2026.7.2 (2026-06-08)
 

--- a/data/src/preview.rs
+++ b/data/src/preview.rs
@@ -387,6 +387,24 @@ async fn fetch(
         .get(url.clone())
         .timeout(Duration::from_millis(config.request.timeout_ms));
 
+    // Accept HTML and images; for images, prefer known-supported
+    // IANA-registered types
+    // https://www.iana.org/assignments/media-types/media-types.xhtml#image
+    req = req.header(
+        header::ACCEPT,
+        "text/html,\
+         image/avif,\
+         image/bmp,\
+         image/gif,\
+         image/vnd.microsoft.icon,\
+         image/jpeg,\
+         image/png,\
+         image/svg+xml,\
+         image/tiff,\
+         image/webp,\
+         image/*;q=0.8",
+    );
+
     if let Ok(user_agent) = HeaderValue::from_str(&config.request.user_agent) {
         req = req.header(header::USER_AGENT, user_agent);
     }

--- a/data/src/server_icon.rs
+++ b/data/src/server_icon.rs
@@ -3,6 +3,7 @@ use std::io;
 use std::sync::Arc;
 
 use iced::Task;
+use reqwest::header;
 use sha2::{Digest, Sha256};
 use tokio::fs;
 use url::Url;
@@ -209,11 +210,25 @@ async fn fetch(
     http_client: Arc<reqwest::Client>,
     cache: &FileCache,
 ) -> Result<Image, LoadError> {
-    let mut resp = http_client
-        .get(url.clone())
-        .send()
-        .await?
-        .error_for_status()?;
+    let mut req = http_client.get(url.clone());
+
+    // Accept images; prefer known-supported IANA-registered types
+    // https://www.iana.org/assignments/media-types/media-types.xhtml#image
+    req = req.header(
+        header::ACCEPT,
+        "image/avif,\
+         image/bmp,\
+         image/gif,\
+         image/vnd.microsoft.icon,\
+         image/jpeg,\
+         image/png,\
+         image/svg+xml,\
+         image/tiff,\
+         image/webp,\
+         image/*;q=0.8",
+    );
+
+    let mut resp = req.send().await?.error_for_status()?;
 
     let Some(first_chunk) = resp.chunk().await? else {
         return Err(LoadError::EmptyBody);


### PR DESCRIPTION
Sets accept headers for preview and server icon fetch requests, favoring IANA-registered image types that are known to be supported by iced.