### PR TITLE
Minor Log Files Tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Added:
 - Shortcuts displayed in pane button tooltips (where available/configured)
 - `servers.<name>.do_not_request` can be specified to prevent IRCv3 capability requests (e.g. `servers.<name>.do_not_request = [ "labeled-response" ]` will prevent [labeled-response](https://ircv3.net/specs/extensions/labeled-response) from being requested from the server)
 - `follow` option for reroute rules (`servers.<name>.reroute`) to reroute messages to the focused buffer
+- `logs.max_file_count` setting to control the number of Halloy log files that are stored on disk
 
 Fixed:
 
@@ -65,6 +66,7 @@ Changed:
 - Set window icon also on Linux for X11
 - `keyboard.file_transfers` shortcut is disabled when `file_transfer.enabled = false`
 - Rerouted messages are marked with a icon next to the nickname
+- More than one Halloy log file can be saved (configurable, defaults to 4);  accordingly there is not a singular log file `<data_dir>/halloy/halloy.log`, instead log files are placed in `<data_dir>/halloy/logs/`
 
 Thanks:
 

--- a/data/src/config/logs.rs
+++ b/data/src/config/logs.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 pub struct Logs {
     pub file_level: LevelFilter,
     pub pane_level: LevelFilter,
+    pub max_file_count: usize,
 }
 
 impl Default for Logs {
@@ -12,6 +13,7 @@ impl Default for Logs {
         Self {
             file_level: LevelFilter::Debug,
             pane_level: LevelFilter::Info,
+            max_file_count: 4,
         }
     }
 }

--- a/data/src/log.rs
+++ b/data/src/log.rs
@@ -2,14 +2,18 @@ use std::cmp::Ordering;
 use std::path::PathBuf;
 use std::{fs, io};
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Local, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::config::logs::LevelFilter;
 use crate::environment;
 
 pub fn file() -> Result<fs::File, Error> {
-    let path = path()?;
+    let path = dir()?.join(
+        Local::now()
+            .format("halloy.%Y-%m-%d-%H-%M-%S.log")
+            .to_string(),
+    );
 
     Ok(fs::OpenOptions::new()
         .write(true)
@@ -19,14 +23,37 @@ pub fn file() -> Result<fs::File, Error> {
         .open(path)?)
 }
 
-fn path() -> Result<PathBuf, Error> {
-    let parent = environment::data_dir();
+fn dir() -> Result<PathBuf, Error> {
+    let dir = environment::data_dir().join("logs");
 
-    if !parent.exists() {
-        fs::create_dir_all(&parent)?;
+    if !dir.exists() {
+        fs::create_dir_all(&dir)?;
     }
 
-    Ok(parent.join("halloy.log"))
+    Ok(dir)
+}
+
+pub fn clear(number_of_logs_to_keep: usize) {
+    if let Ok(dir) = dir() {
+        for (index, dir_entry) in walkdir::WalkDir::new(dir)
+            .max_depth(1)
+            .sort_by(|a, b| b.file_name().cmp(a.file_name()))
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|dir_entry| {
+                dir_entry.file_type().is_file()
+                    && dir_entry.file_name().to_str().is_some_and(|file_name| {
+                        file_name.starts_with("halloy.")
+                            && file_name.ends_with(".log")
+                    })
+            })
+            .enumerate()
+        {
+            if index >= number_of_logs_to_keep {
+                let _ = fs::remove_file(dir_entry.path());
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/docs/configuration/logs.md
+++ b/docs/configuration/logs.md
@@ -1,16 +1,34 @@
 # Logs
 
-Customize log buffer
+Customize what is written to Halloy in-application and file logs.
+
+## `pane_level`
+
+The least urgent (most verbose) log level to record to the Logs pane.
+E.g. a `pane_level` setting of `"info"` will record all `ERROR`, `WARN`, and `INFO` messages to the Logs pane.
+The Logs pane will only contain log messages since Halloy was launched.  Log messages that are not recorded to the Logs pane may still be found in log files.
+
+```toml
+# Type: string
+# Values: "off", "error", "warn", "info", "debug", "trace"
+# Default: "info"
+
+[logs]
+pane_level = "info"
+```
+
+## Files
+
+Log files are named based on the Halloy launch time, with the [strftime](https://pubs.opengroup.org/onlinepubs/007908799/xsh/strftime.html) format `halloy.%Y-%m-%d-%H-%M-%S.log`.  They can be found in the log file directory:
+
+* Windows: `%AppData%\Roaming\halloy\logs\`
+* Mac: `~/Library/Application Support/halloy/logs` or `$HOME/.local/share/halloy/logs`
+* Linux: `$XDG_DATA_HOME/halloy/logs`, `$HOME/.local/share/halloy/logs`, or `$HOME/.var/app/org.squidowl.halloy/data/halloy/logs` (Flatpak)
 
 ## `file_level`
 
-The least urgent (most verbose) log level to record to the log file.
+The least urgent (most verbose) log level to record to log files.
 E.g. a `file_level` setting of `"debug"` will record all `ERROR`, `WARN`, `INFO`, and `DEBUG` messages to the log file.
-The log file is overwritten on each launch (i.e. contains log messages for the last session only).  It can be accessed at:
-
-* Windows: `%AppData%\Roaming\halloy\halloy.log`
-* Mac: `~/Library/Application Support/halloy/halloy.log` or `$HOME/.local/share/halloy/halloy.log`
-* Linux: `$XDG_DATA_HOME/halloy/halloy.log`, `$HOME/.local/share/halloy/halloy.log`, or `$HOME/.var/app/org.squidowl.halloy/data/halloy/halloy.log` (Flatpak)
 
 ::: warning
 Changes to file_level require an application restart to take effect.
@@ -25,17 +43,15 @@ Changes to file_level require an application restart to take effect.
 file_level = "debug"
 ```
 
-## `pane_level`
+## `max_file_count`
 
-The least urgent (most verbose) log level to record to the Logs pane.
-E.g. a `pane_level` setting of `"info"` will record all `ERROR`, `WARN`, and `INFO` messages to the Logs pane.
-Log messages that are not recorded to the Logs pane may still be found in the log file.
+The number of log files to keep in the [log file directory](#files).
 
 ```toml
-# Type: string
-# Values: "off", "error", "warn", "info", "debug", "trace"
-# Default: "info"
+# Type: non-negative integer
+# Values: any non-negative integer
+# Default: 4
 
 [logs]
-pane_level = "info"
+max_file_count = 0
 ```

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -17,52 +17,119 @@ pub fn setup(
         .as_deref()
         .and_then(|rust_log| str::parse::<log::Level>(rust_log).ok());
 
-    let file_level_filter = env_rust_log
-        .map_or(log::LevelFilter::from(config.file_level), |env| {
-            env.to_level_filter()
-        });
+    let file_sink = file_dispatch(config, env_rust_log);
 
+    let (pane_sink, pane_receiver) = pane_dispatch(env_rust_log);
+
+    let mut dispatch = fern::Dispatch::new().chain(pane_sink);
+
+    if let Some(file_sink) = file_sink {
+        dispatch = dispatch.chain(file_sink);
+    }
+
+    dispatch.apply()?;
+
+    Ok(pane_receiver)
+}
+
+fn file_dispatch(
+    config: config::Logs,
+    env_rust_log: Option<log::Level>,
+) -> Option<fern::Dispatch> {
+    data::log::clear(config.max_file_count.saturating_sub(1));
+
+    if config.max_file_count == 0 {
+        return None;
+    }
+
+    data::log::file().ok().map(|log_file| {
+        let file_level_filter = env_rust_log
+            .map_or(log::LevelFilter::from(config.file_level), |env| {
+                env.to_level_filter()
+            });
+
+        fern::Dispatch::new()
+            .format(|out, message, record| {
+                let timestamp = chrono::Local::now().format("%H:%M:%S%.3f");
+
+                if message
+                    .as_str()
+                    .is_none_or(|message| message.contains('\n'))
+                {
+                    let formatted_message = format!("{message}");
+
+                    let message = if formatted_message.contains('\n') {
+                        let mut lines = formatted_message.lines();
+
+                        let mut message =
+                            lines.next().unwrap_or_default().to_string();
+
+                        for line in lines {
+                            message = format!(
+                                "{message}\n{}{line}",
+                                if line.is_empty() {
+                                    ""
+                                } else {
+                                    // Indent width of format!("{} {:5} -- ", timestamp, record.level())
+                                    "                      "
+                                }
+                            );
+                        }
+
+                        message
+                    } else {
+                        formatted_message
+                    };
+
+                    out.finish(format_args!(
+                        "{} {:>5} -- {}",
+                        timestamp,
+                        record.level(),
+                        message
+                    ));
+
+                    return;
+                }
+
+                out.finish(format_args!(
+                    "{} {:>5} -- {}",
+                    timestamp,
+                    record.level(),
+                    message
+                ));
+            })
+            .chain(log_file)
+            .level(log::LevelFilter::Off)
+            .level_for("panic", log::LevelFilter::Error)
+            .level_for("iced_wgpu", log::LevelFilter::Info)
+            .level_for("data", file_level_filter)
+            .level_for("ipc", file_level_filter)
+            .level_for("halloy", file_level_filter)
+    })
+}
+
+fn pane_dispatch(
+    env_rust_log: Option<log::Level>,
+) -> (fern::Dispatch, ReceiverStream<Vec<Record>>) {
+    // Set filter to trace in order to perform filtering when receiving for logs
+    // pane so that filter-level can be changed without restarting the
+    // application
     let channel_level_filter = env_rust_log
         .map_or(log::LevelFilter::Trace, |env| env.to_level_filter());
 
-    let mut io_sink = fern::Dispatch::new().format(|out, message, record| {
-        out.finish(format_args!(
-            "{}:{} -- {}",
-            chrono::Local::now().format("%H:%M:%S%.3f"),
-            record.level(),
-            message
-        ));
-    });
-
-    let log_file = data::log::file()?;
-
-    io_sink = io_sink.chain(log_file);
-
-    io_sink = io_sink
-        .level(log::LevelFilter::Off)
-        .level_for("panic", log::LevelFilter::Error)
-        .level_for("iced_wgpu", log::LevelFilter::Info)
-        .level_for("data", file_level_filter)
-        .level_for("ipc", file_level_filter)
-        .level_for("halloy", file_level_filter);
-
     let (channel_sink, receiver) = channel_logger();
 
-    let channel_sink = fern::Dispatch::new()
-        .chain(channel_sink)
-        .level(log::LevelFilter::Off)
-        .level_for("panic", log::LevelFilter::Error)
-        .level_for("iced_wgpu", log::LevelFilter::Info)
-        .level_for("data", channel_level_filter)
-        .level_for("ipc", channel_level_filter)
-        .level_for("halloy", channel_level_filter);
-
-    fern::Dispatch::new()
-        .chain(io_sink)
-        .chain(channel_sink)
-        .apply()?;
-
-    Ok(receiver)
+    (
+        fern::Dispatch::new()
+            .chain(channel_sink)
+            .level(log::LevelFilter::Off)
+            .level_for("panic", log::LevelFilter::Error)
+            .level_for("iced_wgpu", log::LevelFilter::Info)
+            .level_for("data", channel_level_filter)
+            .level_for("ipc", channel_level_filter)
+            .level_for("halloy", channel_level_filter),
+        receiver,
+    )
 }
 
 fn channel_logger() -> (Box<dyn Log>, ReceiverStream<Vec<Record>>) {


### PR DESCRIPTION
Adds setting `logs.max_file_count` to allow the user to control how many Halloy log files are kept.  Default is set to four log files (i.e. logs for the four most recent times Halloy was open) to make it more likely a log file will be available when users report issues in `#halloy`.  Also makes some minor changes to log message formatting to improve scannability.