### PR TITLE
Improve recent nick autocomplete activity tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Changed:
 
 - User avatars are configurable with `metadata.avatar.size`
 - Ensure Theme Editor appends a `.toml` extension when saving a theme without one
+- Recent nick autocomplete now counts `/me` actions, keeps last-seen across nick changes, and sorts your own nick last
 
 Thanks:
 

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -1794,7 +1794,7 @@ pub fn update_last_seen(
     last_seen: &mut HashMap<Nick, DateTime<Utc>>,
     message: &Message,
 ) {
-    if let Source::User(user) = message.target.source() {
+    if let Some(user) = message.target.source().user() {
         let nickname = user.nickname().to_owned();
 
         if let Some(date_time) = last_seen.get_mut(&nickname) {
@@ -1803,6 +1803,18 @@ pub fn update_last_seen(
             }
         } else {
             last_seen.insert(nickname, message.server_time);
+        }
+    } else if let Source::Server(Some(server)) = message.target.source()
+        && matches!(server.kind(), message::source::server::Kind::ChangeNick)
+        && let (Some(old), Some(message::source::server::Change::Nick(new))) =
+            (server.nick(), server.change())
+        && let Some(when) = last_seen.remove(old)
+    {
+        match last_seen.get(new) {
+            Some(existing) if *existing >= when => {}
+            _ => {
+                last_seen.insert(new.clone(), when);
+            }
         }
     }
 }

--- a/src/buffer/input_view/completion.rs
+++ b/src/buffer/input_view/completion.rs
@@ -130,6 +130,7 @@ impl Completion {
                 cursor_position,
                 casemapping,
                 users,
+                our_nickname,
                 filters,
                 last_seen,
                 channels.iter().copied(),
@@ -1980,6 +1981,7 @@ impl Words {
         cursor_position: usize,
         casemapping: isupport::CaseMap,
         users: Option<&ChannelUsers>,
+        our_nickname: Option<NickRef>,
         filters: FilterChain,
         last_seen: &HashMap<Nick, DateTime<Utc>>,
         channels: impl IntoIterator<Item = &'a target::Channel>,
@@ -2001,6 +2003,7 @@ impl Words {
                 cursor_position,
                 casemapping,
                 users,
+                our_nickname,
                 filters,
                 current_target.and_then(Target::as_channel),
                 server,
@@ -2016,6 +2019,7 @@ impl Words {
         cursor_position: usize,
         casemapping: isupport::CaseMap,
         users: Option<&ChannelUsers>,
+        our_nickname: Option<NickRef>,
         filters: FilterChain,
         current_channel: Option<&target::Channel>,
         server: &Server,
@@ -2040,34 +2044,51 @@ impl Words {
                     && user.as_normalized_str().starts_with(&nick)
             })
             .sorted_by(|a, b| {
-                if matches!(autocomplete.order_by, OrderBy::Recent) {
-                    if let Some(a_last_seen) =
-                        last_seen.get(&a.nickname().to_owned())
-                    {
-                        if let Some(b_last_seen) =
-                            last_seen.get(&b.nickname().to_owned())
-                        {
-                            b_last_seen.cmp(a_last_seen)
+                let a_is_self =
+                    our_nickname.is_some_and(|nick| a.nickname() == nick);
+                let b_is_self =
+                    our_nickname.is_some_and(|nick| b.nickname() == nick);
+
+                match (a_is_self, b_is_self) {
+                    (true, false) => Ordering::Greater,
+                    (false, true) => Ordering::Less,
+                    _ => {
+                        if matches!(autocomplete.order_by, OrderBy::Recent) {
+                            if let Some(a_last_seen) =
+                                last_seen.get(&a.nickname().to_owned())
+                            {
+                                if let Some(b_last_seen) =
+                                    last_seen.get(&b.nickname().to_owned())
+                                {
+                                    b_last_seen.cmp(a_last_seen)
+                                } else {
+                                    Ordering::Less
+                                }
+                            } else if last_seen
+                                .get(&b.nickname().to_owned())
+                                .is_some()
+                            {
+                                Ordering::Greater
+                            } else {
+                                match autocomplete.sort_direction {
+                                    SortDirection::Asc => {
+                                        a.nickname().cmp(&b.nickname())
+                                    }
+                                    SortDirection::Desc => {
+                                        b.nickname().cmp(&a.nickname())
+                                    }
+                                }
+                            }
                         } else {
-                            Ordering::Less
-                        }
-                    } else if last_seen.get(&b.nickname().to_owned()).is_some()
-                    {
-                        Ordering::Greater
-                    } else {
-                        match autocomplete.sort_direction {
-                            SortDirection::Asc => {
-                                a.nickname().cmp(&b.nickname())
-                            }
-                            SortDirection::Desc => {
-                                b.nickname().cmp(&a.nickname())
+                            match autocomplete.sort_direction {
+                                SortDirection::Asc => {
+                                    a.nickname().cmp(&b.nickname())
+                                }
+                                SortDirection::Desc => {
+                                    b.nickname().cmp(&a.nickname())
+                                }
                             }
                         }
-                    }
-                } else {
-                    match autocomplete.sort_direction {
-                        SortDirection::Asc => a.nickname().cmp(&b.nickname()),
-                        SortDirection::Desc => b.nickname().cmp(&a.nickname()),
                     }
                 }
             })


### PR DESCRIPTION
Ref #629

Count /me actions toward last-seen, migrate last-seen on nick change, and sort the local nick last when completing.