### PR TITLE
Always Show Pane Title Bar Buttons Setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Added:
 - `servers.<name>.do_not_request` can be specified to prevent IRCv3 capability requests (e.g. `servers.<name>.do_not_request = [ "labeled-response" ]` will prevent [labeled-response](https://ircv3.net/specs/extensions/labeled-response) from being requested from the server)
 - `follow` option for reroute rules (`servers.<name>.reroute`) to reroute messages to the focused buffer
 - `logs.max_file_count` setting to control the number of Halloy log files that are stored on disk
+- `pane.always_show_title_bar_buttons` setting to prevent pane title bar buttons from being hidden when the pane is not hovered
 
 Fixed:
 
@@ -72,7 +73,7 @@ Thanks:
 
 - Contributions: @englut, @luca020400, @classabbyamp, @KaiKorla, @TheDcoder, @City-busz, @rtmongold, @Gelbpunkt, @zsigisti
 - Bug reports: @luca020400, agent314, @FlooferLand, @englut
-- Feature requests: @FlooferLand
+- Feature requests: @FlooferLand, quark
 
 # 2026.7.2 (2026-06-08)
 

--- a/data/src/config/pane.rs
+++ b/data/src/config/pane.rs
@@ -10,6 +10,7 @@ pub struct Pane {
     pub scrollbar: Scrollbar,
     pub restore_on_launch: bool,
     pub gap: Gap,
+    pub always_show_title_bar_buttons: bool,
 }
 
 impl Default for Pane {
@@ -19,6 +20,7 @@ impl Default for Pane {
             scrollbar: Scrollbar::default(),
             restore_on_launch: true,
             gap: Gap::default(),
+            always_show_title_bar_buttons: false,
         }
     }
 }

--- a/docs/configuration/pane.md
+++ b/docs/configuration/pane.md
@@ -93,3 +93,16 @@ Controls the padding around the outer edge of the pane grid.
 [pane.gap]
 outer = 8
 ```
+
+## `always_show_title_bar_buttons`
+
+Whether to always show buttons in pane title bars, otherwise title bar buttons are only visible when the pane is hovered.
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: false
+
+[pane]
+always_show_title_bar_buttons = true
+```

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -180,7 +180,8 @@ impl Pane {
             maximized,
             clients,
             settings,
-            self.modal.is_none(),
+            !config.pane.always_show_title_bar_buttons,
+            self.modal.is_some(),
             config.tooltips.show_for_buttons() && self.modal.is_none(),
             is_popout,
             config,
@@ -297,7 +298,8 @@ impl TitleBar {
         maximized: bool,
         clients: &'a data::client::Map,
         settings: Option<&'a buffer::Settings>,
-        show_controls: bool,
+        only_show_controls_on_hover: bool,
+        hide_controls: bool,
         show_tooltips: bool,
         is_popout: bool,
         config: &'a Config,
@@ -776,12 +778,16 @@ impl TitleBar {
             .padding([0, 4])
             .align_y(iced::alignment::Vertical::Center);
 
-        let title_bar = widget::TitleBar::new(title).padding(6);
+        let mut title_bar = widget::TitleBar::new(title).padding(6);
 
-        if show_controls {
-            title_bar.controls(pane_grid::Controls::new(controls))
-        } else {
+        if !only_show_controls_on_hover {
+            title_bar = title_bar.always_show_controls();
+        }
+
+        if hide_controls {
             title_bar
+        } else {
+            title_bar.controls(pane_grid::Controls::new(controls))
         }
     }
 }


### PR DESCRIPTION
Adds `pane.always_show_title_bar_buttons` setting to prevent pane title bar buttons from being hidden when the pane is not hovered.