### PR TITLE
Don't Fetch When All Previews are Excluded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Fixed:
 - Do not reconnect automatically when the server closes the connection in response to a requested quit
 - Don't show a transient terminal window when running `/exec` on Windows
 - Suppress connection status messages while macOS is asleep
+- When both card and image previews are excluded for a buffer, previews will not be pre-fetched for URLs in that buffer
 
 Changed:
 
@@ -73,7 +74,7 @@ Changed:
 Thanks:
 
 - Contributions: @englut, @luca020400, @classabbyamp, @KaiKorla, @TheDcoder, @City-busz, @rtmongold, @Gelbpunkt, @zsigisti
-- Bug reports: @luca020400, agent314, @FlooferLand, @englut
+- Bug reports: @luca020400, agent314, @FlooferLand, @englut, @rexbinary
 - Feature requests: @FlooferLand, quark
 
 # 2026.7.2 (2026-06-08)

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 pub use data::buffer::{Internal, Settings, Upstream};
 use data::config::buffer::text_input::Autocomplete;
 use data::dashboard::BufferAction;
-use data::target::{self, Target};
+use data::target::{self, Target, TargetRef};
 use data::user::Nick;
 use data::{
     Config, Image, buffer, file_transfer, history, input, message, preview,
@@ -228,6 +228,20 @@ impl Buffer {
                 Some(Target::Channel(state.target.clone()))
             }
             Buffer::Query(state) => Some(Target::Query(state.target.clone())),
+            Buffer::Empty
+            | Buffer::Server(_)
+            | Buffer::FileTransfers(_)
+            | Buffer::Logs(_)
+            | Buffer::Highlights(_)
+            | Buffer::ChannelDiscovery(_)
+            | Buffer::ConfigEditor(_) => None,
+        }
+    }
+
+    pub fn target_ref<'a>(&'a self) -> Option<TargetRef<'a>> {
+        match self {
+            Buffer::Channel(state) => Some(TargetRef::Channel(&state.target)),
+            Buffer::Query(state) => Some(TargetRef::Query(&state.target)),
             Buffer::Empty
             | Buffer::Server(_)
             | Buffer::FileTransfers(_)

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -247,21 +247,22 @@ impl Dashboard {
         config: &Config,
     ) -> Task<Message> {
         Task::batch(
-            self.visible_urls_with_preview_clients(clients)
-                .into_iter()
-                .map(|(url, client)| {
-                    Task::perform(
-                        data::preview::load(
-                            url.clone(),
-                            client.clone(),
-                            config.preview.clone(),
-                            self.previews_cache.clone(),
-                        ),
-                        move |result| {
-                            Message::LoadPreview((url.clone(), result))
-                        },
-                    )
-                }),
+            self.visible_preview_urls_with_preview_clients(
+                clients,
+                &config.preview,
+            )
+            .into_iter()
+            .map(|(url, client)| {
+                Task::perform(
+                    data::preview::load(
+                        url.clone(),
+                        client.clone(),
+                        config.preview.clone(),
+                        self.previews_cache.clone(),
+                    ),
+                    move |result| Message::LoadPreview((url.clone(), result)),
+                )
+            }),
         )
     }
 
@@ -2464,7 +2465,10 @@ impl Dashboard {
                 }
             }
             buffer::Event::PreviewChanged => {
-                let visible = self.visible_urls_with_preview_clients(clients);
+                let visible = self.visible_preview_urls_with_preview_clients(
+                    clients,
+                    &config.preview,
+                );
                 let tracking =
                     self.previews.keys().cloned().collect::<HashSet<_>>();
                 let missing = visible
@@ -5020,27 +5024,49 @@ impl Dashboard {
         self.panes.main_window
     }
 
-    fn visible_urls_with_preview_clients(
+    // URLs are filtered if there is no available preview client (an error) or
+    // previews are disabled for the buffer (configuration)
+    fn visible_preview_urls_with_preview_clients(
         &self,
         clients: &client::Map,
+        config: &config::preview::Preview,
     ) -> HashMap<url::Url, Arc<reqwest::Client>> {
         let pane_map = |pane: &Pane| -> Vec<(url::Url, Arc<reqwest::Client>)> {
-            let preview_client = if let Some(server) = pane.buffer.server()
-                && clients.get_server_proxy_config(&server).is_some()
+            let server = pane.buffer.server();
+
+            let preview_client = if let Some(server) = server.as_ref()
+                && clients.get_server_proxy_config(server).is_some()
             {
-                clients.get_server_http_client(&server)
+                clients.get_server_http_client(server)
             } else {
                 self.http_client.clone()
             };
 
-            if let Some(preview_client) = preview_client {
-                pane.visible_urls()
-                    .into_iter()
-                    .map(move |url| (url.clone(), preview_client.clone()))
-                    .collect()
-            } else {
-                vec![]
+            let Some(preview_client) = preview_client else {
+                return vec![];
+            };
+
+            if let Some(server) = server.as_ref()
+                && let Some(target_ref) = pane.buffer.target_ref()
+            {
+                let casemapping =
+                    clients.get_server_casemapping_or_default(server);
+
+                if matches!(
+                    config.card.visible(target_ref, server, casemapping),
+                    config::preview::Visibility::None
+                ) && matches!(
+                    config.image.visible(target_ref, server, casemapping),
+                    config::preview::Visibility::None
+                ) {
+                    return vec![];
+                }
             }
+
+            pane.visible_urls()
+                .into_iter()
+                .map(move |url| (url.clone(), preview_client.clone()))
+                .collect()
         };
 
         self.panes


### PR DESCRIPTION
Prevents URLs from being fetched when the buffer they're in has all (both) preview types excluded.  Fixes #2147. 