### PR TITLE
Treat WHOX "0"/"*" account sentinel as no account in from_whoreply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ Changed:
 
 Thanks:
 
-- Contributions: @englut, @luca020400, @classabbyamp, @KaiKorla, @TheDcoder, @City-busz, @rtmongold, @Gelbpunkt, @zsigisti
+- Contributions: @englut, @luca020400, @classabbyamp, @KaiKorla, @TheDcoder, @City-busz, @rtmongold, @Gelbpunkt, @zsigisti, quark
 - Bug reports: @luca020400, agent314, @FlooferLand, @englut, @rexbinary
 - Feature requests: @FlooferLand, quark, @daniiooo
 

--- a/data/src/user.rs
+++ b/data/src/user.rs
@@ -473,7 +473,9 @@ impl User {
             nickname: Nick::from_str(nick, casemapping),
             username: Some(user.to_string()),
             hostname: Some(host.to_string()),
-            accountname: account.map(ToString::to_string),
+            accountname: account
+                .filter(|account| *account != "*" && *account != "0")
+                .map(ToString::to_string),
             access_levels,
             away,
             bot,


### PR DESCRIPTION
`User::with_accountname` already maps the WHOX no-account sentinels ("*" and
"0") to `None`, but `User::from_whoreply` (used for the InitialJoin WHO poll,
`%tcuhnfa,999`) stored the account field verbatim. As a result a logged-out
user whose WHOX account field is "0" is shown as if authenticated
("Authenticated as 0", with the padlock).

This only shows when the server/bouncer advertises `no-implicit-names`,
which is what makes Halloy use the InitialJoin poll and route the reply through
`from_whoreply` instead of `with_accountname`.

This patch normalises the sentinel in `from_whoreply` the same way `with_accountname`
does.
