### PR TITLE
font clean up and reply char fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Added:
 - Config file path is now shown in config editor
 - Config option to include ignored nicknames in autocomplete
   (`buffer.text_input.autocomplete.include_ignored`)
+- Optional `font.code` setting for code-formatted text
 
 Fixed:
 

--- a/data/src/config.rs
+++ b/data/src/config.rs
@@ -238,6 +238,7 @@ impl Default for Scrollbar {
 #[serde(default)]
 pub struct Font {
     pub family: Option<String>,
+    pub code: Option<String>,
     #[serde(deserialize_with = "deserialize_font_stretch_from_string")]
     pub stretch: font::Stretch,
     #[serde(deserialize_with = "deserialize_u8_positive_integer_maybe")]
@@ -257,6 +258,7 @@ impl Default for Font {
     fn default() -> Self {
         Self {
             family: None,
+            code: None,
             stretch: font::Stretch::Normal,
             size: None,
             line_height: None,

--- a/docs/configuration/font.md
+++ b/docs/configuration/font.md
@@ -27,6 +27,19 @@ Font family to use.
 family = "Comic Mono"
 ```
 
+## `code`
+
+Font family to use for monospace-formatted text and the config editor. If not set, `family` is used.
+
+```toml
+# Type: string
+# Values: any string
+# Default: not set
+
+[font]
+code = "SF Mono"
+```
+
 ## `stretch`
 
 Font stretch.

--- a/docs/configuration/font.md
+++ b/docs/configuration/font.md
@@ -12,11 +12,7 @@ If Halloy is unable to load the specified font, stretch, & weight, an fallback f
 
 ## `family`
 
-Monospaced font family to use.
-
-::: warning
-Variable-weight fonts are not currently supported.
-:::
+Font family to use.
 
 ```toml
 # Type: string

--- a/src/appearance/theme/rule.rs
+++ b/src/appearance/theme/rule.rs
@@ -48,3 +48,10 @@ pub fn date(theme: &Theme) -> Style {
         snap: true,
     }
 }
+
+pub fn timestamp(theme: &Theme) -> Style {
+    Style {
+        color: theme.styles().buffer.timestamp.color,
+        ..primary(theme)
+    }
+}

--- a/src/buffer/config_editor.rs
+++ b/src/buffer/config_editor.rs
@@ -346,7 +346,7 @@ pub fn view<'a>(
         .id(state.id.clone())
         .padding(8)
         .height(Length::Fill)
-        .font(font::PRIMARY.clone())
+        .font(font::CODE.clone())
         .style(theme::text_editor::primary)
         .on_action(Message::Action)
         .key_binding(move |key_press| {

--- a/src/buffer/config_editor.rs
+++ b/src/buffer/config_editor.rs
@@ -346,7 +346,7 @@ pub fn view<'a>(
         .id(state.id.clone())
         .padding(8)
         .height(Length::Fill)
-        .font(font::MONO.clone())
+        .font(font::PRIMARY.clone())
         .style(theme::text_editor::primary)
         .on_action(Message::Action)
         .key_binding(move |key_press| {

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -14,8 +14,8 @@ use data::{Config, Preview, User, history, message, metadata, target};
 use iced::Length::Fit;
 use iced::widget::text::LineHeight;
 use iced::widget::{
-    Space, button, center, column, container, mouse_area, right, row, space,
-    stack, text,
+    Space, button, center, column, container, mouse_area, right, row, rule,
+    space, stack, text,
 };
 use iced::{Color, ContentFit, Length, alignment, padding};
 
@@ -1673,42 +1673,52 @@ impl<'a> ChannelQueryLayout<'a> {
             )
         };
 
-        let char_width = font::width_from_str("a", &self.config.font);
-
-        let timestamp_chars = self
+        let timestamp_width = self
             .config
             .buffer
             .format_timestamp(&message.server_time)
-            .map_or(0, |s| s.chars().count());
+            .map_or(0.0, |timestamp| {
+                font::width_from_str(&timestamp, &self.config.font)
+            });
+        let elbow_width = font::width_from_str("┌", &self.config.font);
 
         // right-aligned: fixed short arm offset to content column.
         // left-aligned / top-aligned: arm spans from timestamp midpoint to its edge.
-        let arm_text: Element<'_, _> = if let Some(nick_col_width) =
-            right_aligned_width
-        {
-            let nick_col_chars = (nick_col_width / char_width).round() as usize;
-            let indent = timestamp_chars + nick_col_chars - 2;
-            text(" ".repeat(indent) + "┌──")
-                .size(text_size)
-                .style(theme::text::timestamp)
-                .line_height(LineHeight::Relative(1.0))
-                .into()
-        } else {
-            let half = timestamp_chars / 2;
-            let arm = format!(
-                "{}┌{}",
-                " ".repeat(half),
-                "─".repeat(
-                    half.saturating_sub(1)
-                        + usize::from(!timestamp_chars.is_multiple_of(2))
-                ),
-            );
-            text(arm)
-                .size(text_size)
-                .style(theme::text::timestamp)
-                .line_height(LineHeight::Relative(1.0))
-                .into()
-        };
+        let (indent_width, arm_width) =
+            if let Some(nick_col_width) = right_aligned_width {
+                let arm_width = font::width_from_str("──", &self.config.font);
+
+                (
+                    (timestamp_width + nick_col_width - arm_width).max(0.0),
+                    arm_width,
+                )
+            } else {
+                let indent_width = timestamp_width / 2.0;
+                (
+                    indent_width,
+                    (timestamp_width - indent_width - elbow_width).max(0.0),
+                )
+            };
+        let connector_width = elbow_width + arm_width;
+        let connector_height = text_size;
+        let arm: Element<'_, _> = row![
+            Space::new().width(indent_width),
+            stack![
+                container(rule::vertical(1).style(theme::rule::timestamp))
+                    .padding(padding::top(connector_height / 2.0))
+                    .width(connector_width)
+                    .height(connector_height),
+                container(rule::horizontal(1).style(theme::rule::timestamp))
+                    .width(connector_width)
+                    .height(connector_height)
+                    .align_y(alignment::Vertical::Center),
+            ]
+            .width(connector_width)
+            .height(connector_height),
+        ]
+        .spacing(0)
+        .align_y(iced::Alignment::Center)
+        .into();
 
         let delay = iced::time::Duration::from_millis(
             self.config.buffer.reply.tooltip.delay,
@@ -1770,8 +1780,9 @@ impl<'a> ChannelQueryLayout<'a> {
                 interactive
             };
 
-        let element: Element<'_, _> =
-            row![arm_text, interactive].spacing(char_width).into();
+        let element: Element<'_, _> = row![arm, interactive]
+            .spacing(font::width_from_str(" ", &self.config.font))
+            .into();
 
         Some(element)
     }

--- a/src/font.rs
+++ b/src/font.rs
@@ -10,6 +10,10 @@ pub static PRIMARY: Font = Font::new(false, false);
 pub static PRIMARY_BOLD: Font = Font::new(true, false);
 pub static PRIMARY_ITALICS: Font = Font::new(false, true);
 pub static PRIMARY_BOLD_ITALICS: Font = Font::new(true, true);
+pub static CODE: Font = Font::new(false, false);
+pub static CODE_BOLD: Font = Font::new(true, false);
+pub static CODE_ITALICS: Font = Font::new(false, true);
+pub static CODE_BOLD_ITALICS: Font = Font::new(true, true);
 pub static ICON: LazyLock<iced::Font> =
     LazyLock::new(|| iced::Font::with_family("halloy-icons"));
 pub const MESSAGE_MARKER_FONT_SCALE: f32 = 1.33;
@@ -93,6 +97,10 @@ pub fn set(config: &config::Font) {
     let font = config.family.as_ref().map_or_else(default_font, |family| {
         iced::Font::with_family(family.as_str())
     });
+    let code_font = config
+        .code
+        .as_ref()
+        .map_or(font, |family| iced::Font::with_family(family.as_str()));
 
     let bold_weight = config.bold_weight.unwrap_or(match config.weight {
         font::Weight::Thin => font::Weight::Normal,
@@ -110,6 +118,15 @@ pub fn set(config: &config::Font) {
     PRIMARY_BOLD.set(font, config.stretch, config.weight, bold_weight);
     PRIMARY_ITALICS.set(font, config.stretch, config.weight, bold_weight);
     PRIMARY_BOLD_ITALICS.set(font, config.stretch, config.weight, bold_weight);
+    CODE.set(code_font, config.stretch, config.weight, bold_weight);
+    CODE_BOLD.set(code_font, config.stretch, config.weight, bold_weight);
+    CODE_ITALICS.set(code_font, config.stretch, config.weight, bold_weight);
+    CODE_BOLD_ITALICS.set(
+        code_font,
+        config.stretch,
+        config.weight,
+        bold_weight,
+    );
 
     let line_height = config
         .line_height
@@ -207,5 +224,14 @@ pub fn get(font_style: FontStyle) -> Font {
         FontStyle::Bold => PRIMARY_BOLD.clone(),
         FontStyle::Italic => PRIMARY_ITALICS.clone(),
         FontStyle::ItalicBold => PRIMARY_BOLD_ITALICS.clone(),
+    }
+}
+
+pub fn get_code(font_style: FontStyle) -> Font {
+    match font_style {
+        FontStyle::Normal => CODE.clone(),
+        FontStyle::Bold => CODE_BOLD.clone(),
+        FontStyle::Italic => CODE_ITALICS.clone(),
+        FontStyle::ItalicBold => CODE_BOLD_ITALICS.clone(),
     }
 }

--- a/src/font.rs
+++ b/src/font.rs
@@ -6,10 +6,10 @@ use data::config;
 use iced::font;
 use iced::widget::text::LineHeight;
 
-pub static MONO: Font = Font::new(false, false);
-pub static MONO_BOLD: Font = Font::new(true, false);
-pub static MONO_ITALICS: Font = Font::new(false, true);
-pub static MONO_BOLD_ITALICS: Font = Font::new(true, true);
+pub static PRIMARY: Font = Font::new(false, false);
+pub static PRIMARY_BOLD: Font = Font::new(true, false);
+pub static PRIMARY_ITALICS: Font = Font::new(false, true);
+pub static PRIMARY_BOLD_ITALICS: Font = Font::new(true, true);
 pub static ICON: LazyLock<iced::Font> =
     LazyLock::new(|| iced::Font::with_family("halloy-icons"));
 pub const MESSAGE_MARKER_FONT_SCALE: f32 = 1.33;
@@ -65,6 +65,18 @@ pub fn line_height() -> LineHeight {
     LINE_HEIGHT.get().copied().unwrap_or_default()
 }
 
+pub fn shaping() -> iced::advanced::text::Shaping {
+    #[cfg(debug_assertions)]
+    {
+        iced::advanced::text::Shaping::Basic
+    }
+
+    #[cfg(not(debug_assertions))]
+    {
+        iced::advanced::text::Shaping::Advanced
+    }
+}
+
 fn default_font() -> iced::Font {
     #[cfg(feature = "iosevka-font")]
     {
@@ -94,10 +106,10 @@ pub fn set(config: &config::Font) {
         | font::Weight::Black => font::Weight::Black,
     });
 
-    MONO.set(font, config.stretch, config.weight, bold_weight);
-    MONO_BOLD.set(font, config.stretch, config.weight, bold_weight);
-    MONO_ITALICS.set(font, config.stretch, config.weight, bold_weight);
-    MONO_BOLD_ITALICS.set(font, config.stretch, config.weight, bold_weight);
+    PRIMARY.set(font, config.stretch, config.weight, bold_weight);
+    PRIMARY_BOLD.set(font, config.stretch, config.weight, bold_weight);
+    PRIMARY_ITALICS.set(font, config.stretch, config.weight, bold_weight);
+    PRIMARY_BOLD_ITALICS.set(font, config.stretch, config.weight, bold_weight);
 
     let line_height = config
         .line_height
@@ -150,7 +162,7 @@ pub fn width_from_str(text: &str, config: &config::Font) -> f32 {
         bounds: Size::INFINITE,
         size: config.size.map_or(theme::TEXT_SIZE, f32::from).into(),
         line_height: line_height(),
-        font: MONO.clone().into(),
+        font: PRIMARY.clone().into(),
         align_x: text::Alignment::Right,
         align_y: alignment::Vertical::Top,
         shaping: text::Shaping::Basic,
@@ -191,9 +203,9 @@ pub fn width_of_message_marker(config: &config::Font) -> f32 {
 
 pub fn get(font_style: FontStyle) -> Font {
     match font_style {
-        FontStyle::Normal => MONO.clone(),
-        FontStyle::Bold => MONO_BOLD.clone(),
-        FontStyle::Italic => MONO_ITALICS.clone(),
-        FontStyle::ItalicBold => MONO_BOLD_ITALICS.clone(),
+        FontStyle::Normal => PRIMARY.clone(),
+        FontStyle::Bold => PRIMARY_BOLD.clone(),
+        FontStyle::Italic => PRIMARY_ITALICS.clone(),
+        FontStyle::ItalicBold => PRIMARY_BOLD_ITALICS.clone(),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,7 +178,7 @@ fn settings(
         .map_or_else(|_| Runtime::default(), |config| config.runtime);
 
     iced::Settings {
-        default_font: font::MONO.clone().into(),
+        default_font: font::PRIMARY.clone().into(),
         default_text_size: default_text_size.into(),
         backend: backend_from_config(runtime.backend),
         power_preference: power_preference_from_config(

--- a/src/screen/welcome.rs
+++ b/src/screen/welcome.rs
@@ -87,7 +87,7 @@ impl Welcome {
             .spacing(1)
             .push(image(self.logo.clone()).width(128))
             .push(space::vertical().height(10))
-            .push(text("Welcome to Halloy!").font(font::MONO_BOLD.clone()))
+            .push(text("Welcome to Halloy!").font(font::PRIMARY_BOLD.clone()))
             .push(space::vertical().height(4))
             .push(text("Halloy is configured through a config file."))
             .push(row![

--- a/src/widget/message_content.rs
+++ b/src/widget/message_content.rs
@@ -345,7 +345,16 @@ fn message_content_impl<'a, T: Copy + 'a, M: 'a + std::clone::Clone>(
                                     formatting.italics,
                                 )));
 
-                                span.font_maybe(formatted_style.map(font::get))
+                                let formatted_font =
+                                    formatted_style.map(|style| {
+                                        if formatting.monospace {
+                                            font::get_code(style)
+                                        } else {
+                                            font::get(style)
+                                        }
+                                    });
+
+                                span.font_maybe(formatted_font)
                             }
                             data::message::Fragment::Condensed {
                                 text,

--- a/src/widget/reply.rs
+++ b/src/widget/reply.rs
@@ -20,7 +20,7 @@ pub fn reply_preview_content<'a, Message: 'a + std::clone::Clone>(
     config: &'a Config,
     theme: &'a Theme,
 ) -> Element<'a, Message> {
-    let char_width = font::width_from_str("a", &config.font);
+    let spacing = font::width_from_str(" ", &config.font);
 
     // the message may not be loaded
     let Some(reply) = reply else {
@@ -39,7 +39,7 @@ pub fn reply_preview_content<'a, Message: 'a + std::clone::Clone>(
     } else {
         row![]
     }
-    .spacing(char_width);
+    .spacing(spacing);
 
     if !reply.blocked {
         if reply.is_action {

--- a/src/widget/selectable_text.rs
+++ b/src/widget/selectable_text.rs
@@ -45,10 +45,7 @@ where
         Text {
             fragment: fragment.into_fragment(),
             format: Format {
-                #[cfg(debug_assertions)]
-                shaping: Shaping::Basic,
-                #[cfg(not(debug_assertions))]
-                shaping: Shaping::Advanced,
+                shaping: crate::font::shaping(),
                 wrapping: Wrapping::WordOrGlyph,
                 line_height: crate::font::line_height(),
                 ..Format::default()


### PR DESCRIPTION
* We technically support variable fonts so i cleaned up and changed MONO to PRIMARY. I also cleaned up docs.
* Then i noticed reply was using `┌──` so i replaced that with horizontal and vertical rule in a stack. See below.


Before
<img width="337" height="96" alt="Screenshot 2026-07-29 at 23 00 59" src="https://github.com/user-attachments/assets/074d14a9-98ba-46e4-aa9c-b5f500fb7961" />

After
<img width="369" height="64" alt="Screenshot 2026-07-29 at 23 02 09" src="https://github.com/user-attachments/assets/df2af33f-a218-43ea-ad7b-9a2c89541c30" />
