### PR TITLE
docs(tls): document compatibility and troubleshooting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,6 +208,7 @@ workspace = true
 [workspace.metadata.typos.default]
 extend-ignore-re = [
     "(?Rm)^.*(#|//)\\s*spellchecker:disable-line$", # Ignore lines with trailing spellchecker:disable-line
+    "nmap -Pn",
 ]
 extend-ignore-identifiers-re = [
     "ERR_[A-Z]+", # IRC Error Numeric

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -17,6 +17,7 @@ const guidesItems = [
   { text: "Building for macOS", link: "/guides/macos-application" },
   { text: "Connect with soju", link: "/guides/connect-with-soju" },
   { text: "Connect with ZNC", link: "/guides/connect-with-znc" },
+  { text: "TLS Troubleshooting", link: "/guides/tls" },
   { text: "Custom Themes", link: "/guides/custom-themes" },
   { text: "Exec Command", link: "/guides/exec-command" },
   {

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -372,7 +372,10 @@ umodes = "+RB-x"
 
 ## `use_tls`
 
-Whether or not to use TLS. Clients will automatically panic if this is enabled without TLS support.
+Whether or not to use TLS. Halloy uses the secure protocol and cipher suite
+defaults provided by rustls. See
+[TLS compatibility and troubleshooting](/guides/tls) for details and commands
+that can be used to test a server.
 
 ```toml
 # Type: boolean
@@ -424,7 +427,10 @@ websocket_ping_interval = 60
 
 ## `dangerously_accept_invalid_certs`
 
-When `true`, all certificate validations are skipped.
+When `true`, all certificate validations are skipped. This does not enable
+unsupported protocol versions, cipher suites, signature algorithms, or key
+exchange methods. See
+[TLS compatibility and troubleshooting](/guides/tls) for more information.
 
 ```toml
 # Type: boolean

--- a/docs/guides/connect-with-znc.md
+++ b/docs/guides/connect-with-znc.md
@@ -42,11 +42,12 @@ Older ZNC or OpenSSL installations may only offer legacy cipher suites that
 are not supported by Halloy's TLS library. A server offering TLS 1.2 is not
 necessarily compatible if the client and server have no cipher suite in
 common. See [TLS compatibility and troubleshooting](/guides/tls) for Halloy's
-TLS defaults and commands that can be used to test a server.
+TLS defaults and commands that can be used to diagnose failed TLS handshakes.
 
 ZNC administrators can configure the accepted cipher suites and protocol
-versions using `SSLCiphers` and `SSLProtocols`. Refer to the official
-[ZNC configuration documentation](https://wiki.znc.in/Configuration) for the
-options supported by the installed ZNC version. Updating ZNC and OpenSSL and
-enabling modern ECDHE cipher suites is recommended instead of weakening the
-client-side TLS requirements.
+versions using global configuration settings `SSLCiphers` and `SSLProtocols`.
+Refer to the official [ZNC configuration
+documentation](https://wiki.znc.in/Configuration) for the options supported by
+the installed ZNC version. The official [ZNC hardening
+documentation](https://wiki.znc.in/HardeningTest) provides further security
+recommendations that are compatible with Halloy.

--- a/docs/guides/connect-with-znc.md
+++ b/docs/guides/connect-with-znc.md
@@ -35,3 +35,18 @@ Does your znc listen on a different port? See:
 
 Are you connecting with multiple clients? See:
 [multiple clients](https://wiki.znc.in/Multiple_clients)
+
+## TLS compatibility
+
+Older ZNC or OpenSSL installations may only offer legacy cipher suites that
+are not supported by Halloy's TLS library. A server offering TLS 1.2 is not
+necessarily compatible if the client and server have no cipher suite in
+common. See [TLS compatibility and troubleshooting](/guides/tls) for Halloy's
+TLS defaults and commands that can be used to test a server.
+
+ZNC administrators can configure the accepted cipher suites and protocol
+versions using `SSLCiphers` and `SSLProtocols`. Refer to the official
+[ZNC configuration documentation](https://wiki.znc.in/Configuration) for the
+options supported by the installed ZNC version. Updating ZNC and OpenSSL and
+enabling modern ECDHE cipher suites is recommended instead of weakening the
+client-side TLS requirements.

--- a/docs/guides/tls.md
+++ b/docs/guides/tls.md
@@ -1,57 +1,65 @@
 # TLS Compatibility and Troubleshooting
 
-Halloy uses [rustls](https://github.com/rustls/rustls) with its `ring` crypto
-provider for TLS connections. TLS 1.2 and TLS 1.3 are enabled, using the
+Halloy uses the [rustls](https://github.com/rustls/rustls) `ring` crypto
+provider for TLS connections. TLS 1.2 and TLS 1.3 are enabled, with the
 protocol versions, cipher suites, key exchange groups, and signature
-verification algorithms provided by rustls's secure defaults. Halloy does not
-add legacy cipher suites to those defaults.
+verification algorithms provided by rustls's secure defaults. The definitive
+listing of the default cipher suites can be found in the [`rustls`
+documentation](https://docs.rs/rustls/latest/rustls/crypto/ring/static.DEFAULT_CIPHER_SUITES.html),
+but for convenience it is reproduced here:
 
-The current cipher suites used by the `ring` provider are listed in the
-[`rustls` documentation](https://docs.rs/rustls/latest/rustls/crypto/ring/fn.default_provider.html).
-Because these defaults can change when rustls is updated, the rustls
-documentation is the authoritative source rather than a list maintained here.
+| TLS 1.2                                        | TLS 1.3                        |
+| ---------------------------------------------- | ------------------------------ |
+| TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384        | TLS13_AES_256_GCM_SHA384       |
+| TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256        | TLS13_AES_128_GCM_SHA256       |
+| TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256  | TLS13_CHACHA20_POLY1305_SHA256 |
+| TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384          |                                |
+| TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256          |                                |
+| TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256    |                                |
 
 ## Troubleshooting a TLS handshake
 
-A server supporting TLS 1.2 or TLS 1.3 does not necessarily mean it is
-compatible with Halloy. The client and server must also have a cipher suite,
-signature algorithm, and key exchange group in common.
+The error `received fatal alert: HandshakeFailure` indicates a TLS handshake
+could not be completed with the server. For a successful handshake, the server
+*must* support TLS 1.2 or TLS 1.3, and it *must* have a cipher suite, signature
+algorithm, and key exchange group in common with Halloy.
 
-An error such as `received fatal alert: HandshakeFailure` can indicate that no
-compatible parameters were found. It does not by itself identify which TLS
-parameter caused the failure.
+::: tip
+[`dangerously_accept_invalid_certs`](/configuration/servers#dangerously_accept_invalid_certs)
+only disables certificate validation. It does not enable unsupported protocol
+versions, cipher suites, signature algorithms, or key exchange methods.
+:::
 
-You can test a single TLS 1.2 handshake with OpenSSL:
+### [OpenSSL](https://openssl-library.org/)
+
+You can test a server's TLS 1.3 handshake with OpenSSL with the command:
 
 ```sh
-openssl s_client -connect HOST:PORT -tls1_2 -brief
+echo | openssl s_client -connect HOST:PORT -tls1_3 -brief
 ```
 
-Or test a TLS 1.3 handshake:
+where `HOST` and `PORT` should be replaced with the address and port used in
+your Halloy server configuration.
+
+Or test a TLS 1.2 handshake with:
 
 ```sh
-openssl s_client -connect HOST:PORT -tls1_3 -brief
+echo | openssl s_client -connect HOST:PORT -tls1_2 -brief
 ```
 
-Replace `HOST` and `PORT` with the address and port used in your Halloy server
-configuration. If the server uses name-based TLS configuration, connect using
-its hostname and add `-servername HOST`.
+::: tip
+If connecting to a server where `HOST` is (or can be) a name, rather than an IP
+address, then adding `-servername HOST` after `HOST:PORT` may be necessary. This
+option sets the TLS Server Name Indication, informing the server which hostname
+the client is attempting to connect to.
+:::
 
-A successful OpenSSL handshake only shows the single cipher suite negotiated
-by that connection. To enumerate the cipher suites accepted by a server, use
-Nmap:
-
-```sh
-nmap -sV --script ssl-enum-ciphers -p PORT HOST
-```
-
-For TLS 1.2, the following OpenSSL command can also check whether the server
-accepts modern ECDHE cipher suites:
+For TLS 1.2, the following OpenSSL command can be used to check whether the
+server accepts modern ECDHE cipher suites:
 
 ```sh
-openssl s_client \
+echo | openssl s_client \
   -connect HOST:PORT \
-  -servername HOST \
   -tls1_2 \
   -cipher 'ECDHE+AESGCM:ECDHE+CHACHA20' \
   -brief
@@ -59,19 +67,27 @@ openssl s_client \
 
 If an unrestricted TLS 1.2 handshake succeeds but the ECDHE-restricted test
 fails, the server may only offer obsolete cipher suites which rustls
-intentionally does not support. Update the TLS configuration of the IRC server
-or bouncer to offer modern cipher suites.
+intentionally does not support. If possible, it is recommended that the TLS
+configuration of the IRC server or bouncer be updated to offer modern cipher
+suites.
 
-::: warning
-[`dangerously_accept_invalid_certs`](/configuration/servers#dangerously_accept_invalid_certs)
-only disables certificate validation. It does not enable unsupported protocol
-versions, cipher suites, signature algorithms, or key exchange methods.
-:::
+### [Nmap](https://nmap.org/)
+
+A successful OpenSSL handshake only shows the single cipher suite negotiated by
+that connection. Nmap is an alternative that can be used to enumerate the cipher
+suites accepted by a server.  Using the command:
+
+```sh
+nmap -sV --script ssl-enum-ciphers -p PORT HOST
+```
+
+Nmap will attempt to enumerate all cipher suites that the server accepts by
+repeatedly initiating SSLv3/TLS connections.
 
 ## Connections protected by another transport
 
-Disabling TLS with `use_tls = false` sends the IRC connection as plaintext.
-This may be a deliberate choice when the entire connection is already carried
-through a trusted encrypted transport, such as a carefully configured VPN.
-Halloy cannot detect or assess the security of the surrounding network, so this
-decision must be made by the user responsible for that network.
+Halloy does not allow its accepted cipher suites to be configured. However, if
+the entire connection is carried through a trusted encrypted transport, such as
+a carefully configured VPN, then TLS can be disabled with `use_tls = false`
+(sending the IRC connection as plaintext). It is recommended to use TLS whenever
+possible, and only disable it if you understand the associated risks.

--- a/docs/guides/tls.md
+++ b/docs/guides/tls.md
@@ -1,0 +1,77 @@
+# TLS Compatibility and Troubleshooting
+
+Halloy uses [rustls](https://github.com/rustls/rustls) with its `ring` crypto
+provider for TLS connections. TLS 1.2 and TLS 1.3 are enabled, using the
+protocol versions, cipher suites, key exchange groups, and signature
+verification algorithms provided by rustls's secure defaults. Halloy does not
+add legacy cipher suites to those defaults.
+
+The current cipher suites used by the `ring` provider are listed in the
+[`rustls` documentation](https://docs.rs/rustls/latest/rustls/crypto/ring/fn.default_provider.html).
+Because these defaults can change when rustls is updated, the rustls
+documentation is the authoritative source rather than a list maintained here.
+
+## Troubleshooting a TLS handshake
+
+A server supporting TLS 1.2 or TLS 1.3 does not necessarily mean it is
+compatible with Halloy. The client and server must also have a cipher suite,
+signature algorithm, and key exchange group in common.
+
+An error such as `received fatal alert: HandshakeFailure` can indicate that no
+compatible parameters were found. It does not by itself identify which TLS
+parameter caused the failure.
+
+You can test a single TLS 1.2 handshake with OpenSSL:
+
+```sh
+openssl s_client -connect HOST:PORT -tls1_2 -brief
+```
+
+Or test a TLS 1.3 handshake:
+
+```sh
+openssl s_client -connect HOST:PORT -tls1_3 -brief
+```
+
+Replace `HOST` and `PORT` with the address and port used in your Halloy server
+configuration. If the server uses name-based TLS configuration, connect using
+its hostname and add `-servername HOST`.
+
+A successful OpenSSL handshake only shows the single cipher suite negotiated
+by that connection. To enumerate the cipher suites accepted by a server, use
+Nmap:
+
+```sh
+nmap -sV --script ssl-enum-ciphers -p PORT HOST
+```
+
+For TLS 1.2, the following OpenSSL command can also check whether the server
+accepts modern ECDHE cipher suites:
+
+```sh
+openssl s_client \
+  -connect HOST:PORT \
+  -servername HOST \
+  -tls1_2 \
+  -cipher 'ECDHE+AESGCM:ECDHE+CHACHA20' \
+  -brief
+```
+
+If an unrestricted TLS 1.2 handshake succeeds but the ECDHE-restricted test
+fails, the server may only offer obsolete cipher suites which rustls
+intentionally does not support. Update the TLS configuration of the IRC server
+or bouncer to offer modern cipher suites.
+
+::: warning
+[`dangerously_accept_invalid_certs`](/configuration/servers#dangerously_accept_invalid_certs)
+only disables certificate validation. It does not enable unsupported protocol
+versions, cipher suites, signature algorithms, or key exchange methods.
+:::
+
+## Connections protected by another transport
+
+Disabling TLS with `use_tls = false` sends the IRC connection as plaintext.
+This may be a deliberate choice when the entire connection is already carried
+through a trusted encrypted transport, such as a carefully configured VPN.
+Halloy cannot detect or assess the security of the surrounding network, so this
+decision must be made by the user responsible for that network.

--- a/docs/guides/tls.md
+++ b/docs/guides/tls.md
@@ -5,17 +5,7 @@ provider for TLS connections. TLS 1.2 and TLS 1.3 are enabled, with the
 protocol versions, cipher suites, key exchange groups, and signature
 verification algorithms provided by rustls's secure defaults. The definitive
 listing of the default cipher suites can be found in the [`rustls`
-documentation](https://docs.rs/rustls/latest/rustls/crypto/ring/static.DEFAULT_CIPHER_SUITES.html),
-but for convenience it is reproduced here:
-
-| TLS 1.2                                        | TLS 1.3                        |
-| ---------------------------------------------- | ------------------------------ |
-| TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384        | TLS13_AES_256_GCM_SHA384       |
-| TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256        | TLS13_AES_128_GCM_SHA256       |
-| TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256  | TLS13_CHACHA20_POLY1305_SHA256 |
-| TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384          |                                |
-| TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256          |                                |
-| TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256    |                                |
+documentation](https://docs.rs/rustls/latest/rustls/crypto/ring/static.DEFAULT_CIPHER_SUITES.html).
 
 ## Troubleshooting a TLS handshake
 
@@ -53,23 +43,6 @@ address, then adding `-servername HOST` after `HOST:PORT` may be necessary. This
 option sets the TLS Server Name Indication, informing the server which hostname
 the client is attempting to connect to.
 :::
-
-For TLS 1.2, the following OpenSSL command can be used to check whether the
-server accepts modern ECDHE cipher suites:
-
-```sh
-echo | openssl s_client \
-  -connect HOST:PORT \
-  -tls1_2 \
-  -cipher 'ECDHE+AESGCM:ECDHE+CHACHA20' \
-  -brief
-```
-
-If an unrestricted TLS 1.2 handshake succeeds but the ECDHE-restricted test
-fails, the server may only offer obsolete cipher suites which rustls
-intentionally does not support. If possible, it is recommended that the TLS
-configuration of the IRC server or bouncer be updated to offer modern cipher
-suites.
 
 ### [Nmap](https://nmap.org/)
 

--- a/docs/guides/tls.md
+++ b/docs/guides/tls.md
@@ -78,7 +78,7 @@ that connection. Nmap is an alternative that can be used to enumerate the cipher
 suites accepted by a server.  Using the command:
 
 ```sh
-nmap -sV --script ssl-enum-ciphers -p PORT HOST
+nmap -Pn --script ssl-enum-ciphers -p PORT HOST
 ```
 
 Nmap will attempt to enumerate all cipher suites that the server accepts by


### PR DESCRIPTION
- Document Halloy’s rustls TLS defaults.
- Add examples for OpenSSL and Nmap commands for testing server compatibility.
- Clarify the limitations of dangerously_accept_invalid_certs.
- Add ZNC-specific guidance for configuring modern TLS cipher suites.

Related to #2177.