### PR TITLE
Suppress connection status messages during macOS sleep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Fixed:
 - Apply mode arguments to the correct targets when a `MODE` message mixes added and removed modes (e.g. `-o+v foo bar` de-ops `foo` and voices `bar`)
 - Do not reconnect automatically when the server closes the connection in response to a requested quit
 - Don't show a transient terminal window when running `/exec` on Windows
+- Suppress connection status messages while macOS is asleep
 
 Changed:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2839,6 +2839,7 @@ dependencies = [
  "mundy",
  "notify-rust",
  "nucleo-matcher",
+ "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
  "open",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ iced = { workspace = true, features = [
 ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6.4"
 objc2-app-kit = { version = "0.3.2", default-features = false, features = [
     "std",
     "NSWorkspace",

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod open_url;
 mod platform_specific;
 mod screen;
 mod stream;
+mod system;
 mod unix_signal;
 mod url;
 mod widget;
@@ -236,6 +237,7 @@ struct Halloy {
     focused_window: Option<window::Id>,
     pending_logs: Vec<data::log::Record>,
     notifications: Notifications,
+    power: system::State,
 }
 
 impl Halloy {
@@ -318,6 +320,7 @@ impl Halloy {
                 focused_window: None,
                 pending_logs: vec![],
                 notifications,
+                power: system::State::default(),
             },
             commands,
         )
@@ -356,6 +359,7 @@ pub enum Message {
     RuntimeConfigured(Result<(), iced::backend::Error>),
     SystemInformation(iced::system::Information),
     Notification(notification::Event),
+    System(system::Event),
 }
 
 impl Halloy {
@@ -795,6 +799,16 @@ impl Halloy {
                     None => Task::none(),
                 }
             }
+            Message::System(system::Event::Suspending) => {
+                log::info!("system suspending");
+                self.power = system::State::Suspended;
+                Task::none()
+            }
+            Message::System(system::Event::Resumed) => {
+                log::info!("system resumed");
+                self.power = system::State::Awake;
+                Task::none()
+            }
             Message::Stream(update) => match update {
                 stream::Update::Disconnected {
                     server,
@@ -814,7 +828,7 @@ impl Halloy {
                         &self.config,
                     );
 
-                    if is_initial {
+                    if is_initial || self.power.suppresses_connection_events() {
                         Task::none()
                     } else {
                         if !self.main_window.focused {
@@ -843,6 +857,10 @@ impl Halloy {
                     }
                 }
                 stream::Update::Connecting { server, sent_time } => {
+                    if self.power.suppresses_connection_events() {
+                        return Task::none();
+                    }
+
                     let Screen::Dashboard(dashboard) = &mut self.screen else {
                         return Task::none();
                     };
@@ -877,6 +895,10 @@ impl Halloy {
                         &self.clients,
                         &self.config,
                     );
+
+                    if self.power.suppresses_connection_events() {
+                        return Task::none();
+                    }
 
                     let (notification, broadcast_kind) = if is_initial {
                         (Notification::Connected, Broadcast::Connected)
@@ -914,6 +936,10 @@ impl Halloy {
                     error,
                     sent_time,
                 } => {
+                    if self.power.suppresses_connection_events() {
+                        return Task::none();
+                    }
+
                     let Screen::Dashboard(dashboard) = &mut self.screen else {
                         return Task::none();
                     };
@@ -1495,6 +1521,7 @@ impl Halloy {
             events().map(|(window, event)| Message::Event(window, event)),
             window::events()
                 .map(|(window, event)| Message::Window(window, event)),
+            system::events().map(Message::System),
             tick,
             streams,
         ];

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,0 +1,33 @@
+use iced::Subscription;
+
+#[cfg(target_os = "macos")]
+mod macos;
+
+#[derive(Debug, Clone, Copy)]
+pub enum Event {
+    Suspending,
+    Resumed,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum State {
+    #[default]
+    Awake,
+    Suspended,
+}
+
+impl State {
+    pub fn suppresses_connection_events(self) -> bool {
+        !matches!(self, Self::Awake)
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub fn events() -> Subscription<Event> {
+    macos::events()
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn events() -> Subscription<Event> {
+    Subscription::none()
+}

--- a/src/system/macos.rs
+++ b/src/system/macos.rs
@@ -51,6 +51,8 @@ struct Registration(Retained<Observer>);
 impl Registration {
     fn new(sender: mpsc::UnboundedSender<Event>) -> Self {
         let observer = Observer::new(sender);
+        // Workspace associated with the process, shared by all threads
+        // of the app.
         let notification_center =
             NSWorkspace::sharedWorkspace().notificationCenter();
 

--- a/src/system/macos.rs
+++ b/src/system/macos.rs
@@ -19,6 +19,8 @@ define_class! {
     // SAFETY: NSObject has no subclassing requirements and the ivars are Send.
     #[unsafe(super(NSObject))]
     #[name = "HalloyPowerObserver"]
+    // An instance variable (ivar) is a variable that exists and holds its
+    // value for the life of the NSObject.
     #[ivars = Ivars]
     struct Observer;
 

--- a/src/system/macos.rs
+++ b/src/system/macos.rs
@@ -1,0 +1,99 @@
+use futures::channel::mpsc;
+use futures::{SinkExt, StreamExt};
+use iced::Subscription;
+use objc2::rc::Retained;
+use objc2::{AllocAnyThread as _, DeclaredClass, define_class, msg_send, sel};
+use objc2_app_kit::{
+    NSWorkspace, NSWorkspaceDidWakeNotification,
+    NSWorkspaceWillSleepNotification,
+};
+use objc2_foundation::NSObject;
+
+use super::Event;
+
+struct Ivars {
+    sender: mpsc::UnboundedSender<Event>,
+}
+
+define_class! {
+    // SAFETY: NSObject has no subclassing requirements and the ivars are Send.
+    #[unsafe(super(NSObject))]
+    #[name = "HalloyPowerObserver"]
+    #[ivars = Ivars]
+    struct Observer;
+
+    impl Observer {
+        #[unsafe(method(systemWillSleep))]
+        fn system_will_sleep(&self) {
+            let _ = self.ivars().sender.unbounded_send(Event::Suspending);
+        }
+
+        #[unsafe(method(systemDidWake))]
+        fn system_did_wake(&self) {
+            let _ = self.ivars().sender.unbounded_send(Event::Resumed);
+        }
+    }
+}
+
+impl Observer {
+    fn new(sender: mpsc::UnboundedSender<Event>) -> Retained<Self> {
+        let observer = Self::alloc().set_ivars(Ivars { sender });
+
+        // SAFETY: The observer is allocated and its ivars have been initialized.
+        unsafe { msg_send![super(observer), init] }
+    }
+}
+
+struct Registration(Retained<Observer>);
+
+impl Registration {
+    fn new(sender: mpsc::UnboundedSender<Event>) -> Self {
+        let observer = Observer::new(sender);
+        let notification_center =
+            NSWorkspace::sharedWorkspace().notificationCenter();
+
+        // SAFETY: The selectors are implemented by Observer and it remains
+        // alive until both registrations are removed.
+        unsafe {
+            notification_center.addObserver_selector_name_object(
+                &observer,
+                sel!(systemWillSleep),
+                Some(NSWorkspaceWillSleepNotification),
+                None,
+            );
+            notification_center.addObserver_selector_name_object(
+                &observer,
+                sel!(systemDidWake),
+                Some(NSWorkspaceDidWakeNotification),
+                None,
+            );
+        }
+
+        Self(observer)
+    }
+}
+
+impl Drop for Registration {
+    fn drop(&mut self) {
+        let notification_center =
+            NSWorkspace::sharedWorkspace().notificationCenter();
+
+        // SAFETY: This observer was registered with this notification center.
+        unsafe { notification_center.removeObserver(&self.0) };
+    }
+}
+
+pub fn events() -> Subscription<Event> {
+    Subscription::run(|| {
+        iced::stream::channel(10, async |mut output| {
+            let (sender, mut receiver) = mpsc::unbounded();
+            let _registration = Registration::new(sender);
+
+            while let Some(event) = receiver.next().await {
+                if output.send(event).await.is_err() {
+                    break;
+                }
+            }
+        })
+    })
+}

--- a/src/system/macos.rs
+++ b/src/system/macos.rs
@@ -78,7 +78,8 @@ impl Drop for Registration {
         let notification_center =
             NSWorkspace::sharedWorkspace().notificationCenter();
 
-        // SAFETY: This observer was registered with this notification center.
+        // SAFETY: This observer was registered with this notification center in
+        // Registration::new.
         unsafe { notification_center.removeObserver(&self.0) };
     }
 }


### PR DESCRIPTION
This suppresses connection status message while macOS is sleeping

<img width="516" height="318" alt="Screenshot 2026-07-20 at 17 20 46" src="https://github.com/user-attachments/assets/0dd1e6c3-e333-4ceb-80c5-bb9529ba8132" />
