### PR TITLE
iced Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Fixed:
 
 - Remove blank space above the input after marking a buffer as read
 - User avatars are only shown when `avatar` is included in `metadata.preferred_keys`
+- Text in input box being scrolled/clipped 2px on the left on pane load or when navigating history
 
 Changed:
 
@@ -25,6 +26,7 @@ Changed:
 Thanks:
 
 - Contributions: @rollecode, @luca020400, @rtmongold
+- Bug reports: sebbu
 - Feature requests: @daniiooo
 
 # 2026.8 (2026-07-24)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3174,7 +3174,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=a6cd98b0debe317ba9ad0d8b364684939e086fa3#a6cd98b0debe317ba9ad0d8b364684939e086fa3"
+source = "git+https://github.com/squidowl/iced?rev=8d458d2495f79cc2c90b31a2997139a46e5c0ae4#8d458d2495f79cc2c90b31a2997139a46e5c0ae4"
 dependencies = [
  "iced_core",
  "iced_debug",
@@ -3192,7 +3192,7 @@ dependencies = [
 [[package]]
 name = "iced_beacon"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=a6cd98b0debe317ba9ad0d8b364684939e086fa3#a6cd98b0debe317ba9ad0d8b364684939e086fa3"
+source = "git+https://github.com/squidowl/iced?rev=8d458d2495f79cc2c90b31a2997139a46e5c0ae4#8d458d2495f79cc2c90b31a2997139a46e5c0ae4"
 dependencies = [
  "bincode 1.3.3",
  "futures",
@@ -3207,7 +3207,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=a6cd98b0debe317ba9ad0d8b364684939e086fa3#a6cd98b0debe317ba9ad0d8b364684939e086fa3"
+source = "git+https://github.com/squidowl/iced?rev=8d458d2495f79cc2c90b31a2997139a46e5c0ae4#8d458d2495f79cc2c90b31a2997139a46e5c0ae4"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
@@ -3226,7 +3226,7 @@ dependencies = [
 [[package]]
 name = "iced_debug"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=a6cd98b0debe317ba9ad0d8b364684939e086fa3#a6cd98b0debe317ba9ad0d8b364684939e086fa3"
+source = "git+https://github.com/squidowl/iced?rev=8d458d2495f79cc2c90b31a2997139a46e5c0ae4#8d458d2495f79cc2c90b31a2997139a46e5c0ae4"
 dependencies = [
  "iced_beacon",
  "iced_core",
@@ -3237,7 +3237,7 @@ dependencies = [
 [[package]]
 name = "iced_devtools"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=a6cd98b0debe317ba9ad0d8b364684939e086fa3#a6cd98b0debe317ba9ad0d8b364684939e086fa3"
+source = "git+https://github.com/squidowl/iced?rev=8d458d2495f79cc2c90b31a2997139a46e5c0ae4#8d458d2495f79cc2c90b31a2997139a46e5c0ae4"
 dependencies = [
  "iced_debug",
  "iced_program",
@@ -3248,7 +3248,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=a6cd98b0debe317ba9ad0d8b364684939e086fa3#a6cd98b0debe317ba9ad0d8b364684939e086fa3"
+source = "git+https://github.com/squidowl/iced?rev=8d458d2495f79cc2c90b31a2997139a46e5c0ae4#8d458d2495f79cc2c90b31a2997139a46e5c0ae4"
 dependencies = [
  "futures",
  "iced_core",
@@ -3262,7 +3262,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=a6cd98b0debe317ba9ad0d8b364684939e086fa3#a6cd98b0debe317ba9ad0d8b364684939e086fa3"
+source = "git+https://github.com/squidowl/iced?rev=8d458d2495f79cc2c90b31a2997139a46e5c0ae4#8d458d2495f79cc2c90b31a2997139a46e5c0ae4"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
@@ -3282,7 +3282,7 @@ dependencies = [
 [[package]]
 name = "iced_highlighter"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=a6cd98b0debe317ba9ad0d8b364684939e086fa3#a6cd98b0debe317ba9ad0d8b364684939e086fa3"
+source = "git+https://github.com/squidowl/iced?rev=8d458d2495f79cc2c90b31a2997139a46e5c0ae4#8d458d2495f79cc2c90b31a2997139a46e5c0ae4"
 dependencies = [
  "iced_core",
  "two-face",
@@ -3291,7 +3291,7 @@ dependencies = [
 [[package]]
 name = "iced_program"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=a6cd98b0debe317ba9ad0d8b364684939e086fa3#a6cd98b0debe317ba9ad0d8b364684939e086fa3"
+source = "git+https://github.com/squidowl/iced?rev=8d458d2495f79cc2c90b31a2997139a46e5c0ae4#8d458d2495f79cc2c90b31a2997139a46e5c0ae4"
 dependencies = [
  "iced_graphics",
  "iced_runtime",
@@ -3300,7 +3300,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=a6cd98b0debe317ba9ad0d8b364684939e086fa3#a6cd98b0debe317ba9ad0d8b364684939e086fa3"
+source = "git+https://github.com/squidowl/iced?rev=8d458d2495f79cc2c90b31a2997139a46e5c0ae4#8d458d2495f79cc2c90b31a2997139a46e5c0ae4"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -3312,7 +3312,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=a6cd98b0debe317ba9ad0d8b364684939e086fa3#a6cd98b0debe317ba9ad0d8b364684939e086fa3"
+source = "git+https://github.com/squidowl/iced?rev=8d458d2495f79cc2c90b31a2997139a46e5c0ae4#8d458d2495f79cc2c90b31a2997139a46e5c0ae4"
 dependencies = [
  "bytes",
  "iced_core",
@@ -3323,7 +3323,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=a6cd98b0debe317ba9ad0d8b364684939e086fa3#a6cd98b0debe317ba9ad0d8b364684939e086fa3"
+source = "git+https://github.com/squidowl/iced?rev=8d458d2495f79cc2c90b31a2997139a46e5c0ae4#8d458d2495f79cc2c90b31a2997139a46e5c0ae4"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -3340,7 +3340,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=a6cd98b0debe317ba9ad0d8b364684939e086fa3#a6cd98b0debe317ba9ad0d8b364684939e086fa3"
+source = "git+https://github.com/squidowl/iced?rev=8d458d2495f79cc2c90b31a2997139a46e5c0ae4#8d458d2495f79cc2c90b31a2997139a46e5c0ae4"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
@@ -3359,7 +3359,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=a6cd98b0debe317ba9ad0d8b364684939e086fa3#a6cd98b0debe317ba9ad0d8b364684939e086fa3"
+source = "git+https://github.com/squidowl/iced?rev=8d458d2495f79cc2c90b31a2997139a46e5c0ae4#8d458d2495f79cc2c90b31a2997139a46e5c0ae4"
 dependencies = [
  "iced_highlighter",
  "iced_renderer",
@@ -3375,7 +3375,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.15.0-dev"
-source = "git+https://github.com/squidowl/iced?rev=a6cd98b0debe317ba9ad0d8b364684939e086fa3#a6cd98b0debe317ba9ad0d8b364684939e086fa3"
+source = "git+https://github.com/squidowl/iced?rev=8d458d2495f79cc2c90b31a2997139a46e5c0ae4#8d458d2495f79cc2c90b31a2997139a46e5c0ae4"
 dependencies = [
  "arboard",
  "iced_debug",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,9 +168,9 @@ embed-resource = "3.0.2"
 windows_exe_info = "0.4"
 
 [patch.crates-io]
-iced = { git = "https://github.com/squidowl/iced", rev = "a6cd98b0debe317ba9ad0d8b364684939e086fa3" }
-iced_core = { git = "https://github.com/squidowl/iced", rev = "a6cd98b0debe317ba9ad0d8b364684939e086fa3" }
-iced_wgpu = { git = "https://github.com/squidowl/iced", rev = "a6cd98b0debe317ba9ad0d8b364684939e086fa3" }
+iced = { git = "https://github.com/squidowl/iced", rev = "8d458d2495f79cc2c90b31a2997139a46e5c0ae4" }
+iced_core = { git = "https://github.com/squidowl/iced", rev = "8d458d2495f79cc2c90b31a2997139a46e5c0ae4" }
+iced_wgpu = { git = "https://github.com/squidowl/iced", rev = "8d458d2495f79cc2c90b31a2997139a46e5c0ae4" }
 
 [profile.packaging]
 inherits = "release"


### PR DESCRIPTION
Includes new patch commit that prevents a text editor from being horizontally scrolled when the cursor is moved before it is shown.  I.e. prevents text in input box being scrolled/clipped 2px on the left on pane load or when navigating history.