### PR TITLE
Document command-line and Windows installer arguments

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -18,6 +18,7 @@ const guidesItems = [
   { text: "Connect with soju", link: "/guides/connect-with-soju" },
   { text: "Connect with ZNC", link: "/guides/connect-with-znc" },
   { text: "TLS Troubleshooting", link: "/guides/tls" },
+  { text: "Command Line", link: "/guides/command-line" },
   { text: "Custom Themes", link: "/guides/custom-themes" },
   { text: "Exec Command", link: "/guides/exec-command" },
   {

--- a/docs/guides/command-line.md
+++ b/docs/guides/command-line.md
@@ -1,0 +1,36 @@
+# Command Line
+
+## Halloy
+
+Halloy accepts a small set of command-line arguments.
+
+| Argument | Description |
+| --- | --- |
+| `--version`, `-V` | Print the version and exit. Must be the first argument. |
+| URL | Open an IRC or Halloy URL. See [URL Schemes](/guides/url-schemes). |
+
+There is no `--help`, `-h`, or `-?` flag. Unknown arguments are ignored and Halloy starts normally.
+
+Configuration and data directories are not set via command-line flags. See [Portable Mode](/guides/portable-mode).
+
+### Examples
+
+```bash
+halloy --version
+halloy ircs://irc.libera.chat/#halloy
+```
+
+## Windows installer
+
+The Windows installer is built with [Inno Setup](https://jrsoftware.org/isinfo.php). Run the installer with `/HELP` or `/?` to list its command-line options.
+
+Common options:
+
+| Argument | Description |
+| --- | --- |
+| `/SILENT` | Install with a progress window, without prompts. |
+| `/VERYSILENT` | Install with no UI. |
+| `/DIR="path"` | Set the installation directory. |
+| `/TASKS="desktopicon"` | Create a desktop shortcut. |
+
+For the full list, see the [Inno Setup command-line documentation](https://jrsoftware.org/ishelp/index.php?topic=setupcmdline).

--- a/docs/guides/command-line.md
+++ b/docs/guides/command-line.md
@@ -28,9 +28,9 @@ Common options:
 
 | Argument | Description |
 | --- | --- |
-| `/SILENT` | Install with a progress window, without prompts. |
-| `/VERYSILENT` | Install with no UI. |
-| `/DIR="path"` | Set the installation directory. |
+| `/SILENT` | Hide the installer wizard, but show the installation progress window. |
+| `/VERYSILENT` | Hide the installer wizard and installation progress window. |
+| `/DIR="C:\Apps\Halloy"` | Set the installation directory. Use an absolute path. |
 | `/TASKS="desktopicon"` | Create a desktop shortcut. |
 
 For the full list, see the [Inno Setup command-line documentation](https://jrsoftware.org/ishelp/index.php?topic=setupcmdline).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,6 +46,8 @@ The following third party repositories are available for Linux
 winget install squidowl.halloy
 ```
 
+Command-line options for the GitHub Windows installer (`.exe`) are documented in the [Command Line](/guides/command-line) guide.
+
 ### Build from source
 
 Clone the Halloy GitHub repository into a directory of your choice and build with cargo.


### PR DESCRIPTION
Closes #1652 

Add a Command Line guide covering existing flags (--version/-V, URL args) and common Inno Setup installer options.