### PR TITLE
Bound the number of concurrently open IRCv3 batches from a server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Fixed:
 - Scroll-to-reply when clicking a reply preview
 - Show registration-required join errors in the channel buffer instead of the server buffer
 - Include/exclude conditions are properly accounted for when highlighting nicknames
+- Cap the number of concurrently open IRCv3 batches a server can hold open, so a
+  single connection cannot grow memory without bound
 
 Changed:
 

--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -52,6 +52,12 @@ const CHATHISTORY_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
 const MODE_REQUEST_DELAY: Duration = Duration::from_millis(600);
 const MODE_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
 const TYPING_TIMEOUT: Duration = Duration::from_secs(6);
+// Upper bound on concurrently open IRCv3 batches. A server opens a batch with
+// `BATCH +<ref>` and must close it with `BATCH -<ref>`; without a ceiling a
+// malicious or buggy server could open batches without ever closing them and
+// grow the `batches` map without bound. Far above any legitimate use (including
+// nested multiline/chathistory batches).
+const MAX_OPEN_BATCHES: usize = 1024;
 
 #[derive(Debug, Clone, Copy)]
 pub enum Status {
@@ -1113,7 +1119,20 @@ impl Client {
                             _ => None,
                         };
 
-                        self.batches.insert(reference, batch);
+                        // Cap concurrently open batches so a server cannot grow
+                        // this map without bound by opening batches it never
+                        // closes. Beyond the cap the open is dropped; messages
+                        // tagged with it are handled without batch context, so
+                        // no existing batch state is disturbed.
+                        if self.batches.len() >= MAX_OPEN_BATCHES {
+                            log::warn!(
+                                "[{}] ignoring BATCH open (reference {reference}): \
+                                 {MAX_OPEN_BATCHES} batches already open",
+                                self.server
+                            );
+                        } else {
+                            self.batches.insert(reference, batch);
+                        }
                     }
                     '-' => {
                         if let Some(mut finished) =


### PR DESCRIPTION
A `BATCH +<ref>` message opens a batch that lives in `self.batches` until the
matching `BATCH -<ref>` closes it. Nothing bounds how many batches a server may
open without ever closing them, so a malicious or buggy server can grow this map
without limit from a single connection.

This caps concurrently open batches at `MAX_OPEN_BATCHES` (1024 — far above any
legitimate use, including nested multiline/chathistory batches). Beyond the cap
the batch open is dropped with a warning; messages tagged with the dropped
reference are simply handled without batch context, so no existing batch state is
disturbed. The wire is otherwise unchanged.

This addresses the clearest server-driven unbounded-collection vector; other
server-populated maps are more naturally bounded by the user's own subscriptions.

Reported via a private security advisory on this repository.
