### PR TITLE
Configurable avatar size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Added:
 Fixed:
 
 - Remove blank space above the input after marking a buffer as read
+- User avatars are only shown when `avatar` is included in `metadata.preferred_keys`
+
+Changed:
+
+- User avatars are configurable with `metadata.avatar.size`
 
 Thanks:
 

--- a/data/src/config/metadata.rs
+++ b/data/src/config/metadata.rs
@@ -33,6 +33,12 @@ impl Metadata {
     pub fn preferred_key_strs(&self) -> impl Iterator<Item = &'static str> {
         self.preferred_keys.iter().copied().map(Key::to_str)
     }
+
+    pub fn avatar_size(&self) -> Option<u16> {
+        self.preferred_keys
+            .contains(&metadata::Key::Avatar)
+            .then_some(self.avatar.size)
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -40,6 +46,7 @@ impl Metadata {
 pub struct Avatar {
     pub enabled: bool,
     pub exclude: Exclude,
+    pub size: u16,
 }
 
 impl Default for Avatar {
@@ -47,6 +54,7 @@ impl Default for Avatar {
         Self {
             enabled: true,
             exclude: Exclude::default(),
+            size: 64,
         }
     }
 }

--- a/docs/configuration/metadata.md
+++ b/docs/configuration/metadata.md
@@ -41,6 +41,19 @@ Enable or disable loading avatars.
 enabled = true
 ```
 
+### `size`
+
+Avatar width and height in pixels.
+
+```toml
+# Type: integer
+# Values: positive integers
+# Default: 64
+
+[metadata.avatar]
+size = 64
+```
+
 ### `exclude`
 
 Exclude avatar URLs from loading by providing regex patterns.

--- a/src/buffer/channel/topic.rs
+++ b/src/buffer/channel/topic.rs
@@ -176,7 +176,10 @@ pub fn view<'a>(
                             channel: Some(channel),
                             registry,
                             avatar: context_menu::user_avatar(
-                                user, registry, previews,
+                                user,
+                                registry,
+                                previews,
+                                config.metadata.avatar_size(),
                             ),
                             user,
                             current_user,

--- a/src/buffer/context_menu.rs
+++ b/src/buffer/context_menu.rs
@@ -21,8 +21,6 @@ use crate::widget::{
 };
 use crate::{Theme, font, icon, theme, widget};
 
-const AVATAR_SIZE: u16 = 36;
-
 pub struct UserContext<'a> {
     pub server: &'a Server,
     pub prefix: &'a [isupport::PrefixMap],
@@ -1296,12 +1294,11 @@ fn user_with_entries<'a>(
     } else {
         content.into()
     };
-    let avatar = user_avatar(user, registry, previews);
-    let on_open = config
-        .context_menu
-        .show_user_metadata
-        .then(|| avatar_url(user, registry))
-        .flatten()
+    let avatar_size = config.metadata.avatar_size();
+    let avatar = user_avatar(user, registry, previews, avatar_size);
+    let on_open = avatar_size
+        .filter(|_| config.context_menu.show_user_metadata)
+        .and_then(|size| avatar_url(user, registry, size))
         .filter(|url| !previews.contains_key(url))
         .map(|url| {
             let server = server.clone();
@@ -1514,20 +1511,21 @@ fn user_metadata<'a>(
     length: Length,
 ) -> Element<'a, Message> {
     let query = target::Query::from(user);
+    let avatar_size = config.metadata.avatar.size;
     let avatar: Option<Element<'a, Message>> = avatar.map(|avatar| {
         let content: Element<'a, Message> = match avatar {
             UserAvatar::Loaded(data) => {
                 container(image::from_data(data, true, ContentFit::Cover))
-                    .width(f32::from(AVATAR_SIZE))
-                    .height(f32::from(AVATAR_SIZE))
+                    .width(f32::from(avatar_size))
+                    .height(f32::from(avatar_size))
                     .into()
             }
-            UserAvatar::Pending => avatar_placeholder(),
+            UserAvatar::Pending => avatar_placeholder(avatar_size),
         };
 
         container(content)
-            .width(Length::Fixed(f32::from(AVATAR_SIZE)))
-            .height(Length::Fixed(f32::from(AVATAR_SIZE)))
+            .width(Length::Fixed(f32::from(avatar_size)))
+            .height(Length::Fixed(f32::from(avatar_size)))
             .into()
     });
     let rows = config
@@ -1599,33 +1597,27 @@ fn user_metadata<'a>(
             )
         });
 
-    let mut content = column![];
-
-    let inter_column_spacing = if let Some(avatar) = avatar {
-        content = content.push(avatar);
-
-        6
+    let rows = column(rows).spacing(2);
+    let content = if let Some(avatar) = avatar {
+        column![avatar, rows].spacing(6)
     } else {
-        0
+        column![rows]
     };
 
-    row![content, column(rows).spacing(2)]
-        .spacing(inter_column_spacing)
-        .align_y(iced::alignment::Vertical::Top)
-        .padding(right_justified_padding(config))
-        .into()
+    content.padding(right_justified_padding(config)).into()
 }
 
 fn avatar_url(
     user: &User,
     registry: &dyn metadata::Registry,
+    size: u16,
 ) -> Option<url::Url> {
     let query = target::Query::from(user);
     let avatar = registry.avatar(target::TargetRef::Query(&query))?;
 
     // Replace optional `{size}` in the avatar URL with the display size
     // https://ircv3.net/registry#user-metadata
-    let sized_avatar = avatar.replace("{size}", &format!("{AVATAR_SIZE}"));
+    let sized_avatar = avatar.replace("{size}", &size.to_string());
 
     url::Url::parse(&sized_avatar).ok()
 }
@@ -1634,8 +1626,11 @@ pub fn user_avatar<'a>(
     user: &User,
     registry: &dyn metadata::Registry,
     previews: &'a preview::Collection,
+    size: Option<u16>,
 ) -> Option<UserAvatar<'a>> {
-    avatar_url(user, registry).map(|url| match previews.get(&url) {
+    let size = size?;
+
+    avatar_url(user, registry, size).map(|url| match previews.get(&url) {
         Some(preview::State::Loaded(preview)) => {
             UserAvatar::Loaded(preview.image())
         }
@@ -1643,10 +1638,10 @@ pub fn user_avatar<'a>(
     })
 }
 
-fn avatar_placeholder<'a>() -> Element<'a, Message> {
+fn avatar_placeholder<'a>(size: u16) -> Element<'a, Message> {
     center(icon::people().size(16).style(theme::text::secondary))
-        .width(Length::Fixed(f32::from(AVATAR_SIZE)))
-        .height(Length::Fixed(f32::from(AVATAR_SIZE)))
+        .width(Length::Fixed(f32::from(size)))
+        .height(Length::Fixed(f32::from(size)))
         .style(|theme| {
             let general = theme.styles().general;
             let text = theme.styles().text;

--- a/src/buffer/message_feed.rs
+++ b/src/buffer/message_feed.rs
@@ -289,6 +289,7 @@ pub fn view<'a>(
                                     user,
                                     clients.get_registry(server),
                                     previews,
+                                    config.metadata.avatar_size(),
                                 ),
                                 user,
                                 current_user,

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -1070,6 +1070,7 @@ impl<'a> ChannelQueryLayout<'a> {
                         user,
                         self.registry,
                         self.previews.collection(),
+                        self.config.metadata.avatar_size(),
                     ),
                     user,
                     current_user,


### PR DESCRIPTION
Fixes #2215.

Adds `metadata.avatar.size` to configure avatar size. Increased the default size is 64 pixels.