### PR TITLE
Minor Regression Fix

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -88,6 +88,7 @@ pub enum Event {
     InputSent {
         history_task: Task<history::manager::Message>,
         open_buffers: Vec<(Target, BufferAction)>,
+        was_join_command: bool,
     },
     SendUnsafeList(data::Server),
     ConfigSaved,
@@ -336,9 +337,11 @@ impl Buffer {
                     channel::Event::InputSent {
                         history_task,
                         open_buffers,
+                        was_join_command,
                     } => Event::InputSent {
                         history_task,
                         open_buffers,
+                        was_join_command,
                     },
                     channel::Event::FilehostUpload {
                         server,
@@ -400,9 +403,11 @@ impl Buffer {
                     server::Event::InputSent {
                         history_task,
                         open_buffers,
+                        was_join_command,
                     } => Event::InputSent {
                         history_task,
                         open_buffers,
+                        was_join_command,
                     },
                     server::Event::FilehostUpload {
                         server,
@@ -469,9 +474,11 @@ impl Buffer {
                     query::Event::InputSent {
                         history_task,
                         open_buffers,
+                        was_join_command,
                     } => Event::InputSent {
                         history_task,
                         open_buffers,
+                        was_join_command,
                     },
                     query::Event::FilehostUpload {
                         server,

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -47,6 +47,7 @@ pub enum Event {
     InputSent {
         history_task: Task<history::manager::Message>,
         open_buffers: Vec<(Target, BufferAction)>,
+        was_join_command: bool,
     },
     FilehostUpload {
         server: Server,
@@ -423,6 +424,7 @@ impl Channel {
                     Some(input_view::Event::InputSent {
                         history_task,
                         open_buffers,
+                        was_join_command,
                     }) => {
                         let command = Task::batch(vec![
                             command,
@@ -436,6 +438,7 @@ impl Channel {
                             Some(Event::InputSent {
                                 history_task,
                                 open_buffers,
+                                was_join_command,
                             }),
                         )
                     }

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -53,6 +53,7 @@ pub enum Event {
     InputSent {
         history_task: Task<history::manager::Message>,
         open_buffers: Vec<(Target, BufferAction)>,
+        was_join_command: bool,
     },
     OpenBuffers {
         server: Server,
@@ -2055,6 +2056,7 @@ impl State {
             Some(Event::InputSent {
                 history_task,
                 open_buffers: vec![],
+                was_join_command: false,
             }),
         )
     }
@@ -2451,39 +2453,44 @@ impl State {
                 Task::batch(history_tasks.into_iter().map(Task::future));
         }
 
-        let open_buffers = if let Some(command::Irc::Join(targets, _)) =
-            input.command()
-        {
-            let chantypes =
-                clients.get_server_chantypes_or_default(buffer.server());
-            let statusmsg =
-                clients.get_server_statusmsg_or_default(buffer.server());
-            let casemapping =
-                clients.get_server_casemapping_or_default(buffer.server());
+        let (open_buffers, was_join_command) =
+            if let Some(command::Irc::Join(targets, _)) = input.command() {
+                let chantypes =
+                    clients.get_server_chantypes_or_default(buffer.server());
+                let statusmsg =
+                    clients.get_server_statusmsg_or_default(buffer.server());
+                let casemapping =
+                    clients.get_server_casemapping_or_default(buffer.server());
 
-            targets
-                .split(',')
-                .filter_map(|target| {
-                    let target = Target::parse(
-                        target,
-                        chantypes,
-                        statusmsg,
-                        casemapping,
-                    );
+                (
+                    targets
+                        .split(',')
+                        .filter_map(|target| {
+                            let target = Target::parse(
+                                target,
+                                chantypes,
+                                statusmsg,
+                                casemapping,
+                            );
 
-                    matches!(target, Target::Channel(_))
-                        .then_some((target, config.actions.buffer.join_channel))
-                })
-                .collect()
-        } else {
-            vec![]
-        };
+                            matches!(target, Target::Channel(_)).then_some((
+                                target,
+                                config.actions.buffer.join_channel,
+                            ))
+                        })
+                        .collect(),
+                    true,
+                )
+            } else {
+                (vec![], false)
+            };
 
         (
             Task::none(),
             Some(Event::InputSent {
                 history_task,
                 open_buffers,
+                was_join_command,
             }),
         )
     }

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -43,6 +43,7 @@ pub enum Event {
     InputSent {
         history_task: Task<history::manager::Message>,
         open_buffers: Vec<(Target, BufferAction)>,
+        was_join_command: bool,
     },
     FilehostUpload {
         server: Server,
@@ -342,6 +343,7 @@ impl Query {
                     Some(input_view::Event::InputSent {
                         history_task,
                         open_buffers,
+                        was_join_command,
                     }) => {
                         let command = Task::batch(vec![
                             command,
@@ -355,6 +357,7 @@ impl Query {
                             Some(Event::InputSent {
                                 history_task,
                                 open_buffers,
+                                was_join_command,
                             }),
                         )
                     }

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -62,6 +62,7 @@ pub enum Event {
     InputSent {
         history_task: Task<history::manager::Message>,
         open_buffers: Vec<(Target, BufferAction)>,
+        was_join_command: bool,
     },
     FilehostUpload {
         server: data::server::Server,
@@ -442,6 +443,7 @@ impl Server {
                     Some(input_view::Event::InputSent {
                         history_task,
                         open_buffers,
+                        was_join_command,
                     }) => (
                         Task::batch(vec![
                             command,
@@ -452,6 +454,7 @@ impl Server {
                         Some(Event::InputSent {
                             history_task,
                             open_buffers,
+                            was_join_command,
                         }),
                     ),
                     Some(input_view::Event::OpenBuffers {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1335,6 +1335,7 @@ impl Halloy {
                             &mut self.clients,
                             buffer_action,
                             &self.config,
+                            true,
                         ));
                     }
 

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1,9 +1,9 @@
 use std::collections::{HashMap, HashSet, VecDeque, hash_map};
-use std::convert;
 use std::ops::RangeInclusive;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use std::{convert, slice};
 
 use chrono::{DateTime, Utc};
 use data::capabilities::{
@@ -2388,6 +2388,7 @@ impl Dashboard {
                         clients,
                         buffer_action,
                         config,
+                        true,
                     ));
                 }
 
@@ -2555,6 +2556,7 @@ impl Dashboard {
             buffer::Event::InputSent {
                 history_task,
                 open_buffers,
+                was_join_command,
             } => {
                 let mut tasks = vec![];
 
@@ -2571,6 +2573,7 @@ impl Dashboard {
                             clients,
                             buffer_action,
                             config,
+                            !was_join_command,
                         ));
                     }
                 }
@@ -4913,9 +4916,16 @@ impl Dashboard {
         clients: &mut data::client::Map,
         buffer_action: BufferAction,
         config: &Config,
+        join_channel_if_not_joined: bool,
     ) -> Task<Message> {
         match target {
             Target::Channel(channel) => {
+                if join_channel_if_not_joined
+                    && !clients.contains_channel(&server, &channel)
+                {
+                    clients.join(&server, slice::from_ref(&channel));
+                }
+
                 let buffer = data::Buffer::Upstream(buffer::Upstream::Channel(
                     server, channel,
                 ));


### PR DESCRIPTION
When preventing duplicate `JOIN`s being sent when the `/join` command is used, joins were also suppressed whenever opening a buffer with a channel that has not been joined.  This restores the latter behavior by joining channels when opening them in a pane, unless the channel is already joined or the pane was opened as the result of a `/join` command.