### PR TITLE
Per-network configuration for bouncer networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Added:
 
+- Ability to configure individual bouncer networks with `servers.<name>.networks.<network>`
 - CTCP actions to private message context menus
 - Remember sidebar visibility
 - Expanded `servers.<name>.max_connection_attempts` to allow unlimited attempts

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -181,7 +181,7 @@ pub enum Event {
     MonitoredOnline(Vec<User>),
     MonitoredOffline(Vec<Nick>),
     OnConnect(on_connect::Stream),
-    BouncerNetwork(Server, config::Server),
+    BouncerNetwork(Server, Arc<config::Server>),
     AddToSidebar(target::Query),
     AuthenticationFailed(Option<String>),
     UpdateIcon,
@@ -197,6 +197,17 @@ struct ChatHistoryRequest {
 struct MonitoredUser {
     online: bool,
     automated: bool,
+}
+
+/// How Halloy should use a connection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConnectionRole {
+    /// A normal IRC connection.
+    Regular,
+    /// Lists and manages a bouncer's networks.
+    BouncerControl,
+    /// A connection to one network on a bouncer.
+    BouncerNetwork,
 }
 
 pub struct Client {
@@ -309,22 +320,16 @@ impl Client {
         }
     }
 
-    // For each bouncer, we reserve a primary (unbound) TCP connection for bouncer communication.
-    // This function returns true if we are that connection.
-    //
-    // The curious reader may wonder why we store the netID twice. The answer is that the netID in
-    // `self.server` is the netID that we are _requesting_, while `resolved_netid` is the netID
-    // that is received. Even if we do not request to be bound to a network, we may be bound
-    // nonetheless. For example, this happens in soju when one uses a `user/network` username.
-    //
-    // If we realize the server we connected to is bound, we could try to update this `Server`
-    // across the halloy structures... but this would be very difficult and error prone. Instead in
-    // this file we simply accept being a non-primary connection and forego any bouncer
-    // communication.
-    //
-    // If !is_primary holds, then resolved_netid and server.bouncer_netid() must match.
-    fn is_primary(&self) -> bool {
-        !self.server.is_bouncer_network() && self.resolved_netid.is_none()
+    fn connection_role(&self) -> ConnectionRole {
+        if !self.capabilities.acknowledged(Capability::BouncerNetworks) {
+            ConnectionRole::Regular
+        } else if self.server.bouncer_netid().is_some()
+            || self.resolved_netid.is_some()
+        {
+            ConnectionRole::BouncerNetwork
+        } else {
+            ConnectionRole::BouncerControl
+        }
     }
 
     pub fn connect(&mut self) -> Result<()> {
@@ -1320,9 +1325,8 @@ impl Client {
                 }
             }
             Command::BOUNCER(subcommand, params) if subcommand == "NETWORK" => {
-                if !self.is_primary() {
-                    // we should only be receiving bouncer communication on the primary channel. Just for
-                    // safety and future proofing, ignore in bound networks.
+                // Only the bouncer control connection discovers networks.
+                if self.connection_role() != ConnectionRole::BouncerControl {
                     return Ok(vec![]);
                 }
                 let [netid, network] = params.as_slice() else {
@@ -1345,7 +1349,8 @@ impl Client {
                 }
 
                 let network = BouncerNetwork::parse(netid, network)?;
-                let network_config = self.config.bouncer_config();
+                let network_config =
+                    self.config.bouncer_network_config(&network);
                 return Ok(vec![Event::BouncerNetwork(
                     Server {
                         network: Some(network.into()),
@@ -3159,11 +3164,7 @@ impl Client {
                 // Request bouncer networks
                 // TODO(pounce) replace this with "bouncer-networks-notify" after the cap handling
                 // is cleaned up.
-                if self.is_primary()
-                    && self
-                        .capabilities
-                        .acknowledged(Capability::BouncerNetworks)
-                {
+                if self.connection_role() == ConnectionRole::BouncerControl {
                     self.handle
                         .try_send(command!("BOUNCER", "LISTNETWORKS"))?;
                 }
@@ -3212,7 +3213,7 @@ impl Client {
                     })
                     .collect::<Vec<_>>();
 
-                // Send JOIN on non bouncer networks
+                // The bouncer keeps the upstream channel state.
                 if !self.capabilities.acknowledged(Capability::BouncerNetworks)
                 {
                     for message in group_joins(
@@ -3272,10 +3273,7 @@ impl Client {
                     ))))
                     .collect::<Vec<_>>();
 
-                if (!self
-                    .capabilities
-                    .acknowledged(Capability::BouncerNetworks)
-                    || !self.is_primary())
+                if self.connection_role() != ConnectionRole::BouncerControl
                     && matches!(
                         self.features.version_request,
                         VersionRequest::Need(true)
@@ -5360,6 +5358,16 @@ impl Map {
         self.client(server).is_some_and(|client| {
             client.capabilities.acknowledged(Capability::EchoMessage)
         })
+    }
+
+    /// The config used by this server connection.
+    ///
+    /// Unlike `config.servers`, this distinguishes networks on the same bouncer.
+    pub fn get_server_config(
+        &self,
+        server: &Server,
+    ) -> Option<&config::Server> {
+        self.client(server).map(|client| client.config.as_ref())
     }
 
     pub fn get_server_supports_typing(&self, server: &Server) -> bool {

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -369,6 +369,13 @@ impl Client {
                 }
             }
 
+            if self.connection_role() == ConnectionRole::BouncerControl
+                && config.reenables_bouncer_network(&self.config)
+            {
+                let _ =
+                    self.handle.try_send(command!("BOUNCER", "LISTNETWORKS"));
+            }
+
             // TODO: allow from_modal when modal matching to bouncer networks is added.
             if !self.capabilities.acknowledged(Capability::BouncerNetworks)
                 || config.do_not_request.contains(&Capability::BouncerNetworks)
@@ -1349,8 +1356,11 @@ impl Client {
                 }
 
                 let network = BouncerNetwork::parse(netid, network)?;
-                let network_config =
-                    self.config.bouncer_network_config(&network);
+                let Some(network_config) =
+                    self.config.bouncer_network_config(&network)
+                else {
+                    return Ok(vec![]);
+                };
                 return Ok(vec![Event::BouncerNetwork(
                     Server {
                         network: Some(network.into()),

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -1,15 +1,19 @@
 use std::collections::HashMap;
 use std::num::NonZeroU16;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
+use indexmap::IndexMap;
 use irc::connection;
 use serde::{Deserialize, Deserializer};
 use tokio::fs;
 use tokio::process::Command;
 
+use self::bouncer_network::Overrides;
 use self::filehost::Filehost;
 use self::icon::Icon;
+use crate::bouncer::BouncerNetwork;
 use crate::capabilities::Capability;
 use crate::config::inclusivities::{
     Inclusivities, is_target_channel_included, is_target_query_included,
@@ -23,6 +27,7 @@ use crate::serde::{
 };
 use crate::{config, isupport, metadata, target};
 
+mod bouncer_network;
 pub mod filehost;
 pub mod filters;
 pub mod icon;
@@ -166,6 +171,8 @@ pub struct Server {
     /// Whether & how to log all IRC protocol messages
     pub irc_protocol_log: IrcProtocolLog,
     pub sidebar_visibility: SidebarVisibility,
+    /// Settings for this bouncer's networks.
+    pub(crate) networks: Arc<IndexMap<String, Overrides>>,
 }
 
 impl Server {
@@ -229,22 +236,40 @@ impl Server {
         }
     }
 
-    pub fn bouncer_config(&self) -> Self {
+    /// Returns the config for a bouncer network.
+    pub fn bouncer_network_config(
+        &self,
+        network: &BouncerNetwork,
+    ) -> Arc<Self> {
+        let mut config = self.bouncer_network_defaults();
+
+        if let Some((_, overrides)) = self
+            .networks
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case(&network.name))
+        {
+            overrides.apply(&mut config);
+        }
+
+        Arc::new(config)
+    }
+
+    fn bouncer_network_defaults(&self) -> Self {
+        let defaults = Self::default();
+
         Self {
-            // nickserv info not relevant to the bounced network
-            nick_password_keyring: config::keyring::Password::default(),
-            nick_password_file: Option::default(),
-            nick_password_command: Option::default(),
-            nick_identify_syntax: Option::default(),
-
-            // channel_keys not relevant
-            channel_keys: HashMap::default(),
-            channel_keys_keyring: HashMap::default(),
-
-            // ghost sequence not relevant
-            should_ghost: Default::default(),
-            ghost_sequence: Server::default().ghost_sequence,
-
+            nick_password: defaults.nick_password,
+            nick_password_keyring: defaults.nick_password_keyring,
+            nick_password_file: defaults.nick_password_file,
+            nick_password_file_first_line_only: defaults
+                .nick_password_file_first_line_only,
+            nick_password_command: defaults.nick_password_command,
+            nick_identify_syntax: defaults.nick_identify_syntax,
+            channel_keys: defaults.channel_keys,
+            channel_keys_keyring: defaults.channel_keys_keyring,
+            should_ghost: defaults.should_ghost,
+            ghost_sequence: defaults.ghost_sequence,
+            networks: defaults.networks,
             ..self.clone()
         }
     }
@@ -335,6 +360,7 @@ impl Default for Server {
             do_not_request: vec![],
             irc_protocol_log: IrcProtocolLog::default(),
             sidebar_visibility: SidebarVisibility::Expanded,
+            networks: Arc::default(),
         }
     }
 }
@@ -903,5 +929,36 @@ mod tests {
                 if label == "Filehost credentials password"
                     && context == "server `libera`"
         ));
+    }
+
+    #[test]
+    fn bouncer_network_config_uses_network_overrides() {
+        let config: Server = toml::from_str(
+            r##"
+            server = "bouncer.example.org"
+            nick_password = "secret"
+            channel_keys = { "#halloy" = "secret" }
+            should_ghost = true
+
+            [networks.libera]
+            channels = ["#rust"]
+
+            [networks.libera.filters]
+            ignore = ["Guest9702"]
+            "##,
+        )
+        .unwrap();
+
+        let network_config = config.bouncer_network_config(&BouncerNetwork {
+            id: "1".into(),
+            name: "Libera".into(),
+        });
+
+        assert_eq!(network_config.server, "bouncer.example.org");
+        assert_eq!(network_config.channels[0].name, "#rust");
+        assert_eq!(network_config.filters.as_ref().unwrap().ignore.len(), 1);
+        assert!(network_config.nick_password.is_none());
+        assert!(network_config.channel_keys.is_empty());
+        assert!(!network_config.should_ghost);
     }
 }

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -947,14 +947,14 @@ mod tests {
             channel_keys = { "#halloy" = "secret" }
             should_ghost = true
 
-            [networks.libera]
+            [networks.Libera]
             enabled = true
             channels = ["#rust"]
 
-            [networks.libera.filters]
+            [networks.Libera.filters]
             ignore = ["Guest9702"]
 
-            [networks.quakenet]
+            [networks.QuakeNet]
             enabled = false
             "##,
         )

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -243,11 +243,7 @@ impl Server {
     ) -> Option<Arc<Self>> {
         let mut config = self.bouncer_network_defaults();
 
-        if let Some((_, overrides)) = self
-            .networks
-            .iter()
-            .find(|(name, _)| name.eq_ignore_ascii_case(&network.name))
-        {
+        if let Some(overrides) = self.networks.get(&network.name) {
             if !overrides.enabled() {
                 return None;
             }
@@ -261,11 +257,7 @@ impl Server {
     pub(crate) fn reenables_bouncer_network(&self, old: &Self) -> bool {
         old.networks.iter().any(|(name, old)| {
             !old.enabled()
-                && self
-                    .networks
-                    .iter()
-                    .find(|(new_name, _)| new_name.eq_ignore_ascii_case(name))
-                    .is_none_or(|(_, new)| new.enabled())
+                && self.networks.get(name).is_none_or(Overrides::enabled)
         })
     }
 

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -236,11 +236,11 @@ impl Server {
         }
     }
 
-    /// Returns the config for a bouncer network.
+    /// Returns the config for an enabled bouncer network.
     pub fn bouncer_network_config(
         &self,
         network: &BouncerNetwork,
-    ) -> Arc<Self> {
+    ) -> Option<Arc<Self>> {
         let mut config = self.bouncer_network_defaults();
 
         if let Some((_, overrides)) = self
@@ -248,10 +248,25 @@ impl Server {
             .iter()
             .find(|(name, _)| name.eq_ignore_ascii_case(&network.name))
         {
+            if !overrides.enabled() {
+                return None;
+            }
+
             overrides.apply(&mut config);
         }
 
-        Arc::new(config)
+        Some(Arc::new(config))
+    }
+
+    pub(crate) fn reenables_bouncer_network(&self, old: &Self) -> bool {
+        old.networks.iter().any(|(name, old)| {
+            !old.enabled()
+                && self
+                    .networks
+                    .iter()
+                    .find(|(new_name, _)| new_name.eq_ignore_ascii_case(name))
+                    .is_none_or(|(_, new)| new.enabled())
+        })
     }
 
     fn bouncer_network_defaults(&self) -> Self {
@@ -941,18 +956,24 @@ mod tests {
             should_ghost = true
 
             [networks.libera]
+            enabled = true
             channels = ["#rust"]
 
             [networks.libera.filters]
             ignore = ["Guest9702"]
+
+            [networks.quakenet]
+            enabled = false
             "##,
         )
         .unwrap();
 
-        let network_config = config.bouncer_network_config(&BouncerNetwork {
-            id: "1".into(),
-            name: "Libera".into(),
-        });
+        let network_config = config
+            .bouncer_network_config(&BouncerNetwork {
+                id: "1".into(),
+                name: "Libera".into(),
+            })
+            .unwrap();
 
         assert_eq!(network_config.server, "bouncer.example.org");
         assert_eq!(network_config.channels[0].name, "#rust");
@@ -960,5 +981,14 @@ mod tests {
         assert!(network_config.nick_password.is_none());
         assert!(network_config.channel_keys.is_empty());
         assert!(!network_config.should_ghost);
+
+        assert!(
+            config
+                .bouncer_network_config(&BouncerNetwork {
+                    id: "2".into(),
+                    name: "QuakeNet".into(),
+                })
+                .is_none()
+        );
     }
 }

--- a/data/src/config/server/bouncer_network.rs
+++ b/data/src/config/server/bouncer_network.rs
@@ -1,0 +1,84 @@
+//! Per-network settings for a bouncer.
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+use super::{
+    ConfirmMessageDelivery, Filters, Icon, Muteable, OptionalTyping, Reroute,
+    Server, SidebarVisibility,
+};
+use crate::config::sidebar::OrderChannelsBy;
+use crate::metadata;
+
+/// Settings that can be overridden for a bouncer network.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub(crate) struct Overrides {
+    filters: Option<Filters>,
+    reroute: Option<Reroute>,
+    channels: Option<Vec<Muteable>>,
+    order_channels_by: Option<OrderChannelsBy>,
+    queries: Option<Vec<Muteable>>,
+    umodes: Option<String>,
+    on_connect: Option<Vec<String>>,
+    who_poll_enabled: Option<bool>,
+    monitor: Option<Vec<String>>,
+    #[serde(alias = "chathistory")]
+    automated_chathistory: Option<bool>,
+    confirm_message_delivery: Option<ConfirmMessageDelivery>,
+    typing: Option<OptionalTyping>,
+    metadata: Option<HashMap<metadata::Key, String>>,
+    icon: Option<Icon>,
+    sidebar_visibility: Option<SidebarVisibility>,
+}
+
+impl Overrides {
+    pub(super) fn apply(&self, config: &mut Server) {
+        if let Some(value) = &self.filters {
+            config.filters = Some(value.clone());
+        }
+        if let Some(value) = &self.reroute {
+            config.reroute.clone_from(value);
+        }
+        if let Some(value) = &self.channels {
+            config.channels.clone_from(value);
+        }
+        if let Some(value) = self.order_channels_by {
+            config.order_channels_by = Some(value);
+        }
+        if let Some(value) = &self.queries {
+            config.queries.clone_from(value);
+        }
+        if let Some(value) = &self.umodes {
+            config.umodes = Some(value.clone());
+        }
+        if let Some(value) = &self.on_connect {
+            config.on_connect.clone_from(value);
+        }
+        if let Some(value) = self.who_poll_enabled {
+            config.who_poll_enabled = value;
+        }
+        if let Some(value) = &self.monitor {
+            config.monitor.clone_from(value);
+        }
+        if let Some(value) = self.automated_chathistory {
+            config.automated_chathistory = value;
+        }
+        if let Some(value) = &self.confirm_message_delivery {
+            config.confirm_message_delivery.clone_from(value);
+        }
+        if let Some(value) = &self.typing {
+            config.typing.clone_from(value);
+        }
+        if let Some(value) = &self.metadata {
+            config.metadata.clone_from(value);
+        }
+        if let Some(value) = &self.icon {
+            config.icon.clone_from(value);
+        }
+        if let Some(value) = self.sidebar_visibility {
+            config.sidebar_visibility = value;
+        }
+    }
+}

--- a/data/src/config/server/bouncer_network.rs
+++ b/data/src/config/server/bouncer_network.rs
@@ -15,6 +15,7 @@ use crate::metadata;
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(default)]
 pub(crate) struct Overrides {
+    enabled: Option<bool>,
     filters: Option<Filters>,
     reroute: Option<Reroute>,
     channels: Option<Vec<Muteable>>,
@@ -34,6 +35,10 @@ pub(crate) struct Overrides {
 }
 
 impl Overrides {
+    pub(super) fn enabled(&self) -> bool {
+        self.enabled.unwrap_or(true)
+    }
+
     pub(super) fn apply(&self, config: &mut Server) {
         if let Some(value) = &self.filters {
             config.filters = Some(value.clone());

--- a/data/src/history/reroute.rs
+++ b/data/src/history/reroute.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use crate::user::Nick;
 use crate::{
@@ -70,7 +69,7 @@ impl RerouteRules {
     pub fn sync_isupport(
         &mut self,
         server: &Server,
-        config: Arc<config::Server>,
+        config: &config::Server,
         chantypes: &[char],
         statusmsg: &[char],
         casemapping: isupport::CaseMap,

--- a/data/src/server.rs
+++ b/data/src/server.rs
@@ -340,8 +340,9 @@ impl ConfigMap {
         self.0.iter()
     }
 
-    pub fn get(&self, server: &Server) -> Option<Arc<config::Server>> {
-        self.0.get(&server.name).cloned()
+    /// Returns a configured parent server.
+    pub fn get(&self, server: &ServerName) -> Option<Arc<config::Server>> {
+        self.0.get(server).cloned()
     }
 }
 

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -21,8 +21,9 @@ Use `networks` to change settings for individual networks on a bouncer.
 ignore = ["Guest9702"]
 ```
 
-Here, `home` is the server name and `libera` is the network name from
-the bouncer. Network names are not case-sensitive.
+Here, `home` is the server name given for the bouncer in Halloy's configuration
+file, and `libera` is the network name as configured on the bouncer. Network
+names are not case-sensitive.
 
 The network uses the settings from `[servers.home]` unless you override them.
 

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -26,9 +26,9 @@ the bouncer. Network names are not case-sensitive.
 
 The network uses the settings from `[servers.home]` unless you override them.
 
-You can use `enabled = false` to hide a network and disconnect Halloy from it.
-Changing it back to `true` reconnects the network.
-This does not disable the network on the bouncer.
+You can use `enabled = false` to hide a network and disconnect Halloy from it
+(this does not disable the network on the bouncer). Changing `enabled` back to
+`true` will reconnect Halloy to the network.
 
 You can also override:
 

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -36,7 +36,21 @@ You can also override:
 `enabled`, `filters`, `reroute`, `channels`, `order_channels_by`, `queries`,
 `umodes`, `on_connect`, `who_poll_enabled`, `monitor`,
 `automated_chathistory`, `confirm_message_delivery`, `typing`, `metadata`, `icon`,
-`sidebar_visibility`
+- `automated_chathistory`
+- `channels`
+- `confirm_message_delivery`
+- `filters`
+- `icon`
+- `metadata`
+- `monitor`
+- `on_connect`
+- `order_channels_by`
+- `queries`
+- `reroute`
+- `sidebar_visibility`
+- `typing`
+- `umodes`
+- `who_poll_enabled`
 
 See [Connect with soju](../guides/connect-with-soju.md#configure-individual-networks)
 for an example.

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -26,11 +26,15 @@ the bouncer. Network names are not case-sensitive.
 
 The network uses the settings from `[servers.home]` unless you override them.
 
-You can override:
+You can use `enabled = false` to hide a network and disconnect Halloy from it.
+Changing it back to `true` reconnects the network.
+This does not disable the network on the bouncer.
 
-`filters`, `reroute`, `channels`, `order_channels_by`, `queries`, `umodes`,
-`on_connect`, `who_poll_enabled`, `monitor`, `automated_chathistory`,
-`confirm_message_delivery`, `typing`, `metadata`, `icon`,
+You can also override:
+
+`enabled`, `filters`, `reroute`, `channels`, `order_channels_by`, `queries`,
+`umodes`, `on_connect`, `who_poll_enabled`, `monitor`,
+`automated_chathistory`, `confirm_message_delivery`, `typing`, `metadata`, `icon`,
 `sidebar_visibility`
 
 See [Connect with soju](../guides/connect-with-soju.md#configure-individual-networks)

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -9,6 +9,33 @@ Examples can be found in the following guides:
 - [Connect with soju](../guides/connect-with-soju.md)
 - [Connect with ZNC](../guides/connect-with-znc.md)
 
+## `networks`
+
+Use `networks` to change settings for individual networks on a bouncer.
+
+```toml
+# Type: map of network names to server settings
+# Default: not set
+
+[servers.home.networks.libera.filters]
+ignore = ["Guest9702"]
+```
+
+Here, `home` is the server name and `libera` is the network name from
+the bouncer. Network names are not case-sensitive.
+
+The network uses the settings from `[servers.home]` unless you override them.
+
+You can override:
+
+`filters`, `reroute`, `channels`, `order_channels_by`, `queries`, `umodes`,
+`on_connect`, `who_poll_enabled`, `monitor`, `automated_chathistory`,
+`confirm_message_delivery`, `typing`, `metadata`, `icon`,
+`sidebar_visibility`
+
+See [Connect with soju](../guides/connect-with-soju.md#configure-individual-networks)
+for an example.
+
 ## `nickname`
 
 The client's nickname.

--- a/docs/guides/connect-with-soju.md
+++ b/docs/guides/connect-with-soju.md
@@ -46,12 +46,37 @@ username = "<your-username>"
 password = "<your-password>"
 ```
 
-If you haven't configured any networks beforehand, you can do so after connecting. Note that you might need to restart Halloy to see newly created networks in the sidebar.
+### Configure individual networks
 
-```sh
-/msg BouncerServ net create -addr irc.libera.chat
+Add a `networks` section when one network needs different settings:
+
+```toml
+[servers.home]
+nickname = "<your-nickname>"
+server = "<your-bouncer-url>"
+
+[servers.home.sasl.plain]
+username = "<your-username>"
+password = "<your-password>"
+
+[servers.home.networks.libera.filters]
+ignore = ["Guest9702"]
 ```
 
+`home` is the server name. `libera` is the network name from soju.
+The filter only applies to that network. Other supported settings still come
+from `[servers.home]`.
+
+See [`networks`](../configuration/servers.md#networks) for all supported
+settings.
+
+To add a network to soju after connecting:
+
+```sh
+/msg BouncerServ net create -addr irc.libera.chat -name libera
+```
+
+Restart Halloy if the new network does not appear in the sidebar.
 
 ## Manual per-network configuration (legacy)
 

--- a/docs/guides/connect-with-soju.md
+++ b/docs/guides/connect-with-soju.md
@@ -63,7 +63,7 @@ password = "<your-password>"
 ignore = ["Guest9702"]
 ```
 
-`home` is the server name. `libera` is the network name from soju.
+`home` is the locally configured server name for the bouncer, and `libera` is the network name as specified with soju.
 The filter only applies to that network. Other supported settings still come
 from `[servers.home]`.
 

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -81,11 +81,13 @@ pub fn view<'a>(
     let registry = clients.get_registry(server);
     let channel = &state.target;
     let confirm_message_delivery = clients.get_server_supports_echoes(server)
-        && config.servers.get(server).is_some_and(|server_config| {
-            server_config
-                .confirm_message_delivery
-                .is_target_channel_included(channel, server, casemapping)
-        });
+        && clients
+            .get_server_config(server)
+            .is_some_and(|server_config| {
+                server_config
+                    .confirm_message_delivery
+                    .is_target_channel_included(channel, server, casemapping)
+            });
     let our_nick: Option<data::user::NickRef<'_>> =
         clients.nickname(&state.server);
 

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -76,11 +76,13 @@ pub fn view<'a>(
     let registry = clients.get_registry(server);
     let query = &state.target;
     let confirm_message_delivery = clients.get_server_supports_echoes(server)
-        && config.servers.get(server).is_some_and(|server_config| {
-            server_config
-                .confirm_message_delivery
-                .is_target_query_included(query, server, casemapping)
-        });
+        && clients
+            .get_server_config(server)
+            .is_some_and(|server_config| {
+                server_config
+                    .confirm_message_delivery
+                    .is_target_query_included(query, server, casemapping)
+            });
     let our_nick = clients.nickname(server);
     let our_user = our_nick.map(|our_nick| User::from(Nick::from(our_nick)));
     let show_typing = clients.get_server_show_typing(server);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1006,29 +1006,15 @@ impl Halloy {
                     server,
                     updated_config,
                 } => {
+                    // Bouncer networks are updated separately.
                     let events = self.clients.update_config(
                         &server,
-                        updated_config.clone(),
+                        updated_config,
                         false,
                     );
 
-                    let mut bouncer_network_events = vec![];
-
-                    for bouncer_network in
-                        self.servers.get_bouncer_networks(&server)
-                    {
-                        bouncer_network_events.push((
-                            bouncer_network.clone(),
-                            self.clients.update_config(
-                                bouncer_network,
-                                updated_config.bouncer_config().into(),
-                                false,
-                            ),
-                        ));
-                    }
-
                     if let Screen::Dashboard(dashboard) = &mut self.screen {
-                        let commands = handle_client_events(
+                        return handle_client_events(
                             &server,
                             events,
                             dashboard,
@@ -1039,32 +1025,6 @@ impl Halloy {
                             &mut self.controllers,
                             &self.main_window,
                         );
-
-                        if bouncer_network_events.is_empty() {
-                            return commands;
-                        }
-
-                        let mut bouncer_network_commands = vec![];
-
-                        for (bouncer_network, events) in bouncer_network_events
-                        {
-                            bouncer_network_commands.push(
-                                handle_client_events(
-                                    &bouncer_network,
-                                    events,
-                                    dashboard,
-                                    &mut self.clients,
-                                    &self.config,
-                                    &mut self.notifications,
-                                    &mut self.servers,
-                                    &mut self.controllers,
-                                    &self.main_window,
-                                ),
-                            );
-                        }
-
-                        return commands
-                            .chain(Task::batch(bouncer_network_commands));
                     }
 
                     Task::none()
@@ -1652,12 +1612,26 @@ impl Halloy {
                             .collect::<Vec<_>>();
 
                         for bouncer_network in bouncer_networks {
-                            if let Some(bouncer_network) =
+                            let Some(network) =
+                                bouncer_network.network.as_ref()
+                            else {
+                                continue;
+                            };
+
+                            let network_config =
+                                config.bouncer_network_config(network);
+
+                            if let Some(existing) =
                                 self.servers.get_mut(&bouncer_network)
                             {
-                                *bouncer_network =
-                                    config.bouncer_config().into();
+                                existing.clone_from(&network_config);
                             }
+
+                            self.controllers.update_config(
+                                &bouncer_network,
+                                network_config,
+                                updated.proxy.clone(),
+                            );
                         }
 
                         self.controllers.update_config(
@@ -2065,7 +2039,7 @@ fn handle_client_events(
                 );
             }
             Event::BouncerNetwork(server, server_config) => {
-                servers.insert(server, server_config.into());
+                servers.insert(server, server_config);
 
                 dashboard.set_reroute_rules(servers, clients);
 
@@ -2809,7 +2783,7 @@ fn handle_isupport_param(
             let chantypes = clients.get_server_chantypes_or_default(server);
             let casemapping = clients.get_server_casemapping_or_default(server);
 
-            if let Some(server_config) = config.servers.get(server) {
+            if let Some(server_config) = clients.get_server_config(server) {
                 let reroute_rules = dashboard.get_reroute_rules_mut();
 
                 reroute_rules.sync_isupport(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1618,8 +1618,21 @@ impl Halloy {
                                 continue;
                             };
 
-                            let network_config =
-                                config.bouncer_network_config(network);
+                            let Some(network_config) =
+                                config.bouncer_network_config(network)
+                            else {
+                                self.controllers.end(
+                                    &bouncer_network,
+                                    &updated
+                                        .buffer
+                                        .commands
+                                        .quit
+                                        .default_reason,
+                                );
+                                self.servers.remove(&bouncer_network);
+                                self.clients.remove(&bouncer_network);
+                                continue;
+                            };
 
                             if let Some(existing) =
                                 self.servers.get_mut(&bouncer_network)

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -230,8 +230,18 @@ impl Sidebar {
                                      state: &client::State|
          -> Option<SidebarBufferGroup> {
             let casemapping = clients.get_server_casemapping_or_default(server);
+            let server_config = servers.get(server);
+            let server_icon_enabled = server_config
+                .as_ref()
+                .is_some_and(|config| config.icon.enabled);
+            let server_sidebar_visibility = server_config
+                .as_ref()
+                .map_or_else(SidebarVisibility::default, |config| {
+                    config.sidebar_visibility
+                });
 
-            let is_collapsed = !self.collapse.is_expanded(config, server);
+            let is_collapsed =
+                !self.collapse.is_expanded(server, server_sidebar_visibility);
 
             match state {
                 data::client::State::Disconnected {
@@ -255,6 +265,8 @@ impl Sidebar {
                             },
                             has_collapsible_buffers: false,
                             casemapping,
+                            server_icon_enabled,
+                            server_sidebar_visibility,
                         }
                     })
                 }
@@ -345,6 +357,8 @@ impl Sidebar {
                             },
                             has_collapsible_buffers,
                             casemapping,
+                            server_icon_enabled,
+                            server_sidebar_visibility,
                         }
                     })
                 }
@@ -873,6 +887,8 @@ impl Sidebar {
                         connection_status,
                         has_collapsible_buffers,
                         casemapping,
+                        server_icon_enabled,
+                        server_sidebar_visibility,
                     } => {
                         let server_has_unread =
                             history.server_has_unread(&server);
@@ -894,6 +910,8 @@ impl Sidebar {
                                 server_has_unread,
                                 supports_detach,
                                 casemapping,
+                                server_icon_enabled,
+                                server_sidebar_visibility,
                                 history,
                                 width,
                                 theme,
@@ -1041,6 +1059,8 @@ enum SidebarBufferGroup {
         connection_status: ConnectionStatus,
         casemapping: isupport::CaseMap,
         has_collapsible_buffers: bool,
+        server_icon_enabled: bool,
+        server_sidebar_visibility: SidebarVisibility,
     },
     Internal {
         visible_buffers: Vec<InternalBufferSidebarData>,
@@ -1397,6 +1417,8 @@ struct UpstreamButtonContext<'a> {
     server_has_unread: bool,
     supports_detach: bool,
     casemapping: isupport::CaseMap,
+    server_icon_enabled: bool,
+    server_sidebar_visibility: SidebarVisibility,
     history: &'a history::Manager,
     width: Length,
     theme: &'a Theme,
@@ -1517,6 +1539,8 @@ fn upstream_buffer_button<'a>(
         connection_status,
         server_has_collapsible_buffers,
         casemapping,
+        server_icon_enabled,
+        server_sidebar_visibility,
         history,
         width,
         theme,
@@ -1576,10 +1600,7 @@ fn upstream_buffer_button<'a>(
     let icon = if dimensions.icon_size > 0
         && let buffer::Upstream::Server(server) = buffer
     {
-        if config
-            .servers
-            .get(server)
-            .is_some_and(|server_config| server_config.icon.enabled)
+        if *server_icon_enabled
             && let Some(server_icon) = server_icons.get(server)
         {
             Some(Icon::Upstream(server_icon))
@@ -1676,6 +1697,7 @@ fn upstream_buffer_button<'a>(
         collapse.disclosure(
             config,
             server,
+            *server_sidebar_visibility,
             connection_status,
             *server_has_collapsible_buffers,
             font_size.max(sidebar_icon_height as f32),
@@ -1813,6 +1835,7 @@ fn upstream_buffer_context_menu<'a>(
         history,
         theme,
         collapse,
+        server_sidebar_visibility,
         ..
     } = context;
 
@@ -1974,7 +1997,8 @@ fn upstream_buffer_context_menu<'a>(
                 },
                 Entry::ToggleCollapse => {
                     let server = buffer.server();
-                    let is_expanded = collapse.is_expanded(config, server);
+                    let is_expanded =
+                        collapse.is_expanded(server, server_sidebar_visibility);
                     (
                         if is_expanded {
                             "Collapse server"

--- a/src/screen/dashboard/sidebar/collapse.rs
+++ b/src/screen/dashboard/sidebar/collapse.rs
@@ -18,18 +18,13 @@ impl State {
         self.visibility.insert(server, visibility);
     }
 
-    pub fn is_expanded(&self, config: &Config, server: &Server) -> bool {
-        let visibility = self
-            .visibility
-            .get(server)
-            .copied()
-            .or_else(|| {
-                config
-                    .servers
-                    .get(server)
-                    .map(|server| server.sidebar_visibility)
-            })
-            .unwrap_or_default();
+    pub fn is_expanded(
+        &self,
+        server: &Server,
+        default: SidebarVisibility,
+    ) -> bool {
+        let visibility =
+            self.visibility.get(server).copied().unwrap_or(default);
 
         matches!(visibility, SidebarVisibility::Expanded)
     }
@@ -38,6 +33,7 @@ impl State {
         &self,
         config: &Config,
         server: &Server,
+        default: SidebarVisibility,
         connection_status: &ConnectionStatus,
         has_members: bool,
         content_height: f32,
@@ -49,7 +45,7 @@ impl State {
             return None;
         }
 
-        let is_expanded = self.is_expanded(config, server);
+        let is_expanded = self.is_expanded(server, default);
         let indicator = match (config.sidebar.position, is_expanded) {
             (
                 data::config::sidebar::Position::Left


### PR DESCRIPTION
This supersedes #1985.

Per-network configuration for bouncer networks.

```toml
[servers.home.networks.libera]
filters = { ignore = ["foobar"] }
```