### PR TITLE
expand actions.sidebar behavior options with modifier key variants 

### DIFF
--- a/data/src/config/actions.rs
+++ b/data/src/config/actions.rs
@@ -53,6 +53,12 @@ pub struct Sidebar {
     pub query: Option<BufferAction>,
     pub focused_buffer: Option<BufferFocusedAction>,
     pub cycle: CycleAction,
+    #[serde(default = "default_channel_with_modifier")]
+    pub channel_with_modifier: BufferAction,
+}
+
+fn default_channel_with_modifier() -> BufferAction {
+    BufferAction::NewWindow
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/data/src/config/actions.rs
+++ b/data/src/config/actions.rs
@@ -53,11 +53,14 @@ pub struct Sidebar {
     pub query: Option<BufferAction>,
     pub focused_buffer: Option<BufferFocusedAction>,
     pub cycle: CycleAction,
-    #[serde(default = "default_channel_with_modifier")]
-    pub channel_with_modifier: BufferAction,
+    #[serde(default = "default_buffer_with_modifier")]
+    pub buffer_with_modifier: BufferAction,
+    pub channel_with_modifier: Option<BufferAction>,
+    pub query_with_modifier: Option<BufferAction>,
+    pub focused_buffer_with_modifier: Option<BufferFocusedAction>,
 }
 
-fn default_channel_with_modifier() -> BufferAction {
+fn default_buffer_with_modifier() -> BufferAction {
     BufferAction::NewWindow
 }
 

--- a/data/src/config/actions.rs
+++ b/data/src/config/actions.rs
@@ -57,7 +57,6 @@ pub struct Sidebar {
     pub buffer_with_modifier: BufferAction,
     pub channel_with_modifier: Option<BufferAction>,
     pub query_with_modifier: Option<BufferAction>,
-    pub focused_buffer_with_modifier: Option<BufferFocusedAction>,
 }
 
 fn default_buffer_with_modifier() -> BufferAction {

--- a/docs/configuration/actions.md
+++ b/docs/configuration/actions.md
@@ -242,6 +242,19 @@ Action when clicking buffers in the sidebar. `"new-pane"` opens a new pane each 
 buffer = "replace-pane"
 ```
 
+### `buffer_with_modifier`
+
+Action when clicking buffers in the sidebar while holding the modifier key (Command/⌘ key on macOs, Control on Linux/Windows). `"new-pane"` opens a new pane each time. `"replace-pane"` replaces the focused pane with the clicked buffer. `"new-window"` opens a new window each time.
+
+```toml
+# Type: string
+# Values: "new-pane", "replace-pane", "new-window"
+# Default: "new-window"
+
+[actions.sidebar]
+buffer_with_modifier = "new-window"
+```
+
 ### `channel`
 
 Action when clicking a channel buffer in the sidebar. If unset, it falls back to the value of `buffer`.
@@ -255,6 +268,19 @@ Action when clicking a channel buffer in the sidebar. If unset, it falls back to
 channel = "replace-pane"
 ```
 
+### `channel_with_modifier`
+
+Action when clicking a channel buffer in the sidebar while holding the modifier key (Command/⌘ key on macOs, Control on Linux/Windows). If unset, it falls back to the value of `buffer_with_modifier`.
+
+```toml
+# Type: string
+# Values: "new-pane", "replace-pane", "new-window"
+# Default: not set (falls back to `buffer_with_modifier`)
+
+[actions.sidebar]
+channel_with_modifier = "replace-pane"
+```
+
 ### `query`
 
 Action when clicking a user/query buffer in the sidebar. If unset, it falls back to the value of `buffer`.
@@ -266,6 +292,19 @@ Action when clicking a user/query buffer in the sidebar. If unset, it falls back
 
 [actions.sidebar]
 query = "new-window"
+```
+
+### `query_with_modifier`
+
+Action when clicking a user/query buffer in the sidebar while holding the modifier key (Command/⌘ key on macOs, Control on Linux/Windows). If unset, it falls back to the value of `buffer_with_modifier`.
+
+```toml
+# Type: string
+# Values: "new-pane", "replace-pane", "new-window"
+# Default: not set (falls back to `buffer_with_modifier`)
+
+[actions.sidebar]
+query_with_modifier = "new-window"
 ```
 
 ### `focused_buffer`

--- a/src/event.rs
+++ b/src/event.rs
@@ -5,6 +5,7 @@ pub enum Event {
     Copy,
     Escape,
     LeftClick,
+    ModifiersChanged(keyboard::Modifiers),
     UpdatePrimaryClipboard,
 }
 
@@ -29,6 +30,9 @@ fn filtered_events(
             modifiers,
             ..
         }) if c.as_str() == "c" && modifiers.command() => Some(Event::Copy),
+        iced::Event::Keyboard(keyboard::Event::ModifiersChanged(modifiers)) => {
+            Some(Event::ModifiersChanged(*modifiers))
+        }
         iced::Event::Mouse(mouse::Event::ButtonPressed {
             button: mouse::Button::Left,
             ..

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -73,6 +73,7 @@ pub struct Dashboard {
     typing_animation: Option<buffer::typing::Animation>,
     http_client: Option<Arc<reqwest::Client>>,
     buffer_settings: dashboard::BufferSettings,
+    modifiers: iced::keyboard::Modifiers,
     pub filehost: filehost::Manager,
 }
 
@@ -159,6 +160,7 @@ impl Dashboard {
             typing_animation: None,
             http_client: http_client_from_config(config).map(Arc::new),
             buffer_settings: dashboard::BufferSettings::default(),
+            modifiers: iced::keyboard::Modifiers::default(),
             filehost: filehost::Manager::new(),
         };
 
@@ -1864,6 +1866,7 @@ impl Dashboard {
                 version,
                 theme,
                 self.buffer_settings.show_muted,
+                self.modifiers,
             )
             .map(|e| e.map(Message::Sidebar));
 
@@ -2887,6 +2890,10 @@ impl Dashboard {
                 )
             }),
             LeftClick => self.refocus_pane(),
+            ModifiersChanged(modifiers) => {
+                self.modifiers = modifiers;
+                Task::none()
+            }
             UpdatePrimaryClipboard => {
                 selectable_text::selected(|selected_text| {
                     Message::SelectedText(
@@ -4742,6 +4749,7 @@ impl Dashboard {
             typing_animation: None,
             http_client: http_client_from_config(config).map(Arc::new),
             buffer_settings: data.buffer_settings.clone(),
+            modifiers: iced::keyboard::Modifiers::default(),
             filehost: filehost::Manager::new(),
         };
 

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -3127,6 +3127,10 @@ impl Dashboard {
         }
     }
 
+    fn clear_modifiers(&mut self) {
+        self.modifiers = iced::keyboard::Modifiers::default();
+    }
+
     fn open_buffer(
         &mut self,
         buffer: data::Buffer,
@@ -3303,6 +3307,8 @@ impl Dashboard {
                 Task::none()
             }
             BufferAction::NewWindow => {
+                self.clear_modifiers();
+
                 iced::window::position(self.main_window()).then({
                     let pane = Pane::new(Buffer::from_data(
                         buffer.clone(),

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -1530,6 +1530,17 @@ fn upstream_buffer_title<'a>(
     }
 }
 
+fn buffer_action_message(
+    action: BufferAction,
+    buffer: data::Buffer,
+) -> Message {
+    match action {
+        BufferAction::NewPane => Message::New(buffer),
+        BufferAction::ReplacePane => Message::Replace(buffer),
+        BufferAction::NewWindow => Message::Popout(buffer),
+    }
+}
+
 fn upstream_buffer_button<'a>(
     context: UpstreamButtonContext<'a>,
 ) -> Element<'a, Message> {
@@ -1739,17 +1750,10 @@ fn upstream_buffer_button<'a>(
             if let Some((window, pane)) = open_as_window_pane {
                 Message::Focus(window, pane)
             } else {
-                match config.actions.sidebar.channel_with_modifier {
-                    BufferAction::NewPane => {
-                        Message::New(buffer.clone().into())
-                    }
-                    BufferAction::ReplacePane => {
-                        Message::Replace(buffer.clone().into())
-                    }
-                    BufferAction::NewWindow => {
-                        Message::Popout(buffer.clone().into())
-                    }
-                }
+                buffer_action_message(
+                    config.actions.sidebar.channel_with_modifier,
+                    buffer.clone().into(),
+                )
             }
         } else {
             match focused_as_window_pane {
@@ -1786,17 +1790,7 @@ fn upstream_buffer_button<'a>(
                             _ => config.actions.sidebar.buffer,
                         };
 
-                        match action {
-                            BufferAction::NewPane => {
-                                Message::New(buffer.clone().into())
-                            }
-                            BufferAction::ReplacePane => {
-                                Message::Replace(buffer.clone().into())
-                            }
-                            BufferAction::NewWindow => {
-                                Message::Popout(buffer.clone().into())
-                            }
-                        }
+                        buffer_action_message(action, buffer.clone().into())
                     }
                 }
             }
@@ -2200,17 +2194,10 @@ fn internal_buffer_button<'a>(
                 if let Some((window, pane)) = open_as_window_pane {
                     Message::Focus(window, pane)
                 } else {
-                    match config.actions.sidebar.channel_with_modifier {
-                        BufferAction::NewPane => {
-                            Message::New(buffer.clone().into())
-                        }
-                        BufferAction::ReplacePane => {
-                            Message::Replace(buffer.clone().into())
-                        }
-                        BufferAction::NewWindow => {
-                            Message::Popout(buffer.clone().into())
-                        }
-                    }
+                    buffer_action_message(
+                        config.actions.sidebar.channel_with_modifier,
+                        buffer.clone().into(),
+                    )
                 }
             } else {
                 match focused_as_window_pane {
@@ -2233,17 +2220,10 @@ fn internal_buffer_button<'a>(
                         if let Some((window, pane)) = open_as_window_pane {
                             Message::Focus(window, pane)
                         } else {
-                            match config.actions.sidebar.buffer {
-                                BufferAction::NewPane => {
-                                    Message::New(buffer.clone().into())
-                                }
-                                BufferAction::ReplacePane => {
-                                    Message::Replace(buffer.clone().into())
-                                }
-                                BufferAction::NewWindow => {
-                                    Message::Popout(buffer.clone().into())
-                                }
-                            }
+                            buffer_action_message(
+                                config.actions.sidebar.buffer,
+                                buffer.clone().into(),
+                            )
                         }
                     }
                 }

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -1736,7 +1736,11 @@ fn upstream_buffer_button<'a>(
     .padding(config.sidebar.padding.buffer)
     .on_press({
         if modifiers.command() {
-            Message::Popout(buffer.clone().into())
+            if let Some((window, pane)) = open_as_window_pane {
+                Message::Focus(window, pane)
+            } else {
+                Message::Popout(buffer.clone().into())
+            }
         } else {
             match focused_as_window_pane {
                 Some((window, pane)) => {
@@ -2183,7 +2187,11 @@ fn internal_buffer_button<'a>(
             })
             .padding(config.sidebar.padding.buffer)
             .on_press(if modifiers.command() {
-                Message::Popout(buffer.clone().into())
+                if let Some((window, pane)) = open_as_window_pane {
+                    Message::Focus(window, pane)
+                } else {
+                    Message::Popout(buffer.clone().into())
+                }
             } else {
                 match focused_as_window_pane {
                     Some((window, pane)) => {

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -17,7 +17,8 @@ use iced::widget::{
     rule, scrollable, space, stack,
 };
 use iced::{
-    Alignment, Border, ContentFit, Length, Padding, Task, mouse, padding,
+    Alignment, Border, ContentFit, Length, Padding, Task, keyboard, mouse,
+    padding,
 };
 use itertools::Either;
 use tokio::time;
@@ -825,6 +826,7 @@ impl Sidebar {
         version: &'a Version,
         theme: &'a Theme,
         show_muted_buffers: bool,
+        modifiers: keyboard::Modifiers,
     ) -> Option<Element<'a, Message>> {
         if self.hidden {
             return None;
@@ -916,6 +918,7 @@ impl Sidebar {
                                 width,
                                 theme,
                                 collapse: &self.collapse,
+                                modifiers,
                             };
 
                             buffers.push(upstream_buffer_button(context));
@@ -934,6 +937,7 @@ impl Sidebar {
                                 history,
                                 width,
                                 theme,
+                                modifiers,
                             ));
                         }
                     }
@@ -1423,6 +1427,7 @@ struct UpstreamButtonContext<'a> {
     width: Length,
     theme: &'a Theme,
     collapse: &'a collapse::State,
+    modifiers: keyboard::Modifiers,
 }
 
 fn upstream_buffer_title<'a>(
@@ -1545,6 +1550,7 @@ fn upstream_buffer_button<'a>(
         width,
         theme,
         collapse,
+        modifiers,
         ..
     } = &context;
 
@@ -1729,49 +1735,53 @@ fn upstream_buffer_button<'a>(
     })
     .padding(config.sidebar.padding.buffer)
     .on_press({
-        match focused_as_window_pane {
-            Some((window, pane)) => {
-                if let Some(focus_action) =
-                    config.actions.sidebar.focused_buffer
-                {
-                    match focus_action {
-                        BufferFocusedAction::ClosePane => {
-                            Message::Close(window, pane)
+        if modifiers.command() {
+            Message::Popout(buffer.clone().into())
+        } else {
+            match focused_as_window_pane {
+                Some((window, pane)) => {
+                    if let Some(focus_action) =
+                        config.actions.sidebar.focused_buffer
+                    {
+                        match focus_action {
+                            BufferFocusedAction::ClosePane => {
+                                Message::Close(window, pane)
+                            }
                         }
+                    } else {
+                        // Re-focus pane on press instead of disabling the button in order
+                        // to have hover status of the button for styling
+                        Message::Focus(window, pane)
                     }
-                } else {
-                    // Re-focus pane on press instead of disabling the button in order
-                    // to have hover status of the button for styling
-                    Message::Focus(window, pane)
                 }
-            }
-            None => {
-                if let Some((window, pane)) = open_as_window_pane {
-                    Message::Focus(window, pane)
-                } else {
-                    let action = match &buffer {
-                        buffer::Upstream::Channel(_, _) => config
-                            .actions
-                            .sidebar
-                            .channel
-                            .unwrap_or(config.actions.sidebar.buffer),
-                        buffer::Upstream::Query(_, _) => config
-                            .actions
-                            .sidebar
-                            .query
-                            .unwrap_or(config.actions.sidebar.buffer),
-                        _ => config.actions.sidebar.buffer,
-                    };
+                None => {
+                    if let Some((window, pane)) = open_as_window_pane {
+                        Message::Focus(window, pane)
+                    } else {
+                        let action = match &buffer {
+                            buffer::Upstream::Channel(_, _) => config
+                                .actions
+                                .sidebar
+                                .channel
+                                .unwrap_or(config.actions.sidebar.buffer),
+                            buffer::Upstream::Query(_, _) => config
+                                .actions
+                                .sidebar
+                                .query
+                                .unwrap_or(config.actions.sidebar.buffer),
+                            _ => config.actions.sidebar.buffer,
+                        };
 
-                    match action {
-                        BufferAction::NewPane => {
-                            Message::New(buffer.clone().into())
-                        }
-                        BufferAction::ReplacePane => {
-                            Message::Replace(buffer.clone().into())
-                        }
-                        BufferAction::NewWindow => {
-                            Message::Popout(buffer.clone().into())
+                        match action {
+                            BufferAction::NewPane => {
+                                Message::New(buffer.clone().into())
+                            }
+                            BufferAction::ReplacePane => {
+                                Message::Replace(buffer.clone().into())
+                            }
+                            BufferAction::NewWindow => {
+                                Message::Popout(buffer.clone().into())
+                            }
                         }
                     }
                 }
@@ -2040,6 +2050,7 @@ fn internal_buffer_button<'a>(
     history: &'a history::Manager,
     width: Length,
     theme: &'a Theme,
+    modifiers: keyboard::Modifiers,
 ) -> Element<'a, Message> {
     let open_as_window_pane =
         panes.iter().find_map(|(window_id, pane, state)| {
@@ -2171,35 +2182,39 @@ fn internal_buffer_button<'a>(
                 )
             })
             .padding(config.sidebar.padding.buffer)
-            .on_press(match focused_as_window_pane {
-                Some((window, pane)) => {
-                    if let Some(focus_action) =
-                        config.actions.sidebar.focused_buffer
-                    {
-                        match focus_action {
-                            BufferFocusedAction::ClosePane => {
-                                Message::Close(window, pane)
+            .on_press(if modifiers.command() {
+                Message::Popout(buffer.clone().into())
+            } else {
+                match focused_as_window_pane {
+                    Some((window, pane)) => {
+                        if let Some(focus_action) =
+                            config.actions.sidebar.focused_buffer
+                        {
+                            match focus_action {
+                                BufferFocusedAction::ClosePane => {
+                                    Message::Close(window, pane)
+                                }
                             }
+                        } else {
+                            // Re-focus pane on press instead of disabling the button in order
+                            // to have hover status of the button for styling
+                            Message::Focus(window, pane)
                         }
-                    } else {
-                        // Re-focus pane on press instead of disabling the button in order
-                        // to have hover status of the button for styling
-                        Message::Focus(window, pane)
                     }
-                }
-                None => {
-                    if let Some((window, pane)) = open_as_window_pane {
-                        Message::Focus(window, pane)
-                    } else {
-                        match config.actions.sidebar.buffer {
-                            BufferAction::NewPane => {
-                                Message::New(buffer.clone().into())
-                            }
-                            BufferAction::ReplacePane => {
-                                Message::Replace(buffer.clone().into())
-                            }
-                            BufferAction::NewWindow => {
-                                Message::Popout(buffer.clone().into())
+                    None => {
+                        if let Some((window, pane)) = open_as_window_pane {
+                            Message::Focus(window, pane)
+                        } else {
+                            match config.actions.sidebar.buffer {
+                                BufferAction::NewPane => {
+                                    Message::New(buffer.clone().into())
+                                }
+                                BufferAction::ReplacePane => {
+                                    Message::Replace(buffer.clone().into())
+                                }
+                                BufferAction::NewWindow => {
+                                    Message::Popout(buffer.clone().into())
+                                }
                             }
                         }
                     }

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -1746,52 +1746,50 @@ fn upstream_buffer_button<'a>(
     })
     .padding(config.sidebar.padding.buffer)
     .on_press({
-        if modifiers.command() {
-            if let Some((window, pane)) = open_as_window_pane {
-                Message::Focus(window, pane)
-            } else {
-                buffer_action_message(
-                    config.actions.sidebar.channel_with_modifier,
-                    buffer.clone().into(),
-                )
-            }
+        // Select the normal or modifier action set, then resolve identically.
+        let (base, channel, query, focused) = if modifiers.command() {
+            (
+                config.actions.sidebar.buffer_with_modifier,
+                config.actions.sidebar.channel_with_modifier,
+                config.actions.sidebar.query_with_modifier,
+                config.actions.sidebar.focused_buffer_with_modifier,
+            )
         } else {
-            match focused_as_window_pane {
-                Some((window, pane)) => {
-                    if let Some(focus_action) =
-                        config.actions.sidebar.focused_buffer
-                    {
-                        match focus_action {
-                            BufferFocusedAction::ClosePane => {
-                                Message::Close(window, pane)
-                            }
-                        }
-                    } else {
-                        // Re-focus pane on press instead of disabling the button in order
-                        // to have hover status of the button for styling
-                        Message::Focus(window, pane)
-                    }
-                }
-                None => {
-                    if let Some((window, pane)) = open_as_window_pane {
-                        Message::Focus(window, pane)
-                    } else {
-                        let action = match &buffer {
-                            buffer::Upstream::Channel(_, _) => config
-                                .actions
-                                .sidebar
-                                .channel
-                                .unwrap_or(config.actions.sidebar.buffer),
-                            buffer::Upstream::Query(_, _) => config
-                                .actions
-                                .sidebar
-                                .query
-                                .unwrap_or(config.actions.sidebar.buffer),
-                            _ => config.actions.sidebar.buffer,
-                        };
+            (
+                config.actions.sidebar.buffer,
+                config.actions.sidebar.channel,
+                config.actions.sidebar.query,
+                config.actions.sidebar.focused_buffer,
+            )
+        };
 
-                        buffer_action_message(action, buffer.clone().into())
+        match focused_as_window_pane {
+            Some((window, pane)) => {
+                if let Some(focus_action) = focused {
+                    match focus_action {
+                        BufferFocusedAction::ClosePane => {
+                            Message::Close(window, pane)
+                        }
                     }
+                } else {
+                    // Re-focus pane on press instead of disabling the button in order
+                    // to have hover status of the button for styling
+                    Message::Focus(window, pane)
+                }
+            }
+            None => {
+                if let Some((window, pane)) = open_as_window_pane {
+                    Message::Focus(window, pane)
+                } else {
+                    let action = match &buffer {
+                        buffer::Upstream::Channel(_, _) => {
+                            channel.unwrap_or(base)
+                        }
+                        buffer::Upstream::Query(_, _) => query.unwrap_or(base),
+                        _ => base,
+                    };
+
+                    buffer_action_message(action, buffer.clone().into())
                 }
             }
         }
@@ -2190,21 +2188,22 @@ fn internal_buffer_button<'a>(
                 )
             })
             .padding(config.sidebar.padding.buffer)
-            .on_press(if modifiers.command() {
-                if let Some((window, pane)) = open_as_window_pane {
-                    Message::Focus(window, pane)
-                } else {
-                    buffer_action_message(
-                        config.actions.sidebar.channel_with_modifier,
-                        buffer.clone().into(),
+            .on_press({
+                let (base, focused) = if modifiers.command() {
+                    (
+                        config.actions.sidebar.buffer_with_modifier,
+                        config.actions.sidebar.focused_buffer_with_modifier,
                     )
-                }
-            } else {
+                } else {
+                    (
+                        config.actions.sidebar.buffer,
+                        config.actions.sidebar.focused_buffer,
+                    )
+                };
+
                 match focused_as_window_pane {
                     Some((window, pane)) => {
-                        if let Some(focus_action) =
-                            config.actions.sidebar.focused_buffer
-                        {
+                        if let Some(focus_action) = focused {
                             match focus_action {
                                 BufferFocusedAction::ClosePane => {
                                     Message::Close(window, pane)
@@ -2220,10 +2219,7 @@ fn internal_buffer_button<'a>(
                         if let Some((window, pane)) = open_as_window_pane {
                             Message::Focus(window, pane)
                         } else {
-                            buffer_action_message(
-                                config.actions.sidebar.buffer,
-                                buffer.clone().into(),
-                            )
+                            buffer_action_message(base, buffer.clone().into())
                         }
                     }
                 }

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -1747,25 +1747,25 @@ fn upstream_buffer_button<'a>(
     .padding(config.sidebar.padding.buffer)
     .on_press({
         // Select the normal or modifier action set, then resolve identically.
-        let (base, channel, query, focused) = if modifiers.command() {
+        let (base, channel, query) = if modifiers.command() {
             (
                 config.actions.sidebar.buffer_with_modifier,
                 config.actions.sidebar.channel_with_modifier,
                 config.actions.sidebar.query_with_modifier,
-                config.actions.sidebar.focused_buffer_with_modifier,
             )
         } else {
             (
                 config.actions.sidebar.buffer,
                 config.actions.sidebar.channel,
                 config.actions.sidebar.query,
-                config.actions.sidebar.focused_buffer,
             )
         };
 
         match focused_as_window_pane {
             Some((window, pane)) => {
-                if let Some(focus_action) = focused {
+                if let Some(focus_action) =
+                    config.actions.sidebar.focused_buffer
+                {
                     match focus_action {
                         BufferFocusedAction::ClosePane => {
                             Message::Close(window, pane)
@@ -2189,21 +2189,17 @@ fn internal_buffer_button<'a>(
             })
             .padding(config.sidebar.padding.buffer)
             .on_press({
-                let (base, focused) = if modifiers.command() {
-                    (
-                        config.actions.sidebar.buffer_with_modifier,
-                        config.actions.sidebar.focused_buffer_with_modifier,
-                    )
+                let base = if modifiers.command() {
+                    config.actions.sidebar.buffer_with_modifier
                 } else {
-                    (
-                        config.actions.sidebar.buffer,
-                        config.actions.sidebar.focused_buffer,
-                    )
+                    config.actions.sidebar.buffer
                 };
 
                 match focused_as_window_pane {
                     Some((window, pane)) => {
-                        if let Some(focus_action) = focused {
+                        if let Some(focus_action) =
+                            config.actions.sidebar.focused_buffer
+                        {
                             match focus_action {
                                 BufferFocusedAction::ClosePane => {
                                     Message::Close(window, pane)

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -1739,7 +1739,17 @@ fn upstream_buffer_button<'a>(
             if let Some((window, pane)) = open_as_window_pane {
                 Message::Focus(window, pane)
             } else {
-                Message::Popout(buffer.clone().into())
+                match config.actions.sidebar.channel_with_modifier {
+                    BufferAction::NewPane => {
+                        Message::New(buffer.clone().into())
+                    }
+                    BufferAction::ReplacePane => {
+                        Message::Replace(buffer.clone().into())
+                    }
+                    BufferAction::NewWindow => {
+                        Message::Popout(buffer.clone().into())
+                    }
+                }
             }
         } else {
             match focused_as_window_pane {
@@ -2190,7 +2200,17 @@ fn internal_buffer_button<'a>(
                 if let Some((window, pane)) = open_as_window_pane {
                     Message::Focus(window, pane)
                 } else {
-                    Message::Popout(buffer.clone().into())
+                    match config.actions.sidebar.channel_with_modifier {
+                        BufferAction::NewPane => {
+                            Message::New(buffer.clone().into())
+                        }
+                        BufferAction::ReplacePane => {
+                            Message::Replace(buffer.clone().into())
+                        }
+                        BufferAction::NewWindow => {
+                            Message::Popout(buffer.clone().into())
+                        }
+                    }
                 }
             } else {
                 match focused_as_window_pane {


### PR DESCRIPTION
Halloy already has a set of options under [actions.sidebar](https://halloy.chat/configuration/actions#sidebar) that controls what happens when clicking a generic buffer, channel, query, or focused_buffer listed in the sidebar.

This PR adds similar `*_with_modifier` options which configures what behavior happens when performing the above action while holding a modifier key. With these changes, the default behavior will be such that the clicked buffer/channel/query/etc is opened in a new window if a modifier key is held while clicking its name. The original behavior (click without modifier key) is retained.

The "modifier key" is the key that iced's [Modifiers.command](https://docs.rs/iced/latest/iced/keyboard/struct.Modifiers.html#method.command) defaults to.

This partially satisfies #2259. 

I still need to ~~update the docs~~ and other meta-items (am I supposed to add an entry to the changelog?).