### PR TITLE
Decode ISO-8859-1 lines instead of replacing invalid bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Added:
 
 Fixed:
 
+- Display messages from legacy ISO-8859-1 clients instead of replacing invalid UTF-8 bytes
 - Remove blank space above the input after marking a buffer as read
 - User avatars are only shown when `avatar` is included in `metadata.preferred_keys`
 - Text in input box being scrolled/clipped 2px on the left on pane load or when navigating history

--- a/irc/proto/src/parse.rs
+++ b/irc/proto/src/parse.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::{alpha1, char, crlf, none_of, one_of, satisfy};
@@ -13,8 +15,22 @@ use nom::{Finish, IResult, Parser};
 use crate::{Command, Message, Source, Tags, User};
 
 pub fn message_bytes(bytes: &[u8]) -> Result<Message, Error> {
-    let input = String::from_utf8_lossy(bytes);
+    let input = decode(bytes);
     message(&input)
+}
+
+/// Decodes a raw line, falling back to ISO-8859-1 when it is not valid UTF-8.
+///
+/// Legacy clients (older mIRC and friends) still send ISO-8859-1, where `ä` is
+/// a single byte that is invalid UTF-8. Decoding those lossily replaces each
+/// such byte with U+FFFD and the text is unrecoverable, so decode them as
+/// ISO-8859-1 instead, whose bytes map one-to-one onto the first 256
+/// codepoints. Outgoing messages are always UTF-8.
+fn decode(bytes: &[u8]) -> Cow<'_, str> {
+    match str::from_utf8(bytes) {
+        Ok(utf8) => Cow::Borrowed(utf8),
+        Err(_) => Cow::Owned(bytes.iter().map(|&byte| byte as char).collect()),
+    }
 }
 
 /// Parses a single IRC message terminated by '\r\n`
@@ -207,6 +223,33 @@ mod test {
 
     use crate::command::Numeric::*;
     use crate::{Command, Message, Source, User};
+
+    #[test]
+    fn iso_8859_1_fallback() {
+        // "moi ää" with ä as a single 0xE4 byte, as a legacy client sends it.
+        let mut bytes = b"PRIVMSG #chan :moi ".to_vec();
+        bytes.extend_from_slice(&[0xE4, 0xE4]);
+        bytes.extend_from_slice(b"\r\n");
+
+        let message = super::message_bytes(&bytes).unwrap();
+
+        assert_eq!(
+            message.command,
+            Command::PRIVMSG("#chan".into(), "moi ää".into())
+        );
+    }
+
+    #[test]
+    fn utf8_is_preferred() {
+        let message =
+            super::message_bytes("PRIVMSG #chan :moi ää\r\n".as_bytes())
+                .unwrap();
+
+        assert_eq!(
+            message.command,
+            Command::PRIVMSG("#chan".into(), "moi ää".into())
+        );
+    }
 
     #[test]
     fn user() {
@@ -466,7 +509,7 @@ mod test {
             (
                 Vec::from(b"@id=invalid\x80utf8 :dan!d@localhost PRIVMSG #chan :Hello \xF0\x90\x80World\r\n"),
                 Message {
-                    tags: tags!["id" => "invalid�utf8"],
+                    tags: tags!["id" => "invalid\u{80}utf8"],
                     source: Some(Source::User(User {
                         nickname: "dan".into(),
                         username: Some("d".into()),
@@ -474,7 +517,7 @@ mod test {
                     })),
                     command: Command::PRIVMSG(
                         "#chan".to_string(),
-                        "Hello �World".to_string(),
+                        "Hello ð\u{90}\u{80}World".to_string(),
                     ),
                 },
             ),
@@ -489,7 +532,7 @@ mod test {
                     })),
                     command: Command::PART(
                         "#halloy".to_string(),
-                        Some("My utf8 is br���ken".to_string()),
+                        Some("My utf8 is brô\u{91}\u{87}ken".to_string()),
                     ),
                 },
             ),

--- a/irc/proto/src/parse.rs
+++ b/irc/proto/src/parse.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::{alpha1, char, crlf, none_of, one_of, satisfy};
@@ -13,25 +11,6 @@ use nom::sequence::{preceded, terminated};
 use nom::{Finish, IResult, Parser};
 
 use crate::{Command, Message, Source, Tags, User};
-
-pub fn message_bytes(bytes: &[u8]) -> Result<Message, Error> {
-    let input = decode(bytes);
-    message(&input)
-}
-
-/// Decodes a raw line, falling back to ISO-8859-1 when it is not valid UTF-8.
-///
-/// Legacy clients (older mIRC and friends) still send ISO-8859-1, where `ä` is
-/// a single byte that is invalid UTF-8. Decoding those lossily replaces each
-/// such byte with U+FFFD and the text is unrecoverable, so decode them as
-/// ISO-8859-1 instead, whose bytes map one-to-one onto the first 256
-/// codepoints. Outgoing messages are always UTF-8.
-fn decode(bytes: &[u8]) -> Cow<'_, str> {
-    match str::from_utf8(bytes) {
-        Ok(utf8) => Cow::Borrowed(utf8),
-        Err(_) => Cow::Owned(bytes.iter().map(|&byte| byte as char).collect()),
-    }
-}
 
 /// Parses a single IRC message terminated by '\r\n`
 pub fn message(input: &str) -> Result<Message, Error> {
@@ -223,33 +202,6 @@ mod test {
 
     use crate::command::Numeric::*;
     use crate::{Command, Message, Source, User};
-
-    #[test]
-    fn iso_8859_1_fallback() {
-        // "moi ää" with ä as a single 0xE4 byte, as a legacy client sends it.
-        let mut bytes = b"PRIVMSG #chan :moi ".to_vec();
-        bytes.extend_from_slice(&[0xE4, 0xE4]);
-        bytes.extend_from_slice(b"\r\n");
-
-        let message = super::message_bytes(&bytes).unwrap();
-
-        assert_eq!(
-            message.command,
-            Command::PRIVMSG("#chan".into(), "moi ää".into())
-        );
-    }
-
-    #[test]
-    fn utf8_is_preferred() {
-        let message =
-            super::message_bytes("PRIVMSG #chan :moi ää\r\n".as_bytes())
-                .unwrap();
-
-        assert_eq!(
-            message.command,
-            Command::PRIVMSG("#chan".into(), "moi ää".into())
-        );
-    }
 
     #[test]
     fn user() {
@@ -506,40 +458,11 @@ mod test {
                     ),
                 },
             ),
-            (
-                Vec::from(b"@id=invalid\x80utf8 :dan!d@localhost PRIVMSG #chan :Hello \xF0\x90\x80World\r\n"),
-                Message {
-                    tags: tags!["id" => "invalid\u{80}utf8"],
-                    source: Some(Source::User(User {
-                        nickname: "dan".into(),
-                        username: Some("d".into()),
-                        hostname: Some("localhost".into()),
-                    })),
-                    command: Command::PRIVMSG(
-                        "#chan".to_string(),
-                        "Hello ð\u{90}\u{80}World".to_string(),
-                    ),
-                },
-            ),
-            (
-                Vec::from(b":dan!d@localhost PART #halloy :My utf8 is br\xF4\x91\x87ken\r\n"),
-                Message {
-                    tags: tags![],
-                    source: Some(Source::User(User {
-                        nickname: "dan".into(),
-                        username: Some("d".into()),
-                        hostname: Some("localhost".into()),
-                    })),
-                    command: Command::PART(
-                        "#halloy".to_string(),
-                        Some("My utf8 is brô\u{91}\u{87}ken".to_string()),
-                    ),
-                },
-            ),
         ];
 
         for (test, expected) in tests {
-            let message = super::message_bytes(&test).unwrap();
+            let input = std::str::from_utf8(&test).unwrap();
+            let message = super::message(input).unwrap();
             assert_eq!(message, expected);
         }
     }

--- a/irc/src/codec.rs
+++ b/irc/src/codec.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::io;
 
 use bytes::BytesMut;
@@ -23,6 +24,17 @@ impl Codec {
     }
 }
 
+/// Decodes an IRC line as UTF-8, falling back to ISO-8859-1 when needed.
+///
+/// Keeping wire decoding in the codec lets a connection select a different
+/// encoding without making the IRC message parser configuration-aware.
+fn decode_line(bytes: &[u8]) -> Cow<'_, str> {
+    match str::from_utf8(bytes) {
+        Ok(utf8) => Cow::Borrowed(utf8),
+        Err(_) => Cow::Owned(bytes.iter().map(|&byte| byte as char).collect()),
+    }
+}
+
 impl Decoder for Codec {
     type Item = ParseResult;
     type Error = Error;
@@ -37,7 +49,7 @@ impl Decoder for Codec {
             if src.len() > MAX_LINE_LENGTH {
                 if let Some(logger) = &self.logger {
                     let _ = logger.send(CodecLog::Received(
-                        String::from_utf8_lossy(src).to_string(),
+                        decode_line(src).into_owned(),
                     ));
                 }
 
@@ -47,14 +59,13 @@ impl Decoder for Codec {
         };
 
         let bytes = src.split_to(pos + 2);
+        let line = decode_line(&bytes);
 
         if let Some(logger) = &self.logger {
-            let _ = logger.send(CodecLog::Received(
-                String::from_utf8_lossy(&bytes).to_string(),
-            ));
+            let _ = logger.send(CodecLog::Received(line.to_string()));
         }
 
-        Ok(Some(parse::message_bytes(&bytes)))
+        Ok(Some(parse::message(&line)))
     }
 }
 
@@ -93,4 +104,75 @@ pub enum Error {
     Io(#[from] io::Error),
     #[error("IRC line exceeded the maximum buffered length")]
     LineTooLong,
+}
+
+#[cfg(test)]
+mod test {
+    use bytes::BytesMut;
+    use proto::Command;
+    use tokio_util::codec::Decoder;
+
+    use super::Codec;
+
+    fn decode(input: &[u8]) -> proto::Message {
+        let mut codec = Codec::new(None);
+        let mut input = BytesMut::from(input);
+
+        codec.decode(&mut input).unwrap().unwrap().unwrap()
+    }
+
+    #[test]
+    fn iso_8859_1_fallback() {
+        let mut input = b"PRIVMSG #chan :moi ".to_vec();
+        input.extend_from_slice(&[0xE4, 0xE4]);
+        input.extend_from_slice(b"\r\n");
+
+        let message = decode(&input);
+
+        assert_eq!(
+            message.command,
+            Command::PRIVMSG("#chan".into(), "moi ää".into())
+        );
+    }
+
+    #[test]
+    fn utf8_is_preferred() {
+        let message = decode("PRIVMSG #chan :moi ää\r\n".as_bytes());
+
+        assert_eq!(
+            message.command,
+            Command::PRIVMSG("#chan".into(), "moi ää".into())
+        );
+    }
+
+    #[test]
+    fn iso_8859_1_fallback_applies_to_the_entire_line() {
+        let message = decode(
+            b"@id=invalid\x80utf8 :dan!d@localhost PRIVMSG #chan :Hello \xF0\x90\x80World\r\n",
+        );
+
+        assert_eq!(
+            message.tags.get("id").map(String::as_str),
+            Some("invalid\u{80}utf8")
+        );
+        assert_eq!(
+            message.command,
+            Command::PRIVMSG("#chan".into(), "Hello ð\u{90}\u{80}World".into())
+        );
+    }
+
+    #[test]
+    fn iso_8859_1_fallback_decodes_incomplete_utf8_sequences() {
+        let message = decode(
+            b":dan!d@localhost PART #halloy :My utf8 is br\xF4\x91\x87ken\r\n",
+        );
+
+        assert_eq!(
+            message.command,
+            Command::PART(
+                "#halloy".into(),
+                Some("My utf8 is brô\u{91}\u{87}ken".into())
+            )
+        );
+    }
 }


### PR DESCRIPTION
Messages from clients that still send ISO-8859-1 (older mIRC and similar) arrive as question marks or replacement characters. In Finnish, `ää` shows up as `??`.

`parse::message_bytes` decodes every line with `String::from_utf8_lossy`, which replaces each invalid byte with U+FFFD. The original bytes are lost, so nothing downstream can recover the text.

Lines are now decoded strictly as UTF-8 first, falling back to ISO-8859-1 when that fails, whose bytes map one-to-one onto the first 256 codepoints. Valid UTF-8 is unaffected and still borrows rather than allocating. Outgoing messages are unchanged and remain UTF-8.

Two existing cases in `parse::test::message` asserted the lossy output and now assert the decoded result.

Before:

<img width="511" height="475" alt="image" src="https://github.com/user-attachments/assets/c51978fc-a495-43a4-b44b-cf788f0b84a7" />

After:

<img width="512" height="490" alt="image" src="https://github.com/user-attachments/assets/33831337-dfe0-4fcb-b6bb-15375a29ef80" />

Initially the same thing than my proposed change to thelounge: https://github.com/thelounge/thelounge/pull/5019#issue-3823481306 

Feel free to take it or leave it.