### PR TITLE
Instructions for keyring access when running flatpak

### DIFF
--- a/assets/flatpak/org.squidowl.halloy.json
+++ b/assets/flatpak/org.squidowl.halloy.json
@@ -14,8 +14,7 @@
         "--socket=fallback-x11",
         "--socket=pulseaudio",
         "--socket=wayland",
-        "--talk-name=org.freedesktop.Notifications",
-        "--talk-name=org.freedesktop.secrets"
+        "--talk-name=org.freedesktop.Notifications"
     ],
     "build-options": {
         "append-path" : "/usr/lib/sdk/rust-stable/bin"

--- a/docs/guides/keyring.md
+++ b/docs/guides/keyring.md
@@ -37,3 +37,19 @@ On Windows, entry names are not case-sensitive.
 
 To replace a saved password, remove it from the system store. Halloy asks for
 it again when the configuration is loaded.
+
+### Access in Flatpak
+
+To access keyrings while running in Flatpak, you will need to manually grant your install of
+Halloy access to the system keyring. You can do this by running:
+
+
+```bash
+flatpak override org.squidowl.halloy --talk-name=org.freedesktop.secrets --user
+```
+
+If Halloy Flatpak is installed to the system rather than user:
+
+```bash
+sudo flatpak override org.squidowl.halloy --talk-name=org.freedesktop.secrets --system
+```


### PR DESCRIPTION
Adding the permissions to make our keyring feature work has been [rejected by flathub reviewers](https://github.com/flathub/org.squidowl.halloy/issues/48).

I understand their concerns, and at some point, I am hoping that [keyring-rs](https://github.com/open-source-cooperative/keyring-rs) supports the portal pathway rather than the direct secrets access it currently provides (via the [zbus-secret-service-keyring-store](https://github.com/open-source-cooperative/zbus-secret-service-keyring-store) store we use.

In the mean time, I am hoping this blurb in the keyring guide is enough to steer flatpak users in the right direction.

TL;DR: run the following to fix permissions for keyring access:
```bash
flatpak override org.squidowl.halloy --talk-name=org.freedesktop.secrets --user
```