### PR TITLE
Include ignored nicknames in autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Fixed:
 Thanks:
 
 - Contributions: @rollecode, @luca020400, @rtmongold
+- Feature requests: @daniiooo
 
 # 2026.8 (2026-07-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Added:
 - `file_transfer.send_completion_message` setting to control whether a PRIVMSG is sent to the remote user when a file
   transfer completes.
 - Config file path is now shown in config editor
+- Config option to include ignored nicknames in autocomplete
+  (`buffer.text_input.autocomplete.include_ignored`)
 
 Fixed:
 

--- a/data/src/config/buffer/text_input.rs
+++ b/data/src/config/buffer/text_input.rs
@@ -93,6 +93,7 @@ pub struct Autocomplete {
     pub order_by: OrderBy,
     pub sort_direction: SortDirection,
     pub completion_suffixes: [String; 2],
+    pub include_ignored: bool,
 }
 
 impl Default for Autocomplete {
@@ -101,6 +102,7 @@ impl Default for Autocomplete {
             order_by: OrderBy::default(),
             sort_direction: SortDirection::default(),
             completion_suffixes: [": ".to_string(), " ".to_string()],
+            include_ignored: false,
         }
     }
 }

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -373,11 +373,11 @@ impl Manager {
         );
     }
 
-    pub fn get_filters(&mut self) -> &mut Vec<Filter> {
+    pub fn get_filters_mut(&mut self) -> &mut Vec<Filter> {
         &mut self.filters
     }
 
-    pub fn filters(&self) -> &[Filter] {
+    pub fn get_filters(&self) -> &[Filter] {
         &self.filters
     }
 

--- a/docs/configuration/buffer.md
+++ b/docs/configuration/buffer.md
@@ -1349,6 +1349,19 @@ Sets what suffix is added after autocompleting. The first option is for when a n
 completion_suffixes = [": ", " "]
 ```
 
+#### `include_ignored`
+
+Include ignored nicknames in nickname autocomplete. Ignore filters still hide their messages (and typing).
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: false
+
+[buffer.text_input.autocomplete]
+include_ignored = false
+```
+
 ### `nickname`
 
 Customize nickname left of text input

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -577,7 +577,7 @@ impl Channel {
                 &clients.get_channel_typing_users(server, channel),
                 Some(channel),
                 server,
-                FilterChain::borrow(history.filters()),
+                FilterChain::borrow(history.get_filters()),
                 casemapping,
             ),
             casemapping,

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -1486,7 +1486,7 @@ impl State {
                             });
                             let last_seen = history.get_last_seen(buffer);
                             let filters =
-                                FilterChain::borrow(history.get_filters());
+                                FilterChain::borrow(history.filters());
                             let is_connected = clients
                                 .get_server_is_connected(buffer.server());
                             let isupport =

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -1486,7 +1486,7 @@ impl State {
                             });
                             let last_seen = history.get_last_seen(buffer);
                             let filters =
-                                FilterChain::borrow(history.filters());
+                                FilterChain::borrow(history.get_filters());
                             let is_connected = clients
                                 .get_server_is_connected(buffer.server());
                             let isupport =
@@ -2470,7 +2470,7 @@ impl State {
                 clients.get_channel_users(buffer.server(), channel)
             });
             let last_seen = history.get_last_seen(buffer);
-            let filters = FilterChain::borrow(history.filters());
+            let filters = FilterChain::borrow(history.get_filters());
             let is_connected = clients.get_server_is_connected(buffer.server());
             let isupport = clients.get_isupport_ref(buffer.server());
             let features = clients.get_features_ref(buffer.server());

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -2035,7 +2035,8 @@ impl Words {
             .into_iter()
             .flatten()
             .filter(|user| {
-                !filters.filter_user(user, current_channel, server)
+                (autocomplete.include_ignored
+                    || !filters.filter_user(user, current_channel, server))
                     && user.as_normalized_str().starts_with(&nick)
             })
             .sorted_by(|a, b| {

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -475,7 +475,7 @@ impl Query {
                 &clients.get_query_typing_users(server, query),
                 None,
                 server,
-                FilterChain::borrow(history.filters()),
+                FilterChain::borrow(history.get_filters()),
                 casemapping,
             ),
             casemapping,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2814,7 +2814,7 @@ fn handle_isupport_param(
                     | data::isupport::Parameter::CHANTYPES(_)
             ) {
                 FilterChain::sync_isupport(
-                    dashboard.get_filters(),
+                    dashboard.get_filters_mut(),
                     server,
                     chantypes,
                     casemapping,

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -4778,7 +4778,11 @@ impl Dashboard {
         &self.history
     }
 
-    pub fn get_filters(&mut self) -> &mut Vec<Filter> {
+    pub fn get_filters_mut(&mut self) -> &mut Vec<Filter> {
+        self.history.get_filters_mut()
+    }
+
+    pub fn get_filters(&self) -> &[Filter] {
         self.history.get_filters()
     }
 


### PR DESCRIPTION
Fixes #1920

Nickname Tab-completion no longer skips users on the ignore list. Ignore filters still hide their messages (and typing): only completion changes.