### PR TITLE
Expose X11 socket inside flatpack

### DIFF
--- a/assets/flatpak/org.squidowl.halloy.json
+++ b/assets/flatpak/org.squidowl.halloy.json
@@ -11,7 +11,6 @@
         "--device=dri",
         "--share=ipc",
         "--share=network",
-        "--socket=wayland",
         "--socket=pulseaudio",
         "--socket=wayland",
         "--socket=x11",

--- a/assets/flatpak/org.squidowl.halloy.json
+++ b/assets/flatpak/org.squidowl.halloy.json
@@ -15,7 +15,6 @@
         "--socket=pulseaudio",
         "--socket=wayland",
         "--socket=x11",
-        "--socket=pulseaudio",
         "--talk-name=org.freedesktop.Notifications"
     ],
     "build-options": {

--- a/assets/flatpak/org.squidowl.halloy.json
+++ b/assets/flatpak/org.squidowl.halloy.json
@@ -11,9 +11,9 @@
         "--device=dri",
         "--share=ipc",
         "--share=network",
-        "--socket=fallback-x11",
-        "--socket=pulseaudio",
         "--socket=wayland",
+        "--socket=x11",
+        "--socket=pulseaudio",
         "--talk-name=org.freedesktop.Notifications"
     ],
     "build-options": {

--- a/assets/flatpak/org.squidowl.halloy.json
+++ b/assets/flatpak/org.squidowl.halloy.json
@@ -12,6 +12,8 @@
         "--share=ipc",
         "--share=network",
         "--socket=wayland",
+        "--socket=pulseaudio",
+        "--socket=wayland",
         "--socket=x11",
         "--socket=pulseaudio",
         "--talk-name=org.freedesktop.Notifications"


### PR DESCRIPTION
arboard (used by iced) uses the ext-data-control-v1
wayland protocol to interact with the clipboard.

This isn't implemented in all compositors out there
(specifically Mutter) thus we need to expose the X11
socket to enable the fallback path.

NB: fallback-x11 isn't enough, as we need X11 socket
    even if the app is running on wayland.
