### PR TITLE
Guard server-icon decoding against oversized (decompression-bomb) images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Fixed:
 - Scroll-to-reply when clicking a reply preview
 - Show registration-required join errors in the channel buffer instead of the server buffer
 - Include/exclude conditions are properly accounted for when highlighting nicknames
+- Reject server icons whose decoded dimensions would exceed the maximum GPU
+  buffer size, matching the existing link-preview guard
 
 Changed:
 

--- a/data/src/image.rs
+++ b/data/src/image.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use iced_wgpu::wgpu;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -66,6 +67,24 @@ impl Image {
             path,
         }
     }
+}
+
+/// Whether an image of these pixel dimensions would exceed the maximum GPU
+/// buffer size once its rows are padded for upload. Shared decompression-bomb
+/// guard for the link-preview and server-icon fetchers; returns the computed
+/// `(padded_size, max_buffer_size)` when it overflows so callers can surface the
+/// sizes.
+pub fn gpu_buffer_overflow(width: u32, height: u32) -> Option<(u64, u64)> {
+    // As per iced, webgpu requires
+    //   BufferCopyView.layout.bytes_per_row % COPY_BYTES_PER_ROW_ALIGNMENT == 0
+    // so round the row width up to the next multiple first.
+    let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+    let padding = (align - (4 * width) % align) % align;
+    let padded_width = u64::from(4 * width + padding);
+    let padded_size = padded_width * u64::from(height);
+    let max_buffer_size = wgpu::Limits::downlevel_defaults().max_buffer_size;
+
+    (padded_size > max_buffer_size).then_some((padded_size, max_buffer_size))
 }
 
 mod serde_image_format {

--- a/data/src/preview.rs
+++ b/data/src/preview.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 
 use ::image::image_dimensions;
 use fancy_regex::Regex;
-use iced_wgpu::wgpu;
 use log;
 use reqwest::header::{self, HeaderValue};
 use serde::{Deserialize, Serialize};
@@ -338,20 +337,9 @@ async fn load_inner(
         } else if let Ok((image_width, image_height)) =
             image_dimensions(&image.path)
         {
-            // As per iced, it is a webgpu requirement that:
-            //   BufferCopyView.layout.bytes_per_row % wgpu::COPY_BYTES_PER_ROW_ALIGNMENT == 0
-            // So we calculate padded_width by rounding width up to the next
-            // multiple of wgpu::COPY_BYTES_PER_ROW_ALIGNMENT.
-            let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
-            let padding = (align - (4 * image_width) % align) % align;
-            let padded_image_width = u64::from(4 * image_width + padding);
-            let padded_image_data_size =
-                padded_image_width * u64::from(image_height);
-
-            let max_buffer_size =
-                wgpu::Limits::downlevel_defaults().max_buffer_size;
-
-            if padded_image_data_size > max_buffer_size {
+            if let Some((padded_image_data_size, max_buffer_size)) =
+                image::gpu_buffer_overflow(image_width, image_height)
+            {
                 Err(LoadError::ImageDimensionsTooLarge {
                     padded_image_data_size,
                     max_buffer_size,

--- a/data/src/server_icon.rs
+++ b/data/src/server_icon.rs
@@ -3,7 +3,6 @@ use std::io;
 use std::sync::Arc;
 
 use iced::Task;
-use iced_wgpu::wgpu;
 use reqwest::header;
 use sha2::{Digest, Sha256};
 use tokio::fs;
@@ -259,10 +258,9 @@ async fn fetch(
 
     // Guard against decompression bombs: a small compressed payload can still
     // decode to enormous pixel dimensions, so the byte cap above does not bound
-    // the memory needed to decode/upload the icon. Mirror the link-preview
-    // pipeline's check (see preview.rs) and reject icons whose padded
-    // dimensions would exceed the maximum GPU buffer size. SVG has no raster
-    // dimensions, so it is exempt. Done before the blob is written to cache.
+    // the memory needed to decode/upload the icon. Reuse the shared link-preview
+    // buffer-size guard and reject icons that would overflow it. SVG has no
+    // raster dimensions, so it is exempt. Done before the blob is cached.
     if !matches!(format, image::Format::Svg) {
         let dimensions = ::image::ImageReader::new(io::Cursor::new(&bytes))
             .with_guessed_format()
@@ -273,14 +271,7 @@ async fn fetch(
             return Err(LoadError::ParseImage);
         };
 
-        let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
-        let padding = (align - (4 * width) % align) % align;
-        let padded_width = u64::from(4 * width + padding);
-        let padded_image_data_size = padded_width * u64::from(height);
-        let max_buffer_size =
-            wgpu::Limits::downlevel_defaults().max_buffer_size;
-
-        if padded_image_data_size > max_buffer_size {
+        if image::gpu_buffer_overflow(width, height).is_some() {
             return Err(LoadError::TooLarge);
         }
     }

--- a/data/src/server_icon.rs
+++ b/data/src/server_icon.rs
@@ -3,6 +3,7 @@ use std::io;
 use std::sync::Arc;
 
 use iced::Task;
+use iced_wgpu::wgpu;
 use reqwest::header;
 use sha2::{Digest, Sha256};
 use tokio::fs;
@@ -254,6 +255,34 @@ async fn fetch(
             return Err(LoadError::TooLarge);
         }
         bytes.extend_from_slice(&chunk);
+    }
+
+    // Guard against decompression bombs: a small compressed payload can still
+    // decode to enormous pixel dimensions, so the byte cap above does not bound
+    // the memory needed to decode/upload the icon. Mirror the link-preview
+    // pipeline's check (see preview.rs) and reject icons whose padded
+    // dimensions would exceed the maximum GPU buffer size. SVG has no raster
+    // dimensions, so it is exempt. Done before the blob is written to cache.
+    if !matches!(format, image::Format::Svg) {
+        let dimensions = ::image::ImageReader::new(io::Cursor::new(&bytes))
+            .with_guessed_format()
+            .ok()
+            .and_then(|reader| reader.into_dimensions().ok());
+
+        let Some((width, height)) = dimensions else {
+            return Err(LoadError::ParseImage);
+        };
+
+        let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+        let padding = (align - (4 * width) % align) % align;
+        let padded_width = u64::from(4 * width + padding);
+        let padded_image_data_size = padded_width * u64::from(height);
+        let max_buffer_size =
+            wgpu::Limits::downlevel_defaults().max_buffer_size;
+
+        if padded_image_data_size > max_buffer_size {
+            return Err(LoadError::TooLarge);
+        }
     }
 
     let mut hasher = Sha256::default();


### PR DESCRIPTION
Server icons are fetched from a URL the server advertises. `fetch` already caps
the encoded download at 5 MiB (`MAX_ICON_SIZE`), but a small compressed payload
can still decode to enormous pixel dimensions, so the byte cap does not bound the
memory needed to decode/upload the image.

The link-preview pipeline already guards against this (`preview.rs`) by rejecting
images whose padded dimensions exceed the maximum GPU buffer size. This mirrors
that check for server icons: after the body is read and the format detected (and
skipping SVG, which has no raster dimensions), read the image dimensions from the
in-memory bytes and reject the icon with `LoadError::TooLarge` if the padded size
would exceed `wgpu::Limits::downlevel_defaults().max_buffer_size`. The check runs
before the blob is written to the on-disk cache.

Reported via a private security advisory on this repository.
