### PR TITLE
Add timestamp position: left, right, hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Added:
 - Allow image preview on URL click
 - `servers.<name>.max_connection_attempts` setting to control the number of connection of attempts made before autoconnect is automatically disabled (defaults to 10)
 - `logs.file_timestamp` setting to control what timezone is used for timestamps in log files and log file names
+- `buffer.timestamp.position` setting (`"left"` (default), `"right"`, or `"hidden"`) to control where message timestamps are rendered
 - `servers.<name>.irc_protocol_log` settings to enable logging of the IRC protocol messages sent-to / received-from the server
 
 Fixed:
@@ -78,7 +79,7 @@ Changed:
 
 Thanks:
 
-- Contributions: @englut, @luca020400, @classabbyamp, @KaiKorla, @TheDcoder, @City-busz, @rtmongold, @Gelbpunkt, @zsigisti, quark
+- Contributions: @englut, @luca020400, @classabbyamp, @KaiKorla, @TheDcoder, @City-busz, @rtmongold, @Gelbpunkt, @zsigisti, quark, @rollecode
 - Bug reports: @luca020400, agent314, @FlooferLand, @englut, @rexbinary
 - Feature requests: @FlooferLand, quark, @daniiooo
 

--- a/data/src/buffer.rs
+++ b/data/src/buffer.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 pub mod timestamp;
 
-pub use self::timestamp::Timestamp;
+pub use self::timestamp::{Timestamp, TimestampPosition};
 use crate::appearance::theme::hex_to_color;
 use crate::serde::deserialize_strftime_date;
 use crate::target::{self, Target};

--- a/data/src/buffer/timestamp.rs
+++ b/data/src/buffer/timestamp.rs
@@ -8,6 +8,15 @@ use crate::serde::{
     deserialize_strftime_date, deserialize_strftime_date_maybe,
 };
 
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TimestampPosition {
+    #[default]
+    Left,
+    Right,
+    Hidden,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct Timestamp {
@@ -20,6 +29,7 @@ pub struct Timestamp {
     pub copy_format: Option<String>,
     #[serde(deserialize_with = "deserialize_locale")]
     pub locale: Locale,
+    pub position: TimestampPosition,
     pub hide_consecutive: HideConsecutive,
 }
 
@@ -31,6 +41,7 @@ impl Default for Timestamp {
             context_menu_format: "%x".to_string(),
             copy_format: None,
             locale: Locale::default(),
+            position: TimestampPosition::default(),
             hide_consecutive: HideConsecutive::default(),
         }
     }

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use chrono::{DateTime, TimeDelta, Utc};
-use data::buffer::RightAlignmentWidths;
+use data::buffer::{RightAlignmentWidths, TimestampPosition};
 use data::config::buffer::nickname::ShownStatus;
 use data::config::buffer::{CondensationIcon, Dimmed};
 use data::config::preview::HideUrlCondition;
@@ -198,6 +198,10 @@ impl<'a> ChannelQueryLayout<'a> {
         message: &'a data::Message,
         hide_timestamp: bool,
     ) -> Option<Element<'a, Message>> {
+        if self.config.buffer.timestamp.position == TimestampPosition::Hidden {
+            return None;
+        }
+
         self.config
             .buffer
             .format_timestamp(&message.server_time)
@@ -229,6 +233,10 @@ impl<'a> ChannelQueryLayout<'a> {
         end_server_time: &'a DateTime<Utc>,
         hide_timestamp: bool,
     ) -> Option<Element<'a, Message>> {
+        if self.config.buffer.timestamp.position == TimestampPosition::Hidden {
+            return None;
+        }
+
         self.config
             .buffer
             .format_range_end_timestamp(end_server_time)
@@ -1129,10 +1137,19 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
             ));
         }
 
+        let timestamp_on_left =
+            self.config.buffer.timestamp.position == TimestampPosition::Left;
+        let timestamp_on_right =
+            self.config.buffer.timestamp.position == TimestampPosition::Right;
+
         let mut timestamp: Option<Element<_>> =
             self.format_timestamp(message, hide_timestamp);
 
-        if let Some(right_alignment_widths) = right_alignment_widths {
+        // Only reserve a fixed left-hand timestamp column when the timestamp
+        // is rendered on the left.
+        if timestamp_on_left
+            && let Some(right_alignment_widths) = right_alignment_widths
+        {
             timestamp = Some(timestamp.map_or(
                 Space::new().width(right_alignment_widths.timestamp).into(),
                 |timestamp| {
@@ -1143,7 +1160,18 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
             ));
         }
 
-        let left_is_hidden = prefixes.is_none() && hide_timestamp;
+        // Pull the timestamp out for right-edge placement after the body.
+        let right_timestamp = if timestamp_on_right {
+            timestamp.take()
+        } else {
+            None
+        };
+
+        let left_is_hidden = if timestamp_on_left {
+            prefixes.is_none() && hide_timestamp
+        } else {
+            prefixes.is_none()
+        };
 
         let right_alignment_middle_width = right_alignment_widths
             .map(|right_alignment_widths| right_alignment_widths.middle);
@@ -1395,19 +1423,20 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
 
         let middle_is_some = middle.is_some();
 
-        let row = row![
-            prefixes,
-            timestamp,
-            if left_is_hidden {
-                let width = font::width_from_str(" ", &self.config.font);
+        let spacer = if left_is_hidden {
+            let width = font::width_from_str(" ", &self.config.font);
+            Element::from(Space::new().width(width))
+        } else {
+            Element::from(selectable_text(" "))
+        };
 
-                Element::from(Space::new().width(width))
-            } else {
-                Element::from(selectable_text(" "))
-            },
-            middle,
-            middle_is_some.then_some(selectable_text(" ")),
-        ];
+        let trailing_space = middle_is_some.then_some(selectable_text(" "));
+
+        let row = if timestamp_on_left {
+            row![prefixes, timestamp, spacer, middle, trailing_space]
+        } else {
+            row![prefixes, spacer, middle, trailing_space]
+        };
 
         let content = if message_has_urls {
             let mut column = column![].spacing(2);
@@ -1478,10 +1507,25 @@ impl<'a> LayoutMessage<'a> for ChannelQueryLayout<'a> {
             column![content].extend(after_content).into()
         };
 
-        let message_element = if self.content_on_new_line(message) {
-            container(column![row, content]).into()
+        let body: Element<_> = if self.content_on_new_line(message) {
+            column![row, content].into()
         } else {
-            container(row![row, content]).into()
+            row![row, content].into()
+        };
+
+        let message_element = if let Some(right_timestamp) = right_timestamp {
+            // Gap between the message and the right-aligned timestamp, plus a
+            // little breathing room from the edge.
+            let gap = font::width_from_str("  ", &self.config.font);
+            container(
+                row![container(body).width(Length::Fill), right_timestamp]
+                    .spacing(gap)
+                    .align_y(alignment::Vertical::Top),
+            )
+            .padding(padding::right(gap))
+            .into()
+        } else {
+            container(body).into()
         };
 
         let message_element = if let Some(reply_row) = self.reply_line(
@@ -1674,11 +1718,16 @@ impl<'a> ChannelQueryLayout<'a> {
 
         let char_width = font::width_from_str("a", &self.config.font);
 
-        let timestamp_chars = self
-            .config
-            .buffer
-            .format_timestamp(&message.server_time)
-            .map_or(0, |s| s.chars().count());
+        let timestamp_chars = if self.config.buffer.timestamp.position
+            == TimestampPosition::Left
+        {
+            self.config
+                .buffer
+                .format_timestamp(&message.server_time)
+                .map_or(0, |s| s.chars().count())
+        } else {
+            0
+        };
 
         // right-aligned: fixed short arm offset to content column.
         // left-aligned / top-aligned: arm spans from timestamp midpoint to its edge.
@@ -1982,13 +2031,24 @@ impl<'a> ChannelQueryLayout<'a> {
             )
         });
 
+        let timestamp_on_left =
+            self.config.buffer.timestamp.position == TimestampPosition::Left;
+
         let body: Element<_> = row![]
             .spacing(font::width_from_str(" ", &self.config.font))
-            .extend(self.config.buffer.format_timestamp(&server_time).map(
-                |timestamp| -> Element<_> {
-                    text(timestamp).style(theme::text::timestamp).into()
-                },
-            ))
+            .extend(
+                timestamp_on_left
+                    .then(|| {
+                        self.config.buffer.format_timestamp(&server_time).map(
+                            |timestamp| -> Element<_> {
+                                text(timestamp)
+                                    .style(theme::text::timestamp)
+                                    .into()
+                            },
+                        )
+                    })
+                    .flatten(),
+            )
             .extend(action_marker)
             .extend(nick)
             .push(content_col)

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 use chrono::{DateTime, Local, NaiveDate, Utc};
-use data::buffer::RightAlignmentWidths;
+use data::buffer::{RightAlignmentWidths, TimestampPosition};
 use data::command::Irc;
 use data::config::actions::{ImageClickAction, NicknameClickAction};
 use data::config::buffer::{CondensationIcon, HideConsecutiveEnabled};
@@ -428,6 +428,16 @@ pub fn view<'a>(
                 } else {
                     0.0
                 };
+
+            // Timestamps are not on the left, so reserve no left-hand
+            // range-end timestamp width.
+            let range_end_timestamp_width = if config.buffer.timestamp.position
+                == TimestampPosition::Left
+            {
+                range_end_timestamp_width
+            } else {
+                0.0
+            };
 
             let message_marker_width =
                 font::width_of_message_marker(&config.font) + 1.0;
@@ -2410,6 +2420,10 @@ fn prefixes_width(message: &data::Message, config: &Config) -> Option<f32> {
 }
 
 fn timestamp_width(message: &data::Message, config: &Config) -> Option<f32> {
+    if config.buffer.timestamp.position != TimestampPosition::Left {
+        return None;
+    }
+
     config
         .buffer
         .format_timestamp(&message.server_time)


### PR DESCRIPTION
Adds `position` field to `[buffer.timestamp]` config section. Three values:

- `"left"` (default) — current behavior, timestamp before message content
- `"right"` — timestamp after message content, right-aligned in the row
- `"hidden"` — no timestamps rendered, no width reserved

Config example:

```toml
[buffer.timestamp]
position = "right"
```