### PR TITLE
Improve card preview metadata parsing

### DIFF
--- a/data/src/preview.rs
+++ b/data/src/preview.rs
@@ -376,7 +376,7 @@ async fn load_uncached(
                 image_url,
                 title,
                 description,
-            } = parse_meta_tag_properties(&bytes)?;
+            } = parse_meta_tag_properties(&url, &bytes)?;
 
             let image_url =
                 image_url.ok_or(LoadError::MissingProperty("image"))?;
@@ -595,6 +595,7 @@ struct MetaTagProperties {
 }
 
 fn parse_meta_tag_properties(
+    url: &Url,
     bytes: &[u8],
 ) -> Result<MetaTagProperties, LoadError> {
     let mut meta = MetaTagProperties::default();
@@ -646,7 +647,7 @@ fn parse_meta_tag_properties(
             "og:image" | "og:image:url" | "og:image:secure_url"
                 if meta.image_url.is_none() =>
             {
-                meta.image_url = Some(content.parse()?);
+                meta.image_url = Some(url.join(&content)?);
             }
             "og:title" if meta.title.is_none() => {
                 meta.title = Some(content);
@@ -733,6 +734,8 @@ mod tests {
 
     #[test]
     fn parses_mixed_attribute_order_and_quotes() {
+        let url = "https://example.com/page".parse().expect("valid URL");
+
         let html = br#"
             <html><head>
                 <meta property='og:image' content='https://cdn.example.com/a.png'>
@@ -741,7 +744,7 @@ mod tests {
             </head></html>
         "#;
 
-        let meta = parse_meta_tag_properties(html).expect("should parse");
+        let meta = parse_meta_tag_properties(&url, html).expect("should parse");
 
         assert_eq!(
             meta.image_url.as_ref().map(url::Url::as_str),
@@ -753,13 +756,14 @@ mod tests {
 
     #[test]
     fn parses_name_attr_and_secure_image_variant() {
+        let url = "https://example.com/post".parse().expect("valid URL");
         let html = br#"
             <meta name="og:image:secure_url" content="https://img.example.com/secure.jpg">
             <meta name="og:title" content="From name attr">
             <meta name="og:url" content="https://example.com/post">
         "#;
 
-        let meta = parse_meta_tag_properties(html).expect("should parse");
+        let meta = parse_meta_tag_properties(&url, html).expect("should parse");
 
         assert_eq!(
             meta.image_url.as_ref().map(url::Url::as_str),
@@ -770,6 +774,7 @@ mod tests {
 
     #[test]
     fn first_value_wins_for_duplicates() {
+        let url = "https://example.com/page".parse().expect("valid URL");
         let html = br#"
             <meta property="og:title" content="First">
             <meta property="og:title" content="Second">
@@ -779,7 +784,7 @@ mod tests {
             <meta property="og:image" content="https://example.com/img2.png">
         "#;
 
-        let meta = parse_meta_tag_properties(html).expect("should parse");
+        let meta = parse_meta_tag_properties(&url, html).expect("should parse");
 
         assert_eq!(meta.title.as_deref(), Some("First"));
         assert_eq!(
@@ -790,15 +795,33 @@ mod tests {
 
     #[test]
     fn property_attribute_takes_precedence_over_name_on_same_meta_tag() {
+        let url = "https://example.com/page".parse().expect("valid URL");
         let html = br#"
             <meta property="og:image" name="twitter:image" content="https://example.com/og.png">
         "#;
 
-        let meta = parse_meta_tag_properties(html).expect("should parse");
+        let meta = parse_meta_tag_properties(&url, html).expect("should parse");
 
         assert_eq!(
             meta.image_url.as_ref().map(url::Url::as_str),
             Some("https://example.com/og.png")
+        );
+    }
+
+    #[test]
+    fn parses_relative_image_url() {
+        let url = "https://cultofthepartyparrot.com/"
+            .parse()
+            .expect("valid URL");
+        let html = br#"
+            <meta property="og:image" content="/assets/og.png" />
+        "#;
+
+        let meta = parse_meta_tag_properties(&url, html).expect("should parse");
+
+        assert_eq!(
+            meta.image_url.as_ref().map(url::Url::as_str),
+            Some("https://cultofthepartyparrot.com/assets/og.png")
         );
     }
 }

--- a/data/src/preview.rs
+++ b/data/src/preview.rs
@@ -373,7 +373,6 @@ async fn load_uncached(
         Fetched::Image(image) => Ok(Preview::Image(image)),
         Fetched::Other(bytes) => {
             let MetaTagProperties {
-                canonical_url,
                 image_url,
                 title,
                 description,
@@ -406,8 +405,6 @@ async fn load_uncached(
 
             Ok(Preview::Card(Card {
                 url: url.clone(),
-                canonical_url: canonical_url
-                    .ok_or(LoadError::MissingProperty("url"))?,
                 image,
                 title: title.ok_or(LoadError::MissingProperty("title"))?,
                 description,
@@ -592,7 +589,6 @@ fn decode_html_string(s: &str) -> String {
 
 #[derive(Debug, Default)]
 struct MetaTagProperties {
-    canonical_url: Option<Url>,
     image_url: Option<Url>,
     title: Option<String>,
     description: Option<String>,
@@ -647,9 +643,6 @@ fn parse_meta_tag_properties(
         };
 
         match property.trim().to_ascii_lowercase().as_str() {
-            "og:url" if meta.canonical_url.is_none() => {
-                meta.canonical_url = Some(content.parse()?);
-            }
             "og:image" | "og:image:url" | "og:image:secure_url"
                 if meta.image_url.is_none() =>
             {
@@ -742,7 +735,6 @@ mod tests {
     fn parses_mixed_attribute_order_and_quotes() {
         let html = br#"
             <html><head>
-                <meta content="https://example.com/page" property="og:url">
                 <meta property='og:image' content='https://cdn.example.com/a.png'>
                 <meta content="Title" property="og:title">
                 <meta property="og:description" content="  Hello &amp; goodbye  ">
@@ -751,10 +743,6 @@ mod tests {
 
         let meta = parse_meta_tag_properties(html).expect("should parse");
 
-        assert_eq!(
-            meta.canonical_url.as_ref().map(url::Url::as_str),
-            Some("https://example.com/page")
-        );
         assert_eq!(
             meta.image_url.as_ref().map(url::Url::as_str),
             Some("https://cdn.example.com/a.png")
@@ -778,10 +766,6 @@ mod tests {
             Some("https://img.example.com/secure.jpg")
         );
         assert_eq!(meta.title.as_deref(), Some("From name attr"));
-        assert_eq!(
-            meta.canonical_url.as_ref().map(url::Url::as_str),
-            Some("https://example.com/post")
-        );
     }
 
     #[test]
@@ -798,10 +782,6 @@ mod tests {
         let meta = parse_meta_tag_properties(html).expect("should parse");
 
         assert_eq!(meta.title.as_deref(), Some("First"));
-        assert_eq!(
-            meta.canonical_url.as_ref().map(url::Url::as_str),
-            Some("https://example.com/one")
-        );
         assert_eq!(
             meta.image_url.as_ref().map(url::Url::as_str),
             Some("https://example.com/img1.png")

--- a/data/src/preview/card.rs
+++ b/data/src/preview/card.rs
@@ -6,7 +6,6 @@ use super::Image;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Card {
     pub url: Url,
-    pub canonical_url: Url,
     pub image: Image,
     pub title: String,
     pub description: Option<String>,


### PR DESCRIPTION
- **Remove canonical_url**
- **Handle relative images in card previews**

<img width="517" height="311" alt="image" src="https://github.com/user-attachments/assets/2205512a-0d6d-4cd7-8ab0-1cc0fa468e1c" />

