### PR TITLE
Update h2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2825,9 +2825,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
Update h2 to address [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258.html).  Closes #2300.