### PR TITLE
Change websocket ping interval behavior

### DIFF
--- a/irc/src/connection/websocket.rs
+++ b/irc/src/connection/websocket.rs
@@ -91,12 +91,16 @@ impl<Codec> WebSocketConnection<Codec> {
         let (stream, response) =
             client_async_with_config(request, transport, Some(config)).await?;
 
+        let mut ping_interval = tokio::time::interval(ping_interval);
+        ping_interval
+            .set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
         Ok(Self {
             stream,
             codec,
             read: BytesMut::new(),
             mode: mode_from_response(&response)?,
-            ping_interval: tokio::time::interval(ping_interval),
+            ping_interval,
             ping: PingState::Idle,
         })
     }


### PR DESCRIPTION
In the default `Burst` mode `::Interval` replays every missed tick
back-to-back as soon as it's next polled.

If we miss the window to send a Ping (e.g. the process is suspended),
we'd fire a burst of Message::Ping on resume, or fail to send them.

`Delay` instead resets the window if it notices we missed an interval
and starts as normal with a new cycle.
