### PR TITLE
Add file_transfer.send_completion_message config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Added:
 
 - Expanded `servers.<name>.max_connection_attempts` to allow unlimited attempts
+- `file_transfer.send_completion_message` setting to control whether a PRIVMSG is sent to the remote user when a file
+  transfer completes.
 
 Fixed:
 
@@ -10,7 +12,7 @@ Fixed:
 
 Thanks:
 
-- Contributions: @rollecode, @luca020400
+- Contributions: @rollecode, @luca020400, @rtmongold
 
 # 2026.8 (2026-07-24)
 

--- a/data/src/config/file_transfer.rs
+++ b/data/src/config/file_transfer.rs
@@ -20,6 +20,8 @@ pub struct FileTransfer {
     pub passive: bool,
     /// Time in seconds to wait before timing out a transfer waiting to be accepted.
     pub timeout: u64,
+    /// If true, send a PRIVMSG to the remote user when a file transfer completes.
+    pub send_completion_message: bool,
     /// Auto-accept configuration for incoming file transfers.
     pub auto_accept: AutoAccept,
     pub server: Option<Server>,
@@ -32,6 +34,7 @@ impl Default for FileTransfer {
             save_directory: None,
             passive: true,
             timeout: 60 * 5,
+            send_completion_message: true,
             auto_accept: AutoAccept::default(),
             server: None,
         }

--- a/data/src/file_transfer/manager.rs
+++ b/data/src/file_transfer/manager.rs
@@ -126,6 +126,7 @@ impl Manager {
             self.server(config),
             Duration::from_secs(config.file_transfer.timeout),
             config.proxy.clone(),
+            config.file_transfer.send_completion_message,
         );
 
         self.items.insert(
@@ -199,6 +200,7 @@ impl Manager {
             self.server(config),
             Duration::from_secs(config.file_transfer.timeout),
             config.proxy.as_ref().cloned(),
+            config.file_transfer.send_completion_message,
         );
 
         // Auto-accept if enabled and save directory is set

--- a/data/src/file_transfer/task.rs
+++ b/data/src/file_transfer/task.rs
@@ -105,6 +105,7 @@ impl Task {
         server: Option<Server>,
         timeout: Duration,
         proxy: Option<config::Proxy>,
+        send_completion_message: bool,
     ) -> (Handle, impl Stream<Item = Update>) {
         let (action_sender, action_receiver) = mpsc::channel(1);
         let (update_sender, update_receiver) = mpsc::channel(100);
@@ -129,6 +130,7 @@ impl Task {
                         server,
                         timeout,
                         proxy,
+                        send_completion_message,
                     )
                     .await
                     {
@@ -157,6 +159,7 @@ impl Task {
                         server,
                         timeout,
                         proxy,
+                        send_completion_message,
                     )
                     .await
                     {
@@ -217,6 +220,7 @@ async fn receive(
     server: Option<Server>,
     timeout: Duration,
     proxy: Option<config::Proxy>,
+    send_completion_message: bool,
 ) -> Result<(), Error> {
     // Wait for approval
     let Some(Action::Approve { save_to }) = action.next().await else {
@@ -352,13 +356,15 @@ async fn receive(
 
     let sha256 = hex::encode(hasher.finalize());
 
-    let _ = server_handle
-        .send(command!(
-            "PRIVMSG",
-            remote_user.nickname().to_string(),
-            format!("Finished receiving \"{filename}\", sha256: {sha256}")
-        ))
-        .await;
+    if send_completion_message {
+        let _ = server_handle
+            .send(command!(
+                "PRIVMSG",
+                remote_user.nickname().to_string(),
+                format!("Finished receiving \"{filename}\", sha256: {sha256}")
+            ))
+            .await;
+    }
 
     let _ = update
         .send(Update::Finished {
@@ -383,6 +389,7 @@ async fn send(
     server: Option<Server>,
     timeout: Duration,
     proxy: Option<config::Proxy>,
+    send_completion_message: bool,
 ) -> Result<(), Error> {
     let mut file = File::open(path).await?;
     let size = file.metadata().await?.len();
@@ -516,15 +523,17 @@ async fn send(
 
     let sha256 = hex::encode(hasher.finalize());
 
-    let _ = server_handle
-        .send(command!(
-            "PRIVMSG",
-            remote_user.nickname().to_string(),
-            format!(
-                "Finished sending \"{sanitized_filename}\", sha256: {sha256}"
-            )
-        ))
-        .await;
+    if send_completion_message {
+        let _ = server_handle
+            .send(command!(
+                "PRIVMSG",
+                remote_user.nickname().to_string(),
+                format!(
+                    "Finished sending \"{sanitized_filename}\", sha256: {sha256}"
+                )
+            ))
+            .await;
+    }
 
     let _ = update
         .send(Update::Finished {

--- a/docs/configuration/file-transfer.md
+++ b/docs/configuration/file-transfer.md
@@ -55,6 +55,20 @@ Time (in seconds) to wait before timing out a transfer waiting to be accepted.
 timeout = 300
 ```
 
+## `send_completion_message`
+
+If true, send a PRIVMSG to the remote user when a file transfer completes
+(including the filename and SHA-256 checksum).
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: true
+
+[file_transfer]
+send_completion_message = true
+```
+
 ## `auto_accept`
 
 Configuration for automatically accepting incoming file transfers.


### PR DESCRIPTION
Fixes #2220

Adds `file_transfer.send_completion_message` (default `true`) so the Finished receiving/sending PRIVMSG after a successful DCC transfer can be turned off.