### PR TITLE
Respect modifiers for focus keybinds

### DIFF
--- a/data/src/config/keys.rs
+++ b/data/src/config/keys.rs
@@ -247,13 +247,24 @@ impl Keyboard {
         let matches =
             |binds: &KeyBinds| binds.iter().any(|bind| bind == key_bind);
 
-        if matches(&self.focus_up) {
+        // Focus navigation keys need to exist in both focus and non-focus
+        // modes. When not in focus mode modifiers are expected and in focus
+        // mode modifiers are not expected, so allow them to match without
+        // modifiers when in focus mode.
+        let matches_ignore_modifiers = |binds: &KeyBinds| {
+            binds.iter().any(|bind| {
+                bind == key_bind
+                    || (in_focus && bind.eq_ignore_modifiers(key_bind))
+            })
+        };
+
+        if matches_ignore_modifiers(&self.focus_up) {
             Some(FocusCommand::Up)
-        } else if matches(&self.focus_down) {
+        } else if matches_ignore_modifiers(&self.focus_down) {
             Some(FocusCommand::Down)
-        } else if matches(&self.focus_left) {
+        } else if matches_ignore_modifiers(&self.focus_left) {
             Some(FocusCommand::Left)
-        } else if matches(&self.focus_right) {
+        } else if matches_ignore_modifiers(&self.focus_right) {
             Some(FocusCommand::Right)
         } else if matches(&self.focus_activate) {
             Some(FocusCommand::Activate)

--- a/data/src/config/keys.rs
+++ b/data/src/config/keys.rs
@@ -244,14 +244,8 @@ impl Keyboard {
         key_bind: &KeyBind,
         in_focus: bool,
     ) -> Option<FocusCommand> {
-        let matches = |binds: &KeyBinds| {
-            binds.iter().any(|bind| {
-                bind == key_bind
-                    || (in_focus
-                        && !key_bind.has_modifiers()
-                        && key_bind.key_code() == bind.key_code())
-            })
-        };
+        let matches =
+            |binds: &KeyBinds| binds.iter().any(|bind| bind == key_bind);
 
         if matches(&self.focus_up) {
             Some(FocusCommand::Up)
@@ -276,5 +270,36 @@ impl Keyboard {
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use iced_core::keyboard;
+
+    use super::*;
+
+    #[test]
+    fn focus_command_requires_configured_modifiers() {
+        let config: Keyboard = toml::from_str(
+            r#"
+            focus_redact = "ctrl+x"
+            "#,
+        )
+        .unwrap();
+        let ctrl_x = KeyBind::from((
+            keyboard::Key::Character("x".into()),
+            keyboard::Modifiers::CTRL,
+        ));
+        let x = KeyBind::from((
+            keyboard::Key::Character("x".into()),
+            keyboard::Modifiers::default(),
+        ));
+
+        assert_eq!(
+            config.focus_command(&ctrl_x, true),
+            Some(FocusCommand::Redact)
+        );
+        assert_eq!(config.focus_command(&x, true), None);
     }
 }

--- a/data/src/shortcut.rs
+++ b/data/src/shortcut.rs
@@ -303,6 +303,22 @@ impl KeyBind {
             KeyBind::Unbind => String::new(),
         }
     }
+
+    pub fn eq_ignore_modifiers(&self, other: &KeyBind) -> bool {
+        if let KeyBind::Bind {
+            key_code: self_key_code,
+            ..
+        } = self
+            && let KeyBind::Bind {
+                key_code: other_key_code,
+                ..
+            } = other
+        {
+            self_key_code == other_key_code
+        } else {
+            false
+        }
+    }
 }
 
 impl PartialEq for KeyBind {

--- a/data/src/shortcut.rs
+++ b/data/src/shortcut.rs
@@ -24,20 +24,6 @@ impl Shortcut {
 }
 
 impl KeyBind {
-    pub fn has_modifiers(&self) -> bool {
-        matches!(
-            self,
-            KeyBind::Bind { modifiers, .. } if !modifiers.0.is_empty()
-        )
-    }
-
-    pub fn key_code(&self) -> Option<&KeyCode> {
-        match self {
-            KeyBind::Bind { key_code, .. } => Some(key_code),
-            KeyBind::Unbind => None,
-        }
-    }
-
     /// Built-in (non-configurable) gestures while a message selection is active
     pub fn builtin_focus_command(&self) -> Option<FocusCommand> {
         let KeyBind::Bind {


### PR DESCRIPTION
Focus mode ignored configured key modifiers, so a shortcut like `Ctrl+x` could also be triggered by pressing `x`