### PR TITLE
Decouple `+draft/unreact` from `+draft/react`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,11 +44,12 @@ Changed:
 - The XDG data directory `~/.local/share/halloy` can be used for storing history/logs/etc macOS, instead of `~/Library/Application Support/halloy/` (move entire directory to migrate)
 - Offline nicknames are styled only by `buffer.nickname.offline`; `buffer.nickname.away` no longer applies to them
 - `esc` in the input box now scrolls the buffer to the bottom
+- Decouple `+draft/unreact` from `+draft/react`
 
 Thanks:
 
 - Contributions: @rollecode, @luca020400, @rtmongold, @tranzystorekk, @englut, @furudean
-- Bug reports: @sebbu2, @dpedu, kurwavidae, @ncfavier, wwWraith, kurwavidae, @SRAZKVT, @WinnerWind
+- Bug reports: @sebbu2, @dpedu, kurwavidae, @ncfavier, wwWraith, kurwavidae, @SRAZKVT, @WinnerWind, @edwardloveall
 - Feature requests: @daniiooo, @fabricionaweb, @RoboDanjal, @AbandonedCranium, tbo, ivocavalcante, @sebbu2, @coraxioU9, @ncfavier, @darienm
 
 # 2026.8 (2026-07-24)

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -4539,6 +4539,10 @@ impl Client {
     fn can_send_reactions(&self) -> bool {
         self.can_send_replies()
             && isupport::is_client_tag_allowed(&self.isupport, "draft/react")
+    }
+
+    fn can_send_unreactions(&self) -> bool {
+        self.can_send_replies()
             && isupport::is_client_tag_allowed(&self.isupport, "draft/unreact")
     }
 
@@ -5386,6 +5390,11 @@ impl Map {
 
     pub fn get_server_can_send_reactions(&self, server: &Server) -> bool {
         self.client(server).is_some_and(Client::can_send_reactions)
+    }
+
+    pub fn get_server_can_send_unreactions(&self, server: &Server) -> bool {
+        self.client(server)
+            .is_some_and(Client::can_send_unreactions)
     }
 
     pub fn get_server_can_redact(&self, server: &Server) -> bool {

--- a/src/buffer/channel.rs
+++ b/src/buffer/channel.rs
@@ -72,6 +72,7 @@ pub fn view<'a>(
     let server = &state.server;
     let connected = matches!(clients.status(server), client::Status::Connected);
     let can_send_reactions = clients.get_server_can_send_reactions(server);
+    let can_send_unreactions = clients.get_server_can_send_unreactions(server);
     let can_redact = clients.get_server_can_redact(server);
     let can_send_replies = clients.get_server_can_send_replies(server);
     let chantypes = clients.get_server_chantypes_or_default(server);
@@ -121,6 +122,7 @@ pub fn view<'a>(
         registry,
         confirm_message_delivery,
         can_send_reactions,
+        can_send_unreactions,
         can_redact,
         can_send_replies,
         our_nick,

--- a/src/buffer/message_view.rs
+++ b/src/buffer/message_view.rs
@@ -93,6 +93,7 @@ pub struct ChannelQueryLayout<'a> {
     pub confirm_message_delivery: bool,
     pub can_send_replies: bool,
     pub can_send_reactions: bool,
+    pub can_send_unreactions: bool,
     pub can_redact: bool,
     pub our_nick: Option<NickRef<'a>>,
     pub connected: bool,
@@ -376,22 +377,24 @@ impl<'a> ChannelQueryLayout<'a> {
         let mut on_open_picker = None;
 
         if let Some(msgid) = message.id.as_ref() {
-            on_react = Some(|text: &'a str| Message::Reacted {
-                msgid: msgid.clone(),
-                text: text.to_owned().into(),
-            });
-            on_unreact = Some(|text: &'a str| Message::Unreacted {
-                msgid: msgid.clone(),
-                text: text.to_owned().into(),
-            });
-
             if self.can_send_reactions {
+                on_react = Some(|text: &'a str| Message::Reacted {
+                    msgid: msgid.clone(),
+                    text: text.to_owned().into(),
+                });
+
                 on_open_picker = Some(Message::ContextMenu(
                     context_menu::Message::OpenReactionModal(
                         msgid.clone(),
                         message.server_time,
                     ),
                 ));
+            }
+            if self.can_send_unreactions {
+                on_unreact = Some(|text: &'a str| Message::Unreacted {
+                    msgid: msgid.clone(),
+                    text: text.to_owned().into(),
+                });
             }
         }
 

--- a/src/buffer/query.rs
+++ b/src/buffer/query.rs
@@ -67,6 +67,7 @@ pub fn view<'a>(
     let server = &state.server;
     let connected = matches!(clients.status(server), client::Status::Connected);
     let can_send_reactions = clients.get_server_can_send_reactions(server);
+    let can_send_unreactions = clients.get_server_can_send_unreactions(server);
     let can_redact = clients.get_server_can_redact(server);
     let can_send_replies = clients.get_server_can_send_replies(server);
     let chantypes = clients.get_server_chantypes_or_default(server);
@@ -108,6 +109,7 @@ pub fn view<'a>(
         registry,
         confirm_message_delivery,
         can_send_reactions,
+        can_send_unreactions,
         can_redact,
         can_send_replies,
         our_nick,


### PR DESCRIPTION
Addresses #2302.

Some servers implement an older version of `+draft/react` where there was no `+draft/unreact` yet. These implementations allow for react & unreact. Decoupling the two in our codebase allows reacting to work for these servers.

Found two so far:

[reaction plugin for UnrealIRCd](https://github.com/unrealircd/unrealircd-contrib/blob/unreal6/files/react.c)
[matrix2051](https://github.com/progval/matrix2051/issues/92)