### PR TITLE
Add spellcheck for the message input

### DIFF
--- a/.github/linux-deps.txt
+++ b/.github/linux-deps.txt
@@ -6,3 +6,5 @@ libxkbcommon-dev
 libfontconfig1-dev
 libasound2-dev
 libx11-xcb-dev
+libhunspell-dev
+libclang-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ Added:
   - Links and channel mentions within a message can be focused and opened
   - New `buffer.focus` theme color for the focused message border
 - Server context menu action to open Channel Discovery with that server selected
+- Spellcheck for the message input (`buffer.text_input.spellcheck`)
+  - Uses the platform spellchecker; optional `locale`
+  - Skips channel names and known nicks
+  - <kbd>Tab</kbd> / <kbd>Shift</kbd>+<kbd>Tab</kbd> cycles suggestions when
+    autocomplete does not apply (`suggestions = true`)
+- Theme style `text.spellcheck_misspelled`
+  (default: `text.error` in italic when unset)
 
 Fixed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ Added:
 - Optional `font.code` setting for code-formatted text
 - Settings to control how internal and server buffers are opened from the sidebar (`actions.sidebar.internal` and `actions.sidebar.server`)
 - `buffer.nickname.offline` supports `"dimmed"` / `{ dimmed = float }`, and `{ color = "theme"|"nickname", alpha = ...}` so theme offline color and dimming can be combined
+- Spellcheck for the message input (`buffer.text_input.spellcheck`)
+  - Uses the platform spellchecker; optional `locale`
+  - Skips channel names and known nicks
+  - <kbd>Tab</kbd> / <kbd>Shift</kbd>+<kbd>Tab</kbd> cycles suggestions when
+    autocomplete does not apply (`suggestions = true`)
+- Theme style `text.spellcheck_misspelled`
+  (default: `text.error` in italic when unset)
 
 Fixed:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,6 +727,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a022e58a142a46fea340d68012b9201c094e93ec3d033a944a24f8fd4a4f09a"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 1.0.109",
+ "which",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,6 +1019,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cfb"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,6 +1085,17 @@ dependencies = [
  "crypto-common 0.1.7",
  "inout",
  "zeroize",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -2742,6 +2784,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f22fb22f065b308be0d8724e3706c7fa3fc2a6c7d6899df4cad7860e7a75436"
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
 name = "glob-match"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2890,6 +2938,7 @@ dependencies = [
  "rfd",
  "rodio",
  "signal-hook",
+ "spellkit",
  "strsim 0.11.1",
  "strum",
  "thiserror 2.0.19",
@@ -3006,6 +3055,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "hostname-validator"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3076,6 +3134,16 @@ checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
 dependencies = [
  "humantime",
  "serde",
+]
+
+[[package]]
+name = "hunspell-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9228605394e47acb7e5c20da4f9d8d5175fd767230e51d3095623bc5e20b7dec"
+dependencies = [
+ "bindgen",
+ "pkg-config",
 ]
 
 [[package]]
@@ -3987,6 +4055,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "leb128fmt"
@@ -5259,6 +5333,12 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem-rfc7468"
@@ -7063,6 +7143,20 @@ dependencies = [
  "web-sys",
  "windows-sys 0.61.2",
  "x11rb",
+]
+
+[[package]]
+name = "spellkit"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a7f9fb5087b79c7f81b24df733182d5d4c184987a53c7f27c742fc8fe2dd81"
+dependencies = [
+ "cfg-if",
+ "hunspell-sys",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -9906,6 +10000,18 @@ dependencies = [
  "log",
  "raw-window-handle",
  "web-sys",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,6 +727,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a022e58a142a46fea340d68012b9201c094e93ec3d033a944a24f8fd4a4f09a"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 1.0.109",
+ "which",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,6 +1019,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cfb"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,6 +1085,17 @@ dependencies = [
  "crypto-common 0.1.7",
  "inout",
  "zeroize",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -2742,6 +2784,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f22fb22f065b308be0d8724e3706c7fa3fc2a6c7d6899df4cad7860e7a75436"
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
 name = "glob-match"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2890,6 +2938,7 @@ dependencies = [
  "rfd",
  "rodio",
  "signal-hook",
+ "spellkit",
  "strsim 0.11.1",
  "strum",
  "thiserror 2.0.19",
@@ -3006,6 +3055,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "hostname-validator"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3076,6 +3134,16 @@ checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
 dependencies = [
  "humantime",
  "serde",
+]
+
+[[package]]
+name = "hunspell-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9228605394e47acb7e5c20da4f9d8d5175fd767230e51d3095623bc5e20b7dec"
+dependencies = [
+ "bindgen",
+ "pkg-config",
 ]
 
 [[package]]
@@ -3987,6 +4055,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "leb128fmt"
@@ -5259,6 +5333,12 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem-rfc7468"
@@ -7063,6 +7143,20 @@ dependencies = [
  "web-sys",
  "windows-sys 0.61.2",
  "x11rb",
+]
+
+[[package]]
+name = "spellkit"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fab7dba33b814b2d6259f9451a26c5bb72f3b6720075df5138bf33be3612470"
+dependencies = [
+ "cfg-if",
+ "hunspell-sys",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -9906,6 +10000,18 @@ dependencies = [
  "log",
  "raw-window-handle",
  "web-sys",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ percent-encoding = { workspace = true }
 data = { version = "0.1.0", path = "data" }
 ipc = { version = "0.1.0", path = "ipc" }
 irc = { version = "0.1.0", path = "irc" }
+spellkit = "0.3"
 
 signal-hook = "0.3.18"
 notify-rust = { version = "4.18", features = [ "images" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ percent-encoding = { workspace = true }
 data = { version = "0.1.0", path = "data" }
 ipc = { version = "0.1.0", path = "ipc" }
 irc = { version = "0.1.0", path = "irc" }
+spellkit = "0.4"
 
 signal-hook = "0.3.18"
 notify-rust = { version = "4.18", features = [ "images" ] }

--- a/data/src/appearance/theme.rs
+++ b/data/src/appearance/theme.rs
@@ -323,6 +323,7 @@ pub struct Text {
     pub info: OptionalTextStyle,
     pub debug: OptionalTextStyle,
     pub trace: OptionalTextStyle,
+    pub spellcheck_misspelled: OptionalTextStyle,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
@@ -908,6 +909,7 @@ mod binary {
         BufferFocusBorder = 60,
         BufferFocusBackground = 61,
         BufferSelfMessage = 62,
+        TextSpellcheckMisspelled = 63,
     }
 
     impl Tag {
@@ -927,6 +929,9 @@ mod binary {
                 Tag::TextError => styles.text.error.color,
                 Tag::TextWarning => styles.text.warning.color?,
                 Tag::TextInfo => styles.text.info.color?,
+                Tag::TextSpellcheckMisspelled => {
+                    styles.text.spellcheck_misspelled.color?
+                }
                 Tag::TextDebug => styles.text.debug.color?,
                 Tag::TextTrace => styles.text.trace.color?,
                 Tag::BufferAction => styles.buffer.action.color,
@@ -1065,6 +1070,9 @@ mod binary {
                 Tag::TextError => styles.text.error.color = color,
                 Tag::TextWarning => styles.text.warning.color = Some(color),
                 Tag::TextInfo => styles.text.info.color = Some(color),
+                Tag::TextSpellcheckMisspelled => {
+                    styles.text.spellcheck_misspelled.color = Some(color);
+                }
                 Tag::TextDebug => styles.text.debug.color = Some(color),
                 Tag::TextTrace => styles.text.trace.color = Some(color),
                 Tag::BufferAction => styles.buffer.action.color = color,

--- a/data/src/appearance/theme.rs
+++ b/data/src/appearance/theme.rs
@@ -265,6 +265,7 @@ pub struct Text {
     pub info: OptionalTextStyle,
     pub debug: OptionalTextStyle,
     pub trace: OptionalTextStyle,
+    pub spellcheck_misspelled: OptionalTextStyle,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
@@ -847,6 +848,7 @@ mod binary {
         BufferServerMessagesRequestTopic = 57,
         ButtonsPrimaryBorderActive = 58,
         ButtonsSecondaryBorderActive = 59,
+        TextSpellcheckMisspelled = 60,
     }
 
     impl Tag {
@@ -866,6 +868,9 @@ mod binary {
                 Tag::TextError => styles.text.error.color,
                 Tag::TextWarning => styles.text.warning.color?,
                 Tag::TextInfo => styles.text.info.color?,
+                Tag::TextSpellcheckMisspelled => {
+                    styles.text.spellcheck_misspelled.color?
+                }
                 Tag::TextDebug => styles.text.debug.color?,
                 Tag::TextTrace => styles.text.trace.color?,
                 Tag::BufferAction => styles.buffer.action.color,
@@ -1001,6 +1006,9 @@ mod binary {
                 Tag::TextError => styles.text.error.color = color,
                 Tag::TextWarning => styles.text.warning.color = Some(color),
                 Tag::TextInfo => styles.text.info.color = Some(color),
+                Tag::TextSpellcheckMisspelled => {
+                    styles.text.spellcheck_misspelled.color = Some(color);
+                }
                 Tag::TextDebug => styles.text.debug.color = Some(color),
                 Tag::TextTrace => styles.text.trace.color = Some(color),
                 Tag::BufferAction => styles.buffer.action.color = color,

--- a/data/src/config/buffer/text_input.rs
+++ b/data/src/config/buffer/text_input.rs
@@ -16,6 +16,7 @@ pub struct TextInput {
     pub max_lines: usize,
     pub send_line_delay: u64,
     pub persist: bool,
+    pub spellcheck: Spellcheck,
 }
 
 impl Default for TextInput {
@@ -30,6 +31,25 @@ impl Default for TextInput {
             max_lines: 5,
             send_line_delay: 100,
             persist: true,
+            spellcheck: Spellcheck::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct Spellcheck {
+    pub enabled: bool,
+    pub suggestions: bool,
+    pub locale: Option<String>,
+}
+
+impl Default for Spellcheck {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            suggestions: true,
+            locale: None,
         }
     }
 }

--- a/docs/configuration/buffer.md
+++ b/docs/configuration/buffer.md
@@ -1320,6 +1320,60 @@ If enabled, saves unsent messages on disk.
 persist = true
 ```
 
+### `spellcheck`
+
+Spellcheck for the message input. Misspelled words are highlighted using the theme's `text.spellcheck_misspelled` style (see [Custom themes](/guides/custom-themes)).
+
+When that style is unset, misspelled words use `text.error` in italic.
+
+Halloy uses the platform spellchecker (system APIs on Windows and macOS; Hunspell dictionaries on other Unix-like systems). If no dictionary is available, spellcheck does nothing (a warning may be logged).
+
+Words are not marked as misspelled when they are:
+
+- a channel name (text after a channel prefix such as `#`)
+- your own nick
+- a nick present in the current channel
+- the peer nick in a query
+
+#### `enabled`
+
+Enable spellcheck in the text input.
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: false
+
+[buffer.text_input.spellcheck]
+enabled = true
+```
+
+#### `suggestions`
+
+When enabled, place the caret in a misspelled word and press <kbd>Tab</kbd> / <kbd>Shift</kbd>+<kbd>Tab</kbd> to cycle replacement suggestions (then back to the original spelling). Nickname and command autocomplete still take priority: spell suggestions run only when autocomplete does not produce a candidate.
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: true
+
+[buffer.text_input.spellcheck]
+suggestions = true
+```
+
+#### `locale`
+
+Dictionary locale for the spellchecker. When unset, the system/default locale is used.
+
+```toml
+# Type: string
+# Values: locale id string (e.g. "en-US"), or omit
+# Default: unset (system/default)
+
+[buffer.text_input.spellcheck]
+locale = "en-US"
+```
+
 ### `autocomplete`
 
 Customize autocomplete.

--- a/docs/configuration/buffer.md
+++ b/docs/configuration/buffer.md
@@ -1364,6 +1364,60 @@ If enabled, saves unsent messages on disk.
 persist = true
 ```
 
+### `spellcheck`
+
+Spellcheck for the message input. Misspelled words are highlighted using the theme's `text.spellcheck_misspelled` style (see [Custom themes](/guides/custom-themes)).
+
+When that style is unset, misspelled words use `text.error` in italic.
+
+Halloy uses the platform spellchecker (system APIs on Windows and macOS; Hunspell dictionaries on other Unix-like systems). If no dictionary is available, spellcheck does nothing (a warning may be logged).
+
+Words are not marked as misspelled when they are:
+
+- a channel name (text after a channel prefix such as `#`)
+- your own nick
+- a nick present in the current channel
+- the peer nick in a query
+
+#### `enabled`
+
+Enable spellcheck in the text input.
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: false
+
+[buffer.text_input.spellcheck]
+enabled = true
+```
+
+#### `suggestions`
+
+When enabled, place the caret in a misspelled word and press <kbd>Tab</kbd> / <kbd>Shift</kbd>+<kbd>Tab</kbd> to cycle replacement suggestions (then back to the original spelling). Nickname and command autocomplete still take priority: spell suggestions run only when autocomplete does not produce a candidate.
+
+```toml
+# Type: boolean
+# Values: true, false
+# Default: true
+
+[buffer.text_input.spellcheck]
+suggestions = true
+```
+
+#### `locale`
+
+Dictionary locale for the spellchecker. When unset, the system/default locale is used.
+
+```toml
+# Type: string
+# Values: locale id string (e.g. "en-US"), or omit
+# Default: unset (system/default)
+
+[buffer.text_input.spellcheck]
+locale = "en-US"
+```
+
 ### `autocomplete`
 
 Customize autocomplete.

--- a/docs/guides/custom-themes.md
+++ b/docs/guides/custom-themes.md
@@ -21,7 +21,8 @@ Halloy has a built in theme editor which makes theme creation easier
  string>"`), or table ("`{ color = "<color string>", font_style = "<font style
  string>" }`") with entries for `color` (valid hex color string) and
  `font_style` (valid font style string; `"normal"`, `"italic"`, `"bold"`, or
- `"italic-bold"`).
+ `"italic-bold"`). `spellcheck_misspelled` is optional. If `color` or `font_style`
+ is omitted, falls back to `text.error` + italic for misspelled input words.
 
  A custom theme is structured as follows:
 
@@ -45,6 +46,7 @@ warning = <text style>
 info = <text style>
 debug = <text style>
 trace = <text style>
+spellcheck_misspelled = <text style>
 
 [buttons.primary]
 background = "<color string>"

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -784,7 +784,9 @@ impl Buffer {
     pub fn insert_user_to_input(
         &mut self,
         nick: Nick,
+        clients: &data::client::Map,
         history: &mut history::Manager,
+        config: &Config,
         autocomplete: &Autocomplete,
     ) {
         match self {
@@ -798,18 +800,24 @@ impl Buffer {
             Buffer::Server(state) => state.input_view.insert_user(
                 nick,
                 state.buffer.clone(),
+                clients,
+                config,
                 history,
                 autocomplete,
             ),
             Buffer::Channel(state) => state.input_view.insert_user(
                 nick,
                 state.buffer.clone(),
+                clients,
+                config,
                 history,
                 autocomplete,
             ),
             Buffer::Query(state) => state.input_view.insert_user(
                 nick,
                 state.buffer.clone(),
+                clients,
+                config,
                 history,
                 autocomplete,
             ),
@@ -1293,6 +1301,7 @@ impl Buffer {
 
     pub fn clear_draft_reply(
         &mut self,
+        clients: &data::client::Map,
         history: &mut history::Manager,
         config: &Config,
     ) -> bool {
@@ -1306,16 +1315,19 @@ impl Buffer {
             | Buffer::ConfigEditor(_) => false,
             Buffer::Server(state) => state.input_view.clear_draft_reply(
                 &state.buffer,
+                clients,
                 history,
                 config,
             ),
             Buffer::Channel(state) => state.input_view.clear_draft_reply(
                 &state.buffer,
+                clients,
                 history,
                 config,
             ),
             Buffer::Query(state) => state.input_view.clear_draft_reply(
                 &state.buffer,
+                clients,
                 history,
                 config,
             ),

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -796,7 +796,9 @@ impl Buffer {
     pub fn insert_user_to_input(
         &mut self,
         nick: Nick,
+        clients: &data::client::Map,
         history: &mut history::Manager,
+        config: &Config,
         autocomplete: &Autocomplete,
     ) {
         match self {
@@ -810,18 +812,24 @@ impl Buffer {
             Buffer::Server(state) => state.input_view.insert_user(
                 nick,
                 state.buffer.clone(),
+                clients,
+                config,
                 history,
                 autocomplete,
             ),
             Buffer::Channel(state) => state.input_view.insert_user(
                 nick,
                 state.buffer.clone(),
+                clients,
+                config,
                 history,
                 autocomplete,
             ),
             Buffer::Query(state) => state.input_view.insert_user(
                 nick,
                 state.buffer.clone(),
+                clients,
+                config,
                 history,
                 autocomplete,
             ),
@@ -1303,6 +1311,7 @@ impl Buffer {
 
     pub fn clear_draft_reply(
         &mut self,
+        clients: &data::client::Map,
         history: &mut history::Manager,
         config: &Config,
     ) -> bool {
@@ -1316,16 +1325,19 @@ impl Buffer {
             | Buffer::ConfigEditor(_) => false,
             Buffer::Server(state) => state.input_view.clear_draft_reply(
                 &state.buffer,
+                clients,
                 history,
                 config,
             ),
             Buffer::Channel(state) => state.input_view.clear_draft_reply(
                 &state.buffer,
+                clients,
                 history,
                 config,
             ),
             Buffer::Query(state) => state.input_view.clear_draft_reply(
                 &state.buffer,
+                clients,
                 history,
                 config,
             ),

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -1,10 +1,13 @@
 use std::borrow::Cow;
+use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::convert;
+use std::ops::Range;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
+use data::appearance::theme::FontStyle;
 use data::buffer::{self, Upstream};
 use data::capabilities::{MultilineBatchKind, multiline_concat_lines};
 use data::config::buffer::text_input::{AutoFormat, Autocomplete, KeyBindings};
@@ -18,6 +21,8 @@ use data::target::Target;
 use data::user::{ChannelUsers, Nick};
 use data::{Config, User, client, command, message, metadata, shortcut};
 use iced::Length::Fit;
+use iced::advanced::text::Highlighter;
+use iced::advanced::text::highlighter::Format;
 use iced::advanced::widget::Tree;
 use iced::advanced::{Layout, Shell, mouse};
 use iced::keyboard::{Key, key};
@@ -26,7 +31,9 @@ use iced::widget::{
     self, Space, button, center, column, container, mouse_area, operation, row,
     rule, text_editor,
 };
-use iced::{Alignment, Length, Task, clipboard, event, keyboard, padding};
+use iced::{
+    Alignment, Font, Length, Task, clipboard, event, keyboard, padding,
+};
 use itertools::Itertools;
 use tokio::time;
 use unicode_segmentation::UnicodeSegmentation;
@@ -45,6 +52,22 @@ use crate::{Theme, font, theme};
 
 mod completion;
 mod exec;
+
+// Platform spellchecker is not `Send`; keep one instance per UI thread.
+thread_local! {
+    static SPELL_CHECKER: RefCell<Option<SpellCheckerSlot>> =
+        const { RefCell::new(None) };
+}
+
+enum SpellCheckerSlot {
+    Ready {
+        locale: Option<String>,
+        checker: spellkit::Checker,
+    },
+    Failed {
+        locale: Option<String>,
+    },
+}
 
 const TYPING_REFRESH_INTERVAL: Duration = Duration::from_secs(4);
 
@@ -342,6 +365,21 @@ pub fn view<'a>(
                 _ => text_editor::Binding::from_key_press(key_press),
             }
         });
+
+    let text_input = text_input.highlight_with::<SpellHighlighter>(
+        SpellSettings {
+            errors_by_line: spell_errors_by_line(
+                &state.input_content.text(),
+                &state.spell_errors,
+                line_col_to_byte(
+                    &state.input_content,
+                    state.input_content.cursor().position.line,
+                    state.input_content.cursor().position.column,
+                ),
+            ),
+        },
+        spell_token_format,
+    );
 
     let text_input = decorate(text_input).update(
         move |_state: &mut State,
@@ -717,6 +755,8 @@ pub struct State {
     upload_abort_handles: Vec<futures::future::AbortHandle>,
     draft_reply: Option<input::DraftReply>,
     reply_preview: Option<message::ReplyPreview>,
+    spell_errors: Vec<SpellError>,
+    spell_suggestions: Option<SpellSuggestionSession>,
 }
 
 impl Default for State {
@@ -736,6 +776,8 @@ impl Default for State {
             upload_abort_handles: Vec::new(),
             draft_reply: None,
             reply_preview: None,
+            spell_errors: Vec::new(),
+            spell_suggestions: None,
         }
     }
 }
@@ -765,8 +807,238 @@ impl State {
         };
 
         state.process_completion_and_notice(buffer, clients, history, config);
+        state.refresh_spell_errors(buffer, clients, config);
 
         state
+    }
+
+    fn refresh_spell_errors(
+        &mut self,
+        buffer: &buffer::Upstream,
+        clients: &client::Map,
+        config: &Config,
+    ) {
+        self.spell_errors.clear();
+        let spell = &config.buffer.text_input.spellcheck;
+        if !spell.enabled {
+            self.spell_suggestions = None;
+            SPELL_CHECKER.with(|slot| {
+                *slot.borrow_mut() = None;
+            });
+            return;
+        }
+
+        let chantypes =
+            clients.get_server_chantypes_or_default(buffer.server());
+        let casemapping =
+            clients.get_server_casemapping_or_default(buffer.server());
+        let own_nick = clients.nickname(buffer.server());
+        let channel_users = match buffer {
+            buffer::Upstream::Channel(server, channel) => {
+                clients.get_channel_users(server, channel)
+            }
+            _ => None,
+        };
+        let query_peer = match buffer {
+            buffer::Upstream::Query(_, query) => {
+                Some(query.as_normalized_str())
+            }
+            _ => None,
+        };
+
+        let locale = spell.locale.clone();
+        let text = self.input_content.text();
+        SPELL_CHECKER.with(|slot| {
+            {
+                let mut slot = slot.borrow_mut();
+                let needs_new = match slot.as_ref() {
+                    None => true,
+                    Some(SpellCheckerSlot::Ready {
+                        locale: cached, ..
+                    })
+                    | Some(SpellCheckerSlot::Failed { locale: cached }) => {
+                        cached != &locale
+                    }
+                };
+                if needs_new {
+                    let result = match locale.as_deref() {
+                        Some(locale) => spellkit::Checker::with_locale(locale),
+                        None => spellkit::Checker::new(),
+                    };
+                    match result {
+                        Ok(checker) => {
+                            *slot = Some(SpellCheckerSlot::Ready {
+                                locale,
+                                checker,
+                            });
+                        }
+                        Err(err) => {
+                            self.spell_suggestions = None;
+                            log::warn!("spellcheck unavailable: {err}");
+                            *slot = Some(SpellCheckerSlot::Failed { locale });
+                            return;
+                        }
+                    }
+                }
+            }
+            let slot = slot.borrow();
+            let Some(SpellCheckerSlot::Ready { checker, .. }) = slot.as_ref()
+            else {
+                return;
+            };
+            for err in checker.check(&text) {
+                if is_irc_spell_skip(
+                    &text,
+                    err.start(),
+                    err.text(),
+                    chantypes,
+                    casemapping,
+                    own_nick,
+                    channel_users,
+                    query_peer,
+                ) {
+                    continue;
+                }
+                self.spell_errors.push(SpellError {
+                    start: err.start(),
+                    end: err.end(),
+                });
+            }
+        });
+    }
+
+    fn after_text_mutation(
+        &mut self,
+        buffer: &buffer::Upstream,
+        clients: &client::Map,
+        config: &Config,
+    ) {
+        self.spell_suggestions = None;
+        self.refresh_spell_errors(buffer, clients, config);
+    }
+
+    fn clear_spell_suggestions_if_left(&mut self) {
+        let Some(session) = self.spell_suggestions.as_ref() else {
+            return;
+        };
+        let text = self.input_content.text();
+        let pos = self.input_content.cursor().position;
+        let cursor_byte =
+            line_col_to_byte(&self.input_content, pos.line, pos.column);
+        if !spell_cursor_targets_range(
+            &text,
+            cursor_byte,
+            session.start,
+            session.end,
+        ) {
+            self.spell_suggestions = None;
+        }
+    }
+
+    fn cycle_spell_suggestions(
+        &mut self,
+        reverse: bool,
+        buffer: &buffer::Upstream,
+        clients: &client::Map,
+        history: &mut history::Manager,
+        config: &Config,
+    ) -> bool {
+        if !config.buffer.text_input.spellcheck.enabled
+            || !config.buffer.text_input.spellcheck.suggestions
+        {
+            self.spell_suggestions = None;
+            return false;
+        }
+
+        let text = self.input_content.text();
+        let pos = self.input_content.cursor().position;
+        let cursor_byte =
+            line_col_to_byte(&self.input_content, pos.line, pos.column);
+
+        let in_session = self.spell_suggestions.as_ref().is_some_and(|s| {
+            spell_cursor_targets_range(&text, cursor_byte, s.start, s.end)
+        });
+
+        if !in_session {
+            let Some(err) =
+                spell_error_for_cursor(&text, cursor_byte, &self.spell_errors)
+            else {
+                self.spell_suggestions = None;
+                return false;
+            };
+
+            let start = err.start;
+            let end = err.end;
+            let original = text[start..end].to_string();
+            let suggestions =
+                SPELL_CHECKER.with(|slot| match slot.borrow().as_ref() {
+                    Some(SpellCheckerSlot::Ready { checker, .. }) => {
+                        checker.suggest(&original)
+                    }
+                    _ => Vec::new(),
+                });
+            if suggestions.is_empty() {
+                self.spell_suggestions = None;
+                return false;
+            }
+
+            let index = suggestions.len();
+            self.spell_suggestions = Some(SpellSuggestionSession {
+                start,
+                end,
+                original,
+                suggestions,
+                index,
+            });
+        }
+        let session = self.spell_suggestions.as_mut().unwrap();
+        let count = session.suggestions.len() + 1;
+        session.index = if reverse {
+            (session.index + count - 1) % count
+        } else {
+            (session.index + 1) % count
+        };
+
+        let replacement = if session.index < session.suggestions.len() {
+            session.suggestions[session.index].clone()
+        } else {
+            session.original.clone()
+        };
+
+        let start = session.start;
+        let end = session.end;
+        let old = &text[start..end];
+        let char_start =
+            UnicodeSegmentation::graphemes(&text[..start], true).count();
+        let char_len = UnicodeSegmentation::graphemes(old, true).count();
+        let replaced =
+            format!("{}{}{}", &text[..start], replacement, &text[end..]);
+        let delta = UnicodeSegmentation::graphemes(replacement.as_str(), true)
+            .count() as i64
+            - char_len as i64;
+
+        let cursor = adjust_cursor(
+            &self.input_content,
+            &replaced,
+            char_start,
+            char_len,
+            delta,
+        );
+        self.input_content = text_editor::Content::with_text(&replaced);
+        self.input_content.move_to(cursor);
+
+        if let Some(session) = self.spell_suggestions.as_mut() {
+            session.end = start + replacement.len();
+        }
+
+        history.record_draft(RawInput {
+            buffer: buffer.clone(),
+            text: self.input_content.text(),
+            reply: self.draft_reply.clone(),
+        });
+        self.refresh_spell_errors(buffer, clients, config);
+
+        true
     }
 
     pub fn draft_reply(&self) -> Option<&input::DraftReply> {
@@ -945,7 +1217,9 @@ impl State {
                         config,
                     );
 
-                    self.on_completion(buffer, history, actions, true)
+                    self.on_completion(
+                        buffer, clients, history, config, actions, true,
+                    )
                 // IRCv3 draft/multiline forbids messages consisting
                 // entirely of blank lines, so we will take that as an
                 // IRC norm and require the same
@@ -1014,6 +1288,8 @@ impl State {
                         self.input_content.text().clone(),
                     );
                     self.input_content = text_editor::Content::new();
+                    self.spell_suggestions = None;
+                    self.spell_errors.clear();
                     self.reset_typing();
 
                     let lines = self
@@ -1048,8 +1324,9 @@ impl State {
                         config,
                     );
 
-                    let result =
-                        self.on_completion(buffer, history, actions, true);
+                    let result = self.on_completion(
+                        buffer, clients, history, config, actions, true,
+                    );
 
                     // If there is only one tab candidate process the completion immediately.
                     if self
@@ -1063,6 +1340,9 @@ impl State {
                     }
                     result
                 } else {
+                    let _ = self.cycle_spell_suggestions(
+                        reverse, buffer, clients, history, config,
+                    );
                     (Task::none(), None)
                 }
             }
@@ -1081,8 +1361,9 @@ impl State {
                         config,
                     );
 
-                    let result =
-                        self.on_completion(buffer, history, actions, true);
+                    let result = self.on_completion(
+                        buffer, clients, history, config, actions, true,
+                    );
                     self.process_completion_and_notice(
                         buffer, clients, history, config,
                     );
@@ -1194,7 +1475,7 @@ impl State {
                 if self.close_picker() {
                     return (Task::none(), None);
                 }
-                if self.clear_draft_reply(buffer, history, config) {
+                if self.clear_draft_reply(buffer, clients, history, config) {
                     return (self.focus(), None);
                 }
                 (Task::none(), None)
@@ -1263,7 +1544,7 @@ impl State {
                         self.input_content.perform(text_editor::Action::Edit(
                             text_editor::Edit::Delete,
                         ));
-
+                        self.after_text_mutation(buffer, clients, config);
                         clipboard::write(selection.to_string()).discard()
                     } else {
                         Task::none()
@@ -1453,11 +1734,12 @@ impl State {
                     );
                 }
 
+                self.after_text_mutation(buffer, clients, config);
                 (self.focus(), None)
             }
             Message::ClearDraftReply => {
-                let _ = self.clear_draft_reply(buffer, history, config);
-
+                let _ =
+                    self.clear_draft_reply(buffer, clients, history, config);
                 (self.focus(), None)
             }
             Message::FilehostUploadDone { id, url } => {
@@ -1475,7 +1757,7 @@ impl State {
                     text: self.input_content.text(),
                     reply: self.draft_reply.clone(),
                 });
-
+                self.after_text_mutation(buffer, clients, config);
                 (Task::none(), None)
             }
             Message::Kill(kill, save_to_clipboard) => {
@@ -1485,7 +1767,7 @@ impl State {
                     save_to_clipboard,
                     config.buffer.text_input.kill_to_clipboard,
                 );
-
+                self.after_text_mutation(buffer, clients, config);
                 (task, None)
             }
             Message::Action(action) => {
@@ -1518,6 +1800,8 @@ impl State {
 
                 match &action {
                     text_editor::Action::Edit(_) => {
+                        self.after_text_mutation(buffer, clients, config);
+
                         self.parse_lines_and_maybe_send_typing_status(
                             buffer, clients, config,
                         );
@@ -1593,6 +1877,8 @@ impl State {
                     | text_editor::Action::SelectWord
                     | text_editor::Action::SelectLine
                     | text_editor::Action::SelectAll => {
+                        self.clear_spell_suggestions_if_left();
+                        self.refresh_spell_errors(buffer, clients, config);
                         self.process_completion_and_notice(
                             buffer, clients, history, config,
                         );
@@ -2554,7 +2840,9 @@ impl State {
     fn on_completion(
         &mut self,
         buffer: &buffer::Upstream,
+        clients: &client::Map,
         history: &mut history::Manager,
+        config: &Config,
         actions: Vec<text_editor::Action>,
         record_draft: bool,
     ) -> (Task<Message>, Option<Event>) {
@@ -2570,6 +2858,7 @@ impl State {
             });
         }
 
+        self.after_text_mutation(buffer, clients, config);
         (Task::none(), None)
     }
 
@@ -2601,6 +2890,7 @@ impl State {
 
         // Cursor movement above does not always trigger an Action::Move
         self.process_completion_and_notice(buffer, clients, history, config);
+        self.after_text_mutation(buffer, clients, config);
 
         (Task::none(), None)
     }
@@ -2627,6 +2917,8 @@ impl State {
         &mut self,
         nick: Nick,
         buffer: buffer::Upstream,
+        clients: &client::Map,
+        config: &Config,
         history: &mut history::Manager,
         autocomplete: &Autocomplete,
     ) {
@@ -2682,6 +2974,8 @@ impl State {
             text_editor::Edit::Paste(std::sync::Arc::new(insert_text)),
         ));
 
+        self.after_text_mutation(&buffer, clients, config);
+
         history.record_draft(RawInput {
             buffer,
             text: self.input_content.text(),
@@ -2696,6 +2990,7 @@ impl State {
     pub fn clear_draft_reply(
         &mut self,
         buffer: &buffer::Upstream,
+        clients: &client::Map,
         history: &mut history::Manager,
         config: &Config,
     ) -> bool {
@@ -2735,6 +3030,7 @@ impl State {
                 reply: None,
             });
 
+            self.after_text_mutation(buffer, clients, config);
             true
         } else {
             false
@@ -2999,6 +3295,159 @@ fn line_col_to_char(
     pos
 }
 
+/// Absolute UTF-8 byte offset for a `(line, column)` cursor position.
+fn line_col_to_byte(
+    content: &text_editor::Content,
+    line: usize,
+    col: usize,
+) -> usize {
+    let text = content.text();
+    let mut offset = 0;
+    for (i, l) in text.split('\n').enumerate() {
+        if i == line {
+            return offset + col.min(l.len());
+        }
+        offset += l.len() + 1;
+    }
+    text.len()
+}
+
+fn is_spell_word_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '\''
+}
+
+// Word run under/before the caret (alphanumeric / apostrophe, same as spellkit).
+// Caret at the end of a word counts as still in that word (so it stays unmarked).
+fn spell_word_bounds_at(text: &str, byte: usize) -> Option<(usize, usize)> {
+    let byte = byte.min(text.len());
+    let anchor = if byte > 0
+        && text[..byte]
+            .chars()
+            .next_back()
+            .is_some_and(is_spell_word_char)
+    {
+        byte - text[..byte].chars().next_back().map_or(0, char::len_utf8)
+    } else if byte < text.len()
+        && text[byte..].chars().next().is_some_and(is_spell_word_char)
+    {
+        byte
+    } else {
+        return None;
+    };
+
+    let mut start = anchor;
+    while start > 0 {
+        let Some(c) = text[..start].chars().next_back() else {
+            break;
+        };
+        if !is_spell_word_char(c) {
+            break;
+        }
+        start -= c.len_utf8();
+    }
+
+    let mut end = anchor;
+    for c in text[anchor..].chars() {
+        if !is_spell_word_char(c) {
+            break;
+        }
+        end += c.len_utf8();
+    }
+
+    (start < end).then_some((start, end))
+}
+
+fn should_hide_spell_highlight(
+    text: &str,
+    error: &SpellError,
+    open_word: Option<(usize, usize)>,
+) -> bool {
+    let Some((open_start, open_end)) = open_word else {
+        return false;
+    };
+    if error.start >= open_end || error.end <= open_start {
+        return false;
+    }
+    !spell_word_terminated(text, open_end)
+}
+
+fn spell_word_terminated(text: &str, word_end: usize) -> bool {
+    word_end < text.len()
+        && text[word_end..]
+            .chars()
+            .next()
+            .is_some_and(|c| !is_spell_word_char(c))
+}
+
+/// True when caret is inside `[start, end]` or in the non-word gap immediately after
+/// that range (before the next word starts) — enables Tab after `"typo "`.
+fn spell_cursor_targets_range(
+    text: &str,
+    cursor: usize,
+    start: usize,
+    end: usize,
+) -> bool {
+    if cursor >= start && cursor <= end {
+        return true;
+    }
+    if cursor < end || end > text.len() || start > end {
+        return false;
+    }
+    text[end..cursor.min(text.len())]
+        .chars()
+        .all(|c| !is_spell_word_char(c))
+}
+
+fn spell_error_for_cursor<'a>(
+    text: &str,
+    cursor: usize,
+    errors: &'a [SpellError],
+) -> Option<&'a SpellError> {
+    errors
+        .iter()
+        .filter(|e| spell_cursor_targets_range(text, cursor, e.start, e.end))
+        .max_by_key(|e| e.end)
+}
+
+fn is_irc_spell_skip(
+    text: &str,
+    start: usize,
+    word: &str,
+    chantypes: &[char],
+    casemapping: data::isupport::CaseMap,
+    own_nick: Option<data::user::NickRef<'_>>,
+    channel_users: Option<&ChannelUsers>,
+    query_peer_normalized: Option<&str>,
+) -> bool {
+    // "#channel" → spellkit word is "channel"; prefix sits just before `start`
+    if start > 0
+        && text[..start]
+            .chars()
+            .next_back()
+            .is_some_and(|c| chantypes.contains(&c))
+    {
+        return true;
+    }
+
+    let nick = Nick::from_str(word, casemapping);
+    let nick_ref = nick.as_nickref();
+
+    if own_nick.is_some_and(|own| own == nick_ref) {
+        return true;
+    }
+    if channel_users.is_some_and(|users| users.get_by_nick(nick_ref).is_some())
+    {
+        return true;
+    }
+    if query_peer_normalized
+        .is_some_and(|peer| peer == nick.as_normalized_str())
+    {
+        return true;
+    }
+
+    false
+}
+
 /// Converts a flat grapheme-cluster offset back to a `(line, col)` position.
 ///
 /// `start_pos` is the number of grapheme clusters from the start of `text`.
@@ -3185,6 +3634,143 @@ fn reset_undo_history(content: &mut text_editor::Content) {
 
     *content = text_editor::Content::with_text(&text);
     content.move_to(cursor);
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct SpellSettings {
+    errors_by_line: Vec<Vec<(usize, usize, SpellHighlight)>>,
+}
+
+#[derive(Debug, Clone)]
+struct SpellError {
+    start: usize,
+    end: usize,
+}
+
+#[derive(Debug, Clone)]
+struct SpellSuggestionSession {
+    start: usize,
+    end: usize,
+    original: String,
+    suggestions: Vec<String>,
+    index: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SpellHighlight {
+    Misspelled,
+}
+
+fn spell_token_format(
+    highlight: &SpellHighlight,
+    theme: &Theme,
+) -> Format<Font> {
+    let styles = theme.styles();
+    match highlight {
+        SpellHighlight::Misspelled => Format {
+            color: Some(
+                styles
+                    .text
+                    .spellcheck_misspelled
+                    .color
+                    .unwrap_or(styles.text.error.color),
+            ),
+            font: Some(
+                font::get(
+                    styles
+                        .text
+                        .spellcheck_misspelled
+                        .font_style
+                        .unwrap_or(FontStyle::Italic),
+                )
+                .into(),
+            ),
+        },
+    }
+}
+
+fn spell_errors_by_line(
+    text: &str,
+    errors: &[SpellError],
+    cursor_byte: usize,
+) -> Vec<Vec<(usize, usize, SpellHighlight)>> {
+    let open_word = spell_word_bounds_at(text, cursor_byte);
+    let mut by_line = Vec::new();
+    let mut line_start = 0usize;
+
+    for line in text.split('\n') {
+        let line_end = line_start + line.len();
+        let mut line_errors = Vec::new();
+
+        for error in errors {
+            if should_hide_spell_highlight(text, error, open_word) {
+                continue;
+            }
+            if error.end > line_start && error.start < line_end {
+                let local_start =
+                    error.start.saturating_sub(line_start).min(line.len());
+                let local_end =
+                    error.end.saturating_sub(line_start).min(line.len());
+                if local_start < local_end {
+                    line_errors.push((
+                        local_start,
+                        local_end,
+                        SpellHighlight::Misspelled,
+                    ));
+                }
+            }
+        }
+
+        by_line.push(line_errors);
+        line_start = line_end + 1; // skip '\n'
+    }
+
+    by_line
+}
+
+struct SpellHighlighter {
+    current_line: usize,
+    errors_by_line: Vec<Vec<(usize, usize, SpellHighlight)>>,
+}
+
+impl Highlighter for SpellHighlighter {
+    type Settings = SpellSettings;
+    type Highlight = SpellHighlight;
+    type Iterator<'a> =
+        Box<dyn Iterator<Item = (Range<usize>, Self::Highlight)> + 'a>;
+
+    fn new(settings: &Self::Settings) -> Self {
+        Self {
+            current_line: 0,
+            errors_by_line: settings.errors_by_line.clone(),
+        }
+    }
+
+    fn update(&mut self, settings: &Self::Settings) {
+        self.errors_by_line = settings.errors_by_line.clone();
+        self.current_line = 0;
+    }
+
+    fn change_line(&mut self, line: usize) {
+        self.current_line = line;
+    }
+
+    fn highlight_line(&mut self, _line: &str) -> Self::Iterator<'_> {
+        let i = self.current_line;
+        self.current_line += 1;
+
+        let errors = self.errors_by_line.get(i).cloned().unwrap_or_default();
+
+        Box::new(
+            errors
+                .into_iter()
+                .map(|(start, end, highlight)| (start..end, highlight)),
+        )
+    }
+
+    fn current_line(&self) -> usize {
+        self.current_line
+    }
 }
 
 #[cfg(test)]
@@ -3413,5 +3999,52 @@ mod tests {
                 "text: {ghost_prefix}{ghost}{ghost_suffix} url: {url} motion: {motion}"
             );
         }
+    }
+
+    #[test]
+    fn spell_word_bounds_at_end_of_word() {
+        assert_eq!(spell_word_bounds_at("hello ", 5), Some((0, 5)));
+    }
+
+    const MISSPELLED: &str = "worng"; // spellchecker:disable-line
+
+    #[test]
+    fn spell_word_terminated_after_space() {
+        assert!(spell_word_terminated(&format!("{MISSPELLED} next"), 5));
+        assert!(!spell_word_terminated(MISSPELLED, 5));
+        assert!(spell_word_terminated(&format!("{MISSPELLED},"), 5));
+    }
+
+    #[test]
+    fn should_hide_only_in_progress_open_word() {
+        let err = SpellError { start: 0, end: 5 };
+        // incomplete at start - show
+        assert!(should_hide_spell_highlight(MISSPELLED, &err, Some((0, 5))));
+        // completed word, click back in - show
+        assert!(!should_hide_spell_highlight(
+            &format!("{MISSPELLED} next"),
+            &err,
+            Some((0, 5)),
+        ));
+        // caret after word - typo still shown
+        assert!(!should_hide_spell_highlight(
+            &format!("{MISSPELLED} next"),
+            &err,
+            Some((6, 10)),
+        ));
+    }
+
+    #[test]
+    fn is_irc_spell_skip_channel_name() {
+        assert!(is_irc_spell_skip(
+            "#halloy",
+            1,
+            "halloy",
+            &['#'],
+            data::isupport::CaseMap::default(),
+            None,
+            None,
+            None,
+        ));
     }
 }

--- a/src/buffer/input_view.rs
+++ b/src/buffer/input_view.rs
@@ -1,10 +1,13 @@
 use std::borrow::Cow;
+use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::convert;
+use std::ops::Range;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
+use data::appearance::theme::FontStyle;
 use data::buffer::{self, Upstream};
 use data::capabilities::{MultilineBatchKind, multiline_concat_lines};
 use data::config::buffer::text_input::{AutoFormat, Autocomplete, KeyBindings};
@@ -18,6 +21,8 @@ use data::target::Target;
 use data::user::{ChannelUsers, Nick};
 use data::{Config, User, client, command, message, metadata, shortcut};
 use iced::Length::Fit;
+use iced::advanced::text::Highlighter;
+use iced::advanced::text::highlighter::Format;
 use iced::advanced::widget::Tree;
 use iced::advanced::{Layout, Shell, mouse};
 use iced::keyboard::{Key, key};
@@ -26,7 +31,9 @@ use iced::widget::{
     self, Space, button, center, column, container, mouse_area, operation, row,
     rule, text_editor,
 };
-use iced::{Alignment, Length, Task, clipboard, event, keyboard, padding};
+use iced::{
+    Alignment, Font, Length, Task, clipboard, event, keyboard, padding,
+};
 use itertools::Itertools;
 use tokio::time;
 use unicode_segmentation::UnicodeSegmentation;
@@ -44,6 +51,22 @@ use crate::{Theme, font, theme};
 
 mod completion;
 mod exec;
+
+// Platform spellchecker is not `Send`; keep one instance per UI thread.
+thread_local! {
+    static SPELL_CHECKER: RefCell<Option<SpellCheckerSlot>> =
+        const { RefCell::new(None) };
+}
+
+enum SpellCheckerSlot {
+    Ready {
+        locale: Option<String>,
+        checker: spellkit::Checker,
+    },
+    Failed {
+        locale: Option<String>,
+    },
+}
 
 const TYPING_REFRESH_INTERVAL: Duration = Duration::from_secs(4);
 
@@ -326,6 +349,16 @@ pub fn view<'a>(
                 _ => text_editor::Binding::from_key_press(key_press),
             }
         });
+
+    let text_input = text_input.highlight_with::<SpellHighlighter>(
+        SpellSettings {
+            errors_by_line: spell_errors_by_line(
+                &state.input_content.text(),
+                &state.spell_errors,
+            ),
+        },
+        spell_token_format,
+    );
 
     let text_input = decorate(text_input).update(
         move |_state: &mut State,
@@ -699,6 +732,8 @@ pub struct State {
     upload_abort_handles: Vec<futures::future::AbortHandle>,
     draft_reply: Option<input::DraftReply>,
     reply_preview: Option<message::ReplyPreview>,
+    spell_errors: Vec<SpellError>,
+    spell_suggestions: Option<SpellSuggestionSession>,
 }
 
 impl Default for State {
@@ -718,6 +753,8 @@ impl Default for State {
             upload_abort_handles: Vec::new(),
             draft_reply: None,
             reply_preview: None,
+            spell_errors: Vec::new(),
+            spell_suggestions: None,
         }
     }
 }
@@ -747,8 +784,247 @@ impl State {
         };
 
         state.process_completion_and_notice(buffer, clients, history, config);
+        state.refresh_spell_errors(buffer, clients, config);
 
         state
+    }
+
+    fn refresh_spell_errors(
+        &mut self,
+        buffer: &buffer::Upstream,
+        clients: &client::Map,
+        config: &Config,
+    ) {
+        self.spell_errors.clear();
+        let spell = &config.buffer.text_input.spellcheck;
+        if !spell.enabled {
+            self.spell_suggestions = None;
+            SPELL_CHECKER.with(|slot| {
+                *slot.borrow_mut() = None;
+            });
+            return;
+        }
+
+        let chantypes =
+            clients.get_server_chantypes_or_default(buffer.server());
+        let casemapping =
+            clients.get_server_casemapping_or_default(buffer.server());
+        let own_nick = clients.nickname(buffer.server());
+        let channel_users = match buffer {
+            buffer::Upstream::Channel(server, channel) => {
+                clients.get_channel_users(server, channel)
+            }
+            _ => None,
+        };
+        let query_peer = match buffer {
+            buffer::Upstream::Query(_, query) => {
+                Some(query.as_normalized_str())
+            }
+            _ => None,
+        };
+
+        let locale = spell.locale.clone();
+        let text = self.input_content.text();
+        let pos = self.input_content.cursor().position;
+        let cursor_byte =
+            line_col_to_byte(&self.input_content, pos.line, pos.column);
+        let open_word = spell_word_bounds_at(&text, cursor_byte);
+        SPELL_CHECKER.with(|slot| {
+            {
+                let mut slot = slot.borrow_mut();
+                let needs_new = match slot.as_ref() {
+                    None => true,
+                    Some(SpellCheckerSlot::Ready {
+                        locale: cached, ..
+                    })
+                    | Some(SpellCheckerSlot::Failed { locale: cached }) => {
+                        cached != &locale
+                    }
+                };
+                if needs_new {
+                    let result = match locale.as_deref() {
+                        Some(locale) => spellkit::Checker::with_locale(locale),
+                        None => spellkit::Checker::new(),
+                    };
+                    match result {
+                        Ok(checker) => {
+                            *slot = Some(SpellCheckerSlot::Ready {
+                                locale,
+                                checker,
+                            });
+                        }
+                        Err(err) => {
+                            self.spell_suggestions = None;
+                            log::warn!("spellcheck unavailable: {err}");
+                            *slot = Some(SpellCheckerSlot::Failed { locale });
+                            return;
+                        }
+                    }
+                }
+            }
+            let slot = slot.borrow();
+            let Some(SpellCheckerSlot::Ready { checker, .. }) = slot.as_ref()
+            else {
+                return;
+            };
+            for err in checker.check(&text) {
+                if is_irc_spell_skip(
+                    &text,
+                    err.start(),
+                    err.text(),
+                    chantypes,
+                    casemapping,
+                    own_nick,
+                    channel_users,
+                    query_peer,
+                ) {
+                    continue;
+                }
+                if open_word.is_some_and(|(start, end)| {
+                    err.start() < end && err.end() > start
+                }) {
+                    continue;
+                }
+                self.spell_errors.push(SpellError {
+                    start: err.start(),
+                    end: err.end(),
+                });
+            }
+        });
+    }
+
+    fn after_text_mutation(
+        &mut self,
+        buffer: &buffer::Upstream,
+        clients: &client::Map,
+        config: &Config,
+    ) {
+        self.spell_suggestions = None;
+        self.refresh_spell_errors(buffer, clients, config);
+    }
+
+    fn clear_spell_suggestions_if_left(&mut self) {
+        let Some(session) = self.spell_suggestions.as_ref() else {
+            return;
+        };
+        let text = self.input_content.text();
+        let pos = self.input_content.cursor().position;
+        let cursor_byte =
+            line_col_to_byte(&self.input_content, pos.line, pos.column);
+        if !spell_cursor_targets_range(
+            &text,
+            cursor_byte,
+            session.start,
+            session.end,
+        ) {
+            self.spell_suggestions = None;
+        }
+    }
+
+    fn cycle_spell_suggestions(
+        &mut self,
+        reverse: bool,
+        buffer: &buffer::Upstream,
+        clients: &client::Map,
+        history: &mut history::Manager,
+        config: &Config,
+    ) -> bool {
+        if !config.buffer.text_input.spellcheck.enabled
+            || !config.buffer.text_input.spellcheck.suggestions
+        {
+            self.spell_suggestions = None;
+            return false;
+        }
+
+        let text = self.input_content.text();
+        let pos = self.input_content.cursor().position;
+        let cursor_byte =
+            line_col_to_byte(&self.input_content, pos.line, pos.column);
+
+        let in_session = self.spell_suggestions.as_ref().is_some_and(|s| {
+            spell_cursor_targets_range(&text, cursor_byte, s.start, s.end)
+        });
+
+        if !in_session {
+            let Some(err) =
+                spell_error_for_cursor(&text, cursor_byte, &self.spell_errors)
+            else {
+                self.spell_suggestions = None;
+                return false;
+            };
+
+            let start = err.start;
+            let end = err.end;
+            let original = text[start..end].to_string();
+            let suggestions =
+                SPELL_CHECKER.with(|slot| match slot.borrow().as_ref() {
+                    Some(SpellCheckerSlot::Ready { checker, .. }) => {
+                        checker.suggest(&original)
+                    }
+                    _ => Vec::new(),
+                });
+            if suggestions.is_empty() {
+                self.spell_suggestions = None;
+                return false;
+            }
+
+            let index = suggestions.len();
+            self.spell_suggestions = Some(SpellSuggestionSession {
+                start,
+                end,
+                original,
+                suggestions,
+                index,
+            });
+        }
+        let session = self.spell_suggestions.as_mut().unwrap();
+        let count = session.suggestions.len() + 1;
+        session.index = if reverse {
+            (session.index + count - 1) % count
+        } else {
+            (session.index + 1) % count
+        };
+
+        let replacement = if session.index < session.suggestions.len() {
+            session.suggestions[session.index].clone()
+        } else {
+            session.original.clone()
+        };
+
+        let start = session.start;
+        let end = session.end;
+        let old = &text[start..end];
+        let char_start =
+            UnicodeSegmentation::graphemes(&text[..start], true).count();
+        let char_len = UnicodeSegmentation::graphemes(old, true).count();
+        let replaced =
+            format!("{}{}{}", &text[..start], &replacement, &text[end..]);
+        let delta = UnicodeSegmentation::graphemes(replacement.as_str(), true)
+            .count() as i64
+            - char_len as i64;
+
+        let cursor = adjust_cursor(
+            &self.input_content,
+            &replaced,
+            char_start,
+            char_len,
+            delta,
+        );
+        self.input_content = text_editor::Content::with_text(&replaced);
+        self.input_content.move_to(cursor);
+
+        if let Some(session) = self.spell_suggestions.as_mut() {
+            session.end = start + replacement.len();
+        }
+
+        history.record_draft(RawInput {
+            buffer: buffer.clone(),
+            text: self.input_content.text(),
+            reply: self.draft_reply.clone(),
+        });
+        self.refresh_spell_errors(buffer, clients, config);
+
+        true
     }
 
     pub fn draft_reply(&self) -> Option<&input::DraftReply> {
@@ -926,7 +1202,9 @@ impl State {
                         config,
                     );
 
-                    self.on_completion(buffer, history, actions, true)
+                    self.on_completion(
+                        buffer, clients, history, config, actions, true,
+                    )
                 // IRCv3 draft/multiline forbids messages consisting
                 // entirely of blank lines, so we will take that as an
                 // IRC norm and require the same
@@ -995,6 +1273,8 @@ impl State {
                         self.input_content.text().clone(),
                     );
                     self.input_content = text_editor::Content::new();
+                    self.spell_suggestions = None;
+                    self.spell_errors.clear();
                     self.reset_typing();
 
                     let lines = self
@@ -1029,8 +1309,9 @@ impl State {
                         config,
                     );
 
-                    let result =
-                        self.on_completion(buffer, history, actions, true);
+                    let result = self.on_completion(
+                        buffer, clients, history, config, actions, true,
+                    );
 
                     // If there is only one tab candidate process the completion immediately.
                     if self
@@ -1044,6 +1325,9 @@ impl State {
                     }
                     result
                 } else {
+                    let _ = self.cycle_spell_suggestions(
+                        reverse, buffer, clients, history, config,
+                    );
                     (Task::none(), None)
                 }
             }
@@ -1062,8 +1346,9 @@ impl State {
                         config,
                     );
 
-                    let result =
-                        self.on_completion(buffer, history, actions, true);
+                    let result = self.on_completion(
+                        buffer, clients, history, config, actions, true,
+                    );
                     self.process_completion_and_notice(
                         buffer, clients, history, config,
                     );
@@ -1233,7 +1518,7 @@ impl State {
                         self.input_content.perform(text_editor::Action::Edit(
                             text_editor::Edit::Delete,
                         ));
-
+                        self.after_text_mutation(buffer, clients, config);
                         clipboard::write(selection.to_string()).discard()
                     } else {
                         Task::none()
@@ -1407,11 +1692,12 @@ impl State {
                     }
                 }
 
+                self.after_text_mutation(buffer, clients, config);
                 (self.focus(), None)
             }
             Message::ClearDraftReply => {
-                let _ = self.clear_draft_reply(buffer, history, config);
-
+                let _ =
+                    self.clear_draft_reply(buffer, clients, history, config);
                 (self.focus(), None)
             }
             Message::FilehostUploadDone { id, url } => {
@@ -1429,7 +1715,7 @@ impl State {
                     text: self.input_content.text(),
                     reply: self.draft_reply.clone(),
                 });
-
+                self.after_text_mutation(buffer, clients, config);
                 (Task::none(), None)
             }
             Message::Kill(kill, save_to_clipboard) => {
@@ -1439,7 +1725,7 @@ impl State {
                     save_to_clipboard,
                     config.buffer.text_input.kill_to_clipboard,
                 );
-
+                self.after_text_mutation(buffer, clients, config);
                 (task, None)
             }
             Message::Action(action) => {
@@ -1466,6 +1752,8 @@ impl State {
 
                 match &action {
                     text_editor::Action::Edit(_) => {
+                        self.after_text_mutation(buffer, clients, config);
+
                         self.parse_lines_and_maybe_send_typing_status(
                             buffer, clients, config,
                         );
@@ -1541,6 +1829,8 @@ impl State {
                     | text_editor::Action::SelectWord
                     | text_editor::Action::SelectLine
                     | text_editor::Action::SelectAll => {
+                        self.clear_spell_suggestions_if_left();
+                        self.refresh_spell_errors(buffer, clients, config);
                         self.process_completion_and_notice(
                             buffer, clients, history, config,
                         );
@@ -2502,7 +2792,9 @@ impl State {
     fn on_completion(
         &mut self,
         buffer: &buffer::Upstream,
+        clients: &client::Map,
         history: &mut history::Manager,
+        config: &Config,
         actions: Vec<text_editor::Action>,
         record_draft: bool,
     ) -> (Task<Message>, Option<Event>) {
@@ -2518,6 +2810,7 @@ impl State {
             });
         }
 
+        self.after_text_mutation(buffer, clients, config);
         (Task::none(), None)
     }
 
@@ -2549,6 +2842,7 @@ impl State {
 
         // Cursor movement above does not always trigger an Action::Move
         self.process_completion_and_notice(buffer, clients, history, config);
+        self.after_text_mutation(buffer, clients, config);
 
         (Task::none(), None)
     }
@@ -2575,6 +2869,8 @@ impl State {
         &mut self,
         nick: Nick,
         buffer: buffer::Upstream,
+        clients: &client::Map,
+        config: &Config,
         history: &mut history::Manager,
         autocomplete: &Autocomplete,
     ) {
@@ -2630,6 +2926,8 @@ impl State {
             text_editor::Edit::Paste(std::sync::Arc::new(insert_text)),
         ));
 
+        self.after_text_mutation(&buffer, clients, config);
+
         history.record_draft(RawInput {
             buffer,
             text: self.input_content.text(),
@@ -2644,6 +2942,7 @@ impl State {
     pub fn clear_draft_reply(
         &mut self,
         buffer: &buffer::Upstream,
+        clients: &client::Map,
         history: &mut history::Manager,
         config: &Config,
     ) -> bool {
@@ -2683,6 +2982,7 @@ impl State {
                 reply: None,
             });
 
+            self.after_text_mutation(buffer, clients, config);
             true
         } else {
             false
@@ -2947,6 +3247,137 @@ fn line_col_to_char(
     pos
 }
 
+/// Absolute UTF-8 byte offset for a `(line, column)` cursor position.
+fn line_col_to_byte(
+    content: &text_editor::Content,
+    line: usize,
+    col: usize,
+) -> usize {
+    let text = content.text();
+    let mut offset = 0;
+    for (i, l) in text.split('\n').enumerate() {
+        if i == line {
+            return offset + col.min(l.len());
+        }
+        offset += l.len() + 1;
+    }
+    text.len()
+}
+
+fn is_spell_word_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '\''
+}
+
+// Word run under/before the caret (alphanumeric / apostrophe, same as spellkit).
+// Caret at the end of a word counts as still in that word (so it stays unmarked).
+fn spell_word_bounds_at(text: &str, byte: usize) -> Option<(usize, usize)> {
+    let byte = byte.min(text.len());
+    let anchor = if byte > 0
+        && text[..byte]
+            .chars()
+            .next_back()
+            .is_some_and(is_spell_word_char)
+    {
+        byte - text[..byte].chars().next_back().map_or(0, char::len_utf8)
+    } else if byte < text.len()
+        && text[byte..].chars().next().is_some_and(is_spell_word_char)
+    {
+        byte
+    } else {
+        return None;
+    };
+
+    let mut start = anchor;
+    while start > 0 {
+        let Some(c) = text[..start].chars().next_back() else {
+            break;
+        };
+        if !is_spell_word_char(c) {
+            break;
+        }
+        start -= c.len_utf8();
+    }
+
+    let mut end = anchor;
+    for c in text[anchor..].chars() {
+        if !is_spell_word_char(c) {
+            break;
+        }
+        end += c.len_utf8();
+    }
+
+    (start < end).then_some((start, end))
+}
+
+/// True when caret is inside `[start, end]` or in the non-word gap immediately after
+/// that range (before the next word starts) — enables Tab after `"typo "`.
+fn spell_cursor_targets_range(
+    text: &str,
+    cursor: usize,
+    start: usize,
+    end: usize,
+) -> bool {
+    if cursor >= start && cursor <= end {
+        return true;
+    }
+    if cursor < end || end > text.len() || start > end {
+        return false;
+    }
+    text[end..cursor.min(text.len())]
+        .chars()
+        .all(|c| !is_spell_word_char(c))
+}
+
+fn spell_error_for_cursor<'a>(
+    text: &str,
+    cursor: usize,
+    errors: &'a [SpellError],
+) -> Option<&'a SpellError> {
+    errors
+        .iter()
+        .filter(|e| spell_cursor_targets_range(text, cursor, e.start, e.end))
+        .max_by_key(|e| e.end)
+}
+
+fn is_irc_spell_skip(
+    text: &str,
+    start: usize,
+    word: &str,
+    chantypes: &[char],
+    casemapping: data::isupport::CaseMap,
+    own_nick: Option<data::user::NickRef<'_>>,
+    channel_users: Option<&ChannelUsers>,
+    query_peer_normalized: Option<&str>,
+) -> bool {
+    // "#channel" → spellkit word is "channel"; prefix sits just before `start`
+    if start > 0
+        && text[..start]
+            .chars()
+            .next_back()
+            .is_some_and(|c| chantypes.contains(&c))
+    {
+        return true;
+    }
+
+    let nick = Nick::from_str(word, casemapping);
+    let nick_ref = nick.as_nickref();
+
+    if own_nick.is_some_and(|own| own == nick_ref) {
+        return true;
+    }
+    if channel_users.is_some_and(|users| users.get_by_nick(nick_ref).is_some())
+    {
+        return true;
+    }
+    if query_peer_normalized
+        .is_some_and(|peer| peer == nick.as_normalized_str())
+    {
+        return true;
+    }
+
+    false
+}
+
 /// Converts a flat grapheme-cluster offset back to a `(line, col)` position.
 ///
 /// `start_pos` is the number of grapheme clusters from the start of `text`.
@@ -3133,6 +3564,138 @@ fn reset_undo_history(content: &mut text_editor::Content) {
 
     *content = text_editor::Content::with_text(&text);
     content.move_to(cursor);
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct SpellSettings {
+    errors_by_line: Vec<Vec<(usize, usize, SpellHighlight)>>,
+}
+
+#[derive(Debug, Clone)]
+struct SpellError {
+    start: usize,
+    end: usize,
+}
+
+#[derive(Debug, Clone)]
+struct SpellSuggestionSession {
+    start: usize,
+    end: usize,
+    original: String,
+    suggestions: Vec<String>,
+    index: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SpellHighlight {
+    Misspelled,
+}
+
+fn spell_token_format(
+    highlight: &SpellHighlight,
+    theme: &Theme,
+) -> Format<Font> {
+    let styles = theme.styles();
+    match highlight {
+        SpellHighlight::Misspelled => Format {
+            color: Some(
+                styles
+                    .text
+                    .spellcheck_misspelled
+                    .color
+                    .unwrap_or(styles.text.error.color),
+            ),
+            font: Some(
+                font::get(
+                    styles
+                        .text
+                        .spellcheck_misspelled
+                        .font_style
+                        .unwrap_or(FontStyle::Italic),
+                )
+                .into(),
+            ),
+        },
+    }
+}
+
+fn spell_errors_by_line(
+    text: &str,
+    errors: &[SpellError],
+) -> Vec<Vec<(usize, usize, SpellHighlight)>> {
+    let mut by_line = Vec::new();
+    let mut line_start = 0usize;
+
+    for line in text.split('\n') {
+        let line_end = line_start + line.len();
+        let mut line_errors = Vec::new();
+
+        for error in errors {
+            if error.end > line_start && error.start < line_end {
+                let local_start =
+                    error.start.saturating_sub(line_start).min(line.len());
+                let local_end =
+                    error.end.saturating_sub(line_start).min(line.len());
+                if local_start < local_end {
+                    line_errors.push((
+                        local_start,
+                        local_end,
+                        SpellHighlight::Misspelled,
+                    ));
+                }
+            }
+        }
+
+        by_line.push(line_errors);
+        line_start = line_end + 1; // skip '\n'
+    }
+
+    by_line
+}
+
+struct SpellHighlighter {
+    current_line: usize,
+    errors_by_line: Vec<Vec<(usize, usize, SpellHighlight)>>,
+}
+
+impl Highlighter for SpellHighlighter {
+    type Settings = SpellSettings;
+    type Highlight = SpellHighlight;
+    type Iterator<'a> =
+        Box<dyn Iterator<Item = (Range<usize>, Self::Highlight)> + 'a>;
+
+    fn new(settings: &Self::Settings) -> Self {
+        Self {
+            current_line: 0,
+            errors_by_line: settings.errors_by_line.clone(),
+        }
+    }
+
+    fn update(&mut self, settings: &Self::Settings) {
+        self.errors_by_line = settings.errors_by_line.clone();
+        self.current_line = 0;
+    }
+
+    fn change_line(&mut self, line: usize) {
+        self.current_line = line;
+    }
+
+    fn highlight_line(&mut self, _line: &str) -> Self::Iterator<'_> {
+        let i = self.current_line;
+        self.current_line += 1;
+
+        let errors = self.errors_by_line.get(i).cloned().unwrap_or_default();
+
+        Box::new(
+            errors
+                .into_iter()
+                .map(|(start, end, highlight)| (start..end, highlight)),
+        )
+    }
+
+    fn current_line(&self) -> usize {
+        self.current_line
+    }
 }
 
 #[cfg(test)]
@@ -3361,5 +3924,24 @@ mod tests {
                 "text: {ghost_prefix}{ghost}{ghost_suffix} url: {url} motion: {motion}"
             );
         }
+    }
+
+    #[test]
+    fn spell_word_bounds_at_end_of_word() {
+        assert_eq!(spell_word_bounds_at("hello ", 5), Some((0, 5)));
+    }
+
+    #[test]
+    fn is_irc_spell_skip_channel_name() {
+        assert!(is_irc_spell_skip(
+            "#halloy",
+            1,
+            "halloy",
+            &['#'],
+            data::isupport::CaseMap::default(),
+            None,
+            None,
+            None,
+        ));
     }
 }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1563,7 +1563,7 @@ impl Dashboard {
                         // close_picker does not return true.
                         } else if state
                             .buffer
-                            .clear_draft_reply(history, config)
+                            .clear_draft_reply(clients, history, config)
                         {
                             return (Task::none(), None);
                         }
@@ -2259,7 +2259,9 @@ impl Dashboard {
                         {
                             pane.buffer.insert_user_to_input(
                                 nick,
+                                clients,
                                 history,
+                                config,
                                 &config.buffer.text_input.autocomplete,
                             );
                         }

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1536,7 +1536,7 @@ impl Dashboard {
                         // close_picker does not return true.
                         } else if state
                             .buffer
-                            .clear_draft_reply(history, config)
+                            .clear_draft_reply(clients, history, config)
                         {
                             return (Task::none(), None);
                         }
@@ -2234,7 +2234,9 @@ impl Dashboard {
                         {
                             pane.buffer.insert_user_to_input(
                                 nick,
+                                clients,
                                 history,
+                                config,
                                 &config.buffer.text_input.autocomplete,
                             );
                         }

--- a/src/screen/dashboard/theme_editor.rs
+++ b/src/screen/dashboard/theme_editor.rs
@@ -596,6 +596,7 @@ pub enum Text {
     Info,
     Debug,
     Trace,
+    SpellcheckMisspelled,
 }
 
 impl Text {
@@ -610,6 +611,9 @@ impl Text {
             Text::Info => styles.text.info.color,
             Text::Debug => styles.text.debug.color,
             Text::Trace => styles.text.trace.color,
+            Text::SpellcheckMisspelled => {
+                styles.text.spellcheck_misspelled.color
+            }
         }
     }
 
@@ -624,6 +628,9 @@ impl Text {
             Text::Info => styles.text.info.font_style,
             Text::Debug => styles.text.debug.font_style,
             Text::Trace => styles.text.trace.font_style,
+            Text::SpellcheckMisspelled => {
+                styles.text.spellcheck_misspelled.font_style
+            }
         }
     }
 
@@ -679,6 +686,10 @@ impl Text {
             Text::Trace => {
                 styles.trace.color = color;
                 styles.trace.font_style = font_style;
+            }
+            Text::SpellcheckMisspelled => {
+                styles.spellcheck_misspelled.color = color;
+                styles.spellcheck_misspelled.font_style = font_style;
             }
         }
     }

--- a/src/screen/dashboard/theme_editor.rs
+++ b/src/screen/dashboard/theme_editor.rs
@@ -595,6 +595,7 @@ pub enum Text {
     Info,
     Debug,
     Trace,
+    SpellcheckMisspelled,
 }
 
 impl Text {
@@ -609,6 +610,9 @@ impl Text {
             Text::Info => styles.text.info.color,
             Text::Debug => styles.text.debug.color,
             Text::Trace => styles.text.trace.color,
+            Text::SpellcheckMisspelled => {
+                styles.text.spellcheck_misspelled.color
+            }
         }
     }
 
@@ -623,6 +627,9 @@ impl Text {
             Text::Info => styles.text.info.font_style,
             Text::Debug => styles.text.debug.font_style,
             Text::Trace => styles.text.trace.font_style,
+            Text::SpellcheckMisspelled => {
+                styles.text.spellcheck_misspelled.font_style
+            }
         }
     }
 
@@ -678,6 +685,10 @@ impl Text {
             Text::Trace => {
                 styles.trace.color = color;
                 styles.trace.font_style = font_style;
+            }
+            Text::SpellcheckMisspelled => {
+                styles.spellcheck_misspelled.color = color;
+                styles.spellcheck_misspelled.font_style = font_style;
             }
         }
     }


### PR DESCRIPTION
Opt-in spellcheck for the message input (`buffer.text_input.spellcheck`).

Adds a dependency on [`spellkit`](https://crates.io/crates/spellkit) (`0.3`), a small cross-platform crate ([rtmongold/spellkit](https://github.com/rtmongold/spellkit)) that I updated from an orphaned repo ([euclio/spellbound](https://github.com/euclio/spellbound)).

| Platform | Backend |
| --- | --- |
| macOS | `NSSpellChecker` |
| Windows | `ISpellChecker` |
| Linux / other Unix | Hunspell (system dictionaries, e.g. `hunspell-en_us`) |

If no dictionary is available, spellcheck is a no-op (a warning is logged). Optional `locale` (e.g. `"en-US"`) selects the language; unset uses the system/default.

### Behavior in Input

- **After the word is finished:** the word currently being typed (under/just before the caret) is not marked. Highlighting appears once you complete it (space, punctuation, or moving off the word), so you are not flagged mid-word.
- **Tab suggestions:** with `suggestions = true` (default when spellcheck is on), put the caret in a misspelled word and press Tab / Shift+Tab to cycle replacements from the **native** dictionary, then back to the original spelling.
- **Autocomplete still wins:** nick and command Tab-completion run first. Spell suggestions only run when autocomplete does not produce a candidate.
- **IRC skips:** channel names (`#…`), your nick, nicks in the current channel, and the query peer are not marked misspelled.
- **Theme:** misspellings use `text.spellcheck_misspelled`. If that style is unset, they use `text.error` in italic (would like to explore possible underline later).

Disabled by default:

```toml
[buffer.text_input.spellcheck]
enabled = true
# suggestions = true
# locale = "en-US"
```