### PR TITLE
Optimize a bit scrolling

### DIFF
--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -1462,30 +1462,23 @@ impl State {
                 {
                     let rendered_hashes = heights
                         .iter()
-                        .filter_map(|(key, _)| {
-                            if let keyed::Key::Message(hash) = key {
-                                Some(*hash)
-                            } else {
-                                None
-                            }
+                        .filter_map(|(key, _)| match key {
+                            keyed::Key::Message(hash) => Some(*hash),
+                            _ => None,
                         })
                         .collect::<HashSet<_>>();
 
-                    let mut still_pending = HashSet::new();
-
-                    for hash in self.pending_preview_exits.drain() {
-                        if rendered_hashes.contains(&hash) {
-                            still_pending.insert(hash);
-                        } else if self
-                            .visible_url_messages
-                            .remove(&hash)
-                            .is_some()
-                        {
-                            preview_changed = true;
+                    self.pending_preview_exits.retain(|hash| {
+                        if rendered_hashes.contains(hash) {
+                            true
+                        } else {
+                            if self.visible_url_messages.remove(hash).is_some()
+                            {
+                                preview_changed = true;
+                            }
+                            false
                         }
-                    }
-
-                    self.pending_preview_exits = still_pending;
+                    });
 
                     self.visible_messages
                         .retain(|hash| rendered_hashes.contains(hash));

--- a/src/buffer/scroll_view.rs
+++ b/src/buffer/scroll_view.rs
@@ -2445,7 +2445,7 @@ pub mod keyed {
         widget::operate(CollectHeights {
             active: false,
             scrollable_id: scrollable,
-            heights: vec![],
+            heights: Vec::with_capacity(256),
         })
     }
 }


### PR DESCRIPTION
- **Pre-allocate heights**
- **Use retain directly instead of creating an intermediary map**

From a very hand wavy test via comet this shaves off a few ms in
the layout phase every "scroll" event.
