### PR TITLE
Nightly Version Check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,6 +1608,7 @@ dependencies = [
  "unicode-security",
  "unicode-segmentation",
  "url",
+ "version-compare",
  "walkdir",
  "windows-native-keyring-store",
  "xdg",
@@ -9313,6 +9314,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "version_check"

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -75,6 +75,7 @@ mime_guess = "2.0.5"
 any_ascii = "0.3.3"
 idna = "1.1.0"
 unicode-security = "0.1.2"
+version-compare = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 apple-native-keyring-store = { version = "1", default-features = false, features = [

--- a/data/src/version.rs
+++ b/data/src/version.rs
@@ -28,7 +28,12 @@ impl Version {
 
     pub fn is_old(&self) -> bool {
         match &self.remote {
-            Some(remote) => &self.current != remote,
+            Some(remote) => version_compare::compare_to(
+                &self.current,
+                remote,
+                version_compare::Cmp::Lt,
+            )
+            .is_ok_and(|less_than| less_than),
             None => false,
         }
     }


### PR DESCRIPTION
Use version comparison to check for a new version, rather than inequality, to avoid having a new release notification for the nightly version.