### PR TITLE
Automatically Save Before Reloading Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,12 +47,13 @@ Changed:
 - Offline nicknames are styled only by `buffer.nickname.offline`; `buffer.nickname.away` no longer applies to them
 - `esc` in the input box now scrolls the buffer to the bottom
 - Decouple `+draft/unreact` from `+draft/react`
+- When reloading the config file, if the config file editor pane is opened with unsaved changes then those changes will be saved before reloading
 
 Thanks:
 
 - Contributions: @rollecode, @luca020400, @rtmongold, @tranzystorekk, @englut, @furudean
 - Bug reports: @sebbu2, @dpedu, kurwavidae, @ncfavier, wwWraith, kurwavidae, @SRAZKVT, @WinnerWind, @lojinks, @edwardloveall
-- Feature requests: @daniiooo, @fabricionaweb, @RoboDanjal, @AbandonedCranium, tbo, ivocavalcante, @sebbu2, @coraxioU9, @ncfavier, @darienm
+- Feature requests: @daniiooo, @fabricionaweb, @RoboDanjal, @AbandonedCranium, tbo, ivocavalcante, @sebbu2, @coraxioU9, @ncfavier, @darienm, gkoebel
 
 # 2026.8 (2026-07-24)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1125,14 +1125,12 @@ impl Halloy {
                         modal::Event::KeyringPasswordStored => {
                             self.modal = None;
 
-                            let reload = if matches!(
-                                self.screen,
-                                Screen::Dashboard(_)
-                            ) {
-                                Task::perform(
-                                    Config::load(),
-                                    Message::ConfigReloaded,
-                                )
+                            let reload = if let Screen::Dashboard(dashboard) =
+                                &mut self.screen
+                            {
+                                dashboard
+                                    .reload_config()
+                                    .map(Message::Dashboard)
                             } else {
                                 Task::perform(
                                     Config::load(),
@@ -1598,6 +1596,10 @@ impl Halloy {
         &mut self,
         config: Result<Config, config::Error>,
     ) -> Task<Message> {
+        let reload_complete = Task::done(Message::Dashboard(
+            dashboard::Message::ConfigReloadComplete,
+        ));
+
         match config {
             Ok(updated) => {
                 let reload_channel_monitor =
@@ -1740,10 +1742,12 @@ impl Halloy {
                             .map(Message::Dashboard),
                     );
 
-                    return Task::batch(tasks);
+                    return Task::batch(tasks).chain(reload_complete);
                 }
 
-                return runtime_task.unwrap_or_else(Task::none);
+                return runtime_task
+                    .unwrap_or_else(Task::none)
+                    .chain(reload_complete);
             }
             Err(error) => {
                 let modal = Self::modal_for_missing_keyring_password(&error)
@@ -1752,7 +1756,7 @@ impl Halloy {
             }
         }
 
-        Task::none()
+        reload_complete
     }
 
     fn handle_messages_received(

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -75,6 +75,7 @@ pub struct Dashboard {
     http_client: Option<Arc<reqwest::Client>>,
     buffer_settings: dashboard::BufferSettings,
     pub filehost: filehost::Manager,
+    reloading_config: bool,
 }
 
 #[derive(Debug)]
@@ -99,6 +100,7 @@ pub enum Message {
     Filehost(filehost::Message),
     ProceedWithFilehostUpload,
     CancelFilehostUpload,
+    ConfigReloadComplete,
 }
 
 #[derive(Debug)]
@@ -161,6 +163,7 @@ impl Dashboard {
             http_client: http_client_from_config(config).map(Arc::new),
             buffer_settings: dashboard::BufferSettings::default(),
             filehost: filehost::Manager::new(),
+            reloading_config: false,
         };
 
         if config.buffer.text_input.persist {
@@ -723,8 +726,8 @@ impl Dashboard {
                         ),
                         None,
                     ),
-                    sidebar::Event::ConfigReloaded(conf) => {
-                        (Task::none(), Some(Event::ConfigReloaded(conf)))
+                    sidebar::Event::ReloadConfigFile => {
+                        (self.save_config_editor_or_reload_config(), None)
                     }
                     sidebar::Event::OpenReleaseWebsite => {
                         let _ = open_url::open(RELEASE_WEBSITE);
@@ -1201,10 +1204,7 @@ impl Dashboard {
                     }
                     ReloadConfiguration => {
                         return (
-                            Task::perform(
-                                Config::load(),
-                                Message::ConfigReloaded,
-                            ),
+                            self.save_config_editor_or_reload_config(),
                             None,
                         );
                     }
@@ -1444,27 +1444,8 @@ impl Dashboard {
                         }
                     }
                     ConfigEditorSave => {
-                        let Focus { window, pane } = self.focus;
-
-                        if self.panes.get(window, pane).is_some_and(|state| {
-                            matches!(
-                                &state.buffer,
-                                Buffer::ConfigEditor(editor)
-                                    if editor.has_unsaved_changes()
-                            )
-                        }) {
-                            return (
-                                Task::done(Message::Pane(
-                                    window,
-                                    pane::Message::Buffer(
-                                        pane,
-                                        buffer::Message::ConfigEditor(
-                                            buffer::config_editor::Message::Save,
-                                        ),
-                                    ),
-                                )),
-                                None,
-                            );
+                        if let Some(task) = self.save_config_editor(true) {
+                            return (task, None);
                         }
                     }
                     OpenConfigEditor => {
@@ -1618,11 +1599,14 @@ impl Dashboard {
 
                 // Errors are surfaced within the config editor instead of
                 // the reload error modal.
-                let event = config_result
-                    .is_ok()
-                    .then_some(Event::ConfigReloaded(config_result));
-
-                return (Task::none(), event);
+                if config_result.is_ok() {
+                    return (
+                        Task::none(),
+                        Some(Event::ConfigReloaded(config_result)),
+                    );
+                } else {
+                    self.reloading_config = false;
+                }
             }
             Message::Client(message) => match message {
                 client::Message::ChatHistoryRequest(server, subcommand) => {
@@ -1726,6 +1710,9 @@ impl Dashboard {
             Message::CancelFilehostUpload => {
                 let task = self.filehost.cancel().map(Message::Filehost);
                 return (task, None);
+            }
+            Message::ConfigReloadComplete => {
+                self.reloading_config = false;
             }
         }
 
@@ -2677,13 +2664,7 @@ impl Dashboard {
                 return (Task::none(), None);
             }
             buffer::Event::ConfigSaved => {
-                return (
-                    Task::perform(
-                        Config::load(),
-                        Message::ConfigEditorReloaded,
-                    ),
-                    None,
-                );
+                return (self.reload_config(), None);
             }
             buffer::Event::OpenServer(server) => {
                 return (Task::none(), Some(Event::OpenServer(server)));
@@ -3117,10 +3098,9 @@ impl Dashboard {
                     let _ = open_url::open(environment::WIKI_WEBSITE);
                     (Task::none(), None)
                 }
-                command_bar::Configuration::Reload => (
-                    Task::perform(Config::load(), Message::ConfigReloaded),
-                    None,
-                ),
+                command_bar::Configuration::Reload => {
+                    (self.save_config_editor_or_reload_config(), None)
+                }
                 command_bar::Configuration::OpenConfigFile => {
                     let _ = open_url::open(Config::path());
                     (Task::none(), None)
@@ -4914,6 +4894,7 @@ impl Dashboard {
             http_client: http_client_from_config(config).map(Arc::new),
             buffer_settings: data.buffer_settings.clone(),
             filehost: filehost::Manager::new(),
+            reloading_config: false,
         };
 
         let mut tasks = vec![sidebar_task.map(Message::Sidebar)];
@@ -5445,6 +5426,60 @@ impl Dashboard {
             })
             .collect()
     }
+
+    fn save_config_editor(
+        &self,
+        only_if_focused: bool,
+    ) -> Option<Task<Message>> {
+        let config_editor = if only_if_focused {
+            let Focus { window, pane } = self.focus;
+
+            self.panes
+                .get(window, pane)
+                .map(|state| (window, pane, state))
+        } else {
+            self.panes.get_by_buffer(&data::Buffer::Internal(
+                data::buffer::Internal::ConfigEditor,
+            ))
+        };
+
+        if let Some((window, pane, state)) = config_editor
+            && matches!(
+                &state.buffer,
+                Buffer::ConfigEditor(editor)
+                    if editor.has_unsaved_changes())
+        {
+            return Some(Task::done(Message::Pane(
+                window,
+                pane::Message::Buffer(
+                    pane,
+                    buffer::Message::ConfigEditor(
+                        buffer::config_editor::Message::Save,
+                    ),
+                ),
+            )));
+        }
+
+        None
+    }
+
+    fn save_config_editor_or_reload_config(&mut self) -> Task<Message> {
+        if let Some(task) = self.save_config_editor(false) {
+            task
+        } else {
+            self.reload_config()
+        }
+    }
+
+    pub fn reload_config(&mut self) -> Task<Message> {
+        if !self.reloading_config {
+            self.reloading_config = true;
+
+            Task::perform(Config::load(), Message::ConfigReloaded)
+        } else {
+            Task::none()
+        }
+    }
 }
 
 impl ChannelsContext for Dashboard {
@@ -5603,7 +5638,7 @@ impl Panes {
     }
 
     fn get_by_buffer(
-        &mut self,
+        &self,
         buffer: &data::Buffer,
     ) -> Option<(window::Id, pane_grid::Pane, &Pane)> {
         self.iter().find(|(_, _, state)| {

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -378,18 +378,7 @@ impl TitleBar {
 
                 let reload_button_with_tooltip = tooltip(
                     reload_button,
-                    show_tooltips.then_some(
-                        match config.keyboard.reload_configuration.primary() {
-                            Some(
-                                keybind @ data::shortcut::KeyBind::Bind {
-                                    ..
-                                },
-                            ) => {
-                                format!("Reload file from disk ({keybind})")
-                            }
-                            _ => "Reload file from disk".to_string(),
-                        },
-                    ),
+                    show_tooltips.then_some("Reload file from disk"),
                     tooltip::Position::Bottom,
                     theme,
                 );

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -1,4 +1,3 @@
-use std::time::Duration;
 use std::{convert, iter};
 
 use data::buffer::{Buffer, BufferRef};
@@ -20,7 +19,6 @@ use iced::{
     Alignment, Border, ContentFit, Length, Padding, Task, mouse, padding,
 };
 use itertools::Either;
-use tokio::time;
 
 use super::{Focus, Panes, Server};
 use crate::widget::text_color_svg::TextColorSvg;
@@ -30,8 +28,6 @@ use crate::widget::{
 use crate::{Theme, font, icon, platform_specific, theme, window};
 
 mod collapse;
-
-const CONFIG_RELOAD_DELAY: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -47,7 +43,6 @@ pub enum Message {
     ToggleCommandBar,
     ToggleThemeEditor,
     ReloadConfigFile,
-    ConfigReloaded(Result<Config, config::Error>),
     OpenReleaseWebsite,
     OpenAbout {
         version: String,
@@ -55,7 +50,6 @@ pub enum Message {
         system_information: Option<iced::system::Information>,
     },
     OpenDocumentation,
-    ReloadComplete,
     MarkAsRead(data::Buffer),
     MarkServerAsRead(Server),
     QuitApplication,
@@ -87,7 +81,6 @@ pub enum Event {
         system_information: Option<iced::system::Information>,
     },
     OpenDocumentation,
-    ConfigReloaded(Result<Config, config::Error>),
     MarkAsRead(data::Buffer),
     MarkServerAsRead(Server),
     QuitApplication,
@@ -95,13 +88,13 @@ pub enum Event {
     DisableAutoconnect(Server),
     Remove(Server),
     ShowMutedBuffers(bool),
+    ReloadConfigFile,
 }
 
 #[derive(Clone)]
 pub struct Sidebar {
     pub hidden: bool,
     collapse: collapse::State,
-    reloading_config: bool,
     system_information: Option<iced::system::Information>,
 }
 
@@ -111,7 +104,6 @@ impl Sidebar {
             Self {
                 hidden,
                 collapse: collapse::State::default(),
-                reloading_config: false,
                 system_information: None,
             },
             iced::system::information().map(Message::SystemInformation),
@@ -466,21 +458,10 @@ impl Sidebar {
                 (Task::none(), Some(Event::ToggleThemeEditor))
             }
             Message::ReloadConfigFile => {
-                self.reloading_config = true;
-                (Task::perform(Config::load(), Message::ConfigReloaded), None)
+                (Task::none(), Some(Event::ReloadConfigFile))
             }
-            Message::ConfigReloaded(config) => (
-                Task::perform(time::sleep(CONFIG_RELOAD_DELAY), |()| {
-                    Message::ReloadComplete
-                }),
-                Some(Event::ConfigReloaded(config)),
-            ),
             Message::OpenReleaseWebsite => {
                 (Task::none(), Some(Event::OpenReleaseWebsite))
-            }
-            Message::ReloadComplete => {
-                self.reloading_config = false;
-                (Task::none(), None)
             }
             Message::OpenDocumentation => {
                 (Task::none(), Some(Event::OpenDocumentation))


### PR DESCRIPTION
Automatically save configuration in editor to disk (if editor is open, with unsaved changes) before reloading configuration.  To make for a more intuitive experience when editing the configuration and using "Reload config file" from the sidebar menu, the reload configuration shortcut, or reloading the configuration via the command bar.

Also moves the existing logic for limiting to one reload in-flight from the sidebar into the dashboard, and applies it to all configuration reloads initiated via the dashboard or its children.