### PR TITLE
Miscellaneous Minor Tasks 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Added:
 - `pane.always_show_title_bar_buttons` setting to prevent pane title bar buttons from being hidden when the pane is not hovered
 - Shortcuts displayed in pane button tooltips (where available/configured)
 - `follow` option for reroute rules (`servers.<name>.reroute`) to reroute messages to the focused buffer
+- Add system keyring support for server, NickServ, channel, SASL, filehost credential, and proxy passwords
 - IRCv3
   - IRCv3 `no-implicit-names` support
   - `servers.<name>.do_not_request` can be specified to prevent IRCv3 capability requests (e.g. `servers.<name>.do_not_request = [ "labeled-response" ]` will prevent [labeled-response](https://ircv3.net/specs/extensions/labeled-response) from being requested from the server)
@@ -87,7 +88,7 @@ Thanks:
 
 - Contributions: @englut, @luca020400, @classabbyamp, @KaiKorla, @TheDcoder, @City-busz, @rtmongold, @Gelbpunkt, @zsigisti, quark
 - Bug reports: @luca020400, agent314, @FlooferLand, @englut, @rexbinary, @belthesar, @deepspaceaxolotl, @neilzilla, @0ther0ne
-- Feature requests: @FlooferLand, quark, @daniiooo, @deepspaceaxolotl, @4e554c4c, @RoboDanjal, @Vendicated
+- Feature requests: @FlooferLand, quark, @daniiooo, @deepspaceaxolotl, @4e554c4c, @RoboDanjal, @Vendicated, @raggi, @Avinash-Bhat
 
 # 2026.7.2 (2026-06-08)
 
@@ -95,7 +96,6 @@ Added:
 
 - Add clear buffer shortcut to title bar
 - Indicate in query if user is offline in its title bar
-- Add system keyring support for server, NickServ, channel, SASL, filehost credential, and proxy passwords
 
 Fixed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,35 +3,38 @@
 Added:
 
 - Channel Monitor internal buffer for viewing messages from all joined channels
-- Internal buffers (logs, highlights, etc) can be added to sidebar
-- Channel, query, and internal buffers can be muted (only shown if an unread/highlight indicator should be shown) via `servers.<name>.channels`, `servers.<name>.queries`, and `sidebar.internal_buffers.mute`
-- Config editor pane for editing the config file in-app
+- Config editor internal buffer for editing the config file in-app
+- Sidebar
+  - Collapse & expand servers in sidebar
+  - Internal buffers (logs, highlights, etc) can be added to sidebar
+  - Channel, query, and internal buffers can be muted (only shown if an unread/highlight indicator should be shown) via `servers.<name>.channels`, `servers.<name>.queries`, and `sidebar.internal_buffers.mute`
+  - `sidebar.unread_indicator.exclude` & `sidebar.unread_indicator.include` no longer controls highlight indicators
+  - New `sidebar.highlight_indicator.title`, `sidebar.highlight_indicator.show_on_open_buffers`, `sidebar.highlight_indicator.exclude`, and `sidebar.highlight_indicator.include` settings for independent highlight control
 - Undo/redo in the message input and config editor (`ctrl`/`cmd` + `z`, `ctrl`/`cmd` + `shift` + `z`)
+- Link interactions
+  - Context menu on channel links
+  - `actions.buffer.click_nickname` and `actions.nicklist.click_nickname` can be used to specify whether a nickname will: open query and how the query is opened, insert nickname in the input box, or no action (`"no-action"` or `"noop"`); takes over functionality from `buffer.nickname.click` and `buffer.channel.nicklist.click` and adds the ability to perform no action
+  - `actions.buffer.click_channel_name` and `actions.buffer.click_highlight` can be set to no action (`"no-action"` or `"noop"`) to not open the channel when clicking on the channel name
+  - `actions.buffer.click_channel_discovery` to configure click behavior for channel names in the channel discovery pane (default: `"new-pane"`)
+  - Allow image preview on URL click (`actions.buffer.click_image_url`)
+- `actions.buffer.notifications` settings to control how interacting with notifications is handled
+- Support displaying a larger version of the card images in-app
+- `pane.always_show_title_bar_buttons` setting to prevent pane title bar buttons from being hidden when the pane is not hovered
+- Shortcuts displayed in pane button tooltips (where available/configured)
+- `follow` option for reroute rules (`servers.<name>.reroute`) to reroute messages to the focused buffer
+- IRCv3
+  - IRCv3 `no-implicit-names` support
+  - `servers.<name>.do_not_request` can be specified to prevent IRCv3 capability requests (e.g. `servers.<name>.do_not_request = [ "labeled-response" ]` will prevent [labeled-response](https://ircv3.net/specs/extensions/labeled-response) from being requested from the server)
+- `servers.<name>.max_connection_attempts` setting to control the number of connection of attempts made before autoconnect is automatically disabled (defaults to 10)
 - Improved legibility of the returned values of `MONITOR` list (`/monitor L`)
 - Config option (`preview.card.description_decode_html`) to decode html strings in preview card descriptions
-- Support displaying a larger version of the card images in-app
-- IRCv3 `no-implicit-names` support
-- Keyboard shortcuts validation (e.g no duplicate key binds)
-- `actions.buffer.notifications` settings to control how interacting with notifications is handled
-- `actions.buffer.click_nickname` and `actions.nicklist.click_nickname` can be used to specify whether a nickname will: open query and how the query is opened, insert nickname in the input box, or no action (`"no-action"` or `"noop"`); takes over functionality from `buffer.nickname.click` and `buffer.channel.nicklist.click` and adds the ability to perform no action
-- `actions.buffer.click_channel_name` and `actions.buffer.click_highlight` can be set to no action (`"no-action"` or `"noop"`) to not open the channel when clicking on the channel name
-- Explicit portable mode
-- Theme editor can be closed via Escape
-- `actions.buffer.click_channel_discovery` to configure click behavior for channel names in the channel discovery pane (default: `"new-pane"`)
-- `sidebar.unread_indicator.exclude` & `sidebar.unread_indicator.include` no longer controls highlight indicators
-- New `sidebar.highlight_indicator.title`, `sidebar.highlight_indicator.show_on_open_buffers`, `sidebar.highlight_indicator.exclude`, and `sidebar.highlight_indicator.include` settings for independent highlight control
-- Context menu on channel links
-- Shortcuts displayed in pane button tooltips (where available/configured)
-- `servers.<name>.do_not_request` can be specified to prevent IRCv3 capability requests (e.g. `servers.<name>.do_not_request = [ "labeled-response" ]` will prevent [labeled-response](https://ircv3.net/specs/extensions/labeled-response) from being requested from the server)
-- `follow` option for reroute rules (`servers.<name>.reroute`) to reroute messages to the focused buffer
-- `logs.max_file_count` setting to control the number of Halloy log files that are stored on disk
-- `pane.always_show_title_bar_buttons` setting to prevent pane title bar buttons from being hidden when the pane is not hovered
-- Allow image preview on URL click
-- `servers.<name>.max_connection_attempts` setting to control the number of connection of attempts made before autoconnect is automatically disabled (defaults to 10)
-- `logs.file_timestamp` setting to control what timezone is used for timestamps in log files and log file names
-- `servers.<name>.irc_protocol_log` settings to enable logging of the IRC protocol messages sent-to / received-from the server
 - `runtime.metrics_hinting` setting to control whether widgets are rendered using metrics hinting
-- Collapse & expand servers in sidebar
+- Keyboard shortcuts validation (e.g no duplicate key binds)
+- `servers.<name>.irc_protocol_log` settings to enable logging of the IRC protocol messages sent-to / received-from the server
+- `logs.max_file_count` setting to control the number of Halloy log files that are stored on disk
+- `logs.file_timestamp` setting to control what timezone is used for timestamps in log files and log file names
+- Explicit portable mode via `HALLOY_PORTABLE_DIR` environment variable
+- Theme editor can be closed via Escape
 
 Fixed:
 
@@ -39,31 +42,34 @@ Fixed:
   - Handle nick possessives `<nick>'s` (`<nick>` should be parsed)
   - Skip parsing nicks inside abbreviations (`e.g.` shouldn't have highlights)
 - Notifications no longer immediately dismissed in some Wayland DE(s)
+- Sidebar
+  - Do not show unread/highlight indicators in sidebar for ignored messages
+  - Show unread indicators for panes hidden by maximize
+  - Queries specified in configuration correctly added to the sidebar
+- Do not copy empty selections to the primary clipboard (i.e. do not clear the primary clipboard when a non-selection action is performed, such as moving the cursor or focusing the text input on some systems)
+- Disabled menu entries now block clicks from passing through
+- Only play one sound at a time (if two sounds would overlap, then the second sound is skipped)
+- Allow sound files to be symbolic links
+- When both card and image previews are excluded for a buffer, previews will not be pre-fetched for URLs in that buffer
+- Suppress connection status messages while macOS is asleep
+- Don't show a transient terminal window when running `/exec` on Windows
+- Do not reconnect automatically when the server closes the connection in response to a requested quit
+- Apply mode arguments to the correct targets when a `MODE` message mixes added and removed modes (e.g. `-o+v foo bar` de-ops `foo` and voices `bar`)
+- Prevent anti-flood rate limiting from refilling the token bucket beyond its configured capacity
 - Do not send duplicate `JOIN` message when using `/join`
 - Do not send `MARKREAD` for non-`PRIVMSG`/`NOTICE` messages when the server does not support echoes
-- Do not show unread/highlight indicators for ignored messages
-- Do not copy empty selections to the primary clipboard (i.e. do not clear the primary clipboard when a non-selection action is performed, such as moving the cursor or focusing the text input on some systems)
-- Prevent anti-flood rate limiting from refilling the token bucket beyond its configured capacity
-- Show unread indicators for panes hidden by maximize
 - Allow commands (e.g. `/join`) to be used in the input box of not-joined channels
-- Disabled menu entries now block clicks from passing through
 - Preserve own away state when leaving and rejoining a channel
 - Do not panic when previewing an SVG with a very large filter
 - Reject overlong lines from the server connection instead of buffering them without bound
 - Do not panic when a server-supplied METADATA retry-after value would overflow the retry timer
 - Stop busy-looping on CPU when a DCC file-transfer peer closes its connection early
-- Only play one sound at a time (if two sounds would overlap, then the second sound is skipped)
-- Allow sound files to be symbolic links
-- Queries specified in configuration correctly added to the sidebar
-- Apply mode arguments to the correct targets when a `MODE` message mixes added and removed modes (e.g. `-o+v foo bar` de-ops `foo` and voices `bar`)
-- Do not reconnect automatically when the server closes the connection in response to a requested quit
-- Don't show a transient terminal window when running `/exec` on Windows
-- Suppress connection status messages while macOS is asleep
-- When both card and image previews are excluded for a buffer, previews will not be pre-fetched for URLs in that buffer
 
 Changed:
 
-- `change_mode` server messages are categorized as `actions` (i.e. `actions_dimmed` controls whether they are dimmed by default)
+- Clicking on a message expanded out of a condensed message will always contract it (configurable via `actions.only_contract_expanded_message`)
+- Rerouted messages are marked with a icon next to the nickname
+- When SASL authentication fails, after disconnecting from the server connection will be automatically re-tried if `servers.<name>.autoconnect` is enabled
 - Renamed `sidebar.server_icon` → `sidebar.primary_icon` and `sidebar.server_font_size` → `sidebar.primary_font_size` since the settings now apply to both servers and internal buffers
 - Renamed `sidebar.unread_indicator.highlight_icon` → `sidebar.highlight_indicator.icon` and `sidebar.unread_indicator.highlight_icon_size` → `sidebar.highlight_indicator.icon_size`
 - Renamed `sidebar.font_size` → `sidebar.secondary_font_size` to reflect its relationship to `sidebar.primary_font_size`
@@ -71,13 +77,11 @@ Changed:
 - Renamed `actions.buffer.click_username` to `actions.buffer.click_nickname` for more consistent terminology
 - Renamed `servers.<name>.chathistory` to `servers.<name>.automated_chathistory`, and it now controls whether chathistory requests are made automatically instead of controlling whether the chathistory capability is requested (see `servers.<name>.do_not_request` for controlling whether the capability is requested)
 - Moved functionality from `buffer.nickname.click` → `actions.buffer.click_nickname` and `buffer.channel.nicklist.click` → `actions.nicklist.click_nickname`
-- Clicking on a message expanded out of a condensed message will always contract it (configurable via `actions.only_contract_expanded_message`)
-- Windows release artifacts are signed using SignPath
-- Set window icon also on Linux for X11
+- `change_mode` server messages are categorized as `actions` (i.e. `actions_dimmed` controls whether they are dimmed by default)
 - `keyboard.file_transfers` shortcut is disabled when `file_transfer.enabled = false`
-- Rerouted messages are marked with a icon next to the nickname
 - More than one Halloy log file can be saved (configurable, defaults to 4);  accordingly there is not a singular log file `<data_dir>/halloy/halloy.log`, instead log files are placed in `<data_dir>/halloy/logs/`
-- When SASL authentication fails, after disconnecting from the server connection will be automatically re-tried if `servers.<name>.autoconnect` is enabled
+- Set window icon also on Linux for X11
+- Windows release artifacts are signed using SignPath
 
 Thanks:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,8 +86,8 @@ Changed:
 Thanks:
 
 - Contributions: @englut, @luca020400, @classabbyamp, @KaiKorla, @TheDcoder, @City-busz, @rtmongold, @Gelbpunkt, @zsigisti, quark
-- Bug reports: @luca020400, agent314, @FlooferLand, @englut, @rexbinary
-- Feature requests: @FlooferLand, quark, @daniiooo
+- Bug reports: @luca020400, agent314, @FlooferLand, @englut, @rexbinary, @belthesar, @deepspaceaxolotl, @neilzilla, @0ther0ne
+- Feature requests: @FlooferLand, quark, @daniiooo, @deepspaceaxolotl, @4e554c4c, @RoboDanjal, @Vendicated
 
 # 2026.7.2 (2026-06-08)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,6 +214,7 @@ extend-ignore-identifiers-re = [
     "ERR_[A-Z]+", # IRC Error Numeric
     "RPL_[A-Z]+", # IRC Reply Numeric
     "TehPeGaSuS",
+    "0ther0ne",
 ]
 
 [workspace.metadata.typos.files]

--- a/data/src/config/sidebar.rs
+++ b/data/src/config/sidebar.rs
@@ -27,7 +27,8 @@ pub struct Sidebar {
     #[serde(
         deserialize_with = "deserialize_primary_icon",
         alias = "server_icon",
-        alias = "server_icon_size"
+        alias = "server_icon_size",
+        alias = "primary_icon_size"
     )]
     pub primary_icon: PrimaryIcon,
     #[serde(alias = "server_font_size")]

--- a/data/src/mode.rs
+++ b/data/src/mode.rs
@@ -88,6 +88,9 @@ pub enum Channel {
     Unknown(char),
 }
 
+// These mappings, where not supplied via ISUPPORT, are from typical/common
+// mode letters and cannot be relied upon when certainty is necessary.
+
 impl From<char> for Channel {
     fn from(c: char) -> Self {
         use Channel::*;
@@ -211,6 +214,9 @@ pub enum User {
     HostHiding,
     Unknown(char),
 }
+
+// These mappings, where not supplied via ISUPPORT, are from typical/common
+// mode letters and cannot be relied upon when certainty is necessary.
 
 impl From<char> for User {
     fn from(c: char) -> Self {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -25,7 +25,6 @@ pub use self::server::Server;
 use crate::Theme;
 use crate::screen::dashboard::sidebar;
 use crate::widget::Element;
-use crate::window::Window;
 
 pub mod channel;
 pub mod channel_discovery;
@@ -315,19 +314,12 @@ impl Buffer {
         history: &mut history::Manager,
         previews: &preview::Collection,
         file_transfers: &mut file_transfer::Manager,
-        main_window: &Window,
         config: &Config,
     ) -> (Task<Message>, Option<Event>) {
         match (self, message) {
             (Buffer::Channel(state), Message::Channel(message)) => {
-                let (command, event) = state.update(
-                    message,
-                    clients,
-                    history,
-                    previews,
-                    main_window,
-                    config,
-                );
+                let (command, event) =
+                    state.update(message, clients, history, previews, config);
 
                 let event = event.map(|event| match event {
                     channel::Event::ContextMenu(event) => {
@@ -402,14 +394,8 @@ impl Buffer {
                 (command.map(Message::Channel), event)
             }
             (Buffer::Server(state), Message::Server(message)) => {
-                let (command, event) = state.update(
-                    message,
-                    clients,
-                    history,
-                    previews,
-                    main_window,
-                    config,
-                );
+                let (command, event) =
+                    state.update(message, clients, history, previews, config);
 
                 let event = event.map(|event| match event {
                     server::Event::ContextMenu(event) => {
@@ -469,14 +455,8 @@ impl Buffer {
                 (command.map(Message::Server), event)
             }
             (Buffer::Query(state), Message::Query(message)) => {
-                let (command, event) = state.update(
-                    message,
-                    clients,
-                    history,
-                    previews,
-                    main_window,
-                    config,
-                );
+                let (command, event) =
+                    state.update(message, clients, history, previews, config);
 
                 let event = event.map(|event| match event {
                     query::Event::ContextMenu(event) => {

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -13,7 +13,6 @@ use super::message_view::{ChannelQueryLayout, TargetInfo};
 use super::{context_menu, input_view, scroll_view, typing};
 use crate::Theme;
 use crate::widget::Element;
-use crate::window::Window;
 
 mod topic;
 
@@ -307,7 +306,6 @@ impl Channel {
         clients: &mut data::client::Map,
         history: &mut history::Manager,
         previews: &preview::Collection,
-        main_window: &Window,
         config: &Config,
     ) -> (Task<Message>, Option<Event>) {
         match message {
@@ -340,7 +338,6 @@ impl Channel {
                         &self.buffer,
                         clients,
                         history,
-                        main_window,
                         config,
                     );
 
@@ -417,7 +414,6 @@ impl Channel {
                     &self.buffer,
                     clients,
                     history,
-                    main_window,
                     config,
                 );
                 let command = command.map(Message::InputView);
@@ -493,7 +489,6 @@ impl Channel {
                     &self.buffer,
                     clients,
                     history,
-                    main_window,
                     config,
                 );
                 (task.map(Message::InputView), None)
@@ -504,7 +499,6 @@ impl Channel {
                     &self.buffer,
                     clients,
                     history,
-                    main_window,
                     config,
                 );
                 (

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -40,8 +40,7 @@ use crate::widget::{
     double_pass, reply_preview_content, text, text_editor_key_bindings,
     tooltip,
 };
-use crate::window::Window;
-use crate::{Theme, font, theme, window};
+use crate::{Theme, font, theme};
 
 mod completion;
 mod exec;
@@ -80,7 +79,6 @@ pub enum Event {
 #[derive(Debug, Clone)]
 pub enum Message {
     Action(text_editor::Action),
-    CloseContextMenu(window::Id, bool),
     ExecFinished {
         buffer: Upstream,
         result: Result<String, String>,
@@ -767,7 +765,6 @@ impl State {
         buffer: &buffer::Upstream,
         clients: &mut client::Map,
         history: &mut history::Manager,
-        main_window: &Window,
         config: &Config,
     ) -> (Task<Message>, Option<Event>) {
         let current_target = buffer.target();
@@ -1228,7 +1225,7 @@ impl State {
                     })
                 };
 
-                Self::close_context_menu(main_window.id, vec![task])
+                Self::close_context_menu(vec![task])
             }
             Message::Cut => {
                 let task =
@@ -1242,7 +1239,7 @@ impl State {
                         Task::none()
                     };
 
-                Self::close_context_menu(main_window.id, vec![task])
+                Self::close_context_menu(vec![task])
             }
             Message::Copy => {
                 let task = if let Some(input) = self.input_content.selection() {
@@ -1251,20 +1248,19 @@ impl State {
                     Task::none()
                 };
 
-                Self::close_context_menu(main_window.id, vec![task])
+                Self::close_context_menu(vec![task])
             }
             Message::CopyAll => {
                 let input = self.input_content.text();
                 let task = clipboard::write(input.to_string()).discard();
 
-                Self::close_context_menu(main_window.id, vec![task])
+                Self::close_context_menu(vec![task])
             }
             Message::SelectAll => {
                 self.input_content.perform(text_editor::Action::SelectAll);
 
-                Self::close_context_menu(main_window.id, vec![])
+                Self::close_context_menu(vec![])
             }
-            Message::CloseContextMenu(_, _) => (Task::none(), None),
             Message::UploadFile => (
                 Task::perform(
                     async {
@@ -1689,19 +1685,14 @@ impl State {
     }
 
     fn close_context_menu(
-        window: window::Id,
         tasks: Vec<Task<Message>>,
     ) -> (Task<Message>, Option<Event>) {
         (
             Task::batch(
-                vec![context_menu::close(convert::identity).map(
-                    move |any_closed| {
-                        Message::CloseContextMenu(window, any_closed)
-                    },
-                )]
-                .into_iter()
-                .chain(tasks)
-                .collect::<Vec<_>>(),
+                vec![context_menu::close(convert::identity).discard()]
+                    .into_iter()
+                    .chain(tasks)
+                    .collect::<Vec<_>>(),
             ),
             None,
         )

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -14,7 +14,6 @@ use super::message_view::{ChannelQueryLayout, TargetInfo};
 use super::{context_menu, input_view, scroll_view, typing};
 use crate::Theme;
 use crate::widget::Element;
-use crate::window::Window;
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -236,7 +235,6 @@ impl Query {
         clients: &mut data::client::Map,
         history: &mut history::Manager,
         previews: &preview::Collection,
-        main_window: &Window,
         config: &Config,
     ) -> (Task<Message>, Option<Event>) {
         match message {
@@ -269,7 +267,6 @@ impl Query {
                         &self.buffer,
                         clients,
                         history,
-                        main_window,
                         config,
                     );
 
@@ -336,7 +333,6 @@ impl Query {
                     &self.buffer,
                     clients,
                     history,
-                    main_window,
                     config,
                 );
                 let command = command.map(Message::InputView);
@@ -408,7 +404,6 @@ impl Query {
                     &self.buffer,
                     clients,
                     history,
-                    main_window,
                     config,
                 );
                 (task.map(Message::InputView), None)
@@ -419,7 +414,6 @@ impl Query {
                     &self.buffer,
                     clients,
                     history,
-                    main_window,
                     config,
                 );
                 (

--- a/src/buffer/server.rs
+++ b/src/buffer/server.rs
@@ -13,7 +13,6 @@ use iced::{Color, Length, Size, Task, padding};
 use super::{context_menu, input_view, scroll_view};
 use crate::widget::user_display::UserDisplay;
 use crate::widget::{Element, message_content, selectable_text};
-use crate::window::Window;
 use crate::{Theme, font, theme};
 
 fn row_with_timestamp<'a>(
@@ -376,7 +375,6 @@ impl Server {
         clients: &mut data::client::Map,
         history: &mut history::Manager,
         previews: &preview::Collection,
-        main_window: &Window,
         config: &Config,
     ) -> (Task<Message>, Option<Event>) {
         match message {
@@ -436,7 +434,6 @@ impl Server {
                     &self.buffer,
                     clients,
                     history,
-                    main_window,
                     config,
                 );
                 let command = command.map(Message::InputView);
@@ -504,7 +501,6 @@ impl Server {
                     &self.buffer,
                     clients,
                     history,
-                    main_window,
                     config,
                 );
                 (task.map(Message::InputView), None)
@@ -515,7 +511,6 @@ impl Server {
                     &self.buffer,
                     clients,
                     history,
-                    main_window,
                     config,
                 );
                 (

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -383,7 +383,6 @@ impl Dashboard {
                                 &mut self.history,
                                 &self.previews,
                                 &mut self.file_transfers,
-                                main_window,
                                 config,
                             );
 
@@ -550,7 +549,6 @@ impl Dashboard {
                                         &mut self.history,
                                         &self.previews,
                                         &mut self.file_transfers,
-                                        main_window,
                                         config,
                                     );
 


### PR DESCRIPTION
- Organize & flesh out CHANGELOG
- Minor clean-up by removing a no-longer-used Enum variant
- Add an extra setting alias `primary_icon_size` to aid users moving from `server_icon_size`
- Add some explanatory comments re: mode Enums