### PR TITLE
Ensure Theme Editor saves themes with a .toml extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ Added:
 Fixed:
 
 - Remove blank space above the input after marking a buffer as read
+- Ensure Theme Editor appends a `.toml` extension when saving a theme without one
 
 Thanks:
 
-- Contributions: @rollecode, @luca020400
+- Contributions: @rollecode, @luca020400, @rtmongold
 
 # 2026.8 (2026-07-24)
 

--- a/src/screen/dashboard/theme_editor.rs
+++ b/src/screen/dashboard/theme_editor.rs
@@ -142,6 +142,7 @@ impl ThemeEditor {
                     rfd::AsyncFileDialog::new()
                         .set_directory(Config::themes_dir())
                         .set_file_name("custom-theme.toml")
+                        .add_filter("TOML", &["toml"])
                         .save_file()
                         .await
                         .map(|handle| handle.path().to_path_buf())
@@ -210,8 +211,12 @@ impl ThemeEditor {
                 return (Task::none(), None);
             }
             Message::SavePath(None) => {}
-            Message::SavePath(Some(path)) => {
+            Message::SavePath(Some(mut path)) => {
                 log::debug!("Saving theme to {path:?}");
+
+                if path.extension().is_none() {
+                    path.set_extension("toml");
+                }
 
                 let styles = *theme.styles();
 


### PR DESCRIPTION
Fixes #1921

Add a TOML file filter to the Theme Editor save dialog, and append `.toml` when the chosen path has no extension.