### PR TITLE
Note Ability to Set Monitor Notifications in Guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ Changed:
 Thanks:
 
 - Contributions: @rollecode, @luca020400, @rtmongold, @tranzystorekk, @englut, @furudean
-- Bug reports: @sebbu2, @dpedu, kurwavidae, @ncfavier, wwWraith, kurwavidae, @SRAZKVT
+- Bug reports: @sebbu2, @dpedu, kurwavidae, @ncfavier, wwWraith, kurwavidae, @SRAZKVT, @WinnerWind
 - Feature requests: @daniiooo, @fabricionaweb, @RoboDanjal, @AbandonedCranium, tbo, ivocavalcante, @sebbu2, @coraxioU9, @ncfavier, @darienm
 
 # 2026.8 (2026-07-24)

--- a/docs/guides/monitor-users.md
+++ b/docs/guides/monitor-users.md
@@ -4,8 +4,8 @@ Halloy has [monitor](https://ircv3.net/specs/extensions/monitor) support if the 
 
 To use the feature you need to add the user(s) you wish to monitor. This can be done in two ways:
 
-* You can add a list of user directly to the configuration file. [See configuration option.](../configuration/servers#monitor)
-* You can add users through `/monitor` directly in Halloy.
+* You can add a list of user directly to the configuration file. [See configuration option.](/configuration/servers#monitor)
+* You can add users through `/monitor` directly in Halloy (users added this way will not be remembered across application restarts).
 
 Examples with the `/monitor` command:
 
@@ -16,3 +16,15 @@ Examples with the `/monitor` command:
 /monitor l # Get list of users being monitored
 /monitor s # For each user in the list being monitored, get their current status
 ```
+
+[Notifications](/configuration/notifications#types) can be configured for when monitored users come online or go offline.  For example:
+
+```toml
+[notifications.monitored_online]
+show_toast = true
+
+[notifications.monitored_offline]
+show_toast = true
+```
+
+will show a toast notification whenever a monitored user changes between offline and online.


### PR DESCRIPTION
Notes the ability to set notifications for monitored users coming online and going offline in the monitor users guide.