### PR TITLE
IRC Protocol Logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Added:
 - `pane.always_show_title_bar_buttons` setting to prevent pane title bar buttons from being hidden when the pane is not hovered
 - Allow image preview on URL click
 - `servers.<name>.max_connection_attempts` setting to control the number of connection of attempts made before autoconnect is automatically disabled (defaults to 10)
+- `servers.<name>.log_irc_protocol` setting to enable logging of the IRC protocol messages sent-to / received-from the server
 
 Fixed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Added:
 - `pane.always_show_title_bar_buttons` setting to prevent pane title bar buttons from being hidden when the pane is not hovered
 - Allow image preview on URL click
 - `servers.<name>.max_connection_attempts` setting to control the number of connection of attempts made before autoconnect is automatically disabled (defaults to 10)
-- `servers.<name>.log_irc_protocol` setting to enable logging of the IRC protocol messages sent-to / received-from the server
+- `servers.<name>.irc_protocol_log` settings to enable logging of the IRC protocol messages sent-to / received-from the server
 
 Fixed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Added:
 - `pane.always_show_title_bar_buttons` setting to prevent pane title bar buttons from being hidden when the pane is not hovered
 - Allow image preview on URL click
 - `servers.<name>.max_connection_attempts` setting to control the number of connection of attempts made before autoconnect is automatically disabled (defaults to 10)
+- `logs.file_timestamp` setting to control what timezone is used for timestamps in log files and log file names
 - `servers.<name>.irc_protocol_log` settings to enable logging of the IRC protocol messages sent-to / received-from the server
 
 Fixed:

--- a/data/src/config/logs.rs
+++ b/data/src/config/logs.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 #[serde(default)]
 pub struct Logs {
     pub file_level: LevelFilter,
+    pub file_timestamp: Timestamp,
     pub pane_level: LevelFilter,
     pub max_file_count: usize,
 }
@@ -12,6 +13,7 @@ impl Default for Logs {
     fn default() -> Self {
         Self {
             file_level: LevelFilter::Debug,
+            file_timestamp: Timestamp::default(),
             pane_level: LevelFilter::Info,
             max_file_count: 4,
         }
@@ -40,4 +42,12 @@ impl From<LevelFilter> for log::LevelFilter {
             LevelFilter::Trace => log::LevelFilter::Trace,
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Timestamp {
+    #[default]
+    Local,
+    Utc,
 }

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -14,6 +14,7 @@ use crate::capabilities::Capability;
 use crate::config::inclusivities::{
     Inclusivities, is_target_channel_included, is_target_query_included,
 };
+use crate::config::logs::Timestamp;
 use crate::config::sidebar::OrderChannelsBy;
 use crate::serde::{
     deserialize_path_buf_with_path_transformations,
@@ -156,8 +157,8 @@ pub struct Server {
     pub icon: Icon,
     /// A list of capabilities not to request from the server (even if present).
     pub do_not_request: Vec<Capability>,
-    /// Whether to log all IRC protocol messages
-    pub log_irc_protocol: bool,
+    /// Whether & how to log all IRC protocol messages
+    pub irc_protocol_log: IrcProtocolLog,
 }
 
 impl Server {
@@ -262,7 +263,7 @@ impl Server {
                 != other.password_file_first_line_only
             || self.password_command != other.password_command
             || self.sasl != other.sasl
-            || self.log_irc_protocol != other.log_irc_protocol
+            || self.irc_protocol_log != other.irc_protocol_log
     }
 }
 
@@ -319,7 +320,7 @@ impl Default for Server {
             metadata: HashMap::default(),
             icon: Icon::default(),
             do_not_request: vec![],
-            log_irc_protocol: false,
+            irc_protocol_log: IrcProtocolLog::default(),
         }
     }
 }
@@ -682,4 +683,21 @@ pub async fn read_from_command(
             output.stderr,
         )?))
     }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub struct IrcProtocolLog {
+    pub enabled: bool,
+    pub format: IrcProtocolLogFormat,
+    pub timestamp: Timestamp,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum IrcProtocolLogFormat {
+    #[default]
+    Halloy,
+    Goguma,
+    // TODO: ZNC format
 }

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -156,6 +156,8 @@ pub struct Server {
     pub icon: Icon,
     /// A list of capabilities not to request from the server (even if present).
     pub do_not_request: Vec<Capability>,
+    /// Whether to log all IRC protocol messages
+    pub log_irc_protocol: bool,
 }
 
 impl Server {
@@ -260,6 +262,7 @@ impl Server {
                 != other.password_file_first_line_only
             || self.password_command != other.password_command
             || self.sasl != other.sasl
+            || self.log_irc_protocol != other.log_irc_protocol
     }
 }
 
@@ -316,6 +319,7 @@ impl Default for Server {
             metadata: HashMap::default(),
             icon: Icon::default(),
             do_not_request: vec![],
+            log_irc_protocol: false,
         }
     }
 }

--- a/data/src/log.rs
+++ b/data/src/log.rs
@@ -5,14 +5,17 @@ use std::{fs, io};
 use chrono::{DateTime, Local, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::config::logs::LevelFilter;
+use crate::config::logs::{LevelFilter, Timestamp};
 use crate::environment;
 
-pub fn file() -> Result<fs::File, Error> {
+pub fn file(timestamp: Timestamp) -> Result<fs::File, Error> {
+    let file_format = "halloy.%Y-%m-%d-%H-%M-%S.log";
     let path = dir()?.join(
-        Local::now()
-            .format("halloy.%Y-%m-%d-%H-%M-%S.log")
-            .to_string(),
+        match timestamp {
+            Timestamp::Local => Local::now().format(file_format),
+            Timestamp::Utc => Utc::now().format(file_format),
+        }
+        .to_string(),
     );
 
     Ok(fs::OpenOptions::new()

--- a/data/src/stream.rs
+++ b/data/src/stream.rs
@@ -606,7 +606,7 @@ async fn connect(
     proxy: Option<config::Proxy>,
 ) -> Result<(Stream, Client), connection::Error> {
     let logger = if config.log_irc_protocol {
-        let (sender, receiver) = tokio::sync::mpsc::channel(100);
+        let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
 
         tokio::task::spawn(log_codec(server.clone(), receiver));
 
@@ -637,15 +637,15 @@ async fn connect(
 
 async fn log_codec(
     server: Server,
-    mut receiver: tokio::sync::mpsc::Receiver<CodecLog>,
+    mut receiver: tokio::sync::mpsc::UnboundedReceiver<CodecLog>,
 ) {
     let log_writer = LogWriter::new(&server).await;
 
     match log_writer {
         Ok(mut log_writer) => {
-            let mut timeout_receive = false;
+            let mut set_timeout_to_flush = false;
 
-            while let Some(action) = if timeout_receive {
+            while let Some(action) = if set_timeout_to_flush {
                 tokio::time::timeout(
                     Duration::from_millis(500),
                     receiver.recv(),
@@ -658,11 +658,11 @@ async fn log_codec(
                 match action {
                     Ok(message) => {
                         log_writer.write(message).await;
-                        timeout_receive = true;
+                        set_timeout_to_flush = true;
                     }
                     Err(_) => {
                         log_writer.flush().await;
-                        timeout_receive = false;
+                        set_timeout_to_flush = false;
                     }
                 }
             }

--- a/data/src/stream.rs
+++ b/data/src/stream.rs
@@ -14,6 +14,7 @@ use tokio::io::{AsyncWriteExt, BufWriter};
 use tokio::time::{self, Instant, Interval};
 
 use crate::client::Client;
+use crate::config::server::IrcProtocolLogFormat;
 use crate::server::Server;
 use crate::time::Posix;
 use crate::{config, environment, message, server};
@@ -605,10 +606,14 @@ async fn connect(
     config: Arc<config::Server>,
     proxy: Option<config::Proxy>,
 ) -> Result<(Stream, Client), connection::Error> {
-    let logger = if config.log_irc_protocol {
+    let logger = if config.irc_protocol_log.enabled {
         let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
 
-        tokio::task::spawn(log_codec(server.clone(), receiver));
+        tokio::task::spawn(log_codec(
+            server.clone(),
+            config.irc_protocol_log,
+            receiver,
+        ));
 
         Some(sender)
     } else {
@@ -637,6 +642,7 @@ async fn connect(
 
 async fn log_codec(
     server: Server,
+    config: config::server::IrcProtocolLog,
     mut receiver: tokio::sync::mpsc::UnboundedReceiver<CodecLog>,
 ) {
     let log_writer = LogWriter::new(&server).await;
@@ -657,7 +663,7 @@ async fn log_codec(
             } {
                 match action {
                     Ok(message) => {
-                        log_writer.write(message).await;
+                        log_writer.write(message, &config).await;
                         set_timeout_to_flush = true;
                     }
                     Err(_) => {
@@ -697,9 +703,17 @@ impl LogWriter {
         })
     }
 
-    pub async fn write(&mut self, message: CodecLog) {
+    pub async fn write(
+        &mut self,
+        message: CodecLog,
+        config: &config::server::IrcProtocolLog,
+    ) {
         let now = Local::now();
-        let today = now.date_naive();
+
+        let today = match config.timestamp {
+            config::logs::Timestamp::Local => now.date_naive(),
+            config::logs::Timestamp::Utc => now.to_utc().date_naive(),
+        };
 
         if let Some((date, writer)) = &mut self.date_writer {
             if today != *date {
@@ -713,7 +727,7 @@ impl LogWriter {
 
         if let Some((_, writer)) = &mut self.date_writer {
             let _ = writer
-                .write_all(LogWriter::format(message, now).as_bytes())
+                .write_all(LogWriter::format(message, now, config).as_bytes())
                 .await;
         }
     }
@@ -730,18 +744,33 @@ impl LogWriter {
             .map(|writer| (date, BufWriter::new(writer)));
     }
 
-    fn format(message: CodecLog, received_at: DateTime<Local>) -> String {
-        let (message_content, direction) = match message {
-            CodecLog::Received(content) => (content, "RECEIVED"),
-            CodecLog::Sent(content) => (content, "  SENT  "),
+    fn format(
+        message: CodecLog,
+        received_at: DateTime<Local>,
+        config: &config::server::IrcProtocolLog,
+    ) -> String {
+        let received_at_format = "%H:%M:%S%.3f";
+        let received_at = match config.timestamp {
+            config::logs::Timestamp::Local => {
+                received_at.format(received_at_format)
+            }
+            config::logs::Timestamp::Utc => {
+                received_at.to_utc().format(received_at_format)
+            }
         };
 
-        format!(
-            "{} {} -- {}",
-            received_at.format("%H:%M:%S%.3f"),
-            direction,
-            message_content
-        )
+        let (direction, divider, message_content) = match config.format {
+            IrcProtocolLogFormat::Halloy => match message {
+                CodecLog::Received(content) => ("RECEIVED", " -- ", content),
+                CodecLog::Sent(content) => ("  SENT  ", " -- ", content),
+            },
+            IrcProtocolLogFormat::Goguma => match message {
+                CodecLog::Received(content) => ("<-", " ", content),
+                CodecLog::Sent(content) => ("->", " ", content),
+            },
+        };
+
+        format!("{received_at} {direction}{divider}{message_content}")
     }
 
     pub async fn flush(&mut self) {

--- a/data/src/stream.rs
+++ b/data/src/stream.rs
@@ -1,19 +1,22 @@
 use std::collections::{BTreeMap, HashSet};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Local, NaiveDate, Utc};
 use futures::channel::mpsc;
 use futures::never::Never;
 use futures::{FutureExt, SinkExt, StreamExt, future, stream};
 use irc::proto::{self, Command, command};
-use irc::{Connection, codec, connection};
+use irc::{CodecLog, Connection, codec, connection};
+use tokio::fs::{self, File};
+use tokio::io::{AsyncWriteExt, BufWriter};
 use tokio::time::{self, Instant, Interval};
 
 use crate::client::Client;
 use crate::server::Server;
 use crate::time::Posix;
-use crate::{config, message, server};
+use crate::{config, environment, message, server};
 
 const QUIT_REQUEST_TIMEOUT: Duration = Duration::from_millis(400);
 
@@ -602,8 +605,19 @@ async fn connect(
     config: Arc<config::Server>,
     proxy: Option<config::Proxy>,
 ) -> Result<(Stream, Client), connection::Error> {
+    let logger = if config.log_irc_protocol {
+        let (sender, receiver) = tokio::sync::mpsc::channel(100);
+
+        tokio::task::spawn(log_codec(server.clone(), receiver));
+
+        Some(sender)
+    } else {
+        None
+    };
+
     let connection =
-        Connection::new(config.connection(proxy), irc::Codec).await?;
+        Connection::new(config.connection(proxy), irc::Codec::new(logger))
+            .await?;
 
     let (sender, receiver) = mpsc::channel(100);
 
@@ -619,6 +633,102 @@ async fn connect(
         },
         client,
     ))
+}
+
+async fn log_codec(
+    server: Server,
+    mut receiver: tokio::sync::mpsc::Receiver<CodecLog>,
+) {
+    let log_writer = LogWriter::new(&server).await;
+
+    match log_writer {
+        Ok(mut log_writer) => {
+            while let Some(message) = receiver.recv().await {
+                log_writer.write(message).await;
+            }
+
+            log_writer.flush().await;
+        }
+        Err(error) => {
+            log::error!("unable to create log writer for {server}: {error}");
+        }
+    }
+}
+
+struct LogWriter {
+    log_dir: PathBuf,
+    date_writer: Option<(NaiveDate, BufWriter<File>)>,
+}
+
+impl LogWriter {
+    pub async fn new(server: &Server) -> Result<Self, std::io::Error> {
+        let data_dir = environment::data_dir();
+
+        let log_dir =
+            data_dir.join("irc_protocol_logs").join(server.to_string());
+
+        if !log_dir.exists() {
+            fs::create_dir_all(&log_dir).await?;
+        }
+
+        Ok(Self {
+            log_dir,
+            date_writer: None,
+        })
+    }
+
+    pub async fn write(&mut self, message: CodecLog) {
+        let now = Local::now();
+        let today = now.date_naive();
+
+        if let Some((date, writer)) = &mut self.date_writer {
+            if today != *date {
+                let _ = writer.flush().await;
+
+                self.create_date_writer(today).await;
+            }
+        } else {
+            self.create_date_writer(today).await;
+        }
+
+        if let Some((_, writer)) = &mut self.date_writer {
+            let _ = writer
+                .write_all(LogWriter::format(message, now).as_bytes())
+                .await;
+        }
+    }
+
+    async fn create_date_writer(&mut self, date: NaiveDate) {
+        let log_file = date.format("%Y-%m-%d.log").to_string();
+
+        self.date_writer = File::options()
+            .append(true)
+            .create(true)
+            .open(self.log_dir.join(log_file))
+            .await
+            .ok()
+            .map(|writer| (date, BufWriter::new(writer)));
+    }
+
+    fn format(message: CodecLog, received_at: DateTime<Local>) -> String {
+        let (message_content, direction) = match message {
+            CodecLog::Received(content) => (content, "RECEIVED"),
+            CodecLog::Sent(content) => (content, "  SENT  "),
+        };
+
+        format!(
+            "{} {} -- {}",
+            received_at.format("%H:%M:%S%.3f"),
+            direction,
+            message_content
+        )
+    }
+
+    pub async fn flush(&mut self) {
+        if let Some((_, writer)) = &mut self.date_writer {
+            let _ = writer.flush().await;
+        }
+    }
 }
 
 struct Batch {

--- a/data/src/stream.rs
+++ b/data/src/stream.rs
@@ -643,11 +643,31 @@ async fn log_codec(
 
     match log_writer {
         Ok(mut log_writer) => {
-            while let Some(message) = receiver.recv().await {
-                log_writer.write(message).await;
+            let mut timeout_receive = false;
+
+            while let Some(action) = if timeout_receive {
+                tokio::time::timeout(
+                    Duration::from_millis(500),
+                    receiver.recv(),
+                )
+                .await
+                .transpose()
+            } else {
+                receiver.recv().await.map(Ok)
+            } {
+                match action {
+                    Ok(message) => {
+                        log_writer.write(message).await;
+                        timeout_receive = true;
+                    }
+                    Err(_) => {
+                        log_writer.flush().await;
+                        timeout_receive = false;
+                    }
+                }
             }
 
-            log_writer.flush().await;
+            log_writer.shutdown().await;
         }
         Err(error) => {
             log::error!("unable to create log writer for {server}: {error}");
@@ -727,6 +747,14 @@ impl LogWriter {
     pub async fn flush(&mut self) {
         if let Some((_, writer)) = &mut self.date_writer {
             let _ = writer.flush().await;
+        }
+    }
+
+    pub async fn shutdown(&mut self) {
+        if let Some((_, writer)) = &mut self.date_writer {
+            let _ = writer.flush().await;
+
+            let _ = writer.shutdown().await;
         }
     }
 }

--- a/docs/configuration/logs.md
+++ b/docs/configuration/logs.md
@@ -55,3 +55,16 @@ The number of log files to keep in the [log file directory](#files).
 [logs]
 max_file_count = 0
 ```
+
+### `file_timestamp`
+
+Time zone to use for Halloy-provided timestamps in the file logs and their file names.  `"local"` uses the system's local timezone, and `"utc"` uses the UTC timezone (may be more difficult to understand, but stable if the system changes timezones).
+
+```toml
+# Type: string
+# Values: "local", "utc"
+# Default: "local"
+
+[logs]
+file_timestamp = "utc"
+```

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -1100,6 +1100,27 @@ override_url = "https://libera.chat/static/img/libera-color.svg"
 do_not_request = [ "labeled-response" ]
 ```
 
+## `log_irc_protocol`
+
+Log **all** IRC messages received from and sent to and the server (logged messages may contain sensitive information and will be stored in plain text).  Log files can be found in:
+
+* Windows: `%AppData%\Roaming\halloy\irc_protocol_logs\<name>\`
+* Mac: `~/Library/Application Support/halloy/irc_protocol_logs/<name>/` or `$HOME/.local/share/halloy/irc_protocol_logs/<name>/`
+* Linux: `$XDG_DATA_HOME/halloy/irc_protocol_logs/<name>/`, `$HOME/.local/share/halloy/irc_protocol_logs/<name>/`, or `$HOME/.var/app/org.squidowl.halloy/data/halloy/irc_protocol_logs/<name>/` (Flatpak)
+
+::: warning
+Changing this setting will trigger a disconnect→reconnect if the connection to the server is active.
+:::
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: false
+
+[servers.<name>]
+log_irc_protocol = true
+```
+
 [^1]: Windows path strings should usually be specified as literal strings (e.g. `'C:\Users\Default\'`), otherwise directory separators will need to be escaped (e.g. `"C:\\Users\\Default\\"`).
 
 [^2]: Relative paths are prefixed with the config directory (i.e. if you have your config.toml in `/home/me/.config/halloy/config.toml`, path `.passwd/libera` will be converted to `/home/me/.config/halloy/.passwd/libera`).

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -1100,25 +1100,60 @@ override_url = "https://libera.chat/static/img/libera-color.svg"
 do_not_request = [ "labeled-response" ]
 ```
 
-## `log_irc_protocol`
+## `irc_protocol_log`
 
-Log **all** IRC messages received from and sent to and the server (logged messages may contain sensitive information and will be stored in plain text).  Log files can be found in:
+Logs of **all** IRC messages received from and sent to and the server (logged messages may contain sensitive information and will be stored in plain text).  Log files can be found in:
 
 * Windows: `%AppData%\Roaming\halloy\irc_protocol_logs\<name>\`
 * Mac: `~/Library/Application Support/halloy/irc_protocol_logs/<name>/` or `$HOME/.local/share/halloy/irc_protocol_logs/<name>/`
 * Linux: `$XDG_DATA_HOME/halloy/irc_protocol_logs/<name>/`, `$HOME/.local/share/halloy/irc_protocol_logs/<name>/`, or `$HOME/.var/app/org.squidowl.halloy/data/halloy/irc_protocol_logs/<name>/` (Flatpak)
 
 ::: warning
-Changing this setting will trigger a disconnect→reconnect if the connection to the server is active.
+Changing any settings in this section will trigger a disconnect→reconnect if the connection to the server is active.
 :::
+
+### `enabled`
+
+Control whether IRC messages are logged.
 
 ```toml
 # Type: boolean
 # Values: true, false
 # Default: false
 
-[servers.<name>]
-log_irc_protocol = true
+[servers.<name>.irc_protocol_log]
+enabled = true
+```
+
+### `format`
+
+Format used for logging IRC messages.
+
+| `format`       | **Sent Messages**                       | **Received Messages**                   |
+| -------------- | --------------------------------------- | --------------------------------------- |
+| `"goguma"`     | `{timestamp} RECEIVED -- {irc_message}` | `{timestamp}   SENT   -- {irc_message}` |
+| `"halloy"`     | `{timestamp} <- {irc_message}`          | `{timestamp} -> {irc_message}`          |
+
+```toml
+# Type: string
+# Values: "goguma", "halloy"
+# Default: "halloy"
+
+[servers.<name>.irc_protocol_log]
+format = "goguma"
+```
+
+### `timestamp`
+
+Time zone to use for Halloy-provided timestamps in the logs and their file names.  `"local"` uses the system's local timezone, and `"utc"` uses the UTC timezone (may be more difficult to understand, but stable if the system changes timezones).
+
+```toml
+# Type: string
+# Values: "local", "utc"
+# Default: "local"
+
+[servers.<name>.irc_protocol_log]
+timestamp = "utc"
 ```
 
 [^1]: Windows path strings should usually be specified as literal strings (e.g. `'C:\Users\Default\'`), otherwise directory separators will need to be escaped (e.g. `"C:\\Users\\Default\\"`).

--- a/irc/src/codec.rs
+++ b/irc/src/codec.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use bytes::BytesMut;
 use proto::{Message, format, parse};
-use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::UnboundedSender;
 use tokio_util::codec::{Decoder, Encoder};
 
 pub type ParseResult<T = Message, E = parse::Error> = std::result::Result<T, E>;
@@ -14,11 +14,11 @@ pub type ParseResult<T = Message, E = parse::Error> = std::result::Result<T, E>;
 const MAX_LINE_LENGTH: usize = 16 * 1024;
 
 pub struct Codec {
-    logger: Option<Sender<CodecLog>>,
+    logger: Option<UnboundedSender<CodecLog>>,
 }
 
 impl Codec {
-    pub fn new(logger: Option<Sender<CodecLog>>) -> Self {
+    pub fn new(logger: Option<UnboundedSender<CodecLog>>) -> Self {
         Self { logger }
     }
 }
@@ -36,7 +36,7 @@ impl Decoder for Codec {
             // buffer the "line" without bound, exhausting memory from a single connection.
             if src.len() > MAX_LINE_LENGTH {
                 if let Some(logger) = &self.logger {
-                    let _ = logger.try_send(CodecLog::Received(
+                    let _ = logger.send(CodecLog::Received(
                         String::from_utf8_lossy(src).to_string(),
                     ));
                 }
@@ -49,7 +49,7 @@ impl Decoder for Codec {
         let bytes = src.split_to(pos + 2);
 
         if let Some(logger) = &self.logger {
-            let _ = logger.try_send(CodecLog::Received(
+            let _ = logger.send(CodecLog::Received(
                 String::from_utf8_lossy(&bytes).to_string(),
             ));
         }
@@ -71,7 +71,7 @@ impl Encoder<Message> for Codec {
         let bytes = encoded.into_bytes();
 
         if let Some(logger) = &self.logger {
-            let _ = logger.try_send(CodecLog::Sent(
+            let _ = logger.send(CodecLog::Sent(
                 String::from_utf8_lossy(&bytes).to_string(),
             ));
         }

--- a/irc/src/codec.rs
+++ b/irc/src/codec.rs
@@ -2,15 +2,26 @@ use std::io;
 
 use bytes::BytesMut;
 use proto::{Message, format, parse};
+use tokio::sync::mpsc::Sender;
 use tokio_util::codec::{Decoder, Encoder};
 
 pub type ParseResult<T = Message, E = parse::Error> = std::result::Result<T, E>;
 
-pub struct Codec;
-
-/// Maximum bytes buffered for a single IRC line before it is rejected. Generous headroom over the
-/// IRCv3 message-tags limit (8191) plus the 512-byte message.
+/// Maximum bytes buffered for a single IRC line before it is rejected.
+/// Generous headroom over the / IRCv3 message-tags limit (8191;
+/// https://ircv3.net/specs/extensions/message-tags#size-limit) plus the
+/// 512-byte message.
 const MAX_LINE_LENGTH: usize = 16 * 1024;
+
+pub struct Codec {
+    logger: Option<Sender<CodecLog>>,
+}
+
+impl Codec {
+    pub fn new(logger: Option<Sender<CodecLog>>) -> Self {
+        Self { logger }
+    }
+}
 
 impl Decoder for Codec {
     type Item = ParseResult;
@@ -24,12 +35,26 @@ impl Decoder for Codec {
             // Guard against a peer that never sends CRLF: without a cap the framed stream would
             // buffer the "line" without bound, exhausting memory from a single connection.
             if src.len() > MAX_LINE_LENGTH {
+                if let Some(logger) = &self.logger {
+                    let _ = logger.try_send(CodecLog::Received(
+                        String::from_utf8_lossy(src).to_string(),
+                    ));
+                }
+
                 return Err(Error::LineTooLong);
             }
             return Ok(None);
         };
 
-        Ok(Some(parse::message_bytes(&src.split_to(pos + 2))))
+        let bytes = src.split_to(pos + 2);
+
+        if let Some(logger) = &self.logger {
+            let _ = logger.try_send(CodecLog::Received(
+                String::from_utf8_lossy(&bytes).to_string(),
+            ));
+        }
+
+        Ok(Some(parse::message_bytes(&bytes)))
     }
 }
 
@@ -43,10 +68,23 @@ impl Encoder<Message> for Codec {
     ) -> Result<(), Self::Error> {
         let encoded = format::message(message);
 
-        dst.extend(encoded.into_bytes());
+        let bytes = encoded.into_bytes();
+
+        if let Some(logger) = &self.logger {
+            let _ = logger.try_send(CodecLog::Sent(
+                String::from_utf8_lossy(&bytes).to_string(),
+            ));
+        }
+
+        dst.extend(bytes);
 
         Ok(())
     }
+}
+
+pub enum CodecLog {
+    Received(String),
+    Sent(String),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/irc/src/lib.rs
+++ b/irc/src/lib.rs
@@ -2,7 +2,7 @@
 
 pub use tokio_util::codec::BytesCodec;
 
-pub use self::codec::Codec;
+pub use self::codec::{Codec, CodecLog};
 pub use self::connection::Connection;
 
 pub mod codec;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -42,15 +42,23 @@ fn file_dispatch(
         return None;
     }
 
-    data::log::file().ok().map(|log_file| {
+    data::log::file(config.file_timestamp).ok().map(|log_file| {
         let file_level_filter = env_rust_log
             .map_or(log::LevelFilter::from(config.file_level), |env| {
                 env.to_level_filter()
             });
 
         fern::Dispatch::new()
-            .format(|out, message, record| {
-                let timestamp = chrono::Local::now().format("%H:%M:%S%.3f");
+            .format(move |out, message, record| {
+                let timestamp_format = "%H:%M:%S%.3f";
+                let timestamp = match config.file_timestamp {
+                    config::logs::Timestamp::Local => {
+                        chrono::Local::now().format(timestamp_format)
+                    }
+                    config::logs::Timestamp::Utc => {
+                        chrono::Utc::now().format(timestamp_format)
+                    }
+                };
 
                 if message
                     .as_str()


### PR DESCRIPTION
Initial implementation of IRC protocol message logging.  Logging is controllable per-server, written to plain text files in directories named for the server.  Log files are named with the local date the message was received (`YYYY-MM-DD.log`).