### PR TITLE
Do not lose messages when history flushes race loads.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Fixed:
 - Better support for larger font sizes in modals
 - "Apply Colors & Font Styles" button in Theme Editor persists modifications made via the theme editor
 - Scroll-to-reply when clicking a reply preview
+- Messages no longer occasionally go missing (or get duplicated) in buffers
+- Sent messages no longer briefly appear above the latest received messages when the server clock is ahead
 
 Changed:
 
@@ -479,7 +481,7 @@ Added:
 - Settings to disable (selectively, or for the entire server) confirmation of delivery for sent messages
 - Setting to adjust inner spacing and outer padding for panes (`pane.gap.inner`, `pane.gap.outer`)
 - Setting to style unread query buffers as highlights in the sidebar (`sidebar.unread_indicator.query_as_highlight`)
-- Settings to configure card and image preview dimensions 
+- Settings to configure card and image preview dimensions
 - Support for transparent background.
 
 Fixed:
@@ -565,7 +567,7 @@ Added:
 - Ability to specify a distinct sound for each match highlight set
 - Border radius on both image previews and cards displaying images through meta tags (configurable)
 - Change-host and kick server messages messages can be condensed
-- Context menu added to text input when right clicking 
+- Context menu added to text input when right clicking
 - Context menu item added to server-wide buffers to close all queries
 - Exit application from user menu
 - Fuzzy matching when searching in command bar

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -21,7 +21,7 @@ message_tests = ["iced/tokio"]
 [dependencies]
 thiserror = { workspace = true }
 futures = { workspace = true }
-tokio = { workspace = true, features = ["io-util", "fs", "rt"] }
+tokio = { workspace = true, features = ["io-util", "fs", "rt", "sync"] }
 chrono = { workspace = true }
 bytes = { workspace = true }
 strum = { workspace = true }

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -507,6 +507,9 @@ pub enum History {
         flushing_messages: Vec<(Message, Option<LabeledResponseContext>)>,
         flushing_reactions: HashMap<message::Id, reaction::Pending>,
         flushing_redactions: HashMap<message::Id, redaction::Pending>,
+        flushed_messages: Vec<(Message, Option<LabeledResponseContext>)>,
+        flushed_reactions: HashMap<message::Id, reaction::Pending>,
+        flushed_redactions: HashMap<message::Id, redaction::Pending>,
     },
     Full {
         kind: Kind,
@@ -538,6 +541,9 @@ impl History {
             flushing_messages: vec![],
             flushing_reactions: HashMap::new(),
             flushing_redactions: HashMap::new(),
+            flushed_messages: vec![],
+            flushed_reactions: HashMap::new(),
+            flushed_redactions: HashMap::new(),
         }
     }
 
@@ -1086,6 +1092,9 @@ impl History {
                         flushing_messages: vec![],
                         flushing_reactions: HashMap::new(),
                         flushing_redactions: HashMap::new(),
+                        flushed_messages: vec![],
+                        flushed_reactions: HashMap::new(),
+                        flushed_redactions: HashMap::new(),
                     };
 
                     return Some(
@@ -1128,6 +1137,9 @@ impl History {
                         flushing_messages: vec![],
                         flushing_reactions: HashMap::new(),
                         flushing_redactions: HashMap::new(),
+                        flushed_messages: vec![],
+                        flushed_reactions: HashMap::new(),
+                        flushed_redactions: HashMap::new(),
                     },
                 );
 
@@ -1159,22 +1171,64 @@ impl History {
                 max_triggers_unread,
                 max_triggers_highlight,
                 chathistory_references,
-                pending_reactions,
-                pending_redactions,
+                mut pending_reactions,
+                mut pending_redactions,
+                flushing_messages,
+                flushing_reactions,
+                flushing_redactions,
+                flushed_messages,
+                flushed_reactions,
+                flushed_redactions,
                 ..
-            } => append(
-                &kind,
-                seed,
-                pending_messages,
-                read_marker,
-                max_triggers_unread,
-                max_triggers_highlight,
-                chathistory_references,
-                pending_reactions,
-                pending_redactions,
-            )
-            .await
-            .map(|_| ()),
+            } => {
+                // Data handed to an in-flight flush may not have reached
+                // disk yet (or the flush may still fail). Data from a
+                // completed flush is on disk already. Append both with
+                // forced deduplication so they are persisted exactly once.
+                let pending_messages = flushed_messages
+                    .into_iter()
+                    .chain(flushing_messages)
+                    .map(|(mut message, labeled_response_context)| {
+                        message.deduplicate = true;
+                        (message, labeled_response_context)
+                    })
+                    .chain(pending_messages)
+                    .collect();
+
+                for (id, mut flushing) in
+                    flushing_reactions.into_iter().chain(flushed_reactions)
+                {
+                    for pending_reaction in &mut flushing.reactions {
+                        pending_reaction.deduplicate = true;
+                    }
+
+                    let pending = pending_reactions.entry(id).or_default();
+                    flushing
+                        .reactions
+                        .extend(std::mem::take(&mut pending.reactions));
+                    pending.reactions = flushing.reactions;
+                }
+
+                for (id, flushing) in
+                    flushed_redactions.into_iter().chain(flushing_redactions)
+                {
+                    pending_redactions.entry(id).or_insert(flushing);
+                }
+
+                append(
+                    &kind,
+                    seed,
+                    pending_messages,
+                    read_marker,
+                    max_triggers_unread,
+                    max_triggers_highlight,
+                    chathistory_references,
+                    pending_reactions,
+                    pending_redactions,
+                )
+                .await
+                .map(|_| ())
+            }
             History::Full {
                 kind,
                 messages,
@@ -1606,9 +1660,16 @@ impl History {
                 renormalize_messages(messages.iter_mut(), seed);
             }
             History::Partial {
-                pending_messages, ..
+                pending_messages,
+                flushing_messages,
+                flushed_messages,
+                ..
             } => renormalize_messages(
-                pending_messages.iter_mut().map(|(message, _)| message),
+                pending_messages
+                    .iter_mut()
+                    .chain(flushing_messages.iter_mut())
+                    .chain(flushed_messages.iter_mut())
+                    .map(|(message, _)| message),
                 seed,
             ),
         }
@@ -1978,4 +2039,88 @@ pub enum Error {
     Io(#[from] io::Error),
     #[error(transparent)]
     SerdeJson(#[from] serde_json::Error),
+}
+
+#[cfg(test)]
+pub(crate) fn test_message(
+    server_time: DateTime<Utc>,
+    text: &str,
+) -> Message {
+    let isupport = HashMap::<isupport::Kind, isupport::Parameter>::new();
+    let chantypes = isupport::get_chantypes_or_default(&isupport);
+    let casemapping = isupport::get_casemapping_or_default(&isupport);
+
+    let channel = target::Channel::from_str("#test", chantypes, casemapping);
+    let user = crate::user::User::from(Nick::from_str("nick", casemapping));
+
+    let content = message::plain(text.to_string());
+    let received_at = crate::time::Posix::now();
+    let hash = message::Hash::new(&server_time, &content, &received_at);
+
+    Message {
+        received_at,
+        server_time,
+        direction: message::Direction::Received,
+        target: message::Target::Channel {
+            channel,
+            source: message::Source::User(user),
+        },
+        content,
+        id: None,
+        reply_to: None,
+        reply_preview: None,
+        hash,
+        hidden_urls: std::collections::HashSet::default(),
+        is_echo: false,
+        received_with_server_time: true,
+        blocked: false,
+        condensed: None,
+        expanded: false,
+        command: None,
+        reactions: vec![],
+        rerouted_from: None,
+        deduplicate: false,
+        redaction: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+
+    use super::*;
+
+    #[test]
+    fn insert_message_deduplicates_flushed_data() {
+        let server_time = Utc.with_ymd_and_hms(2026, 8, 13, 12, 0, 0).unwrap();
+
+        let mut messages = vec![
+            test_message(server_time, "hello"),
+            test_message(server_time + chrono::Duration::seconds(2), "world"),
+        ];
+
+        // Flushed data already present in history merges with the stored
+        // copy instead of duplicating it
+        let mut flushed = test_message(server_time, "hello");
+        flushed.deduplicate = true;
+        insert_message(&mut messages, flushed, None);
+        assert_eq!(messages.len(), 2);
+
+        // Flushed data absent from history is inserted, sorted on server
+        // time
+        let mut missed = test_message(
+            server_time + chrono::Duration::seconds(1),
+            "missed",
+        );
+        missed.deduplicate = true;
+        insert_message(&mut messages, missed, None);
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[1].text(), "missed");
+
+        // A live message with identical content in the same second is a
+        // genuinely new message and must not be deduplicated
+        let live = test_message(server_time, "hello");
+        insert_message(&mut messages, live, None);
+        assert_eq!(messages.len(), 4);
+    }
 }

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -638,9 +638,30 @@ impl History {
 
     fn add_message(
         &mut self,
-        message: Message,
+        mut message: Message,
         labeled_response_context: Option<LabeledResponseContext>,
     ) -> Option<ReadMarker> {
+        // Clamp new messages to the latest server time of existing messages,
+        // so that they don't get inserted in "the past", when the server time
+        // is not in perfect sync with the client time.
+        if matches!(message.direction, message::Direction::Sent) {
+            let latest = match self {
+                History::Partial {
+                    pending_messages, ..
+                } => pending_messages
+                    .iter()
+                    .map(|(message, _)| message.server_time)
+                    .max(),
+                History::Full { messages, .. } => {
+                    messages.last().map(|message| message.server_time)
+                }
+            };
+
+            if let Some(latest) = latest {
+                message.server_time = message.server_time.max(latest);
+            }
+        }
+
         if let History::Partial {
             show_in_sidebar,
             max_triggers_unread,
@@ -1712,7 +1733,6 @@ pub fn insert_message(
 
     if let Some(labeled_response_context) = &labeled_response_context {
         let start = labeled_response_context.server_time - fuzz_seconds;
-        let end = labeled_response_context.server_time + fuzz_seconds;
 
         let start_index = match messages
             .binary_search_by(|stored| stored.server_time.cmp(&start))
@@ -1720,14 +1740,11 @@ pub fn insert_message(
             Ok(match_index) => match_index,
             Err(sorted_insert_index) => sorted_insert_index,
         };
-        let end_index = match messages
-            .binary_search_by(|stored| stored.server_time.cmp(&end))
-        {
-            Ok(match_index) => match_index,
-            Err(sorted_insert_index) => sorted_insert_index,
-        };
 
-        if let Some(index) = messages[start_index..end_index]
+        // The sent message was stamped with the context's server time,
+        // but may have been clamped forward (up to the latest received
+        // message) when it was added, so search through the end
+        if let Some(index) = messages[start_index..]
             .iter()
             .enumerate()
             .find_map(|(slice_index, stored)| {
@@ -2122,5 +2139,69 @@ mod tests {
         let live = test_message(server_time, "hello");
         insert_message(&mut messages, live, None);
         assert_eq!(messages.len(), 4);
+    }
+
+    // A sent message clamped past its labeled-response context's server
+    // time (local clock behind the server's) must still be replaced when
+    // its labeled echo arrives
+    #[test]
+    fn labeled_echo_replaces_clamped_sent_message() {
+        use crate::server::ServerName;
+
+        let send_time = Utc.with_ymd_and_hms(2026, 8, 13, 12, 0, 0).unwrap();
+
+        let isupport = HashMap::<isupport::Kind, isupport::Parameter>::new();
+        let chantypes = isupport::get_chantypes_or_default(&isupport);
+        let casemapping = isupport::get_casemapping_or_default(&isupport);
+
+        let kind = Kind::Channel(
+            Server::from(ServerName::from("test-server")),
+            target::Channel::from_str("#test", chantypes, casemapping),
+        );
+
+        // The last received message is 9 seconds ahead of the local clock
+        let mut history = History::Full {
+            kind,
+            messages: vec![test_message(
+                send_time + chrono::Duration::seconds(9),
+                "their message",
+            )],
+            last_updated_at: None,
+            read_marker: None,
+            display_read_marker: None,
+            chathistory_references: None,
+            last_seen: HashMap::new(),
+            cleared: false,
+            last_flushed_at: 0,
+        };
+
+        let context = LabeledResponseContext {
+            label_as_id: ":label=1".to_string().into(),
+            server_time: send_time,
+        };
+
+        let mut sent = test_message(send_time, "our reply");
+        sent.direction = message::Direction::Sent;
+        let sent = sent.with_labeled_response_context(Some(context.clone()));
+
+        history.add_message(sent, Some(context.clone()));
+
+        let mut echo = test_message(
+            send_time + chrono::Duration::seconds(10),
+            "our reply",
+        );
+        echo.is_echo = true;
+
+        history.add_message(echo, Some(context));
+
+        let History::Full { messages, .. } = &history else {
+            unreachable!()
+        };
+
+        assert_eq!(messages.len(), 2);
+        assert!(messages.iter().all(|message| matches!(
+            message.direction,
+            message::Direction::Received
+        )));
     }
 }

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::{Arc, LazyLock, Mutex as SyncMutex};
 use std::time::Duration;
 use std::{fmt, io};
 
@@ -44,6 +45,22 @@ pub(crate) fn truncate_messages(messages: &mut Vec<Message>) {
     if messages.len() > MAX_MESSAGES {
         messages.drain(0..messages.len() - (MAX_MESSAGES - TRUNC_COUNT));
     }
+}
+
+/// Per-[`Kind`] locks serializing all history file I/O.
+///
+/// Loads, appends, and overwrites for the same kind are spawned as
+/// independent tasks. Without serialization their read-modify-write
+/// cycles of the same files can interleave, silently losing, duplicating,
+/// or corrupting messages.
+static FILE_LOCKS: LazyLock<
+    SyncMutex<HashMap<Kind, Arc<tokio::sync::Mutex<()>>>>,
+> = LazyLock::new(|| SyncMutex::new(HashMap::new()));
+
+pub(crate) fn file_lock(kind: &Kind) -> Arc<tokio::sync::Mutex<()>> {
+    let mut locks = FILE_LOCKS.lock().unwrap();
+
+    Arc::clone(locks.entry(kind.clone()).or_default())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -220,6 +237,17 @@ pub enum Seed {
 }
 
 pub async fn load(kind: Kind, seed: Option<Seed>) -> Result<Loaded, Error> {
+    let lock = file_lock(&kind);
+    let _guard = lock.lock().await;
+
+    load_unlocked(kind, seed).await
+}
+
+/// Must be called with the kind's [`file_lock`] held.
+async fn load_unlocked(
+    kind: Kind,
+    seed: Option<Seed>,
+) -> Result<Loaded, Error> {
     let path = path(&kind).await?;
 
     let mut messages = read_all(&path).await.unwrap_or_default();
@@ -230,7 +258,7 @@ pub async fn load(kind: Kind, seed: Option<Seed>) -> Result<Loaded, Error> {
         renormalize_messages(messages.iter_mut(), seed);
     }
 
-    let metadata = metadata::load(kind).await.unwrap_or_default();
+    let metadata = metadata::load_unlocked(kind).await.unwrap_or_default();
 
     Ok(Loaded { messages, metadata })
 }
@@ -263,6 +291,9 @@ pub async fn overwrite(
     read_marker: Option<ReadMarker>,
     chathistory_references: Option<MessageReferences>,
 ) -> Result<(), Error> {
+    let lock = file_lock(kind);
+    let _guard = lock.lock().await;
+
     if messages.is_empty() {
         return metadata::save(
             kind,
@@ -291,7 +322,10 @@ pub async fn append(
     pending_reactions: HashMap<message::Id, reaction::Pending>,
     pending_redactions: HashMap<message::Id, redaction::Pending>,
 ) -> Result<Vec<EchoEvent>, Error> {
-    let loaded = load(kind.clone(), seed).await?;
+    let lock = file_lock(kind);
+    let _guard = lock.lock().await;
+
+    let loaded = load_unlocked(kind.clone(), seed).await?;
 
     let mut echo_events: Vec<EchoEvent> = vec![];
 
@@ -408,6 +442,9 @@ async fn write_messages<'a>(
 }
 
 pub async fn delete(kind: &Kind) -> Result<(), Error> {
+    let lock = file_lock(kind);
+    let _guard = lock.lock().await;
+
     let path = path(kind).await?;
 
     fs::remove_file(path).await?;
@@ -1051,6 +1088,9 @@ impl History {
 
                     return Some(
                         async move {
+                            let lock = file_lock(&kind);
+                            let _guard = lock.lock().await;
+
                             metadata::update(
                                 &kind,
                                 read_marker,

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -1026,6 +1026,8 @@ impl History {
 
                     truncate_messages(messages);
 
+                    *last_flushed_at = messages.len();
+
                     let messages = messages.clone();
 
                     return Some(

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -2505,4 +2505,41 @@ mod tests {
 
         assert_eq!(full_messages_len(&manager, &kind), 1);
     }
+
+    #[test]
+    fn sent_message_is_not_sorted_before_received_messages() {
+        let (mut manager, kind, message) = setup();
+
+        let clients = client::Map::default();
+        let buffer_config = config::Buffer::default();
+
+        manager.update(
+            Message::LoadFull(
+                kind.clone(),
+                Ok(history::Loaded {
+                    messages: vec![message.clone()],
+                    metadata: history::Metadata::default(),
+                }),
+            ),
+            &clients,
+            &buffer_config,
+        );
+
+        // Sent with a local clock 5 seconds behind the server's
+        let mut sent = test_message(
+            message.server_time - chrono::Duration::seconds(5),
+            "our reply",
+        );
+        sent.direction = message::Direction::Sent;
+
+        drop(manager.data.add_message(kind.clone(), sent, None));
+
+        let Some(History::Full { messages, .. }) = manager.data.map.get(&kind)
+        else {
+            panic!("history should be full after loading");
+        };
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages.last().unwrap().text(), "our reply");
+    }
 }

--- a/data/src/history/manager.rs
+++ b/data/src/history/manager.rs
@@ -178,6 +178,8 @@ impl Manager {
                     self.channel_monitor.open(&self.data, clients, config),
                 );
             } else {
+                self.data.loading.insert(resource.kind.clone());
+
                 let seed = clients
                     .and_then(|clients| clients.get_seed(&resource.kind));
 
@@ -195,6 +197,9 @@ impl Manager {
         }
 
         for resource in removed {
+            // Any in-flight load result is no longer expected
+            self.data.loading.remove(&resource.kind);
+
             let task = if resource == channel_monitor {
                 self.channel_monitor.close(&mut self.data)
             } else {
@@ -233,10 +238,6 @@ impl Manager {
         self.channel_monitor.reload(&mut self.data, clients, config)
     }
 
-    fn is_tracked(&self, kind: &history::Kind) -> bool {
-        self.resources.contains(&Resource { kind: kind.clone() })
-    }
-
     pub fn update(
         &mut self,
         message: Message,
@@ -245,25 +246,30 @@ impl Manager {
     ) -> Option<Event> {
         match message {
             Message::LoadFull(kind, Ok(loaded)) => {
-                if !self.is_tracked(&kind) {
-                    return None;
+                if self.data.loading.remove(&kind) {
+                    let len = loaded.messages.len();
+
+                    self.data.load_full(
+                        kind.clone(),
+                        loaded,
+                        FilterChain::borrow(&self.filters),
+                        clients,
+                        buffer_config,
+                    );
+
+                    log::debug!("loaded history for {kind}: {len} messages");
+
+                    return Some(Event::Loaded(kind));
+                } else {
+                    self.data.clear_flushed(&kind);
+
+                    log::debug!("discarded stale history load for {kind}");
                 }
-
-                let len = loaded.messages.len();
-
-                self.data.load_full(
-                    kind.clone(),
-                    loaded,
-                    FilterChain::borrow(&self.filters),
-                    clients,
-                    buffer_config,
-                );
-
-                log::debug!("loaded history for {kind}: {len} messages");
-
-                return Some(Event::Loaded(kind));
             }
             Message::LoadFull(kind, Err(error)) => {
+                self.data.loading.remove(&kind);
+                self.data.clear_flushed(&kind);
+
                 log::warn!("failed to load history for {kind}: {error}");
             }
             Message::LoadChannelMonitor(generation, result) => {
@@ -402,6 +408,9 @@ impl Manager {
         kind: history::Kind,
         clients: &client::Map,
     ) -> Option<impl Future<Output = Message> + use<>> {
+        // Any in-flight load result is no longer expected
+        self.data.loading.remove(&kind);
+
         let history = self.data.map.remove(&kind)?;
 
         Some(
@@ -1523,6 +1532,7 @@ fn with_limit<'a>(
 struct Data {
     map: HashMap<history::Kind, History>,
     input: input::Storage,
+    loading: HashSet<history::Kind>,
 }
 
 impl Data {
@@ -1562,6 +1572,9 @@ impl Data {
                     flushing_messages,
                     flushing_reactions,
                     flushing_redactions,
+                    flushed_messages,
+                    flushed_reactions,
+                    flushed_redactions,
                     ..
                 } => {
                     let read_marker =
@@ -1576,9 +1589,21 @@ impl Data {
 
                     let mut last_seen = last_seen.clone();
 
-                    for (id, pending) in std::mem::take(pending_reactions)
+                    // Flushed and flushing data may already be in the
+                    // loaded messages (depending on how the flush's file
+                    // write ordered with this load's file read), so it is
+                    // merged with forced deduplication.
+                    for (id, pending) in std::mem::take(flushed_reactions)
                         .into_iter()
                         .chain(std::mem::take(flushing_reactions))
+                        .map(|(id, mut pending)| {
+                            for pending_reaction in &mut pending.reactions {
+                                pending_reaction.deduplicate = true;
+                            }
+
+                            (id, pending)
+                        })
+                        .chain(std::mem::take(pending_reactions))
                     {
                         if let Some(server_time) = pending.server_time()
                             && let Some(message) =
@@ -1605,6 +1630,7 @@ impl Data {
                     for (id, pending) in std::mem::take(pending_redactions)
                         .into_iter()
                         .chain(std::mem::take(flushing_redactions))
+                        .chain(std::mem::take(flushed_redactions))
                     {
                         if let Some(message) = history::find_message_mut_by_id(
                             &mut messages,
@@ -1616,9 +1642,14 @@ impl Data {
                     }
 
                     for (message, labeled_response_context) in
-                        std::mem::take(pending_messages)
+                        std::mem::take(flushed_messages)
                             .into_iter()
                             .chain(std::mem::take(flushing_messages))
+                            .map(|(mut message, labeled_response_context)| {
+                                message.deduplicate = true;
+                                (message, labeled_response_context)
+                            })
+                            .chain(std::mem::take(pending_messages))
                     {
                         history::update_last_seen(&mut last_seen, &message);
 
@@ -1643,25 +1674,12 @@ impl Data {
                         last_flushed_at,
                     });
                 }
-                _ => {
-                    let chathistory_references = metadata
-                        .chathistory_references
-                        .max(metadata::latest_can_reference(&messages));
-
-                    let last_seen = history::get_last_seen(&messages);
-                    let last_flushed_at = messages.len();
-
-                    entry.insert(History::Full {
-                        kind,
-                        messages,
-                        last_updated_at: None,
-                        read_marker: metadata.read_marker,
-                        display_read_marker: metadata.read_marker,
-                        chathistory_references,
-                        last_seen,
-                        cleared: false,
-                        last_flushed_at,
-                    });
+                History::Full { .. } => {
+                    // The in-memory state is authoritative, a load result
+                    // can only be equal or older.
+                    log::debug!(
+                        "ignoring history load for already-loaded {kind}"
+                    );
                 }
             },
             hash_map::Entry::Vacant(entry) => {
@@ -2109,6 +2127,8 @@ impl Data {
     }
 
     fn flushed(&mut self, kind: &history::Kind, flush_ok: bool) {
+        let loading = self.loading.contains(kind);
+
         if let Some(History::Partial {
             pending_messages,
             pending_reactions,
@@ -2116,15 +2136,33 @@ impl Data {
             flushing_messages,
             flushing_reactions,
             flushing_redactions,
+            flushed_messages,
+            flushed_reactions,
+            flushed_redactions,
             ..
         }) = self.map.get_mut(kind)
         {
             if flush_ok {
-                flushing_messages.clear();
+                if loading {
+                    // An in-flight load may have read the file before
+                    // this flush wrote it. Hold onto the flushed data so
+                    // it can be merged when the load completes.
+                    flushed_messages.extend(std::mem::take(flushing_messages));
 
-                flushing_reactions.clear();
+                    for (id, flushing) in std::mem::take(flushing_reactions) {
+                        let flushed = flushed_reactions.entry(id).or_default();
 
-                flushing_redactions.clear();
+                        flushed.reactions.extend(flushing.reactions);
+                    }
+
+                    for (id, flushing) in std::mem::take(flushing_redactions) {
+                        flushed_redactions.entry(id).or_insert(flushing);
+                    }
+                } else {
+                    flushing_messages.clear();
+                    flushing_reactions.clear();
+                    flushing_redactions.clear();
+                }
             } else {
                 pending_messages.extend(std::mem::take(flushing_messages));
 
@@ -2138,6 +2176,20 @@ impl Data {
                     pending_redactions.entry(id).or_insert(flushing);
                 }
             }
+        }
+    }
+
+    fn clear_flushed(&mut self, kind: &history::Kind) {
+        if let Some(History::Partial {
+            flushed_messages,
+            flushed_reactions,
+            flushed_redactions,
+            ..
+        }) = self.map.get_mut(kind)
+        {
+            flushed_messages.clear();
+            flushed_reactions.clear();
+            flushed_redactions.clear();
         }
     }
 
@@ -2348,4 +2400,109 @@ fn smart_filter_internal_message(
         .num_seconds();
 
     duration_seconds > *seconds
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+
+    use super::*;
+    use crate::history::test_message;
+    use crate::server::ServerName;
+
+    fn setup() -> (Manager, history::Kind, crate::Message) {
+        let isupport = HashMap::<isupport::Kind, isupport::Parameter>::new();
+        let chantypes = isupport::get_chantypes_or_default(&isupport);
+        let casemapping = isupport::get_casemapping_or_default(&isupport);
+
+        let kind = history::Kind::Channel(
+            Server::from(ServerName::from("test-server")),
+            target::Channel::from_str("#test", chantypes, casemapping),
+        );
+
+        let server_time = Utc.with_ymd_and_hms(2026, 8, 13, 12, 0, 0).unwrap();
+        let message = test_message(server_time, "hello");
+
+        let mut manager = Manager::default();
+
+        // A message arrives while the buffer is closed, then a flush
+        // moves it to flushing_messages and spawns an append task (the
+        // returned tasks are dropped so no file I/O takes place)
+        drop(manager.data.add_message(kind.clone(), message.clone(), None));
+        drop(manager.data.map.get_mut(&kind).unwrap().flush(None, None));
+
+        // The buffer is opened, spawning a full load
+        drop(manager.track(
+            HashSet::from([Resource { kind: kind.clone() }]),
+            None,
+            &config::ChannelMonitor::default(),
+        ));
+
+        (manager, kind, message)
+    }
+
+    fn full_messages_len(manager: &Manager, kind: &history::Kind) -> usize {
+        let Some(History::Full { messages, .. }) = manager.data.map.get(kind)
+        else {
+            panic!("history should be full after loading");
+        };
+
+        messages.len()
+    }
+
+    #[test]
+    fn flush_completing_during_load_is_not_lost() {
+        let (mut manager, kind, _) = setup();
+
+        let clients = client::Map::default();
+        let buffer_config = config::Buffer::default();
+
+        manager.update(
+            Message::Flushed(kind.clone(), Ok(vec![])),
+            &clients,
+            &buffer_config,
+        );
+
+        manager.update(
+            Message::LoadFull(
+                kind.clone(),
+                Ok(history::Loaded {
+                    messages: vec![],
+                    metadata: history::Metadata::default(),
+                }),
+            ),
+            &clients,
+            &buffer_config,
+        );
+
+        assert_eq!(full_messages_len(&manager, &kind), 1);
+    }
+
+    #[test]
+    fn flush_completing_after_load_is_not_duplicated() {
+        let (mut manager, kind, message) = setup();
+
+        let clients = client::Map::default();
+        let buffer_config = config::Buffer::default();
+
+        manager.update(
+            Message::LoadFull(
+                kind.clone(),
+                Ok(history::Loaded {
+                    messages: vec![message],
+                    metadata: history::Metadata::default(),
+                }),
+            ),
+            &clients,
+            &buffer_config,
+        );
+
+        manager.update(
+            Message::Flushed(kind.clone(), Ok(vec![])),
+            &clients,
+            &buffer_config,
+        );
+
+        assert_eq!(full_messages_len(&manager, &kind), 1);
+    }
 }

--- a/data/src/history/manager/channel_monitor/load.rs
+++ b/data/src/history/manager/channel_monitor/load.rs
@@ -85,12 +85,25 @@ fn source(
                 Some(History::Partial {
                     pending_messages,
                     flushing_messages,
+                    flushed_messages,
                     ..
-                }) => pending_messages
+                }) => flushing_messages
                     .iter()
-                    .chain(flushing_messages)
+                    .chain(flushed_messages)
                     .filter(|(message, _)| is_channel_message(message))
-                    .map(|(message, _)| message.clone())
+                    .map(|(message, _)| {
+                        // Mark flushing and flushed messages as deduplicated so
+                        // they don't duplicate the loaded copy.
+                        let mut message = message.clone();
+                        message.deduplicate = true;
+                        message
+                    })
+                    .chain(
+                        pending_messages
+                            .iter()
+                            .filter(|(message, _)| is_channel_message(message))
+                            .map(|(message, _)| message.clone()),
+                    )
                     .collect(),
                 _ => vec![],
             };

--- a/data/src/history/metadata.rs
+++ b/data/src/history/metadata.rs
@@ -114,6 +114,14 @@ pub fn latest_can_reference(messages: &[Message]) -> Option<MessageReferences> {
 }
 
 pub async fn load(kind: Kind) -> Result<Metadata, Error> {
+    let lock = super::file_lock(&kind);
+    let _guard = lock.lock().await;
+
+    load_unlocked(kind).await
+}
+
+/// Must be called with the kind's [`super::file_lock`] held.
+pub(crate) async fn load_unlocked(kind: Kind) -> Result<Metadata, Error> {
     let path = path(&kind).await?;
 
     if let Ok(bytes) = fs::read(path).await {
@@ -123,6 +131,7 @@ pub async fn load(kind: Kind) -> Result<Metadata, Error> {
     }
 }
 
+/// Must be called with the kind's [`super::file_lock`] held.
 pub async fn save(
     kind: &Kind,
     messages: &[Message],
@@ -144,6 +153,7 @@ pub async fn save(
     Ok(())
 }
 
+/// Must be called with the kind's [`super::file_lock`] held.
 pub async fn update(
     kind: &Kind,
     read_marker: Option<ReadMarker>,
@@ -169,7 +179,10 @@ pub async fn update_chathistory_references(
     kind: &Kind,
     chathistory_references: &MessageReferences,
 ) -> Result<(), Error> {
-    let metadata = load(kind.clone()).await?;
+    let lock = super::file_lock(kind);
+    let _guard = lock.lock().await;
+
+    let metadata = load_unlocked(kind.clone()).await?;
 
     if metadata.chathistory_references.is_some_and(
         |metadata_chathistory_references| {
@@ -197,7 +210,10 @@ pub async fn update_read_marker(
     kind: &Kind,
     read_marker: &ReadMarker,
 ) -> Result<(), Error> {
-    let metadata = load(kind.clone()).await?;
+    let lock = super::file_lock(kind);
+    let _guard = lock.lock().await;
+
+    let metadata = load_unlocked(kind.clone()).await?;
 
     if metadata.read_marker.is_some_and(|metadata_read_marker| {
         metadata_read_marker >= *read_marker
@@ -220,6 +236,9 @@ pub async fn update_read_marker(
 }
 
 pub async fn delete(kind: &Kind) -> Result<(), Error> {
+    let lock = super::file_lock(kind);
+    let _guard = lock.lock().await;
+
     let path = path(kind).await?;
 
     fs::remove_file(path).await?;


### PR DESCRIPTION
Disclaimer, I used LLM for this, mostly for the test generation and debugging this. 