### PR TITLE
Make +- optional in /mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Fixed:
 - Cap the number of concurrently open IRCv3 batches a server can hold open, so a
   single connection cannot grow memory without bound
 - Config editor now properly out-scrolls the cursor
+- Allow listing modes by not proviging <+|->
 
 Changed:
 
@@ -59,7 +60,7 @@ Changed:
 Thanks:
 
 - Contributions: @rollecode, @luca020400, @rtmongold, @tranzystorekk, @englut, @furudean, @ncfavier
-- Bug reports: @sebbu2, @dpedu, kurwavidae, @ncfavier, wwWraith, kurwavidae, @SRAZKVT, @WinnerWind, @lojinks, @edwardloveall
+- Bug reports: @sebbu2, @dpedu, kurwavidae, @ncfavier, wwWraith, kurwavidae, @SRAZKVT, @WinnerWind, @lojinks, @edwardloveall, CGML
 - Feature requests: @daniiooo, @fabricionaweb, @RoboDanjal, @AbandonedCranium, tbo, ivocavalcante, @sebbu2, @coraxioU9, @ncfavier, @darienm, @Anonymous1157, gkoebel
 
 # 2026.8 (2026-07-24)

--- a/data/src/command.rs
+++ b/data/src/command.rs
@@ -1938,7 +1938,7 @@ fn validated_mode_string(
         let chanmodes = isupport::get_chanmodes_or_default(isupport);
         let prefix = isupport::get_prefix_or_default(isupport);
 
-        let mut channel_modes_regex = String::from(r"^((\+|\-)?[");
+        let mut channel_modes_regex = String::from(r"^((^|\+|\-)[");
         for chanmode in chanmodes {
             channel_modes_regex += chanmode.modes.as_ref();
         }
@@ -1978,7 +1978,7 @@ fn validated_mode_string(
         // User modes from RPL_MYINFO is unreliable, so use the most permissive
         // regex instead of crafting a regex for the server
 
-        let mut user_modes_regex = String::from(r"^((\+|\-)?[A-Za-z]");
+        let mut user_modes_regex = String::from(r"^((^|\+|\-)[A-Za-z]");
         if let Some(mode_limit) = mode_limit {
             user_modes_regex += r"{1,";
             user_modes_regex += &format!("{mode_limit}");
@@ -2265,6 +2265,34 @@ mod tests {
                 )
                 .is_ok()
             );
+        }
+    }
+
+    #[test]
+    fn mode_limit_with_optional_initial_sign() {
+        for target in ["#channel", "nickname"] {
+            for (modes, expected) in [
+                ("b", true),
+                ("bbb", true),
+                ("+bbb", true),
+                ("-bbb", true),
+                ("b+bb", true),
+                ("+bb-b", true),
+                ("bbbb", false),
+                ("+bbbb", false),
+                ("-bbbb", false),
+            ] {
+                assert_eq!(
+                    super::validated_mode_string(
+                        target,
+                        modes,
+                        &isupport::DEFAULT,
+                        false,
+                    ),
+                    Ok(expected),
+                    "{target} {modes} (default mode limit is three)",
+                );
+            }
         }
     }
 

--- a/data/src/command.rs
+++ b/data/src/command.rs
@@ -1938,7 +1938,7 @@ fn validated_mode_string(
         let chanmodes = isupport::get_chanmodes_or_default(isupport);
         let prefix = isupport::get_prefix_or_default(isupport);
 
-        let mut channel_modes_regex = String::from(r"^((\+|\-)[");
+        let mut channel_modes_regex = String::from(r"^((\+|\-)?[");
         for chanmode in chanmodes {
             channel_modes_regex += chanmode.modes.as_ref();
         }
@@ -1973,12 +1973,12 @@ fn validated_mode_string(
         channel_modes_regex += r")+$";
 
         Regex::new(&channel_modes_regex)
-            .unwrap_or(Regex::new(r"^((\+|\-)[A-Za-z]+)+$").unwrap())
+            .unwrap_or(Regex::new(r"^((\+|\-)?[A-Za-z]+)+$").unwrap())
     } else {
         // User modes from RPL_MYINFO is unreliable, so use the most permissive
         // regex instead of crafting a regex for the server
 
-        let mut user_modes_regex = String::from(r"^((\+|\-)[A-Za-z]");
+        let mut user_modes_regex = String::from(r"^((\+|\-)?[A-Za-z]");
         if let Some(mode_limit) = mode_limit {
             user_modes_regex += r"{1,";
             user_modes_regex += &format!("{mode_limit}");
@@ -1988,7 +1988,7 @@ fn validated_mode_string(
         }
         user_modes_regex += r")+$";
         Regex::new(&user_modes_regex)
-            .unwrap_or(Regex::new(r"^((\+|\-)[A-Za-z]+)+$").unwrap())
+            .unwrap_or(Regex::new(r"^((\+|\-)?[A-Za-z]+)+$").unwrap())
     };
 
     Ok(mode_string_regex.is_match(mode_string).unwrap_or_default())


### PR DESCRIPTION
In most servers not specifying +- switches to the "list" mode

unrealircd: https://github.com/unrealircd/unrealircd/blob/unreal60_dev/src/modules/mode.c#L1493 hardcoded list of supported list modes
ergo: https://github.com/ergochat/ergo/blob/master/irc/modes/modes.go#L193 seems to allow all modes
solanum: https://github.com/solanum-ircd/solanum/blob/main/ircd/chmode.c#L1369 special handling, but seems to decide if query or add depending on mode