### PR TITLE
Allow compressing IRC protocol logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Added:
   - Links and channel mentions within a message can be focused and opened
   - New `buffer.focus` theme color for the focused message border
 - Server context menu action to open Channel Discovery with that server selected
+- `servers.<name>.irc_protocol_log.file_format` settings to allow selecting the log files format, gzip or plain (default)
 
 Fixed:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,18 +446,15 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.19"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06575e6a9673580f52661c92107baabffbf41e2141373441cbcdc47cb733003c"
+checksum = "515a1f282e33d55983c499d7e9e87082e81cbc32974825bf9032f928392d5844"
 dependencies = [
- "flate2",
- "futures-core",
+ "compression-codecs",
+ "compression-core",
  "futures-io",
- "memchr",
  "pin-project-lite",
- "xz2",
- "zstd",
- "zstd-safe",
+ "tokio",
 ]
 
 [[package]]
@@ -1104,6 +1101,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe67f2944eef52fc7b106b8c9450d243a88701a0c065f7f57235e76abaed7df"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "liblzma",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8ccc4ea9f6acc32d102c0f6d471d11d913ad15f20c04de743374861fa1d414"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1564,6 +1581,7 @@ dependencies = [
  "any_ascii",
  "anyhow",
  "apple-native-keyring-store",
+ "async-compression",
  "base64 0.23.1",
  "bytes",
  "chrono",
@@ -1573,7 +1591,6 @@ dependencies = [
  "display-info",
  "emojis",
  "fancy-regex 0.19.0",
- "flate2",
  "futures",
  "hex",
  "html-escape",
@@ -4021,6 +4038,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "liblzma"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe0a34ca854fd4f20c07f696fc8675aec78f87d88d29f5e10257a7490a1b2e1"
+dependencies = [
+ "liblzma-sys",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0dad045e4b1b7b170be4b60b54b780cafb4490165461bac7d1cf7b703f61d5f"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4123,17 +4160,6 @@ name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
-
-[[package]]
-name = "lzma-sys"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
 
 [[package]]
 name = "mac-notification-sys"
@@ -10828,15 +10854,6 @@ name = "xmlwriter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
-
-[[package]]
-name = "xz2"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
-dependencies = [
- "lzma-sys",
-]
 
 [[package]]
 name = "y4m"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3706,7 +3706,6 @@ dependencies = [
  "tokio-rustls",
  "tokio-tungstenite",
  "tokio-util",
- "xz2",
 ]
 
 [[package]]

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -52,7 +52,7 @@ keyring-core = "1"
 base64 = "0.23.0"
 dirs-next = "2.0.0"
 xdg = "3.0.0"
-flate2 = "1.0"
+async-compression = { version = "0.4.44", features = ["tokio", "gzip"] }
 hex = "0.4.3"
 iced_core = "0.15.0-dev"
 iced_wgpu = "0.15.0-dev"

--- a/data/src/compression.rs
+++ b/data/src/compression.rs
@@ -1,30 +1,63 @@
 use std::io;
-use std::io::prelude::*;
 
-use flate2::Compression;
-use flate2::read::GzDecoder;
-use flate2::write::GzEncoder;
-use serde::Serialize;
-use serde::de::DeserializeOwned;
+use async_compression::tokio::bufread::GzipDecoder;
+use async_compression::tokio::write::GzipEncoder;
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncBufRead, AsyncRead, AsyncWrite, AsyncWriteExt as _};
 
-pub fn compress<T: Serialize>(value: &T) -> Result<Vec<u8>, Error> {
-    let bytes = serde_json::to_vec(&value).map_err(Error::Encode)?;
-    let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
-    encoder.write_all(&bytes).map_err(Error::Compression)?;
-    encoder.finish().map_err(Error::Compression)
+pub async fn compress<R, W>(mut reader: R, writer: W) -> Result<(), Error>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut encoder = GzipEncoder::new(writer);
+    tokio::io::copy(&mut reader, &mut encoder)
+        .await
+        .map_err(Error::Io)?;
+    encoder.shutdown().await.map_err(Error::Compression)?;
+    Ok(())
 }
 
-pub fn decompress<T: DeserializeOwned>(data: &[u8]) -> Result<T, Error> {
-    let mut bytes = vec![];
-    let mut encoder = GzDecoder::new(data);
-    encoder
-        .read_to_end(&mut bytes)
-        .map_err(Error::Decompression)?;
-    serde_json::from_slice(&bytes).map_err(Error::Decode)
+pub async fn decompress<R, W>(reader: R, mut writer: W) -> Result<(), Error>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut decoder = GzipDecoder::new(reader);
+    tokio::io::copy(&mut decoder, &mut writer)
+        .await
+        .map_err(Error::Io)?;
+    Ok(())
+}
+
+pub async fn serialize_and_compress<T, W>(
+    value: &T,
+    writer: W,
+) -> Result<(), Error>
+where
+    T: ?Sized + Serialize,
+    W: AsyncWrite + Unpin,
+{
+    let serialized = serde_json::to_vec(value).map_err(Error::Encode)?;
+    compress(&serialized[..], writer).await?;
+    Ok(())
+}
+
+pub async fn decompress_and_deserialize<T, R>(reader: R) -> Result<T, Error>
+where
+    T: for<'de> Deserialize<'de>,
+    R: AsyncBufRead + Unpin,
+{
+    let mut decompressed = Vec::new();
+    decompress(reader, &mut decompressed).await?;
+    let value = serde_json::from_slice(&decompressed).map_err(Error::Decode)?;
+    Ok(value)
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("I/O failed")]
+    Io(io::Error),
     #[error("compression failed")]
     Compression(io::Error),
     #[error("decompression failed")]

--- a/data/src/config/server.rs
+++ b/data/src/config/server.rs
@@ -861,6 +861,7 @@ pub struct IrcProtocolLog {
     pub enabled: bool,
     pub format: IrcProtocolLogFormat,
     pub timestamp: Timestamp,
+    pub file_format: FileFormat,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
@@ -870,6 +871,14 @@ pub enum IrcProtocolLogFormat {
     Halloy,
     Goguma,
     // TODO: ZNC format
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FileFormat {
+    #[default]
+    Plain,
+    Gzip,
 }
 
 #[cfg(test)]

--- a/data/src/dashboard.rs
+++ b/data/src/dashboard.rs
@@ -110,20 +110,19 @@ impl Dashboard {
         Ok(std::fs::exists(path)?)
     }
 
-    pub fn load() -> Result<Self, Error> {
+    pub async fn load() -> Result<Self, Error> {
         let path = path()?;
+        let file = tokio::fs::File::open(&path).await?;
+        let reader = tokio::io::BufReader::new(file);
 
-        let bytes = std::fs::read(path)?;
-
-        Ok(compression::decompress(&bytes)?)
+        Ok(compression::decompress_and_deserialize(reader).await?)
     }
 
     pub async fn save(self) -> Result<(), Error> {
         let path = path()?;
+        let mut file = tokio::fs::File::create(&path).await?;
 
-        let bytes = compression::compress(&self)?;
-
-        tokio::fs::write(path, &bytes).await?;
+        compression::serialize_and_compress(&self, &mut file).await?;
 
         Ok(())
     }

--- a/data/src/history.rs
+++ b/data/src/history.rs
@@ -273,7 +273,7 @@ pub async fn overwrite(
         .await;
     }
 
-    let messages = write_messages(kind, messages).await?;
+    write_messages(kind, messages).await?;
 
     metadata::save(kind, messages, read_marker, chathistory_references).await?;
 
@@ -374,7 +374,7 @@ pub async fn append(
         },
     );
 
-    let _ = write_messages(kind, &all_messages).await?;
+    write_messages(kind, &all_messages).await?;
 
     // Update metadata directly, without referencing all messages, since all
     // messages have not been processed (and so do not have their blocked state
@@ -392,19 +392,19 @@ pub async fn append(
     Ok(echo_events)
 }
 
-async fn write_messages<'a>(
+async fn write_messages(
     kind: &Kind,
-    messages: &'a [Message],
-) -> Result<&'a [Message], Error> {
+    messages: &[Message],
+) -> Result<(), Error> {
     let latest_messages =
         &messages[messages.len().saturating_sub(MAX_MESSAGES)..];
 
     let path = path(kind).await?;
-    let compressed = compression::compress(&latest_messages)?;
+    let mut file = tokio::fs::File::create(&path).await?;
 
-    fs::write(path, &compressed).await?;
+    compression::serialize_and_compress(latest_messages, &mut file).await?;
 
-    Ok(latest_messages)
+    Ok(())
 }
 
 pub async fn delete(kind: &Kind) -> Result<(), Error> {
@@ -416,8 +416,10 @@ pub async fn delete(kind: &Kind) -> Result<(), Error> {
 }
 
 async fn read_all(path: &PathBuf) -> Result<Vec<Message>, Error> {
-    let bytes = fs::read(path).await?;
-    Ok(compression::decompress(&bytes)?)
+    let file = tokio::fs::File::open(path).await?;
+    let reader = tokio::io::BufReader::new(file);
+
+    Ok(compression::decompress_and_deserialize(reader).await?)
 }
 
 pub async fn dir_path() -> Result<PathBuf, Error> {

--- a/data/src/stream.rs
+++ b/data/src/stream.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+use async_compression::tokio::write::GzipEncoder;
 use chrono::{DateTime, Local, NaiveDate, Utc};
 use futures::channel::mpsc;
 use futures::never::Never;
@@ -10,7 +11,7 @@ use futures::{FutureExt, SinkExt, StreamExt, future, stream};
 use irc::proto::{self, Command, command};
 use irc::{CodecLog, Connection, codec, connection};
 use tokio::fs::{self, File};
-use tokio::io::{AsyncWriteExt, BufWriter};
+use tokio::io::{AsyncWrite, AsyncWriteExt, BufWriter};
 use tokio::time::{self, Instant, Interval};
 
 use crate::client::Client;
@@ -643,59 +644,108 @@ async fn connect(
 async fn log_codec(
     server: Server,
     config: config::server::IrcProtocolLog,
-    mut receiver: tokio::sync::mpsc::UnboundedReceiver<CodecLog>,
+    receiver: tokio::sync::mpsc::UnboundedReceiver<CodecLog>,
 ) {
-    let log_writer = LogWriter::new(&server).await;
-
-    match log_writer {
-        Ok(mut log_writer) => {
-            let mut set_timeout_to_flush = false;
-
-            while let Some(action) = if set_timeout_to_flush {
-                tokio::time::timeout(
-                    Duration::from_millis(500),
-                    receiver.recv(),
-                )
-                .await
-                .transpose()
-            } else {
-                receiver.recv().await.map(Ok)
-            } {
-                match action {
-                    Ok(message) => {
-                        log_writer.write(message, &config).await;
-                        set_timeout_to_flush = true;
-                    }
-                    Err(_) => {
-                        log_writer.flush().await;
-                        set_timeout_to_flush = false;
-                    }
-                }
+    match config.file_format {
+        config::server::FileFormat::Plain => {
+            match PlainLogWriter::new(&server).await {
+                Ok(writer) => log_codec_loop(writer, config, receiver).await,
+                Err(err) => log::error!(
+                    "unable to create log writer for {server}: {err}"
+                ),
             }
-
-            log_writer.shutdown().await;
         }
-        Err(error) => {
-            log::error!("unable to create log writer for {server}: {error}");
+        config::server::FileFormat::Gzip => {
+            match GzipLogWriter::new(&server).await {
+                Ok(writer) => log_codec_loop(writer, config, receiver).await,
+                Err(err) => log::error!(
+                    "unable to create log writer for {server}: {err}"
+                ),
+            }
         }
     }
 }
 
-struct LogWriter {
-    log_dir: PathBuf,
-    date_writer: Option<(NaiveDate, BufWriter<File>)>,
+async fn log_codec_loop<E: LogEncoder>(
+    mut log_writer: LogWriter<E>,
+    config: config::server::IrcProtocolLog,
+    mut receiver: tokio::sync::mpsc::UnboundedReceiver<CodecLog>,
+) {
+    let mut set_timeout_to_flush = false;
+
+    while let Some(action) = if set_timeout_to_flush {
+        tokio::time::timeout(Duration::from_millis(500), receiver.recv())
+            .await
+            .transpose()
+    } else {
+        receiver.recv().await.map(Ok)
+    } {
+        match action {
+            Ok(message) => {
+                log_writer.write(message, &config).await;
+                set_timeout_to_flush = true;
+            }
+            Err(_) => {
+                log_writer.flush().await;
+                set_timeout_to_flush = false;
+            }
+        }
+    }
+
+    log_writer.shutdown().await;
 }
 
-impl LogWriter {
-    pub async fn new(server: &Server) -> Result<Self, std::io::Error> {
+pub trait LogEncoder {
+    type Writer: AsyncWrite + Unpin;
+
+    fn extension() -> &'static str;
+    fn wrap(file: File) -> Self::Writer;
+}
+
+pub struct PlainEncoder;
+
+impl LogEncoder for PlainEncoder {
+    type Writer = BufWriter<File>;
+
+    fn extension() -> &'static str {
+        "log"
+    }
+
+    fn wrap(file: File) -> Self::Writer {
+        BufWriter::new(file)
+    }
+}
+
+pub struct GzipFormatEncoder;
+
+impl LogEncoder for GzipFormatEncoder {
+    type Writer = GzipEncoder<File>;
+
+    fn extension() -> &'static str {
+        "log.gz"
+    }
+
+    fn wrap(file: File) -> Self::Writer {
+        GzipEncoder::new(file)
+    }
+}
+
+pub type PlainLogWriter = LogWriter<PlainEncoder>;
+pub type GzipLogWriter = LogWriter<GzipFormatEncoder>;
+
+pub struct LogWriter<E: LogEncoder> {
+    log_dir: PathBuf,
+    date_writer: Option<(NaiveDate, E::Writer)>,
+}
+
+impl<E: LogEncoder> LogWriter<E> {
+    async fn new(server: &Server) -> Result<Self, std::io::Error> {
         let data_dir = environment::data_dir();
 
         let log_dir =
             data_dir.join("irc_protocol_logs").join(server.to_string());
 
-        if !log_dir.exists() {
-            fs::create_dir_all(&log_dir).await?;
-        }
+        fs::create_dir_all(&log_dir).await?;
 
         Ok(Self {
             log_dir,
@@ -715,9 +765,9 @@ impl LogWriter {
             config::logs::Timestamp::Utc => now.to_utc().date_naive(),
         };
 
-        if let Some((date, writer)) = &mut self.date_writer {
+        if let Some((date, _)) = &mut self.date_writer {
             if today != *date {
-                let _ = writer.flush().await;
+                self.shutdown().await;
 
                 self.create_date_writer(today).await;
             }
@@ -727,13 +777,14 @@ impl LogWriter {
 
         if let Some((_, writer)) = &mut self.date_writer {
             let _ = writer
-                .write_all(LogWriter::format(message, now, config).as_bytes())
+                .write_all(Self::format(message, now, config).as_bytes())
                 .await;
         }
     }
 
     async fn create_date_writer(&mut self, date: NaiveDate) {
-        let log_file = date.format("%Y-%m-%d.log").to_string();
+        let log_file =
+            format!("{}.{}", date.format("%Y-%m-%d"), E::extension());
 
         self.date_writer = File::options()
             .append(true)
@@ -741,7 +792,7 @@ impl LogWriter {
             .open(self.log_dir.join(log_file))
             .await
             .ok()
-            .map(|writer| (date, BufWriter::new(writer)));
+            .map(|writer| (date, E::wrap(writer)));
     }
 
     fn format(
@@ -780,9 +831,8 @@ impl LogWriter {
     }
 
     pub async fn shutdown(&mut self) {
-        if let Some((_, writer)) = &mut self.date_writer {
+        if let Some((_, mut writer)) = self.date_writer.take() {
             let _ = writer.flush().await;
-
             let _ = writer.shutdown().await;
         }
     }

--- a/docs/configuration/servers.md
+++ b/docs/configuration/servers.md
@@ -1323,3 +1323,16 @@ timestamp = "utc"
 [^1]: Windows path strings should usually be specified as literal strings (e.g. `'C:\Users\Default\'`), otherwise directory separators will need to be escaped (e.g. `"C:\\Users\\Default\\"`).
 
 [^2]: Relative paths are prefixed with the config directory (i.e. if you have your config.toml in `/home/me/.config/halloy/config.toml`, path `.passwd/libera` will be converted to `/home/me/.config/halloy/.passwd/libera`).
+
+### `file_format`
+
+The format used for the log files.
+
+```toml
+# Type: string
+# Values: "plain", "gzip"
+# Default: "plain"
+
+[servers.<name>.irc_protocol_log]
+file_format = "gzip"
+```

--- a/irc/Cargo.toml
+++ b/irc/Cargo.toml
@@ -36,7 +36,6 @@ tokio-tungstenite = { version = "0.30.0", default-features = false, features = [
 ] }
 tokio-util = { version = "0.7", features = ["codec"] }
 rustls-native-certs = "0.8.1"
-xz2 = { version = "0.1.7", features = ["static"] }
 
 [dependencies.proto]
 path = "proto"

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,12 +95,13 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     log::info!("config dir: {:?}", environment::config_dir());
     log::info!("data dir: {:?}", environment::data_dir());
 
-    let (config_load, window_load) = {
+    let (config_load, window_load, dashboard_load) = {
         rt.block_on(async {
             let config = Config::load().await;
             let window = data::Window::load().await;
+            let dashboard = data::Dashboard::load().await;
 
-            (config, window)
+            (config, window, dashboard.map_err(|e| e.to_string()))
         })
     };
 
@@ -145,6 +146,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
             Halloy::new(
                 config_load.clone(),
                 window_load.clone(),
+                dashboard_load.clone(),
                 destination.clone(),
                 log_stream,
                 // we start with an unspecified mode because we are guaranteed to
@@ -238,6 +240,7 @@ fn handle_irc_error(e: anyhow::Error) {
 struct Halloy {
     version: Version,
     screen: Screen,
+    dashboard: data::Dashboard,
     current_mode: appearance::Mode,
     theme: Theme,
     config: Config,
@@ -275,6 +278,7 @@ impl Halloy {
     pub fn load_from_state(
         main_window: window::Id,
         config_load: Result<Config, config::Error>,
+        dashboard_load: Result<data::Dashboard, String>,
         current_mode: appearance::Mode,
     ) -> (Halloy, Task<Message>) {
         let main_window = Window::new(main_window);
@@ -282,10 +286,11 @@ impl Halloy {
             .as_ref()
             .err()
             .and_then(Self::modal_for_missing_keyring_password);
-        let load_dashboard = |config: &Config| match data::Dashboard::load() {
-            Ok(dashboard) => {
-                screen::Dashboard::restore(dashboard, config, &main_window)
-            }
+        let load_dashboard = |config: &Config| match dashboard_load {
+            Ok(dashboard) => (
+                dashboard.clone(),
+                screen::Dashboard::restore(dashboard, config, &main_window),
+            ),
             Err(error) => {
                 if data::Dashboard::exists().is_ok_and(|exists| exists) {
                     log::warn!("failed to load dashboard: {error}");
@@ -294,22 +299,26 @@ impl Halloy {
                     // downgrade severity to info
                     log::info!("failed to load dashboard: {error}");
                 }
-
-                screen::Dashboard::empty(&main_window, config)
+                (
+                    data::Dashboard::default(),
+                    screen::Dashboard::empty(&main_window, config),
+                )
             }
         };
 
-        let (screen, servers, config, commands) = match config_load {
+        let (dashboard, screen, servers, config, commands) = match config_load {
             Ok(config) => {
                 let mut servers: server::Map = config.servers.clone().into();
                 servers.set_order(config.sidebar.order_by);
-                let (mut screen, mut commands) = load_dashboard(&config);
+                let (dashboard, (mut screen, mut commands)) =
+                    load_dashboard(&config);
                 screen.init_filters(&servers, &data::client::Map::default());
                 screen
                     .set_reroute_rules(&servers, &data::client::Map::default());
                 commands = commands
                     .chain(screen.request_override_server_icons(&servers));
                 (
+                    dashboard,
                     Screen::Dashboard(screen),
                     servers,
                     config,
@@ -318,12 +327,14 @@ impl Halloy {
             }
             // Show regular welcome screen for new users.
             Err(config::Error::ConfigMissing) => (
+                data::Dashboard::default(),
                 Screen::Welcome(screen::Welcome::default()),
                 server::Map::default(),
                 Config::default(),
                 Task::none(),
             ),
             Err(error) => (
+                data::Dashboard::default(),
                 Screen::Help(screen::Help::new(error)),
                 server::Map::default(),
                 // If the config file is not missing but could not be loaded,
@@ -346,6 +357,7 @@ impl Halloy {
             Halloy {
                 version: Version::new(),
                 screen,
+                dashboard,
                 current_mode,
                 theme: current_mode.theme(&config.appearance.selected).into(),
                 clients: data::client::Map::default(),
@@ -422,6 +434,7 @@ impl Halloy {
     fn new(
         config_load: Result<Config, config::Error>,
         window_load: Result<data::Window, window::Error>,
+        dashboard_load: Result<data::Dashboard, String>,
         url_received: Option<data::Url>,
         log_stream: ReceiverStream<Vec<logger::Record>>,
         current_mode: appearance::Mode,
@@ -459,8 +472,12 @@ impl Halloy {
             ..window::settings(config)
         });
 
-        let (mut halloy, command) =
-            Halloy::load_from_state(main_window, config_load, current_mode);
+        let (mut halloy, command) = Halloy::load_from_state(
+            main_window,
+            config_load,
+            dashboard_load,
+            current_mode,
+        );
 
         halloy.main_window.fullscreen = fullscreen;
         halloy.main_window.maximized = maximized;
@@ -598,6 +615,7 @@ impl Halloy {
                 let (mut halloy, command) = Halloy::load_from_state(
                     self.main_window.id,
                     updated,
+                    Ok(self.dashboard.clone()),
                     self.current_mode,
                 );
                 halloy.main_window = saved_window;


### PR DESCRIPTION
This is rather boring change, born out of noticing
~2GB in the logs directory. The ratio of compression
of those files is rather good, approx 5x.

Except I wanted to play with rust type system and decided
to switch the current serde_json compression routines to
async-compression instead of flate2 to avoid 2 deps
with the same functionality.
This is mostly an exercise with no real benefit.
