### PR TITLE
Exclude `target` folder when building for flatpak

### DIFF
--- a/assets/flatpak/org.squidowl.halloy.json
+++ b/assets/flatpak/org.squidowl.halloy.json
@@ -39,7 +39,8 @@
             "sources": [
                 {
                     "type": "dir",
-                    "path": "../.."
+                    "path": "../..",
+                    "skip": ["target", ".git"]
                 },
                 "generated-sources.json"
             ]


### PR DESCRIPTION
Skipping the `target` and `.git` folders when building flatpaks for dev. This will speed up local builds dramatically if you also build with `cargo run`.