### PR TITLE
add condensed message timestamp setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Added:
 
+- `buffer.server_messages.condense.timestamp` setting to control whether a condensed message shows a time range, its start timestamp, its end timestamp, or no timestamp
 - Ability to configure individual bouncer networks with `servers.<name>.networks.<network>`
 - CTCP actions to private message context menus
 - Remember sidebar visibility

--- a/data/src/config/buffer.rs
+++ b/data/src/config/buffer.rs
@@ -634,6 +634,7 @@ pub struct Condensation {
     pub messages: HashSet<CondensationMessage>,
     pub format: CondensationFormat,
     pub icon: CondensationIcon,
+    pub timestamp: CondensationTimestamp,
     #[serde(deserialize_with = "deserialize_dimmed_maybe")]
     pub dimmed: Option<Dimmed>,
     pub max: Option<u16>,
@@ -651,6 +652,7 @@ impl Default for Condensation {
             ]),
             format: CondensationFormat::default(),
             icon: CondensationIcon::default(),
+            timestamp: CondensationTimestamp::default(),
             dimmed: Some(Dimmed::default()),
             max: None,
         }
@@ -725,6 +727,36 @@ pub enum CondensationIcon {
     None,
     Chevron,
     Dot,
+}
+
+#[derive(Debug, Default, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum CondensationTimestamp {
+    #[default]
+    Range,
+    Start,
+    End,
+    None,
+}
+
+impl CondensationTimestamp {
+    pub fn primary<'a>(
+        self,
+        start: &'a DateTime<Utc>,
+        end: &'a DateTime<Utc>,
+    ) -> Option<&'a DateTime<Utc>> {
+        match self {
+            CondensationTimestamp::Range | CondensationTimestamp::Start => {
+                Some(start)
+            }
+            CondensationTimestamp::End => Some(end),
+            CondensationTimestamp::None => None,
+        }
+    }
+
+    pub fn show_range(self) -> bool {
+        matches!(self, CondensationTimestamp::Range)
+    }
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/docs/configuration/buffer.md
+++ b/docs/configuration/buffer.md
@@ -1180,6 +1180,24 @@ Maximum number of user entries to show in a condensed group.
 max = 20
 ```
 
+#### `timestamp`
+
+Controls which timestamp is shown for a condensed group:
+
+- `"range"`: Show the start and end timestamps as a range.
+- `"start"`: Show the timestamp of the first condensed message.
+- `"end"`: Show the timestamp of the last condensed message.
+- `"none"`: Do not show a timestamp.
+
+```toml
+# Type: string
+# Values: "range", "start", "end", "none"
+# Default: "range"
+
+[buffer.server_messages.condense]
+timestamp = "end"
+```
+
 ## `status_message_prefix`
 
 Status message prefix settings.

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -198,9 +198,22 @@ impl<'a> ChannelQueryLayout<'a> {
         message: &'a data::Message,
         hide_timestamp: bool,
     ) -> Option<Element<'a, Message>> {
+        let date_time = match message.target.source() {
+            message::Source::Internal(
+                message::source::Internal::Condensed(end_server_time),
+            ) => self
+                .config
+                .buffer
+                .server_messages
+                .condense
+                .timestamp
+                .primary(&message.server_time, end_server_time),
+            _ => Some(&message.server_time),
+        }?;
+
         self.config
             .buffer
-            .format_timestamp(&message.server_time)
+            .format_timestamp(date_time)
             .map(|timestamp| {
                 if hide_timestamp {
                     let width =
@@ -216,7 +229,7 @@ impl<'a> ChannelQueryLayout<'a> {
                             theme::font_style::timestamp(self.theme)
                                 .map(font::get),
                         ),
-                    &message.server_time,
+                    date_time,
                     self.config,
                     self.theme,
                 )
@@ -886,9 +899,16 @@ impl<'a> ChannelQueryLayout<'a> {
         );
         let moved_link = link.clone();
 
-        let range_end_timestamp = if let message::Source::Internal(
-            message::source::Internal::Condensed(end_server_time),
-        ) = message.target.source()
+        let range_end_timestamp = if formatter
+            .config
+            .buffer
+            .server_messages
+            .condense
+            .timestamp
+            .show_range()
+            && let message::Source::Internal(
+                message::source::Internal::Condensed(end_server_time),
+            ) = message.target.source()
             && message.server_time != *end_server_time
         {
             formatter

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -461,7 +461,14 @@ pub fn view<'a>(
                 .fold(0.0, f32::max);
 
             let range_end_timestamp_width =
-                if config.buffer.server_messages.condense.any() {
+                if config.buffer.server_messages.condense.any()
+                    && config
+                        .buffer
+                        .server_messages
+                        .condense
+                        .timestamp
+                        .show_range()
+                {
                     alignment_messages()
                         .filter_map(|message| {
                             if let message::Source::Internal(
@@ -2431,8 +2438,20 @@ fn prefixes_width(message: &data::Message, config: &Config) -> Option<f32> {
 }
 
 fn timestamp_width(message: &data::Message, config: &Config) -> Option<f32> {
+    let date_time = match message.target.source() {
+        message::Source::Internal(message::source::Internal::Condensed(
+            end_server_time,
+        )) => config
+            .buffer
+            .server_messages
+            .condense
+            .timestamp
+            .primary(&message.server_time, end_server_time),
+        _ => Some(&message.server_time),
+    }?;
+
     config
         .buffer
-        .format_timestamp(&message.server_time)
+        .format_timestamp(date_time)
         .map(|timestamp| font::width_from_str(&timestamp, &config.font) + 1.0)
 }


### PR DESCRIPTION
`buffer.server_messages.condense.timestamp` setting to control whether a condensed message shows a time range, its start timestamp, its end timestamp, or no timestamp