### PR TITLE
Add buffer.nickname.offline = "dimmed"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Added:
   (`buffer.text_input.autocomplete.include_ignored`)
 - Optional `font.code` setting for code-formatted text
 - Settings to control how internal and server buffers are opened from the sidebar (`actions.sidebar.internal` and `actions.sidebar.server`)
+- `buffer.nickname.offline` supports `"dimmed"` / `{ dimmed = float }`, and `{ color = "theme"|"nickname", alpha = ...}` so theme offline color and dimming can be combined
 
 Fixed:
 
@@ -30,6 +31,7 @@ Changed:
 - Ensure Theme Editor appends a `.toml` extension when saving a theme without one
 - Right-aligned nickname columns now size to nearby messages instead of the entire loaded history
 - The XDG data directory `~/.local/share/halloy` can be used for storing history/logs/etc macOS, instead of `~/Library/Application Support/halloy/` (move entire directory to migrate)
+- Offline nicknames are styled only by `buffer.nickname.offline`; `buffer.nickname.away` no longer applies to them
 
 Thanks:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Thanks:
 
 - Contributions: @rollecode, @luca020400, @rtmongold, @tranzystorekk, @englut
 - Bug reports: @sebbu2, @dpedu, kurwavidae, @ncfavier, wwWraith, kurwavidae
-- Feature requests: @daniiooo, @fabricionaweb, @RoboDanjal, @AbandonedCranium, tbo, ivocavalcante, @sebbu2, @coraxioU9
+- Feature requests: @daniiooo, @fabricionaweb, @RoboDanjal, @AbandonedCranium, tbo, ivocavalcante, @sebbu2, @coraxioU9, @ncfavier
 
 # 2026.8 (2026-07-24)
 

--- a/data/src/appearance/theme.rs
+++ b/data/src/appearance/theme.rs
@@ -590,10 +590,10 @@ pub fn nickname_color(
 
 pub fn nickname_alpha(
     color: Color,
-    is_away: Option<buffer::Away>,
+    is_away: Option<buffer::Alpha>,
     background_color: Color,
 ) -> Color {
-    if let Some(buffer::Away::Dimmed(dimmed)) = is_away {
+    if let Some(buffer::Alpha::Dimmed(dimmed)) = is_away {
         dimmed.transform_color(color, background_color)
     } else {
         color

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Deserializer};
 
 pub use self::channel::{Channel, ChannelNameCasing};
 pub use self::hide_consecutive::{HideConsecutive, HideConsecutiveEnabled};
+pub use self::nickname::Offline;
 pub use self::redaction::Redaction;
 pub use self::typing::{Animation, Style, Typing};
 pub use crate::appearance::theme::{alpha_color, alpha_color_calculate};
@@ -391,24 +392,24 @@ where
 }
 
 #[derive(Debug, Clone, Copy)]
-pub enum Away {
+pub enum Alpha {
     Dimmed(Dimmed),
     None,
 }
 
-impl Away {
-    pub fn is_away(&self, is_user_away: bool) -> Option<Away> {
+impl Alpha {
+    pub fn is_away(&self, is_user_away: bool) -> Option<Alpha> {
         is_user_away.then_some(*self)
     }
 }
 
-impl Default for Away {
+impl Default for Alpha {
     fn default() -> Self {
-        Away::Dimmed(Dimmed::default())
+        Alpha::Dimmed(Dimmed::default())
     }
 }
 
-impl<'de> Deserialize<'de> for Away {
+impl<'de> Deserialize<'de> for Alpha {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -421,6 +422,7 @@ impl<'de> Deserialize<'de> for Away {
         }
 
         #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
         struct DimmedStruct {
             dimmed: Option<f32>,
         }
@@ -428,16 +430,16 @@ impl<'de> Deserialize<'de> for Away {
         let repr = AppearanceRepr::deserialize(deserializer)?;
         match repr {
             AppearanceRepr::String(s) => match s.as_str() {
-                "dimmed" => Ok(Away::Dimmed(Dimmed {
+                "dimmed" => Ok(Alpha::Dimmed(Dimmed {
                     enabled: true,
                     alpha: None,
                 })),
-                "solid" | "none" => Ok(Away::None),
+                "solid" | "none" => Ok(Alpha::None),
                 _ => Err(serde::de::Error::custom(format!(
                     "unknown appearance: {s}",
                 ))),
             },
-            AppearanceRepr::Struct(s) => Ok(Away::Dimmed(Dimmed {
+            AppearanceRepr::Struct(s) => Ok(Alpha::Dimmed(Dimmed {
                 enabled: true,
                 alpha: s.dimmed,
             })),

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -398,8 +398,8 @@ pub enum Alpha {
 }
 
 impl Alpha {
-    pub fn is_away(&self, is_user_away: bool) -> Option<Alpha> {
-        is_user_away.then_some(*self)
+    pub fn alpha(&self, active: bool) -> Option<Alpha> {
+        active.then_some(*self)
     }
 }
 

--- a/data/src/config/buffer/nickname.rs
+++ b/data/src/config/buffer/nickname.rs
@@ -1,12 +1,14 @@
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 
 use crate::buffer::{Alignment, Brackets, Color};
-use crate::config::buffer::{AccessLevelFormat, Away, HideConsecutive};
+use crate::config::buffer::{
+    AccessLevelFormat, Alpha, Dimmed, HideConsecutive,
+};
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct Nickname {
-    pub away: Away,
+    pub away: Alpha,
     pub offline: Offline,
     pub color: Color,
     pub brackets: Brackets,
@@ -21,7 +23,7 @@ pub struct Nickname {
 impl Default for Nickname {
     fn default() -> Self {
         Self {
-            away: Away::default(),
+            away: Alpha::default(),
             offline: Offline::default(),
             color: Color::default(),
             brackets: Brackets::default(),
@@ -35,17 +37,105 @@ impl Default for Nickname {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[derive(Debug, Clone, Copy)]
 pub enum Offline {
-    #[default]
-    Solid,
+    Enabled(OfflineStyle),
     None,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct OfflineStyle {
+    pub color: OfflineColor,
+    pub alpha: Alpha,
+}
+
+fn default_offline_alpha() -> Alpha {
+    Alpha::None
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OfflineColor {
+    #[default]
+    Theme,
+    Nickname,
+}
+
+impl Default for Offline {
+    fn default() -> Self {
+        Offline::Enabled(OfflineStyle {
+            color: OfflineColor::Theme,
+            alpha: Alpha::None,
+        })
+    }
+}
+
 impl Offline {
-    pub fn is_offline(&self, is_user_offline: bool) -> bool {
-        is_user_offline && matches!(self, Offline::Solid)
+    pub fn style(&self, is_user_offline: bool) -> Option<OfflineStyle> {
+        match (is_user_offline, self) {
+            (true, Offline::Enabled(style)) => Some(*style),
+            _ => None,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Offline {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum AppearanceRepr {
+            String(String),
+            DimmedShorthand(DimmedShorthand),
+            Struct(OfflineStyleRepr),
+        }
+
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct DimmedShorthand {
+            dimmed: Option<f32>,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct OfflineStyleRepr {
+            #[serde(default)]
+            color: OfflineColor,
+            #[serde(default = "default_offline_alpha")]
+            alpha: Alpha,
+        }
+
+        match AppearanceRepr::deserialize(deserializer)? {
+            AppearanceRepr::String(s) => match s.as_str() {
+                "solid" => Ok(Offline::Enabled(OfflineStyle {
+                    color: OfflineColor::Theme,
+                    alpha: Alpha::None,
+                })),
+                "dimmed" => Ok(Offline::Enabled(OfflineStyle {
+                    color: OfflineColor::Nickname,
+                    alpha: Alpha::Dimmed(Dimmed::default()),
+                })),
+                "none" => Ok(Offline::None),
+                _ => Err(serde::de::Error::custom(format!(
+                    "unknown appearance: {s}"
+                ))),
+            },
+            AppearanceRepr::DimmedShorthand(s) => {
+                Ok(Offline::Enabled(OfflineStyle {
+                    color: OfflineColor::Nickname,
+                    alpha: Alpha::Dimmed(Dimmed {
+                        enabled: true,
+                        alpha: s.dimmed,
+                    }),
+                }))
+            }
+            AppearanceRepr::Struct(s) => Ok(Offline::Enabled(OfflineStyle {
+                color: s.color,
+                alpha: s.alpha,
+            })),
+        }
     }
 }
 

--- a/data/src/config/buffer/nickname.rs
+++ b/data/src/config/buffer/nickname.rs
@@ -50,7 +50,7 @@ pub struct OfflineStyle {
 }
 
 fn default_offline_alpha() -> Alpha {
-    Alpha::None
+    Alpha::default()
 }
 
 #[derive(Debug, Clone, Copy, Default, Deserialize)]
@@ -65,7 +65,7 @@ impl Default for Offline {
     fn default() -> Self {
         Offline::Enabled(OfflineStyle {
             color: OfflineColor::Theme,
-            alpha: Alpha::None,
+            alpha: default_offline_alpha(),
         })
     }
 }

--- a/docs/configuration/buffer.md
+++ b/docs/configuration/buffer.md
@@ -814,16 +814,36 @@ color = { palette = ["#B11E3A", "#2A7FFF", "#1E9E5A"] }
 
 ### `offline`
 
-Controls the appearance of offline nicknames.
+Controls the color of offline nicknames. Can combine a color source with dimming (same alpha options as [`away`](#away)). The "(Offline)" label is independent of this setting.
 
 ```toml
 # Type: string or object
-# Values: "solid" or "none"
+# Values: "solid", "dimmed", "none", { dimmed = float }, or { color = "...", alpha = "..." }
 # Default: "solid"
+#
+# color: "theme" (theme nickname_offline, else nick color) or "nickname" (keep nick color)
+# alpha: same as away - "dimmed", "none", or { dimmed = float }
+
 [buffer.nickname]
 offline = "solid"
+# same as { color = "theme", alpha = "none" }
 
-# no offline indication
+[buffer.nickname]
+offline = "dimmed"
+# same as { color = "nickname", alpha = "dimmed" }
+
+[buffer.nickname]
+offline = { dimmed = 0.5 }
+# same as { color = "nickname", alpha = { dimmed = 0.5 } }
+
+# theme offline color and dim together
+[buffer.nickname]
+offline = { color = "theme", alpha = "dimmed" }
+
+[buffer.nickname]
+offline = { color = "theme", alpha = { dimmed = 0.5 } }
+
+# no offline color styling
 [buffer.nickname]
 offline = "none"
 ```

--- a/src/appearance/theme/selectable_text.rs
+++ b/src/appearance/theme/selectable_text.rs
@@ -138,12 +138,12 @@ pub fn nickname(
     is_away: bool,
     is_user_offline: bool,
 ) -> Style {
-    let is_offline = config.buffer.nickname.offline.style(is_user_offline);
-    let is_away = config.buffer.nickname.away.is_away(is_away);
+    let offline_style = config.buffer.nickname.offline.style(is_user_offline);
+    let away_alpha = config.buffer.nickname.away.alpha(is_away);
 
     if let Some(metadata_color) = metadata_color {
         let background = theme.styles().buffer.background;
-        let color = if let Some(style) = is_offline {
+        let color = if let Some(style) = offline_style {
             let color = match style.color {
                 buffer::nickname::OfflineColor::Theme => theme
                     .styles()
@@ -155,7 +155,7 @@ pub fn nickname(
             };
             nickname_alpha(color, Some(style.alpha), background)
         } else {
-            nickname_alpha(metadata_color, is_away, background)
+            nickname_alpha(metadata_color, away_alpha, background)
         };
 
         Style {
@@ -167,8 +167,8 @@ pub fn nickname(
             theme,
             &config.buffer.nickname.color,
             user,
-            is_away,
-            is_offline,
+            away_alpha,
+            offline_style,
         )
     }
 }
@@ -177,12 +177,17 @@ fn nickname_style(
     theme: &Theme,
     kind: &data::buffer::Color,
     user: &User,
-    is_away: Option<buffer::Alpha>,
-    is_offline: Option<buffer::nickname::OfflineStyle>,
+    away_alpha: Option<buffer::Alpha>,
+    offline_style: Option<buffer::nickname::OfflineStyle>,
 ) -> Style {
-    let color =
-        text::nickname(theme, kind, Some(user.seed()), is_away, is_offline)
-            .color;
+    let color = text::nickname(
+        theme,
+        kind,
+        Some(user.seed()),
+        away_alpha,
+        offline_style,
+    )
+    .color;
 
     Style {
         color,

--- a/src/appearance/theme/selectable_text.rs
+++ b/src/appearance/theme/selectable_text.rs
@@ -138,18 +138,25 @@ pub fn nickname(
     is_away: bool,
     is_user_offline: bool,
 ) -> Style {
-    let is_away = config
-        .buffer
-        .nickname
-        .away
-        .is_away(is_away || is_user_offline);
+    let is_offline = config.buffer.nickname.offline.style(is_user_offline);
+    let is_away = config.buffer.nickname.away.is_away(is_away);
 
     if let Some(metadata_color) = metadata_color {
-        let color = nickname_alpha(
-            metadata_color,
-            is_away,
-            theme.styles().buffer.background,
-        );
+        let background = theme.styles().buffer.background;
+        let color = if let Some(style) = is_offline {
+            let color = match style.color {
+                buffer::nickname::OfflineColor::Theme => theme
+                    .styles()
+                    .buffer
+                    .nickname_offline
+                    .color
+                    .unwrap_or(metadata_color),
+                buffer::nickname::OfflineColor::Nickname => metadata_color,
+            };
+            nickname_alpha(color, Some(style.alpha), background)
+        } else {
+            nickname_alpha(metadata_color, is_away, background)
+        };
 
         Style {
             color: Some(color),
@@ -161,7 +168,7 @@ pub fn nickname(
             &config.buffer.nickname.color,
             user,
             is_away,
-            config.buffer.nickname.offline.is_offline(is_user_offline),
+            is_offline,
         )
     }
 }
@@ -170,8 +177,8 @@ fn nickname_style(
     theme: &Theme,
     kind: &data::buffer::Color,
     user: &User,
-    is_away: Option<buffer::Away>,
-    is_offline: bool,
+    is_away: Option<buffer::Alpha>,
+    is_offline: Option<buffer::nickname::OfflineStyle>,
 ) -> Style {
     let color =
         text::nickname(theme, kind, Some(user.seed()), is_away, is_offline)

--- a/src/appearance/theme/text.rs
+++ b/src/appearance/theme/text.rs
@@ -139,23 +139,24 @@ pub fn nickname(
     theme: &Theme,
     kind: &data::buffer::Color,
     seed: Option<&str>,
-    is_away: Option<buffer::Away>,
-    is_offline: bool,
+    is_away: Option<buffer::Alpha>,
+    is_offline: Option<buffer::nickname::OfflineStyle>,
 ) -> Style {
-    let color = nickname_alpha(
-        if is_offline
-            && let Some(offline_color) =
-                theme.styles().buffer.nickname_offline.color
-        {
-            offline_color
-        } else {
-            let nickname = theme.styles().buffer.nickname;
+    let background = theme.styles().buffer.background;
+    let nickname = theme.styles().buffer.nickname;
+    let base = nickname_color(nickname.color, kind, seed);
 
-            nickname_color(nickname.color, kind, seed)
-        },
-        is_away,
-        theme.styles().buffer.background,
-    );
+    let color = if let Some(style) = is_offline {
+        let color = match style.color {
+            buffer::nickname::OfflineColor::Theme => {
+                theme.styles().buffer.nickname_offline.color.unwrap_or(base)
+            }
+            buffer::nickname::OfflineColor::Nickname => base,
+        };
+        nickname_alpha(color, Some(style.alpha), background)
+    } else {
+        nickname_alpha(base, is_away, background)
+    };
 
     Style { color: Some(color) }
 }

--- a/src/buffer/context_menu.rs
+++ b/src/buffer/context_menu.rs
@@ -1454,17 +1454,13 @@ fn user_info<'a>(
         ),
     };
 
-    // Dimmed if away or offline.
     let is_user_away = config
         .buffer
         .nickname
         .away
-        .is_away(current_user.is_none_or(User::is_away));
-    let is_user_offline = config
-        .buffer
-        .nickname
-        .offline
-        .is_offline(current_user.is_none());
+        .is_away(current_user.is_some_and(User::is_away));
+    let user_offline = current_user.is_none();
+    let is_user_offline = config.buffer.nickname.offline.style(user_offline);
     let style = theme::text::nickname(
         theme,
         &config.buffer.nickname.color,
@@ -1474,7 +1470,7 @@ fn user_info<'a>(
     );
 
     let nickname = text(nickname.to_string()).style(move |_| style).font_maybe(
-        theme::font_style::nickname(theme, is_user_offline).map(font::get),
+        theme::font_style::nickname(theme, user_offline).map(font::get),
     );
 
     column![

--- a/src/buffer/context_menu.rs
+++ b/src/buffer/context_menu.rs
@@ -1454,23 +1454,24 @@ fn user_info<'a>(
         ),
     };
 
-    let is_user_away = config
+    let user_away_alpha = config
         .buffer
         .nickname
         .away
-        .is_away(current_user.is_some_and(User::is_away));
-    let user_offline = current_user.is_none();
-    let is_user_offline = config.buffer.nickname.offline.style(user_offline);
+        .alpha(current_user.is_some_and(User::is_away));
+    let user_is_offline = current_user.is_none();
+    let user_offline_style =
+        config.buffer.nickname.offline.style(user_is_offline);
     let style = theme::text::nickname(
         theme,
         &config.buffer.nickname.color,
         Some(nickname.seed()),
-        is_user_away,
-        is_user_offline,
+        user_away_alpha,
+        user_offline_style,
     );
 
     let nickname = text(nickname.to_string()).style(move |_| style).font_maybe(
-        theme::font_style::nickname(theme, user_offline).map(font::get),
+        theme::font_style::nickname(theme, user_is_offline).map(font::get),
     );
 
     column![

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -837,14 +837,13 @@ fn query_title<'a>(
         .nickname
         .away
         .is_away(current_user.is_some_and(User::is_away));
-    let is_user_offline = config.buffer.nickname.offline.is_offline(
-        shared_channels.is_empty()
-            && !clients
-                .client(server)
-                .is_some_and(|client| client.is_monitored_user_online(&user)),
-    );
+    let user_offline = shared_channels.is_empty()
+        && !clients
+            .client(server)
+            .is_some_and(|client| client.is_monitored_user_online(&user));
+    let is_user_offline = config.buffer.nickname.offline.style(user_offline);
 
-    let state = if is_user_offline {
+    let state = if user_offline {
         Some(
             container(
                 text("(Offline)").style(theme::text::secondary).font_maybe(
@@ -868,7 +867,7 @@ fn query_title<'a>(
             )
         })
         .font_maybe(
-            theme::font_style::nickname(theme, is_user_offline).map(font::get),
+            theme::font_style::nickname(theme, user_offline).map(font::get),
         )
         .shaping(text::Shaping::Advanced)
         .wrapping(Wrapping::None)

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -832,18 +832,19 @@ fn query_title<'a>(
         clients.resolve_user_attributes(server, channel, &user)
     });
 
-    let is_user_away = config
+    let user_away_alpha = config
         .buffer
         .nickname
         .away
-        .is_away(current_user.is_some_and(User::is_away));
-    let user_offline = shared_channels.is_empty()
+        .alpha(current_user.is_some_and(User::is_away));
+    let user_is_offline = shared_channels.is_empty()
         && !clients
             .client(server)
             .is_some_and(|client| client.is_monitored_user_online(&user));
-    let is_user_offline = config.buffer.nickname.offline.style(user_offline);
+    let user_offline_style =
+        config.buffer.nickname.offline.style(user_is_offline);
 
-    let state = if user_offline {
+    let state = if user_is_offline {
         Some(
             container(
                 text("(Offline)").style(theme::text::secondary).font_maybe(
@@ -862,12 +863,12 @@ fn query_title<'a>(
                 theme,
                 &config.buffer.nickname.color,
                 Some(user.seed()),
-                is_user_away,
-                is_user_offline,
+                user_away_alpha,
+                user_offline_style,
             )
         })
         .font_maybe(
-            theme::font_style::nickname(theme, user_offline).map(font::get),
+            theme::font_style::nickname(theme, user_is_offline).map(font::get),
         )
         .shaping(text::Shaping::Advanced)
         .wrapping(Wrapping::None)
@@ -886,8 +887,8 @@ fn query_title<'a>(
                                     theme,
                                     &config.buffer.nickname.color,
                                     Some(resolved_query.as_str()),
-                                    is_user_away,
-                                    is_user_offline,
+                                    user_away_alpha,
+                                    user_offline_style,
                                 )
                             })
                             .line_height(1.0)


### PR DESCRIPTION
Fixes #1783

`buffer.nickname.offline` can be `"dimmed"` / `{ dimmed = ... }` the same way as `away`. Offline nicks no longer pick up `away` styling.