### PR TITLE
Nickname Highlighting Include/Exclude Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Fixed:
 - "Apply Colors & Font Styles" button in Theme Editor persists modifications made via the theme editor
 - Scroll-to-reply when clicking a reply preview
 - Show registration-required join errors in the channel buffer instead of the server buffer
+- Include/exclude conditions are properly accounted for when highlighting nicknames
 
 Changed:
 
@@ -48,7 +49,7 @@ Changed:
 Thanks:
 
 - Contributions: @rollecode, @luca020400, @rtmongold, @tranzystorekk, @englut, @furudean
-- Bug reports: @sebbu2, @dpedu, kurwavidae, @ncfavier, wwWraith, kurwavidae, @SRAZKVT, @WinnerWind
+- Bug reports: @sebbu2, @dpedu, kurwavidae, @ncfavier, wwWraith, kurwavidae, @SRAZKVT, @WinnerWind, liquidity
 - Feature requests: @daniiooo, @fabricionaweb, @RoboDanjal, @AbandonedCranium, tbo, ivocavalcante, @sebbu2, @coraxioU9, @ncfavier, @darienm
 
 # 2026.8 (2026-07-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Changed:
 Thanks:
 
 - Contributions: @rollecode, @luca020400, @rtmongold, @tranzystorekk, @englut, @furudean
-- Bug reports: @sebbu2, @dpedu, kurwavidae, @ncfavier, wwWraith, kurwavidae, @SRAZKVT, @WinnerWind, liquidity
+- Bug reports: @sebbu2, @dpedu, kurwavidae, @ncfavier, wwWraith, kurwavidae, @SRAZKVT, @WinnerWind, @lojinks
 - Feature requests: @daniiooo, @fabricionaweb, @RoboDanjal, @AbandonedCranium, tbo, ivocavalcante, @sebbu2, @coraxioU9, @ncfavier, @darienm
 
 # 2026.8 (2026-07-24)

--- a/data/src/message.rs
+++ b/data/src/message.rs
@@ -1974,9 +1974,9 @@ pub fn parse_fragments_with_highlights(
                         target.as_target_ref(),
                         server,
                         casemapping,
-                    ) && (user.nickname() == *our_nick
+                    ) && ((user.nickname() == *our_nick
                         && highlights.nickname.case_insensitive)
-                        || raw.as_str() == our_nick.as_str() =>
+                        || raw.as_str() == our_nick.as_str()) =>
                 {
                     if highlight_kind.is_none() {
                         highlight_kind = Some(highlight::Kind::Nick);


### PR DESCRIPTION
Account for include/exclude conditions when highlighting nicknames (even when there is an exact match between the text and nickname).