### PR TITLE
Muteable Channels & Queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Added:
 
 - Channel Monitor internal buffer for viewing messages from all joined channels
 - Internal buffers (logs, highlights, etc) can be added to sidebar
-  - They can optionally be hidden depending on the presence of unread messages
+- Channel, query, and internal buffers can be muted (only shown if an unread/highlight indicator should be shown) via `servers.<name>.channels`, `servers.<name>.queries`, and `sidebar.internal_buffers.mute`
 - Config editor pane for editing the config file in-app
 - Undo/redo in the message input and config editor (`ctrl`/`cmd` + `z`, `ctrl`/`cmd` + `shift` + `z`)
 - Improved legibility of the returned values of `MONITOR` list (`/monitor L`)

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -40,7 +40,15 @@ impl From<Internal> for Buffer {
 }
 
 #[derive(
-    Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, strum::Display,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    strum::Display,
+    strum::IntoStaticStr,
 )]
 pub enum Internal {
     #[strum(serialize = "File Transfers")]
@@ -147,8 +155,8 @@ impl Internal {
     }
 }
 
-impl From<config::sidebar::InternalBuffer> for Internal {
-    fn from(config: config::sidebar::InternalBuffer) -> Self {
+impl From<&config::sidebar::InternalBuffer> for Internal {
+    fn from(config: &config::sidebar::InternalBuffer) -> Self {
         match config {
             config::sidebar::InternalBuffer::ConfigEditor => Self::ConfigEditor,
             config::sidebar::InternalBuffer::FileTransfers => {
@@ -162,6 +170,25 @@ impl From<config::sidebar::InternalBuffer> for Internal {
             config::sidebar::InternalBuffer::ChannelDiscovery => {
                 Self::ChannelDiscovery(None)
             }
+        }
+    }
+}
+
+impl From<config::sidebar::InternalBuffer> for Internal {
+    fn from(config: config::sidebar::InternalBuffer) -> Self {
+        Self::from(&config)
+    }
+}
+
+impl From<&Internal> for config::sidebar::InternalBuffer {
+    fn from(buffer: &Internal) -> Self {
+        match buffer {
+            Internal::ConfigEditor => Self::ConfigEditor,
+            Internal::FileTransfers => Self::FileTransfers,
+            Internal::Logs => Self::Logs,
+            Internal::Highlights => Self::Highlights,
+            Internal::ChannelDiscovery(_) => Self::ChannelDiscovery,
+            Internal::ChannelMonitor => Self::ChannelMonitor,
         }
     }
 }

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -374,7 +374,7 @@ impl Client {
                         .iter()
                         .filter_map(|channel| {
                             target::Channel::parse(
-                                channel,
+                                &channel.name,
                                 self.chantypes(),
                                 self.statusmsg(),
                                 self.casemapping(),
@@ -514,7 +514,7 @@ impl Client {
             .iter()
             .filter_map(|query| {
                 target::Query::parse(
-                    query,
+                    &query.name,
                     self.chantypes(),
                     self.statusmsg(),
                     self.casemapping(),
@@ -2612,7 +2612,7 @@ impl Client {
                 // same number as ERR_NOCHANMODES)
                 if !self.chanmap.contains_key(&channel)
                     && self.config.channels.iter().any(|config_channel| {
-                        config_channel == channel.as_str()
+                        config_channel.name == channel.as_str()
                     })
                 {
                     self.registration_required_channels.push(channel.clone());
@@ -3203,7 +3203,7 @@ impl Client {
                     .iter()
                     .filter_map(|channel| {
                         target::Channel::parse(
-                            channel,
+                            &channel.name,
                             self.chantypes(),
                             self.statusmsg(),
                             self.casemapping(),
@@ -3252,7 +3252,7 @@ impl Client {
                     .iter()
                     .filter_map(|query| {
                         target::Query::parse(
-                            query,
+                            &query.name,
                             self.chantypes(),
                             self.statusmsg(),
                             self.casemapping(),
@@ -4117,6 +4117,26 @@ impl Client {
         self.chanmap.keys()
     }
 
+    pub fn channels_with_muted(
+        &self,
+    ) -> impl Iterator<Item = (&target::Channel, bool)> {
+        let casemapping = self.casemapping();
+
+        self.chanmap.keys().map(move |channel| {
+            (
+                channel,
+                self.config
+                    .channels
+                    .iter()
+                    .find(|config_channel| {
+                        casemapping.normalize(&config_channel.name)
+                            == channel.as_normalized_str()
+                    })
+                    .is_some_and(|config_channel| config_channel.mute),
+            )
+        })
+    }
+
     fn channel_users_received(&mut self, target_channel: target::Channel) {
         if let Some(client_channel) = self.chanmap.get_mut(&target_channel)
             && !client_channel.users_init
@@ -4226,6 +4246,30 @@ impl Client {
             .map(|(stored_query, query_state)| {
                 query_state.query.as_ref().unwrap_or(stored_query)
             })
+    }
+
+    pub fn resolve_query_with_muted<'a>(
+        &'a self,
+        query: &target::Query,
+        show_muted_buffers: bool,
+    ) -> (Option<&'a target::Query>, bool) {
+        (
+            self.resolve_query(query),
+            if show_muted_buffers {
+                false
+            } else {
+                let casemapping = self.casemapping();
+
+                self.config
+                    .queries
+                    .iter()
+                    .find(|config_query| {
+                        casemapping.normalize(&config_query.name)
+                            == query.as_normalized_str()
+                    })
+                    .is_some_and(|config_query| config_query.mute)
+            },
+        )
     }
 
     fn record_query(&mut self, query: &target::Query) {
@@ -4649,11 +4693,11 @@ fn compare_channels(
             let a_pos = &config
                 .channels
                 .iter()
-                .position(|ch| casemapping.normalize(ch) == a);
+                .position(|channel| casemapping.normalize(&channel.name) == a);
             let b_pos = &config
                 .channels
                 .iter()
-                .position(|ch| casemapping.normalize(ch) == b);
+                .position(|channel| casemapping.normalize(&channel.name) == b);
             match (a_pos, b_pos) {
                 (Some(a_pos), Some(b_pos)) => a_pos.cmp(b_pos),
                 (Some(_), None) => Ordering::Less,

--- a/data/src/config/actions.rs
+++ b/data/src/config/actions.rs
@@ -52,6 +52,7 @@ pub struct Sidebar {
     pub channel: Option<BufferAction>,
     pub query: Option<BufferAction>,
     pub focused_buffer: Option<BufferFocusedAction>,
+    pub cycle: CycleAction,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -190,4 +191,18 @@ pub enum ImageClickAction {
     #[default]
     OpenUrl,
     Preview,
+}
+
+#[derive(Debug, Copy, Clone, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CycleAction {
+    #[default]
+    IntoCollapsed,
+    SkipCollapsed,
+}
+
+impl CycleAction {
+    pub fn include_collapsed(&self) -> bool {
+        matches!(self, Self::IntoCollapsed)
+    }
 }

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -85,7 +85,7 @@ pub struct Server {
     /// Message reroute settings scoped to this server.
     pub reroute: Reroute,
     /// A list of channels to join on connection.
-    pub channels: Vec<String>,
+    pub channels: Vec<Muteable>,
     /// A mapping of channel names to keys for join-on-connect.
     pub channel_keys: HashMap<String, String>,
     /// A mapping of channel names to keyring entries for join-on-connect.
@@ -93,7 +93,7 @@ pub struct Server {
     /// Order server's channels
     pub order_channels_by: Option<OrderChannelsBy>,
     /// A list of queries to add to the sidebar on connection.
-    pub queries: Vec<String>,
+    pub queries: Vec<Muteable>,
     /// The amount of inactivity in seconds before the client will ping the server.
     #[serde(deserialize_with = "deserialize_u64_positive_integer")]
     pub ping_time: u64,
@@ -173,7 +173,7 @@ impl Server {
         server: String,
         port: Option<NonZeroU16>,
         nickname: String,
-        channels: Vec<String>,
+        channels: Vec<Muteable>,
         use_tls: bool,
         use_websocket: bool,
     ) -> Self {
@@ -335,6 +335,40 @@ impl Default for Server {
             do_not_request: vec![],
             irc_protocol_log: IrcProtocolLog::default(),
             sidebar_visibility: SidebarVisibility::Expanded,
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Debug, Default, Clone)]
+pub struct Muteable {
+    pub name: String,
+    pub mute: bool,
+}
+
+impl<'de> Deserialize<'de> for Muteable {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Data {
+            String(String),
+            Muteable { name: String, mute: bool },
+        }
+
+        match Data::deserialize(deserializer)? {
+            Data::String(name) => Ok(Muteable { name, mute: false }),
+            Data::Muteable { name, mute } => Ok(Muteable { name, mute }),
+        }
+    }
+}
+
+impl Muteable {
+    pub fn default_with_name(name: String) -> Self {
+        Self {
+            name,
+            ..Self::default()
         }
     }
 }

--- a/data/src/config/sidebar.rs
+++ b/data/src/config/sidebar.rs
@@ -39,6 +39,7 @@ pub struct Sidebar {
     pub order_channels_by: OrderChannelsBy,
     pub channel_name_casing: Option<ChannelNameCasing>,
     pub internal_buffers: InternalBuffers,
+    pub cycle_into_collapsed: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]

--- a/data/src/config/sidebar.rs
+++ b/data/src/config/sidebar.rs
@@ -39,7 +39,6 @@ pub struct Sidebar {
     pub order_channels_by: OrderChannelsBy,
     pub channel_name_casing: Option<ChannelNameCasing>,
     pub internal_buffers: InternalBuffers,
-    pub cycle_into_collapsed: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]

--- a/data/src/config/sidebar.rs
+++ b/data/src/config/sidebar.rs
@@ -44,23 +44,38 @@ pub struct Sidebar {
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(default)]
 pub struct InternalBuffers {
-    pub mute: InternalBuffersMutePolicy,
+    #[serde(deserialize_with = "deserialize_muteable_internal_buffers")]
+    pub mute: Vec<InternalBuffer>,
     pub position: InternalBufferPosition,
     pub buffers: Vec<InternalBuffer>,
-}
-
-#[derive(Debug, Copy, Clone, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
-pub enum InternalBuffersMutePolicy {
-    #[default]
-    Never,
-    Read,
 }
 
 impl InternalBuffers {
     pub fn is_before_servers(&self) -> bool {
         matches!(self.position, InternalBufferPosition::BeforeServers)
     }
+}
+
+pub fn deserialize_muteable_internal_buffers<'de, D>(
+    deserializer: D,
+) -> Result<Vec<InternalBuffer>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(rename_all = "kebab-case")]
+    enum MuteableInternalBuffer {
+        Highlights,
+        Logs,
+    }
+
+    Ok(Vec::<MuteableInternalBuffer>::deserialize(deserializer)?
+        .into_iter()
+        .map(|muteable_internal_buffer| match muteable_internal_buffer {
+            MuteableInternalBuffer::Highlights => InternalBuffer::Highlights,
+            MuteableInternalBuffer::Logs => InternalBuffer::Logs,
+        })
+        .collect())
 }
 
 #[derive(Debug, Copy, Clone, Deserialize, Default)]

--- a/data/src/url.rs
+++ b/data/src/url.rs
@@ -9,7 +9,7 @@ use unicode_security::confusable_detection::skeleton;
 use unicode_security::{RestrictionLevel, RestrictionLevelDetection};
 
 use crate::appearance::theme;
-use crate::config::server::default_port;
+use crate::config::server::{Muteable, default_port};
 use crate::server::ServerName;
 use crate::{config, isupport};
 
@@ -186,6 +186,9 @@ fn parse_server_config(url: &url::Url) -> Option<config::Server> {
         }
 
         channels
+            .into_iter()
+            .map(Muteable::default_with_name)
+            .collect()
     };
 
     Some(config::Server::new(
@@ -286,6 +289,22 @@ mod tests {
             expected_channels
                 .iter()
                 .map(ToString::to_string)
+                .map(Muteable::default_with_name)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[track_caller]
+    fn assert_eq_as_unmuted_channels(
+        channels: Vec<Muteable>,
+        channel_names: &[&str],
+    ) {
+        assert_eq!(
+            channels,
+            channel_names
+                .iter()
+                .map(ToString::to_string)
+                .map(Muteable::default_with_name)
                 .collect::<Vec<_>>()
         );
     }
@@ -349,7 +368,7 @@ mod tests {
 
         assert_eq!(config.server, "2001:db8::1");
         assert_eq!(config.port, NonZeroU16::new(6667));
-        assert_eq!(config.channels, vec!["#channel"]);
+        assert_eq_as_unmuted_channels(config.channels, &["#channel"]);
         assert!(!config.use_tls);
     }
 
@@ -360,7 +379,7 @@ mod tests {
                 .unwrap();
         let config = parse_server_config(&url).unwrap();
 
-        assert_eq!(config.channels, vec!["#foo%bar", "&local"]);
+        assert_eq_as_unmuted_channels(config.channels, &["#foo%bar", "&local"]);
     }
 
     #[test]
@@ -369,7 +388,7 @@ mod tests {
             url::Url::parse("irc://irc.example.org/#foo%25bar,%2Bops").unwrap();
         let config = parse_server_config(&url).unwrap();
 
-        assert_eq!(config.channels, vec!["#foo%bar", "#+ops"]);
+        assert_eq_as_unmuted_channels(config.channels, &["#foo%bar", "#+ops"]);
     }
 
     #[test]

--- a/docs/configuration/actions.md
+++ b/docs/configuration/actions.md
@@ -280,3 +280,16 @@ Action when clicking a focused buffer in the sidebar. `"close-pane"` will close 
 [actions.sidebar]
 focused_buffer = "close-pane"
 ```
+
+### `cycle`
+
+How to cycle between buffers when using [cycle shortcuts](/configuration/keyboard#actions).  If set to `"skip-collapsed"` then buffers that are hidden because the server has been [collapsed](/configuration/servers#sidebar-visibility) will be skipped when cycling to the next/previous (unread) buffer.  If set to `"into-collapsed"` then cycling to the next/previous (unread) buffer will include buffers hidden because the server has been [collapsed](/configuration/servers#sidebar-visibility) (collapsed buffers with an open pane will be shown in the sidebar).
+
+```toml
+# Type: string
+# Values: "into-collapsed", "skip-collapsed"
+# Default: "into-collapsed"
+
+[actions.sidebar]
+cycle = "skip-collapsed"
+```

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -1227,7 +1227,7 @@ timestamp = "utc"
 
 [^2]: Relative paths are prefixed with the config directory (i.e. if you have your config.toml in `/home/me/.config/halloy/config.toml`, path `.passwd/libera` will be converted to `/home/me/.config/halloy/.passwd/libera`).
 
-## `sidebar_visibility`
+## `sidebar_visibility` {#sidebar-visibility}
 
 Control the initial visibility of the server in the sidebar.
 

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -257,7 +257,7 @@ Then set `password_command` to `flatpak-spawn --host <password_command>`
 
 ## `channels`
 
-A list of channels to join on connection.
+A list of channels to join on connection.  Channels can be muted (only shown in the sidebar if they have a an unread/highlight indicator), by specifying them as `{ name = "#channel", mute = true }`.
 
 ```toml
 # Type: array of strings
@@ -265,7 +265,7 @@ A list of channels to join on connection.
 # Default: not set
 
 [servers.<name>]
-channels = ["#foo", "#bar"]
+channels = ["#foo", { name = "#bar", mute = true }]
 ```
 
 ## `channel_keys`
@@ -320,7 +320,7 @@ channels = ["#rust", "#halloy", "#halloy-test"]
 
 ## `queries`
 
-A list of queries to add to the sidebar on connection.
+A list of queries to add to the sidebar on connection.  Queries can be muted (only shown in the sidebar if they have a an unread/highlight indicator), by specifying them as `{ name = "#channel", mute = true }`.
 
 ```toml
 # Type: array of strings
@@ -328,7 +328,7 @@ A list of queries to add to the sidebar on connection.
 # Default: not set
 
 [servers.<name>]
-queries = ["alice", "bob"]
+queries = ["alice", { name = "bob", mute = true }]
 ```
 
 ## `ping_time`

--- a/docs/configuration/sidebar.md
+++ b/docs/configuration/sidebar.md
@@ -179,25 +179,20 @@ Internal buffers shown in the sidebar.
 # Default: []
 
 [sidebar.internal_buffers]
-buffers = ["logs", "highlights"]
+buffers = ["highlights", "logs"]
 ```
 
 ### `mute`
 
-Controls when the internal buffers are muted (hidden from the sidebar).
-
-- `"never"`: Never mute the internal buffers (i.e. internal buffers are always visible).
-- `"read"`: Mute internal buffers if they have no unread messages (i.e. only show internal buffers with unread messages).
-
-Note: If a buffer has no concept of "unread messages" (e.g., `file-transfer`), then it will be shown in the sidebar regardless of this setting.
+Controls which internal buffers are muted (hidden from the sidebar when they have no unread message/highlight indicator).
 
 ```toml
-# Type: string
-# Values: "never", "read"
-# Default: "never"
+# Type: array
+# Values: `highlights`, `logs`
+# Default: []
 
 [sidebar.internal_buffers]
-mute = "read"
+mute = ["logs"]
 ```
 
 ## `channel_name_casing`

--- a/docs/configuration/sidebar.md
+++ b/docs/configuration/sidebar.md
@@ -490,3 +490,16 @@ Controls the vertical spacing between servers (i.e. between the last buffer for 
 [sidebar.spacing]
 server = 4
 ```
+
+## `cycle_into_collapsed`
+
+Whether to cycle into collapsed buffers when using [cycle shortcuts](/configuration/keyboard#actions).  If `cycle_into_collapsed` is `false` then buffers that are hidden because the server has been [collapsed](/configuration/servers#sidebar-visibility) will be skipped when cycling to the next/previous buffer.
+
+```toml
+# Type: bool
+# Values: true, false
+# Default: false
+
+[sidebar]
+cycle_into_collapsed = true
+```

--- a/docs/configuration/sidebar.md
+++ b/docs/configuration/sidebar.md
@@ -490,16 +490,3 @@ Controls the vertical spacing between servers (i.e. between the last buffer for 
 [sidebar.spacing]
 server = 4
 ```
-
-## `cycle_into_collapsed`
-
-Whether to cycle into collapsed buffers when using [cycle shortcuts](/configuration/keyboard#actions).  If `cycle_into_collapsed` is `false` then buffers that are hidden because the server has been [collapsed](/configuration/servers#sidebar-visibility) will be skipped when cycling to the next/previous buffer.
-
-```toml
-# Type: bool
-# Values: true, false
-# Default: false
-
-[sidebar]
-cycle_into_collapsed = true
-```

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1086,7 +1086,7 @@ impl Dashboard {
                             &self.panes,
                             config,
                             self.buffer_settings.show_muted,
-                            config.sidebar.cycle_into_collapsed,
+                            config.actions.sidebar.cycle.include_collapsed(),
                         );
 
                         let open_buffers = open_buffers(self);
@@ -1117,7 +1117,7 @@ impl Dashboard {
                             &self.panes,
                             config,
                             self.buffer_settings.show_muted,
-                            config.sidebar.cycle_into_collapsed,
+                            config.actions.sidebar.cycle.include_collapsed(),
                         );
 
                         let open_buffers = open_buffers(self);
@@ -1365,7 +1365,11 @@ impl Dashboard {
                                 &self.panes,
                                 config,
                                 self.buffer_settings.show_muted,
-                                config.sidebar.cycle_into_collapsed,
+                                config
+                                    .actions
+                                    .sidebar
+                                    .cycle
+                                    .include_collapsed(),
                             );
 
                         let open_buffers = open_buffers(self);
@@ -1397,7 +1401,11 @@ impl Dashboard {
                                 &self.panes,
                                 config,
                                 self.buffer_settings.show_muted,
-                                config.sidebar.cycle_into_collapsed,
+                                config
+                                    .actions
+                                    .sidebar
+                                    .cycle
+                                    .include_collapsed(),
                             );
 
                         let open_buffers = open_buffers(self);

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1079,14 +1079,21 @@ impl Dashboard {
                         self.panes.main.restore();
                     }
                     CycleNextBuffer => {
-                        let all_buffers =
-                            all_buffers(config, clients, &self.history);
+                        let cycle_buffers = self.side_menu.visible_buffers(
+                            servers,
+                            clients,
+                            &self.history,
+                            &self.panes,
+                            config,
+                            self.buffer_settings.show_muted,
+                        );
+
                         let open_buffers = open_buffers(self);
 
                         if let Some((_, _, state)) = self.get_focused_mut()
                             && let Some(buffer) = cycle_next_buffer(
                                 state.buffer.data().as_ref(),
-                                all_buffers,
+                                cycle_buffers,
                                 &open_buffers,
                             )
                         {
@@ -1102,14 +1109,21 @@ impl Dashboard {
                         }
                     }
                     CyclePreviousBuffer => {
-                        let all_buffers =
-                            all_buffers(config, clients, &self.history);
+                        let cycle_buffers = self.side_menu.visible_buffers(
+                            servers,
+                            clients,
+                            &self.history,
+                            &self.panes,
+                            config,
+                            self.buffer_settings.show_muted,
+                        );
+
                         let open_buffers = open_buffers(self);
 
                         if let Some((_, _, state)) = self.get_focused_mut()
                             && let Some(buffer) = cycle_previous_buffer(
                                 state.buffer.data().as_ref(),
-                                all_buffers,
+                                cycle_buffers,
                                 &open_buffers,
                             )
                         {
@@ -1341,17 +1355,22 @@ impl Dashboard {
                         return (task, None);
                     }
                     CycleNextUnreadBuffer => {
-                        let all_buffers = all_buffers_with_has_unread(
-                            config,
-                            clients,
-                            &self.history,
-                        );
+                        let cycle_buffers =
+                            self.side_menu.visible_buffers_with_has_unread(
+                                servers,
+                                clients,
+                                &self.history,
+                                &self.panes,
+                                config,
+                                self.buffer_settings.show_muted,
+                            );
+
                         let open_buffers = open_buffers(self);
 
                         if let Some((_, _, state)) = self.get_focused_mut()
                             && let Some(buffer) = cycle_next_unread_buffer(
                                 state.buffer.data().as_ref(),
-                                all_buffers,
+                                cycle_buffers,
                                 &open_buffers,
                             )
                         {
@@ -1367,17 +1386,22 @@ impl Dashboard {
                         }
                     }
                     CyclePreviousUnreadBuffer => {
-                        let all_buffers = all_buffers_with_has_unread(
-                            config,
-                            clients,
-                            &self.history,
-                        );
+                        let cycle_buffers =
+                            self.side_menu.visible_buffers_with_has_unread(
+                                servers,
+                                clients,
+                                &self.history,
+                                &self.panes,
+                                config,
+                                self.buffer_settings.show_muted,
+                            );
+
                         let open_buffers = open_buffers(self);
 
                         if let Some((_, _, state)) = self.get_focused_mut()
                             && let Some(buffer) = cycle_previous_unread_buffer(
                                 state.buffer.data().as_ref(),
-                                all_buffers,
+                                cycle_buffers,
                                 &open_buffers,
                             )
                         {
@@ -5420,45 +5444,6 @@ impl Panes {
     }
 }
 
-fn all_buffers(
-    config: &Config,
-    clients: &client::Map,
-    history: &history::Manager,
-) -> Vec<data::Buffer> {
-    let upstream_buffers = all_upstream_buffers(clients, history)
-        .into_iter()
-        .map(data::Buffer::Upstream);
-
-    let internal_buffers = config
-        .sidebar
-        .internal_buffers
-        .buffers
-        .iter()
-        .filter_map(|&kind| {
-            let buffer = data::Buffer::Internal(kind.into());
-
-            if matches!(
-                config.sidebar.internal_buffers.mute,
-                config::sidebar::InternalBuffersMutePolicy::Never
-            ) {
-                return Some(buffer);
-            }
-
-            match history::Kind::from_buffer(buffer.clone()) {
-                Some(history_kind) => {
-                    history.has_unread(&history_kind).then_some(buffer)
-                }
-                None => Some(buffer),
-            }
-        });
-
-    if config.sidebar.internal_buffers.is_before_servers() {
-        internal_buffers.chain(upstream_buffers).collect()
-    } else {
-        upstream_buffers.chain(internal_buffers).collect()
-    }
-}
-
 fn all_upstream_buffers(
     clients: &client::Map,
     history: &history::Manager,
@@ -5477,58 +5462,6 @@ fn all_upstream_buffers(
                 ))
         })
         .collect()
-}
-
-fn all_buffers_with_has_unread(
-    config: &Config,
-    clients: &client::Map,
-    history: &history::Manager,
-) -> Vec<(data::Buffer, bool)> {
-    let upstream_buffers = clients.connected_servers().flat_map(|server| {
-        std::iter::once((
-            buffer::Upstream::Server(server.clone()).into(),
-            history.has_unread(&history::Kind::Server(server.clone())),
-        ))
-        .chain(clients.get_channels(server).map(|channel| {
-            (
-                buffer::Upstream::Channel(server.clone(), channel.clone())
-                    .into(),
-                history.has_unread(&history::Kind::Channel(
-                    server.clone(),
-                    channel.clone(),
-                )),
-            )
-        }))
-        .chain(history.get_unique_queries(server).into_iter().map(|nick| {
-            (
-                buffer::Upstream::Query(server.clone(), nick.clone()).into(),
-                history.has_unread(&history::Kind::Query(
-                    server.clone(),
-                    nick.clone(),
-                )),
-            )
-        }))
-    });
-
-    let internal_buffers = config
-        .sidebar
-        .internal_buffers
-        .buffers
-        .iter()
-        .map(|&kind| data::Buffer::Internal(kind.into()))
-        .map(|buffer| {
-            if let Some(kind) = history::Kind::from_buffer(buffer.clone()) {
-                (buffer, history.has_unread(&kind))
-            } else {
-                (buffer, false)
-            }
-        });
-
-    if config.sidebar.internal_buffers.is_before_servers() {
-        internal_buffers.chain(upstream_buffers).collect()
-    } else {
-        upstream_buffers.chain(internal_buffers).collect()
-    }
 }
 
 fn open_buffers(dashboard: &Dashboard) -> Vec<data::Buffer> {

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1086,6 +1086,7 @@ impl Dashboard {
                             &self.panes,
                             config,
                             self.buffer_settings.show_muted,
+                            config.sidebar.cycle_into_collapsed,
                         );
 
                         let open_buffers = open_buffers(self);
@@ -1116,6 +1117,7 @@ impl Dashboard {
                             &self.panes,
                             config,
                             self.buffer_settings.show_muted,
+                            config.sidebar.cycle_into_collapsed,
                         );
 
                         let open_buffers = open_buffers(self);
@@ -1363,6 +1365,7 @@ impl Dashboard {
                                 &self.panes,
                                 config,
                                 self.buffer_settings.show_muted,
+                                config.sidebar.cycle_into_collapsed,
                             );
 
                         let open_buffers = open_buffers(self);
@@ -1394,6 +1397,7 @@ impl Dashboard {
                                 &self.panes,
                                 config,
                                 self.buffer_settings.show_muted,
+                                config.sidebar.cycle_into_collapsed,
                             );
 
                         let open_buffers = open_buffers(self);

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -126,6 +126,7 @@ impl Sidebar {
         panes: &Panes,
         config: &Config,
         show_muted_buffers: bool,
+        include_collapsed_buffers: bool,
     ) -> Vec<Buffer> {
         self.sidebar_buffer_groups(
             servers,
@@ -134,6 +135,7 @@ impl Sidebar {
             panes,
             config,
             show_muted_buffers,
+            include_collapsed_buffers,
         )
         .into_iter()
         .flat_map(|sidebar_buffer_group| match sidebar_buffer_group {
@@ -159,6 +161,7 @@ impl Sidebar {
         panes: &Panes,
         config: &Config,
         show_muted_buffers: bool,
+        include_collapsed_buffers: bool,
     ) -> Vec<(Buffer, bool)> {
         self.sidebar_buffer_groups(
             servers,
@@ -167,6 +170,7 @@ impl Sidebar {
             panes,
             config,
             show_muted_buffers,
+            include_collapsed_buffers,
         )
         .into_iter()
         .flat_map(|sidebar_buffer_group| match sidebar_buffer_group {
@@ -202,6 +206,7 @@ impl Sidebar {
         panes: &Panes,
         config: &Config,
         show_muted_buffers: bool,
+        include_collapsed_buffers: bool,
     ) -> Vec<SidebarBufferGroup> {
         let upstream_buffer_data =
             |buffer: buffer::Upstream,
@@ -316,6 +321,14 @@ impl Sidebar {
                                 .collapse_indicators(&collapsible_buffers);
 
                             vec![buffer_data]
+                                .into_iter()
+                                .chain(collapsible_buffers.into_iter().filter(
+                                    |buffer_data| {
+                                        buffer_data.is_visible_pane
+                                            || include_collapsed_buffers
+                                    },
+                                ))
+                                .collect()
                         } else {
                             vec![buffer_data]
                                 .into_iter()
@@ -823,6 +836,7 @@ impl Sidebar {
                 panes,
                 config,
                 show_muted_buffers,
+                false,
             );
 
             let mut buffers = vec![];
@@ -1036,6 +1050,7 @@ enum SidebarBufferGroup {
 struct UpstreamBufferSidebarData {
     buffer: buffer::Upstream,
     kind: history::Kind,
+    is_visible_pane: bool,
     has_unread: bool,
     #[expect(dead_code)] // TODO: Cycle highlights
     has_highlight: bool,
@@ -1099,6 +1114,7 @@ impl UpstreamBufferSidebarData {
         Some(Self {
             buffer,
             kind,
+            is_visible_pane,
             has_unread,
             has_highlight,
             indicators,

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -1,11 +1,13 @@
 use std::time::Duration;
 use std::{convert, iter};
 
+use data::buffer::Buffer;
 use data::config::server::SidebarVisibility;
+use data::config::sidebar::{InternalBuffer, PrimaryIcon};
 use data::config::{self, Config, sidebar};
 use data::dashboard::{BufferAction, BufferFocusedAction};
 use data::{
-    Image, Version, buffer, file_transfer, history, isupport, server,
+    Image, Version, buffer, client, file_transfer, history, isupport, server,
     server_icon, target,
 };
 use iced::Length::Shrink;
@@ -114,6 +116,279 @@ impl Sidebar {
             },
             iced::system::information().map(Message::SystemInformation),
         )
+    }
+
+    pub fn visible_buffers(
+        &self,
+        servers: &server::Map,
+        clients: &data::client::Map,
+        history: &history::Manager,
+        panes: &Panes,
+        config: &Config,
+        show_muted_buffers: bool,
+    ) -> Vec<Buffer> {
+        self.sidebar_buffer_groups(
+            servers,
+            clients,
+            history,
+            panes,
+            config,
+            show_muted_buffers,
+        )
+        .into_iter()
+        .flat_map(|sidebar_buffer_group| match sidebar_buffer_group {
+            SidebarBufferGroup::Upstream {
+                visible_buffers, ..
+            } => visible_buffers
+                .into_iter()
+                .map(|buffer_data| Buffer::Upstream(buffer_data.buffer))
+                .collect::<Vec<Buffer>>(),
+            SidebarBufferGroup::Internal { visible_buffers } => visible_buffers
+                .into_iter()
+                .map(|buffer_data| Buffer::Internal(buffer_data.buffer))
+                .collect::<Vec<Buffer>>(),
+        })
+        .collect()
+    }
+
+    pub fn visible_buffers_with_has_unread(
+        &self,
+        servers: &server::Map,
+        clients: &data::client::Map,
+        history: &history::Manager,
+        panes: &Panes,
+        config: &Config,
+        show_muted_buffers: bool,
+    ) -> Vec<(Buffer, bool)> {
+        self.sidebar_buffer_groups(
+            servers,
+            clients,
+            history,
+            panes,
+            config,
+            show_muted_buffers,
+        )
+        .into_iter()
+        .flat_map(|sidebar_buffer_group| match sidebar_buffer_group {
+            SidebarBufferGroup::Upstream {
+                visible_buffers, ..
+            } => visible_buffers
+                .into_iter()
+                .map(|buffer_data| {
+                    (
+                        Buffer::Upstream(buffer_data.buffer),
+                        buffer_data.has_unread,
+                    )
+                })
+                .collect::<Vec<(Buffer, bool)>>(),
+            SidebarBufferGroup::Internal { visible_buffers } => visible_buffers
+                .into_iter()
+                .map(|buffer_data| {
+                    (
+                        Buffer::Internal(buffer_data.buffer),
+                        buffer_data.has_unread,
+                    )
+                })
+                .collect::<Vec<(Buffer, bool)>>(),
+        })
+        .collect()
+    }
+
+    fn sidebar_buffer_groups(
+        &self,
+        servers: &server::Map,
+        clients: &data::client::Map,
+        history: &history::Manager,
+        panes: &Panes,
+        config: &Config,
+        show_muted_buffers: bool,
+    ) -> Vec<SidebarBufferGroup> {
+        let upstream_buffer_data =
+            |buffer: buffer::Upstream,
+             kind: history::Kind,
+             muted: bool,
+             casemapping: isupport::CaseMap|
+             -> Option<UpstreamBufferSidebarData> {
+                UpstreamBufferSidebarData::from_upstream_buffer(
+                    buffer,
+                    kind,
+                    muted,
+                    casemapping,
+                    show_muted_buffers,
+                    history,
+                    panes,
+                    config,
+                )
+            };
+
+        let upstream_buffer_group = |server: &Server,
+                                     state: &client::State|
+         -> Option<SidebarBufferGroup> {
+            let casemapping = clients.get_server_casemapping_or_default(server);
+
+            let is_collapsed = !self.collapse.is_expanded(config, server);
+
+            match state {
+                data::client::State::Disconnected {
+                    autoconnect,
+                    connecting,
+                } => {
+                    // Hide channels & queries for disconnected servers
+                    upstream_buffer_data(
+                        buffer::Upstream::Server(server.clone()),
+                        history::Kind::Server(server.clone()),
+                        false,
+                        casemapping,
+                    )
+                    .map(|buffer_data| {
+                        SidebarBufferGroup::Upstream {
+                            server: server.clone(),
+                            visible_buffers: vec![buffer_data],
+                            connection_status: ConnectionStatus::Disconnected {
+                                autoconnect: *autoconnect,
+                                connecting: *connecting,
+                            },
+                            has_collapsible_buffers: false,
+                            casemapping,
+                        }
+                    })
+                }
+                data::client::State::Ready(connection) => {
+                    // Connected server.
+                    upstream_buffer_data(
+                        buffer::Upstream::Server(server.clone()),
+                        history::Kind::Server(server.clone()),
+                        false,
+                        casemapping,
+                    )
+                    .map(|mut buffer_data| {
+                        let mut collapsible_buffers = vec![];
+
+                        // Channels from the connected server.
+                        for (channel, muted) in connection.channels_with_muted()
+                        {
+                            if let Some(buffer_data) = upstream_buffer_data(
+                                buffer::Upstream::Channel(
+                                    server.clone(),
+                                    channel.clone(),
+                                ),
+                                history::Kind::Channel(
+                                    server.clone(),
+                                    channel.clone(),
+                                ),
+                                muted,
+                                casemapping,
+                            ) {
+                                collapsible_buffers.push(buffer_data);
+                            }
+                        }
+
+                        // Queries from the connected server.
+                        for query in history.get_unique_queries(server) {
+                            let (resolved_query, muted) = connection
+                                .resolve_query_with_muted(
+                                    query,
+                                    show_muted_buffers,
+                                );
+                            let query = resolved_query.unwrap_or(query);
+
+                            if let Some(buffer_data) = upstream_buffer_data(
+                                buffer::Upstream::Query(
+                                    server.clone(),
+                                    query.clone(),
+                                ),
+                                history::Kind::Query(
+                                    server.clone(),
+                                    query.clone(),
+                                ),
+                                muted,
+                                casemapping,
+                            ) {
+                                collapsible_buffers.push(buffer_data);
+                            }
+                        }
+
+                        let has_collapsible_buffers =
+                            !collapsible_buffers.is_empty();
+
+                        let visible_buffers = if is_collapsed {
+                            buffer_data
+                                .collapse_indicators(&collapsible_buffers);
+
+                            vec![buffer_data]
+                        } else {
+                            vec![buffer_data]
+                                .into_iter()
+                                .chain(collapsible_buffers)
+                                .collect()
+                        };
+
+                        SidebarBufferGroup::Upstream {
+                            server: server.clone(),
+                            visible_buffers,
+                            connection_status: ConnectionStatus::Connected {
+                                registration_complete: connection
+                                    .registration_complete(),
+                            },
+                            has_collapsible_buffers,
+                            casemapping,
+                        }
+                    })
+                }
+            }
+        };
+
+        let upstream_buffers: Vec<SidebarBufferGroup> = servers
+            .keys()
+            .filter_map(|server| {
+                clients
+                    .state(server)
+                    .and_then(|state| upstream_buffer_group(server, state))
+            })
+            .collect();
+
+        let internal_buffer_data =
+            |buffer: &InternalBuffer| -> Option<InternalBufferSidebarData> {
+                let muted =
+                    config.sidebar.internal_buffers.mute.contains(buffer);
+
+                InternalBufferSidebarData::from_internal_buffer(
+                    buffer.into(),
+                    muted,
+                    show_muted_buffers,
+                    history,
+                    panes,
+                    config,
+                )
+            };
+
+        let internal_buffers: Vec<InternalBufferSidebarData> = config
+            .sidebar
+            .internal_buffers
+            .buffers
+            .iter()
+            .filter_map(internal_buffer_data)
+            .collect();
+
+        let internal_buffer_group = if internal_buffers.is_empty() {
+            None
+        } else {
+            Some(SidebarBufferGroup::Internal {
+                visible_buffers: internal_buffers,
+            })
+        };
+
+        if config.sidebar.internal_buffers.is_before_servers() {
+            internal_buffer_group
+                .into_iter()
+                .chain(upstream_buffers)
+                .collect()
+        } else {
+            upstream_buffers
+                .into_iter()
+                .chain(internal_buffer_group)
+                .collect()
+        }
     }
 
     pub fn toggle_visibility(&mut self) {
@@ -238,19 +513,20 @@ impl Sidebar {
 
         // Show notification dot if theres a new version, if there're transfers,
         // or if the logs have unread messages.
-        let show_notification_dot =
-            version.is_old()
-                || (!file_transfers.is_empty()
-                    && config.file_transfer.enabled
-                    && !config.sidebar.internal_buffers.buffers.contains(
-                        &config::sidebar::InternalBuffer::FileTransfers,
-                    ))
-                || (logs_has_unread
-                    && !config
-                        .sidebar
-                        .internal_buffers
-                        .buffers
-                        .contains(&config::sidebar::InternalBuffer::Logs));
+        let show_notification_dot = version.is_old()
+            || (!file_transfers.is_empty()
+                && config.file_transfer.enabled
+                && !config
+                    .sidebar
+                    .internal_buffers
+                    .buffers
+                    .contains(&InternalBuffer::FileTransfers))
+            || (logs_has_unread
+                && !config
+                    .sidebar
+                    .internal_buffers
+                    .buffers
+                    .contains(&InternalBuffer::Logs));
         let system_information = self.system_information.clone();
 
         let icon = icon::menu();
@@ -540,241 +816,97 @@ impl Sidebar {
                     )
                 });
 
+            let sidebar_buffer_groups = self.sidebar_buffer_groups(
+                servers,
+                clients,
+                history,
+                panes,
+                config,
+                show_muted_buffers,
+            );
+
             let mut buffers = vec![];
 
             if config.sidebar.position.is_horizontal() {
                 buffers.push(space::horizontal().width(4).into());
             }
 
-            let mut upstream_buffers = vec![];
-            let mut client_enumeration = 0;
+            for (index, sidebar_buffer_group) in
+                sidebar_buffer_groups.into_iter().enumerate()
+            {
+                // Separator between servers and between servers and
+                // internal buffers
+                if index > 0 {
+                    if config.sidebar.position.is_horizontal() {
+                        buffers.push(
+                            space::horizontal()
+                                .width(config.sidebar.spacing.server)
+                                .into(),
+                        );
+                    } else {
+                        buffers.push(
+                            space::vertical()
+                                .height(config.sidebar.spacing.server)
+                                .into(),
+                        );
+                    }
+                }
 
-            for server in servers.keys() {
-                let server_has_unread = history.server_has_unread(server);
-                let supports_detach =
-                    clients.get_server_supports_detach(server);
-                let casemapping =
-                    clients.get_server_casemapping_or_default(server);
+                match sidebar_buffer_group {
+                    SidebarBufferGroup::Upstream {
+                        server,
+                        visible_buffers,
+                        connection_status,
+                        has_collapsible_buffers,
+                        casemapping,
+                    } => {
+                        let server_has_unread =
+                            history.server_has_unread(&server);
+                        let supports_detach =
+                            clients.get_server_supports_detach(&server);
 
-                let is_server_collapsed =
-                    !self.collapse.is_expanded(config, server);
-
-                let button =
-                    |buffer: buffer::Upstream,
-                     kind: history::Kind,
-                     connection_status: ConnectionStatus,
-                     server_has_members: bool,
-                     collapsed_indicators: IndicatorState| {
-                        let button_context = UpstreamButtonContext {
-                            config,
-                            panes,
-                            focus,
-                            server_icons,
-                            buffer,
-                            kind,
-                            connection_status,
-                            server_has_members,
-                            server_has_unread,
-                            supports_detach,
-                            casemapping,
-                            history,
-                            width,
-                            theme,
-                            collapse: &self.collapse,
-                        };
-                        upstream_buffer_button(
-                            button_context,
-                            collapsed_indicators,
-                        )
-                    };
-
-                if let Some(state) = clients.state(server) {
-                    client_enumeration += 1;
-
-                    match state {
-                        data::client::State::Disconnected {
-                            autoconnect,
-                            connecting,
-                        } => {
-                            // Disconnected server.
-                            upstream_buffers.push(button(
-                                buffer::Upstream::Server(server.clone()),
-                                history::Kind::Server(server.clone()),
-                                ConnectionStatus::Disconnected {
-                                    autoconnect: *autoconnect,
-                                    connecting: *connecting,
-                                },
-                                false,
-                                IndicatorState::default(),
-                            ));
-                        }
-                        data::client::State::Ready(connection) => {
-                            let registration_complete =
-                                connection.registration_complete();
-                            let queries = history.get_unique_queries(server);
-                            let server_has_members =
-                                connection.channels().next().is_some()
-                                    || !queries.is_empty();
-                            let collapsed_indicators = if is_server_collapsed {
-                                collapse::indicators(
-                                    config,
-                                    panes,
-                                    clients,
-                                    connection,
-                                    server,
-                                    &queries,
-                                    casemapping,
-                                    history,
-                                )
-                            } else {
-                                IndicatorState::default()
+                        for buffer_data in visible_buffers {
+                            let context = UpstreamButtonContext {
+                                config,
+                                panes,
+                                focus,
+                                server_icons,
+                                buffer: buffer_data.buffer,
+                                kind: buffer_data.kind,
+                                indicators: buffer_data.indicators,
+                                connection_status,
+                                server_has_collapsible_buffers:
+                                    has_collapsible_buffers,
+                                server_has_unread,
+                                supports_detach,
+                                casemapping,
+                                history,
+                                width,
+                                theme,
+                                collapse: &self.collapse,
                             };
 
-                            // Connected server.
-                            upstream_buffers.push(button(
-                                buffer::Upstream::Server(server.clone()),
-                                history::Kind::Server(server.clone()),
-                                ConnectionStatus::Connected {
-                                    registration_complete,
-                                },
-                                server_has_members,
-                                collapsed_indicators,
+                            buffers.push(upstream_buffer_button(context));
+                        }
+                    }
+
+                    SidebarBufferGroup::Internal { visible_buffers } => {
+                        for buffer_data in visible_buffers {
+                            buffers.push(internal_buffer_button(
+                                config,
+                                panes,
+                                focus,
+                                buffer_data.buffer,
+                                buffer_data.kind,
+                                buffer_data.indicators,
+                                history,
+                                width,
+                                theme,
                             ));
-
-                            if !is_server_collapsed {
-                                // Channels from the connected server.
-                                for channel in connection.channels() {
-                                    upstream_buffers.push(button(
-                                        buffer::Upstream::Channel(
-                                            server.clone(),
-                                            channel.clone(),
-                                        ),
-                                        history::Kind::Channel(
-                                            server.clone(),
-                                            channel.clone(),
-                                        ),
-                                        ConnectionStatus::Connected {
-                                            registration_complete,
-                                        },
-                                        false,
-                                        IndicatorState::default(),
-                                    ));
-                                }
-
-                                // Queries from the connected server.
-                                for query in queries {
-                                    let query = clients
-                                        .resolve_query(server, query)
-                                        .unwrap_or(query);
-
-                                    upstream_buffers.push(button(
-                                        buffer::Upstream::Query(
-                                            server.clone(),
-                                            query.clone(),
-                                        ),
-                                        history::Kind::Query(
-                                            server.clone(),
-                                            query.clone(),
-                                        ),
-                                        ConnectionStatus::Connected {
-                                            registration_complete,
-                                        },
-                                        false,
-                                        IndicatorState::default(),
-                                    ));
-                                }
-                            }
-
-                            // Separator between servers.
-                            if client_enumeration < clients.len() {
-                                if config.sidebar.position.is_horizontal() {
-                                    upstream_buffers.push(
-                                        space::horizontal()
-                                            .width(
-                                                config.sidebar.spacing.server,
-                                            )
-                                            .into(),
-                                    );
-                                } else {
-                                    upstream_buffers.push(
-                                        space::vertical()
-                                            .height(
-                                                config.sidebar.spacing.server,
-                                            )
-                                            .into(),
-                                    );
-                                }
-                            }
                         }
                     }
                 }
             }
-
-            let internal_buffers: Vec<_> = config
-                .sidebar
-                .internal_buffers
-                .buffers
-                .iter()
-                .filter_map(|internal_buffer| {
-                    let (buffer, title) = match internal_buffer {
-                        config::sidebar::InternalBuffer::ConfigEditor => (
-                            buffer::Internal::ConfigEditor,
-                            "Config Editor",
-                        ),
-                        data::config::sidebar::InternalBuffer::FileTransfers => {
-                            config.file_transfer.enabled.then_some((
-                                buffer::Internal::FileTransfers,
-                                "File Transfers",
-                            ))?
-                        }
-                        data::config::sidebar::InternalBuffer::ChannelDiscovery => (
-                            buffer::Internal::ChannelDiscovery(None),
-                            "Channel Discovery",
-                        ),
-                        data::config::sidebar::InternalBuffer::Highlights => (
-                            buffer::Internal::Highlights,
-                            "Highlights",
-                        ),
-                        data::config::sidebar::InternalBuffer::ChannelMonitor => (
-                            buffer::Internal::ChannelMonitor,
-                            "Channel Monitor",
-                        ),
-                        data::config::sidebar::InternalBuffer::Logs => (
-                            buffer::Internal::Logs,
-                            "Logs",
-                        ),
-                    };
-
-                    if show_muted_buffers || should_show_internal_buffer(buffer.clone(), config, history) {
-                        Some(internal_buffer_button(config, panes, focus, buffer, title, history, width, theme))
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-
-            let spacer = if config.sidebar.position.is_horizontal() {
-                space::horizontal()
-                    .width(config.sidebar.spacing.server)
-                    .into()
-            } else {
-                space::vertical()
-                    .height(config.sidebar.spacing.server)
-                    .into()
-            };
-
-            let (left, right) =
-                if config.sidebar.internal_buffers.is_before_servers() {
-                    (internal_buffers, upstream_buffers)
-                } else {
-                    (upstream_buffers, internal_buffers)
-                };
-
-            buffers.extend(left);
-            if !buffers.is_empty() && !right.is_empty() {
-                buffers.push(spacer);
-            }
-            buffers.extend(right);
 
             match config.sidebar.position {
                 sidebar::Position::Left | sidebar::Position::Right => {
@@ -888,6 +1020,161 @@ impl Sidebar {
     }
 }
 
+enum SidebarBufferGroup {
+    Upstream {
+        server: Server,
+        visible_buffers: Vec<UpstreamBufferSidebarData>,
+        connection_status: ConnectionStatus,
+        casemapping: isupport::CaseMap,
+        has_collapsible_buffers: bool,
+    },
+    Internal {
+        visible_buffers: Vec<InternalBufferSidebarData>,
+    },
+}
+
+struct UpstreamBufferSidebarData {
+    buffer: buffer::Upstream,
+    kind: history::Kind,
+    has_unread: bool,
+    #[expect(dead_code)] // TODO: Cycle highlights
+    has_highlight: bool,
+    indicators: IndicatorState,
+}
+
+impl UpstreamBufferSidebarData {
+    fn from_upstream_buffer(
+        buffer: buffer::Upstream,
+        kind: history::Kind,
+        muted: bool,
+        casemapping: isupport::CaseMap,
+        show_muted_buffers: bool,
+        history: &history::Manager,
+        panes: &Panes,
+        config: &Config,
+    ) -> Option<Self> {
+        let is_visible_pane = panes
+            .iter_visible()
+            .any(|(_, _, state)| state.buffer.upstream() == Some(&buffer));
+
+        let has_unread = history.has_unread(&kind);
+
+        let is_unread_query =
+            matches!(buffer, buffer::Upstream::Query(_, _)) && has_unread;
+
+        let has_highlight = history.has_highlight(&kind);
+
+        let indicators = IndicatorState {
+            unread: has_unread
+                && !(is_unread_query
+                    && config.sidebar.unread_indicator.query_as_highlight)
+                && (config.sidebar.unread_indicator.show_on_open_buffers
+                    || !is_visible_pane)
+                && config.sidebar.unread_indicator.should_indicate(
+                    buffer.target().as_ref(),
+                    buffer.server(),
+                    casemapping,
+                ),
+            highlight: (has_highlight
+                || (is_unread_query
+                    && config.sidebar.unread_indicator.query_as_highlight))
+                && (config.sidebar.highlight_indicator.show_on_open_buffers
+                    || !is_visible_pane)
+                && config.sidebar.highlight_indicator.should_indicate(
+                    buffer.target().as_ref(),
+                    buffer.server(),
+                    casemapping,
+                ),
+        };
+
+        if muted
+            && !is_visible_pane
+            && !indicators.unread
+            && !indicators.highlight
+            && !show_muted_buffers
+        {
+            return None;
+        }
+
+        Some(Self {
+            buffer,
+            kind,
+            has_unread,
+            has_highlight,
+            indicators,
+        })
+    }
+
+    fn collapse_indicators(
+        &mut self,
+        collapsed_buffers: &[UpstreamBufferSidebarData],
+    ) {
+        for collapsed_buffer_data in collapsed_buffers {
+            self.indicators.merge(collapsed_buffer_data.indicators);
+        }
+    }
+}
+
+struct InternalBufferSidebarData {
+    buffer: buffer::Internal,
+    kind: Option<history::Kind>,
+    has_unread: bool,
+    #[expect(dead_code)] // TODO: Cycle highlights
+    has_highlight: bool,
+    indicators: IndicatorState,
+}
+
+impl InternalBufferSidebarData {
+    fn from_internal_buffer(
+        buffer: buffer::Internal,
+        muted: bool,
+        show_muted_buffers: bool,
+        history: &history::Manager,
+        panes: &Panes,
+        config: &Config,
+    ) -> Option<Self> {
+        let kind =
+            history::Kind::from_buffer(data::Buffer::Internal(buffer.clone()));
+
+        let is_visible_pane = panes.iter_visible().any(|(_, _, state)| {
+            state.buffer.internal().as_ref() == Some(&buffer)
+        });
+
+        let has_unread =
+            kind.as_ref().is_some_and(|kind| history.has_unread(kind));
+
+        let has_highlight = kind
+            .as_ref()
+            .is_some_and(|kind| history.has_highlight(kind));
+
+        let indicators = IndicatorState {
+            unread: has_unread
+                && (config.sidebar.unread_indicator.show_on_open_buffers
+                    || !is_visible_pane),
+            highlight: has_highlight
+                && (config.sidebar.highlight_indicator.show_on_open_buffers
+                    || !is_visible_pane),
+        };
+
+        if muted
+            && !is_visible_pane
+            && !indicators.unread
+            && !indicators.highlight
+            && !show_muted_buffers
+        {
+            return None;
+        }
+
+        Some(Self {
+            buffer,
+            kind,
+            has_unread,
+            has_highlight,
+            indicators,
+        })
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 enum Menu {
     RefreshConfig,
@@ -911,7 +1198,7 @@ impl Menu {
     fn list(
         has_new_version: bool,
         file_transfer_enabled: bool,
-        internal_buffers_in_sidebar: &[config::sidebar::InternalBuffer],
+        internal_buffers_in_sidebar: &[InternalBuffer],
         show_muted_buffers: bool,
     ) -> Vec<Self> {
         let mut list = vec![Self::Version];
@@ -928,32 +1215,28 @@ impl Menu {
 
         if file_transfer_enabled
             && !internal_buffers_in_sidebar
-                .contains(&config::sidebar::InternalBuffer::FileTransfers)
+                .contains(&InternalBuffer::FileTransfers)
         {
             list.push(Self::FileTransfers);
         }
 
         if !internal_buffers_in_sidebar
-            .contains(&config::sidebar::InternalBuffer::ChannelDiscovery)
+            .contains(&InternalBuffer::ChannelDiscovery)
         {
             list.push(Self::ChannelDiscovery);
         }
 
         if !internal_buffers_in_sidebar
-            .contains(&config::sidebar::InternalBuffer::ChannelMonitor)
+            .contains(&InternalBuffer::ChannelMonitor)
         {
             list.push(Self::ChannelMonitor);
         }
 
-        if !internal_buffers_in_sidebar
-            .contains(&config::sidebar::InternalBuffer::Highlights)
-        {
+        if !internal_buffers_in_sidebar.contains(&InternalBuffer::Highlights) {
             list.push(Self::Highlights);
         }
 
-        if !internal_buffers_in_sidebar
-            .contains(&config::sidebar::InternalBuffer::Logs)
-        {
+        if !internal_buffers_in_sidebar.contains(&InternalBuffer::Logs) {
             list.push(Self::Logs);
         }
 
@@ -993,7 +1276,7 @@ impl Entry {
     fn list(
         buffer: &buffer::Buffer,
         num_panes: usize,
-        open: Option<(window::Id, pane_grid::Pane)>,
+        open_as_window_pane: Option<(window::Id, pane_grid::Pane)>,
         focus: Focus,
         connection_status: Option<ConnectionStatus>,
         supports_detach: bool,
@@ -1029,7 +1312,7 @@ impl Entry {
             entries.push(MarkAsRead);
         }
 
-        match open {
+        match open_as_window_pane {
             None => {
                 entries.extend([NewPane, Popout, Replace]);
             }
@@ -1084,46 +1367,6 @@ impl IndicatorState {
     }
 }
 
-fn indicator_state(
-    config: &Config,
-    panes: &Panes,
-    buffer: &buffer::Upstream,
-    kind: &history::Kind,
-    casemapping: isupport::CaseMap,
-    history: &history::Manager,
-) -> IndicatorState {
-    let is_visible = panes
-        .iter_visible()
-        .any(|(_, _, state)| state.buffer.upstream() == Some(buffer));
-
-    let has_unread = (config.sidebar.unread_indicator.show_on_open_buffers
-        || !is_visible)
-        && history.has_unread(kind);
-    let has_highlight =
-        (config.sidebar.highlight_indicator.show_on_open_buffers
-            || !is_visible)
-            && history.has_highlight(kind);
-
-    let target = buffer.target();
-    let unread = has_unread
-        && config.sidebar.unread_indicator.should_indicate(
-            target.as_ref(),
-            buffer.server(),
-            casemapping,
-        );
-    let highlight = (has_highlight
-        || (matches!(buffer, buffer::Upstream::Query(_, _))
-            && has_unread
-            && config.sidebar.unread_indicator.query_as_highlight))
-        && config.sidebar.highlight_indicator.should_indicate(
-            target.as_ref(),
-            buffer.server(),
-            casemapping,
-        );
-
-    IndicatorState { unread, highlight }
-}
-
 #[derive(Clone)]
 struct UpstreamButtonContext<'a> {
     config: &'a Config,
@@ -1132,8 +1375,9 @@ struct UpstreamButtonContext<'a> {
     server_icons: &'a server_icon::Manager,
     buffer: buffer::Upstream,
     kind: history::Kind,
+    indicators: IndicatorState,
     connection_status: ConnectionStatus,
-    server_has_members: bool,
+    server_has_collapsible_buffers: bool,
     server_has_unread: bool,
     supports_detach: bool,
     casemapping: isupport::CaseMap,
@@ -1245,7 +1489,6 @@ fn upstream_buffer_title<'a>(
 
 fn upstream_buffer_button<'a>(
     context: UpstreamButtonContext<'a>,
-    collapsed_indicators: IndicatorState,
 ) -> Element<'a, Message> {
     let UpstreamButtonContext {
         config,
@@ -1254,8 +1497,9 @@ fn upstream_buffer_button<'a>(
         server_icons,
         buffer,
         kind,
+        indicators,
         connection_status,
-        server_has_members,
+        server_has_collapsible_buffers,
         casemapping,
         history,
         width,
@@ -1264,29 +1508,31 @@ fn upstream_buffer_button<'a>(
         ..
     } = &context;
 
-    let open = panes.iter().find_map(|(window_id, pane, state)| {
-        (state.buffer.upstream() == Some(buffer)).then_some((window_id, pane))
-    });
+    let open_as_window_pane =
+        panes.iter().find_map(|(window_id, pane, state)| {
+            (state.buffer.upstream() == Some(buffer))
+                .then_some((window_id, pane))
+        });
+
+    let focused_as_window_pane =
+        panes.iter().find_map(|(window_id, pane, state)| {
+            (Focus {
+                window: window_id,
+                pane,
+            } == *focus
+                && state.buffer.upstream() == Some(buffer))
+            .then_some((window_id, pane))
+        });
+
     let can_mark_as_read = history.can_mark_as_read(kind);
-    let mut indicators =
-        indicator_state(config, panes, buffer, kind, *casemapping, history);
-    indicators.merge(collapsed_indicators);
 
-    let is_focused = panes.iter().find_map(|(window_id, pane, state)| {
-        (Focus {
-            window: window_id,
-            pane,
-        } == *focus
-            && state.buffer.upstream() == Some(buffer))
-        .then_some((window_id, pane))
-    });
-
-    let show_highlight_icon =
-        indicators.highlight && config.sidebar.highlight_indicator.has_icon();
     let show_unread_icon =
         indicators.unread && config.sidebar.unread_indicator.has_icon();
     let show_unread_title =
         indicators.unread && config.sidebar.unread_indicator.title;
+
+    let show_highlight_icon =
+        indicators.highlight && config.sidebar.highlight_indicator.has_icon();
     let show_highlight_title =
         indicators.highlight && config.sidebar.highlight_indicator.title;
 
@@ -1415,7 +1661,7 @@ fn upstream_buffer_button<'a>(
             config,
             server,
             connection_status,
-            *server_has_members,
+            *server_has_collapsible_buffers,
             font_size.max(sidebar_icon_height as f32),
         )
     } else {
@@ -1439,13 +1685,13 @@ fn upstream_buffer_button<'a>(
         theme::button::sidebar_buffer(
             theme,
             status,
-            is_focused.is_some(),
-            open.is_some(),
+            focused_as_window_pane.is_some(),
+            open_as_window_pane.is_some(),
         )
     })
     .padding(config.sidebar.padding.buffer)
     .on_press({
-        match is_focused {
+        match focused_as_window_pane {
             Some((window, pane)) => {
                 if let Some(focus_action) =
                     config.actions.sidebar.focused_buffer
@@ -1462,7 +1708,7 @@ fn upstream_buffer_button<'a>(
                 }
             }
             None => {
-                if let Some((window, pane)) = open {
+                if let Some((window, pane)) = open_as_window_pane {
                     Message::Focus(window, pane)
                 } else {
                     let action = match &buffer {
@@ -1526,13 +1772,18 @@ fn upstream_buffer_button<'a>(
         base.into()
     };
 
-    upstream_buffer_context_menu(context, base, open, can_mark_as_read)
+    upstream_buffer_context_menu(
+        context,
+        base,
+        open_as_window_pane,
+        can_mark_as_read,
+    )
 }
 
 fn upstream_buffer_context_menu<'a>(
     context: UpstreamButtonContext<'a>,
     base: Element<'a, Message>,
-    open: Option<(window::Id, pane_grid::Pane)>,
+    open_as_window_pane: Option<(window::Id, pane_grid::Pane)>,
     can_mark_as_read: bool,
 ) -> Element<'a, Message> {
     let UpstreamButtonContext {
@@ -1548,10 +1799,11 @@ fn upstream_buffer_context_menu<'a>(
         collapse,
         ..
     } = context;
+
     let entries = Entry::list(
         &buffer.clone().into(),
         panes.len(),
-        open,
+        open_as_window_pane,
         focus,
         Some(connection_status),
         supports_detach,
@@ -1738,65 +1990,36 @@ fn upstream_buffer_context_menu<'a>(
     .into()
 }
 
-fn should_show_internal_buffer(
-    buffer: buffer::Internal,
-    config: &Config,
-    history: &history::Manager,
-) -> bool {
-    match config.sidebar.internal_buffers.mute {
-        config::sidebar::InternalBuffersMutePolicy::Never => true,
-        config::sidebar::InternalBuffersMutePolicy::Read => {
-            history::Kind::from_buffer(data::Buffer::Internal(buffer.clone()))
-                .is_none_or(|kind| history.has_unread(&kind))
-        }
-    }
-}
-
 fn internal_buffer_button<'a>(
     config: &'a Config,
     panes: &'a Panes,
     focus: Focus,
     buffer: buffer::Internal,
-    title: &'a str,
+    kind: Option<history::Kind>,
+    indicators: IndicatorState,
     history: &'a history::Manager,
     width: Length,
     theme: &'a Theme,
 ) -> Element<'a, Message> {
-    let open = panes.iter().find_map(|(window_id, pane, state)| {
-        (state.buffer.internal() == Some(buffer.clone()))
+    let open_as_window_pane =
+        panes.iter().find_map(|(window_id, pane, state)| {
+            (state.buffer.internal().as_ref() == Some(&buffer))
+                .then_some((window_id, pane))
+        });
+
+    let focused_as_window_pane =
+        panes.iter().find_map(|(window_id, pane, state)| {
+            (Focus {
+                window: window_id,
+                pane,
+            } == focus
+                && state.buffer.internal().as_ref() == Some(&buffer))
             .then_some((window_id, pane))
-    });
+        });
 
-    let is_focused = panes.iter().find_map(|(window_id, pane, state)| {
-        (Focus {
-            window: window_id,
-            pane,
-        } == focus
-            && state.buffer.internal() == Some(buffer.clone()))
-        .then_some((window_id, pane))
-    });
-
-    let has_history =
-        history::Kind::from_buffer(buffer.clone().into()).is_some();
-
-    let (has_unread, can_mark_as_read, has_highlight) = match buffer {
-        buffer::Internal::ChannelMonitor => (
-            history.has_unread(&history::Kind::ChannelMonitor),
-            history.can_mark_as_read(&history::Kind::ChannelMonitor),
-            history.has_highlight(&history::Kind::ChannelMonitor),
-        ),
-        buffer::Internal::Highlights => (
-            history.has_unread(&history::Kind::Highlights),
-            history.can_mark_as_read(&history::Kind::Highlights),
-            history.has_unread(&history::Kind::Highlights),
-        ),
-        buffer::Internal::Logs => (
-            history.has_unread(&history::Kind::Logs),
-            history.can_mark_as_read(&history::Kind::Logs),
-            history.has_highlight(&history::Kind::Logs),
-        ),
-        _ => (false, false, false),
-    };
+    let can_mark_as_read = kind
+        .as_ref()
+        .is_some_and(|kind| history.can_mark_as_read(kind));
 
     let dimensions = Dimensions::from(&config.sidebar);
 
@@ -1813,9 +2036,7 @@ fn internal_buffer_button<'a>(
             (show_icon.then_some(icon::file_transfer()), None)
         }
         buffer::Internal::Highlights => {
-            let badge = if has_unread
-                && (config.sidebar.highlight_indicator.show_on_open_buffers
-                    || open.is_none())
+            let badge = if indicators.highlight
                 && let Some(highlight_icon) =
                     icon::from_icon(config.sidebar.highlight_indicator.icon)
             {
@@ -1830,9 +2051,9 @@ fn internal_buffer_button<'a>(
             (show_icon.then_some(icon::highlights()), badge)
         }
         buffer::Internal::Logs => {
-            let badge = if has_unread {
+            let badge = if indicators.unread {
                 Some((
-                    icon::log_indicator().style(if has_highlight {
+                    icon::log_indicator().style(if indicators.highlight {
                         theme::text::error
                     } else {
                         theme::text::warning
@@ -1846,9 +2067,7 @@ fn internal_buffer_button<'a>(
             (show_icon.then_some(icon::logs()), badge)
         }
         buffer::Internal::ChannelMonitor => {
-            let badge = if has_highlight
-                && (config.sidebar.highlight_indicator.show_on_open_buffers
-                    || open.is_none())
+            let badge = if indicators.highlight
                 && let Some(highlight_icon) =
                     icon::from_icon(config.sidebar.highlight_indicator.icon)
             {
@@ -1856,9 +2075,7 @@ fn internal_buffer_button<'a>(
                     highlight_icon.style(theme::text::highlight_indicator),
                     dimensions.highlight_indicator_size,
                 ))
-            } else if has_unread
-                && (config.sidebar.unread_indicator.show_on_open_buffers
-                    || open.is_none())
+            } else if indicators.unread
                 && let Some(unread_icon) =
                     icon::from_icon(config.sidebar.unread_indicator.icon)
             {
@@ -1873,6 +2090,8 @@ fn internal_buffer_button<'a>(
             (show_icon.then_some(icon::channel_monitor()), badge)
         }
     };
+
+    let title: &'static str = (&buffer).into();
 
     let mut content = row![].align_y(iced::Alignment::Center);
 
@@ -1907,12 +2126,12 @@ fn internal_buffer_button<'a>(
                 theme::button::sidebar_buffer(
                     theme,
                     status,
-                    is_focused.is_some(),
-                    open.is_some(),
+                    focused_as_window_pane.is_some(),
+                    open_as_window_pane.is_some(),
                 )
             })
             .padding(config.sidebar.padding.buffer)
-            .on_press(match is_focused {
+            .on_press(match focused_as_window_pane {
                 Some((window, pane)) => {
                     if let Some(focus_action) =
                         config.actions.sidebar.focused_buffer
@@ -1929,7 +2148,7 @@ fn internal_buffer_button<'a>(
                     }
                 }
                 None => {
-                    if let Some((window, pane)) = open {
+                    if let Some((window, pane)) = open_as_window_pane {
                         Message::Focus(window, pane)
                     } else {
                         match config.actions.sidebar.buffer {
@@ -1950,11 +2169,11 @@ fn internal_buffer_button<'a>(
     let entries = Entry::list(
         &buffer.clone().into(),
         panes.len(),
-        open,
+        open_as_window_pane,
         focus,
         None,
         false,
-        has_history,
+        kind.is_some(),
     );
 
     if entries.is_empty() {
@@ -2170,14 +2389,14 @@ impl From<&config::sidebar::Sidebar> for Dimensions {
     fn from(config: &config::sidebar::Sidebar) -> Self {
         let (icon_size, icon_badge_padding, icon_badge_size) =
             match config.primary_icon {
-                config::sidebar::PrimaryIcon::Size(icon_size) => {
+                PrimaryIcon::Size(icon_size) => {
                     let icon_badge_padding = 2;
                     let icon_badge_size =
                         (icon_size / 3).max(4) + 2 * icon_badge_padding;
 
                     (icon_size, icon_badge_padding, icon_badge_size)
                 }
-                config::sidebar::PrimaryIcon::Hidden => (0, 0, 0),
+                PrimaryIcon::Hidden => (0, 0, 0),
             };
 
         let unread_indicator_size = if config.unread_indicator.has_icon() {

--- a/src/screen/dashboard/sidebar/collapse.rs
+++ b/src/screen/dashboard/sidebar/collapse.rs
@@ -1,10 +1,9 @@
 use std::collections::HashMap;
 
+use data::Server;
 use data::config::Config;
 use data::config::server::SidebarVisibility;
-use data::{Server, buffer, client, history, isupport, target};
 
-use super::{IndicatorState, Panes, indicator_state};
 use crate::dashboard::sidebar::ConnectionStatus;
 use crate::widget::Text;
 use crate::{icon, theme};
@@ -98,46 +97,4 @@ impl Disclosure {
     pub fn indicator(self) -> Text<'static> {
         self.indicator.size(8).style(theme::text::secondary)
     }
-}
-
-pub fn indicators(
-    config: &Config,
-    panes: &Panes,
-    clients: &client::Map,
-    connection: &client::Client,
-    server: &Server,
-    queries: &[&target::Query],
-    casemapping: isupport::CaseMap,
-    history: &history::Manager,
-) -> IndicatorState {
-    let mut indicators = IndicatorState::default();
-
-    for channel in connection.channels() {
-        let buffer = buffer::Upstream::Channel(server.clone(), channel.clone());
-        let kind = history::Kind::Channel(server.clone(), channel.clone());
-        indicators.merge(indicator_state(
-            config,
-            panes,
-            &buffer,
-            &kind,
-            casemapping,
-            history,
-        ));
-    }
-
-    for query in queries {
-        let query = clients.resolve_query(server, query).unwrap_or(query);
-        let buffer = buffer::Upstream::Query(server.clone(), query.clone());
-        let kind = history::Kind::Query(server.clone(), query.clone());
-        indicators.merge(indicator_state(
-            config,
-            panes,
-            &buffer,
-            &kind,
-            casemapping,
-            history,
-        ));
-    }
-
-    indicators
 }


### PR DESCRIPTION
Expands the `channels` and `queries` settings to allow upstream buffers to be muted.  Modifies the internal buffers `mute` setting to allow individual buffers to be muted.